### PR TITLE
services/horizon/internal: Include liquidity pools in OrderBookStream

### DIFF
--- a/services/horizon/internal/db2/history/liquidity_pools.go
+++ b/services/horizon/internal/db2/history/liquidity_pools.go
@@ -91,6 +91,7 @@ type QLiquidityPools interface {
 	UpdateLiquidityPool(ctx context.Context, lp LiquidityPool) (int64, error)
 	RemoveLiquidityPool(ctx context.Context, liquidityPoolID string, lastModifiedLedger uint32) (int64, error)
 	GetLiquidityPoolsByID(ctx context.Context, poolIDs []string) ([]LiquidityPool, error)
+	GetAllLiquidityPools(ctx context.Context) ([]LiquidityPool, error)
 	CountLiquidityPools(ctx context.Context) (int, error)
 	FindLiquidityPoolByID(ctx context.Context, liquidityPoolID string) (LiquidityPool, error)
 	GetUpdatedLiquidityPools(ctx context.Context, newerThanSequence uint32) ([]LiquidityPool, error)
@@ -193,6 +194,15 @@ func (q *Q) GetLiquidityPools(ctx context.Context, query LiquidityPoolsQuery) ([
 
 	var results []LiquidityPool
 	if err := q.Select(ctx, &results, sql); err != nil {
+		return nil, errors.Wrap(err, "could not run select query")
+	}
+
+	return results, nil
+}
+
+func (q *Q) GetAllLiquidityPools(ctx context.Context) ([]LiquidityPool, error) {
+	var results []LiquidityPool
+	if err := q.Select(ctx, &results, selectLiquidityPools.Where("deleted = ?", false)); err != nil {
 		return nil, errors.Wrap(err, "could not run select query")
 	}
 

--- a/services/horizon/internal/db2/history/liquidity_pools_test.go
+++ b/services/horizon/internal/db2/history/liquidity_pools_test.go
@@ -164,6 +164,12 @@ func TestFindLiquidityPoolsByAssets(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Len(lps, 1)
 
+	pool := lps[0]
+	lps, err = q.GetAllLiquidityPools(tt.Ctx)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(lps, 1)
+	tt.Assert.Equal(pool, lps[0])
+
 	// query by one asset
 	query = LiquidityPoolsQuery{
 		PageQuery: db2.MustPageQuery("", false, "", 10),
@@ -276,6 +282,10 @@ func TestLiquidityPoolCompaction(t *testing.T) {
 	q.RemoveLiquidityPool(tt.Ctx, lp.PoolID, 200)
 
 	lps, err = q.GetLiquidityPools(tt.Ctx, query)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(lps, 0)
+
+	lps, err = q.GetAllLiquidityPools(tt.Ctx)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(lps, 0)
 

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -276,6 +276,7 @@ type IngestionQ interface {
 	GetExpStateInvalid(context.Context) (bool, error)
 	GetLatestHistoryLedger(context.Context) (uint32, error)
 	GetOfferCompactionSequence(context.Context) (uint32, error)
+	GetLiquidityPoolCompactionSequence(context.Context) (uint32, error)
 	TruncateIngestStateTables(context.Context) error
 	DeleteRangeAll(ctx context.Context, start, end int64) error
 }

--- a/services/horizon/internal/db2/history/mock_q_liquidity_pools.go
+++ b/services/horizon/internal/db2/history/mock_q_liquidity_pools.go
@@ -41,6 +41,11 @@ func (m *MockQLiquidityPools) FindLiquidityPoolByID(ctx context.Context, liquidi
 	return a.Get(0).(LiquidityPool), a.Error(1)
 }
 
+func (m *MockQLiquidityPools) GetAllLiquidityPools(ctx context.Context) ([]LiquidityPool, error) {
+	a := m.Called(ctx)
+	return a.Get(0).([]LiquidityPool), a.Error(1)
+}
+
 func (m *MockQLiquidityPools) GetUpdatedLiquidityPools(ctx context.Context, sequence uint32) ([]LiquidityPool, error) {
 	a := m.Called(ctx, sequence)
 	return a.Get(0).([]LiquidityPool), a.Error(1)

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -287,6 +287,11 @@ func (m *mockDBQ) GetOfferCompactionSequence(ctx context.Context) (uint32, error
 	return args.Get(0).(uint32), args.Error(1)
 }
 
+func (m *mockDBQ) GetLiquidityPoolCompactionSequence(ctx context.Context) (uint32, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(uint32), args.Error(1)
+}
+
 func (m *mockDBQ) GetLastLedgerIngestNonBlocking(ctx context.Context) (uint32, error) {
 	args := m.Called(ctx)
 	return args.Get(0).(uint32), args.Error(1)

--- a/services/horizon/internal/ingest/mock_orderbook_graph.go
+++ b/services/horizon/internal/ingest/mock_orderbook_graph.go
@@ -16,6 +16,10 @@ func (m *mockOrderBookGraph) AddOffer(offer xdr.OfferEntry) {
 	m.Called(offer)
 }
 
+func (m *mockOrderBookGraph) AddLiquidityPool(liquidityPool xdr.LiquidityPoolEntry) {
+	m.Called(liquidityPool)
+}
+
 func (m *mockOrderBookGraph) Apply(ledger uint32) error {
 	args := m.Called(ledger)
 	return args.Error(0)
@@ -36,6 +40,11 @@ func (m *mockOrderBookGraph) Offers() []xdr.OfferEntry {
 	return args.Get(0).([]xdr.OfferEntry)
 }
 
+func (m *mockOrderBookGraph) LiquidityPools() []xdr.LiquidityPoolEntry {
+	args := m.Called()
+	return args.Get(0).([]xdr.LiquidityPoolEntry)
+}
+
 func (m *mockOrderBookGraph) OffersMap() map[xdr.Int64]xdr.OfferEntry {
 	args := m.Called()
 	return args.Get(0).(map[xdr.Int64]xdr.OfferEntry)
@@ -43,6 +52,11 @@ func (m *mockOrderBookGraph) OffersMap() map[xdr.Int64]xdr.OfferEntry {
 
 func (m *mockOrderBookGraph) RemoveOffer(id xdr.Int64) orderbook.OBGraph {
 	args := m.Called(id)
+	return args.Get(0).(orderbook.OBGraph)
+}
+
+func (m *mockOrderBookGraph) RemoveLiquidityPool(params xdr.LiquidityPoolConstantProductParameters) orderbook.OBGraph {
+	args := m.Called(params)
 	return args.Get(0).(orderbook.OBGraph)
 }
 

--- a/services/horizon/internal/ingest/orderbook_test.go
+++ b/services/horizon/internal/ingest/orderbook_test.go
@@ -6,10 +6,11 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/ingest/processors"
 	"github.com/stellar/go/xdr"
+
 	"github.com/stretchr/testify/suite"
 )
 
@@ -92,6 +93,31 @@ func (t *IngestionStatusTestSuite) TestGetOfferCompactionSequenceError() {
 	t.Assert().EqualError(err, "Error from GetOfferCompactionSequence: compaction error")
 }
 
+func (t *IngestionStatusTestSuite) TestLiquidityPoolCompactionSequenceError() {
+	t.historyQ.On("GetExpStateInvalid", t.ctx).
+		Return(false, nil).
+		Once()
+
+	t.historyQ.On("GetLatestHistoryLedger", t.ctx).
+		Return(uint32(200), nil).
+		Once()
+
+	t.historyQ.On("GetLastLedgerIngestNonBlocking", t.ctx).
+		Return(uint32(200), nil).
+		Once()
+
+	t.historyQ.On("GetOfferCompactionSequence", t.ctx).
+		Return(uint32(100), nil).
+		Once()
+
+	t.historyQ.On("GetLiquidityPoolCompactionSequence", t.ctx).
+		Return(uint32(0), fmt.Errorf("compaction error")).
+		Once()
+
+	_, err := t.stream.getIngestionStatus(t.ctx)
+	t.Assert().EqualError(err, "Error from GetLiquidityPoolCompactionSequence: compaction error")
+}
+
 func (t *IngestionStatusTestSuite) TestStateInvalid() {
 	t.historyQ.On("GetExpStateInvalid", t.ctx).
 		Return(true, nil).
@@ -109,13 +135,18 @@ func (t *IngestionStatusTestSuite) TestStateInvalid() {
 		Return(uint32(100), nil).
 		Once()
 
+	t.historyQ.On("GetLiquidityPoolCompactionSequence", t.ctx).
+		Return(uint32(100), nil).
+		Once()
+
 	status, err := t.stream.getIngestionStatus(t.ctx)
 	t.Assert().NoError(err)
 	t.Assert().Equal(ingestionStatus{
-		HistoryConsistentWithState: true,
-		StateInvalid:               true,
-		LastIngestedLedger:         200,
-		LastOfferCompactionLedger:  100,
+		HistoryConsistentWithState:        true,
+		StateInvalid:                      true,
+		LastIngestedLedger:                200,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
 	}, status)
 }
 
@@ -136,13 +167,18 @@ func (t *IngestionStatusTestSuite) TestHistoryInconsistentWithState() {
 		Return(uint32(100), nil).
 		Once()
 
+	t.historyQ.On("GetLiquidityPoolCompactionSequence", t.ctx).
+		Return(uint32(100), nil).
+		Once()
+
 	status, err := t.stream.getIngestionStatus(t.ctx)
 	t.Assert().NoError(err)
 	t.Assert().Equal(ingestionStatus{
-		HistoryConsistentWithState: false,
-		StateInvalid:               true,
-		LastIngestedLedger:         201,
-		LastOfferCompactionLedger:  100,
+		HistoryConsistentWithState:        false,
+		StateInvalid:                      true,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
 	}, status)
 }
 
@@ -163,13 +199,18 @@ func (t *IngestionStatusTestSuite) TestHistoryLatestLedgerZero() {
 		Return(uint32(100), nil).
 		Once()
 
+	t.historyQ.On("GetLiquidityPoolCompactionSequence", t.ctx).
+		Return(uint32(100), nil).
+		Once()
+
 	status, err := t.stream.getIngestionStatus(t.ctx)
 	t.Assert().NoError(err)
 	t.Assert().Equal(ingestionStatus{
-		HistoryConsistentWithState: true,
-		StateInvalid:               false,
-		LastIngestedLedger:         201,
-		LastOfferCompactionLedger:  100,
+		HistoryConsistentWithState:        true,
+		StateInvalid:                      false,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
 	}, status)
 }
 
@@ -199,10 +240,11 @@ func (t *UpdateOrderBookStreamTestSuite) TearDownTest() {
 
 func (t *UpdateOrderBookStreamTestSuite) TestGetAllOffersError() {
 	status := ingestionStatus{
-		HistoryConsistentWithState: true,
-		StateInvalid:               false,
-		LastIngestedLedger:         201,
-		LastOfferCompactionLedger:  100,
+		HistoryConsistentWithState:        true,
+		StateInvalid:                      false,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
 	}
 	t.graph.On("Clear").Return().Once()
 	t.graph.On("Discard").Return().Once()
@@ -218,10 +260,11 @@ func (t *UpdateOrderBookStreamTestSuite) TestGetAllOffersError() {
 
 func (t *UpdateOrderBookStreamTestSuite) TestResetApplyError() {
 	status := ingestionStatus{
-		HistoryConsistentWithState: true,
-		StateInvalid:               false,
-		LastIngestedLedger:         201,
-		LastOfferCompactionLedger:  100,
+		HistoryConsistentWithState:        true,
+		StateInvalid:                      false,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
 	}
 	t.graph.On("Clear").Return().Once()
 	t.graph.On("Discard").Return().Once()
@@ -239,6 +282,10 @@ func (t *UpdateOrderBookStreamTestSuite) TestResetApplyError() {
 	}
 	t.historyQ.On("GetAllOffers", t.ctx).
 		Return([]history.Offer{offer, otherOffer}, nil).
+		Once()
+
+	t.historyQ.MockQLiquidityPools.On("GetAllLiquidityPools", t.ctx).
+		Return([]history.LiquidityPool{}, nil).
 		Once()
 
 	t.graph.On("AddOffer", offerEntry).Return().Once()
@@ -274,6 +321,10 @@ func (t *UpdateOrderBookStreamTestSuite) mockReset(status ingestionStatus) {
 		Return(offers, nil).
 		Once()
 
+	t.historyQ.MockQLiquidityPools.On("GetAllLiquidityPools", t.ctx).
+		Return([]history.LiquidityPool{}, nil).
+		Once()
+
 	t.graph.On("AddOffer", offerEntry).Return().Once()
 	t.graph.On("AddOffer", otherOfferEntry).Return().Once()
 
@@ -284,10 +335,11 @@ func (t *UpdateOrderBookStreamTestSuite) mockReset(status ingestionStatus) {
 
 func (t *UpdateOrderBookStreamTestSuite) TestFirstUpdateSucceeds() {
 	status := ingestionStatus{
-		HistoryConsistentWithState: true,
-		StateInvalid:               false,
-		LastIngestedLedger:         201,
-		LastOfferCompactionLedger:  100,
+		HistoryConsistentWithState:        true,
+		StateInvalid:                      false,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
 	}
 	t.mockReset(status)
 
@@ -299,10 +351,11 @@ func (t *UpdateOrderBookStreamTestSuite) TestFirstUpdateSucceeds() {
 
 func (t *UpdateOrderBookStreamTestSuite) TestInvalidState() {
 	status := ingestionStatus{
-		HistoryConsistentWithState: true,
-		StateInvalid:               true,
-		LastIngestedLedger:         201,
-		LastOfferCompactionLedger:  100,
+		HistoryConsistentWithState:        true,
+		StateInvalid:                      true,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
 	}
 	t.graph.On("Clear").Return().Once()
 
@@ -323,10 +376,11 @@ func (t *UpdateOrderBookStreamTestSuite) TestInvalidState() {
 
 func (t *UpdateOrderBookStreamTestSuite) TestHistoryInconsistentWithState() {
 	status := ingestionStatus{
-		HistoryConsistentWithState: false,
-		StateInvalid:               false,
-		LastIngestedLedger:         201,
-		LastOfferCompactionLedger:  100,
+		HistoryConsistentWithState:        false,
+		StateInvalid:                      false,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
 	}
 	t.graph.On("Clear").Return().Once()
 
@@ -345,12 +399,30 @@ func (t *UpdateOrderBookStreamTestSuite) TestHistoryInconsistentWithState() {
 	t.Assert().True(reset)
 }
 
+func (t *UpdateOrderBookStreamTestSuite) TestOfferCompactionDoesNotMatchLiquidityPoolCompaction() {
+	status := ingestionStatus{
+		HistoryConsistentWithState:        true,
+		StateInvalid:                      false,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 110,
+	}
+	t.mockReset(status)
+
+	t.stream.lastLedger = 201
+	reset, err := t.stream.update(t.ctx, status)
+	t.Assert().NoError(err)
+	t.Assert().Equal(uint32(201), t.stream.lastLedger)
+	t.Assert().True(reset)
+}
+
 func (t *UpdateOrderBookStreamTestSuite) TestLastIngestedLedgerBehindStream() {
 	status := ingestionStatus{
-		HistoryConsistentWithState: true,
-		StateInvalid:               false,
-		LastIngestedLedger:         201,
-		LastOfferCompactionLedger:  100,
+		HistoryConsistentWithState:        true,
+		StateInvalid:                      false,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
 	}
 	t.mockReset(status)
 
@@ -363,10 +435,11 @@ func (t *UpdateOrderBookStreamTestSuite) TestLastIngestedLedgerBehindStream() {
 
 func (t *UpdateOrderBookStreamTestSuite) TestStreamBehindLastCompactionLedger() {
 	status := ingestionStatus{
-		HistoryConsistentWithState: true,
-		StateInvalid:               false,
-		LastIngestedLedger:         201,
-		LastOfferCompactionLedger:  100,
+		HistoryConsistentWithState:        true,
+		StateInvalid:                      false,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
 	}
 	t.mockReset(status)
 
@@ -379,10 +452,11 @@ func (t *UpdateOrderBookStreamTestSuite) TestStreamBehindLastCompactionLedger() 
 
 func (t *UpdateOrderBookStreamTestSuite) TestStreamLedgerEqualsLastIngestedLedger() {
 	status := ingestionStatus{
-		HistoryConsistentWithState: true,
-		StateInvalid:               false,
-		LastIngestedLedger:         201,
-		LastOfferCompactionLedger:  100,
+		HistoryConsistentWithState:        true,
+		StateInvalid:                      false,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
 	}
 
 	t.stream.lastLedger = 201
@@ -394,10 +468,11 @@ func (t *UpdateOrderBookStreamTestSuite) TestStreamLedgerEqualsLastIngestedLedge
 
 func (t *UpdateOrderBookStreamTestSuite) TestGetUpdatedOffersError() {
 	status := ingestionStatus{
-		HistoryConsistentWithState: true,
-		StateInvalid:               false,
-		LastIngestedLedger:         201,
-		LastOfferCompactionLedger:  100,
+		HistoryConsistentWithState:        true,
+		StateInvalid:                      false,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
 	}
 	t.graph.On("Discard").Return().Once()
 
@@ -408,6 +483,30 @@ func (t *UpdateOrderBookStreamTestSuite) TestGetUpdatedOffersError() {
 
 	_, err := t.stream.update(t.ctx, status)
 	t.Assert().EqualError(err, "Error from GetUpdatedOffers: updated offers error")
+	t.Assert().Equal(uint32(100), t.stream.lastLedger)
+}
+
+func (t *UpdateOrderBookStreamTestSuite) TestGetUpdatedLiquidityPoolsError() {
+	status := ingestionStatus{
+		HistoryConsistentWithState:        true,
+		StateInvalid:                      false,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
+	}
+	t.graph.On("Discard").Return().Once()
+
+	t.stream.lastLedger = 100
+	t.historyQ.MockQOffers.On("GetUpdatedOffers", t.ctx, uint32(100)).
+		Return([]history.Offer{}, nil).
+		Once()
+
+	t.historyQ.MockQLiquidityPools.On("GetUpdatedLiquidityPools", t.ctx, t.stream.lastLedger).
+		Return([]history.LiquidityPool{}, fmt.Errorf("updated liquidity pools error")).
+		Once()
+
+	_, err := t.stream.update(t.ctx, status)
+	t.Assert().EqualError(err, "Error from GetUpdatedLiquidityPools: updated liquidity pools error")
 	t.Assert().Equal(uint32(100), t.stream.lastLedger)
 }
 
@@ -432,6 +531,10 @@ func (t *UpdateOrderBookStreamTestSuite) mockUpdate() {
 		Return(offers, nil).
 		Once()
 
+	t.historyQ.MockQLiquidityPools.On("GetUpdatedLiquidityPools", t.ctx, t.stream.lastLedger).
+		Return([]history.LiquidityPool{}, nil).
+		Once()
+
 	t.graph.On("AddOffer", offerEntry).Return().Once()
 	t.graph.On("AddOffer", otherOfferEntry).Return().Once()
 	t.graph.On("RemoveOffer", xdr.Int64(deletedOffer.OfferID)).Return(t.graph).Once()
@@ -439,10 +542,11 @@ func (t *UpdateOrderBookStreamTestSuite) mockUpdate() {
 
 func (t *UpdateOrderBookStreamTestSuite) TestApplyUpdatesError() {
 	status := ingestionStatus{
-		HistoryConsistentWithState: true,
-		StateInvalid:               false,
-		LastIngestedLedger:         201,
-		LastOfferCompactionLedger:  100,
+		HistoryConsistentWithState:        true,
+		StateInvalid:                      false,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
 	}
 
 	t.mockUpdate()
@@ -458,10 +562,11 @@ func (t *UpdateOrderBookStreamTestSuite) TestApplyUpdatesError() {
 
 func (t *UpdateOrderBookStreamTestSuite) TestApplyUpdatesSucceeds() {
 	status := ingestionStatus{
-		HistoryConsistentWithState: true,
-		StateInvalid:               false,
-		LastIngestedLedger:         201,
-		LastOfferCompactionLedger:  100,
+		HistoryConsistentWithState:        true,
+		StateInvalid:                      false,
+		LastIngestedLedger:                201,
+		LastOfferCompactionLedger:         100,
+		LastLiquidityPoolCompactionLedger: 100,
 	}
 
 	t.mockUpdate()
@@ -476,25 +581,23 @@ func (t *UpdateOrderBookStreamTestSuite) TestApplyUpdatesSucceeds() {
 	t.Assert().False(reset)
 }
 
-type VerifyOrderBookStreamTestSuite struct {
+type VerifyOffersStreamTestSuite struct {
 	suite.Suite
-	ctx         context.Context
-	historyQ    *mockDBQ
-	graph       *mockOrderBookGraph
-	stream      *OrderBookStream
-	initialTime time.Time
+	ctx      context.Context
+	historyQ *mockDBQ
+	graph    *mockOrderBookGraph
+	stream   *OrderBookStream
 }
 
-func TestVerifyOrderBookStream(t *testing.T) {
-	suite.Run(t, new(VerifyOrderBookStreamTestSuite))
+func TestVerifyOffersStreamTestSuite(t *testing.T) {
+	suite.Run(t, new(VerifyOffersStreamTestSuite))
 }
 
-func (t *VerifyOrderBookStreamTestSuite) SetupTest() {
+func (t *VerifyOffersStreamTestSuite) SetupTest() {
 	t.ctx = context.Background()
 	t.historyQ = &mockDBQ{}
 	t.graph = &mockOrderBookGraph{}
 	t.stream = NewOrderBookStream(t.historyQ, t.graph)
-	t.initialTime = t.stream.lastVerification
 
 	sellerID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	otherSellerID := "GAXI33UCLQTCKM2NMRBS7XYBR535LLEVAHL5YBN4FTCB4HZHT7ZA5CVK"
@@ -528,33 +631,31 @@ func (t *VerifyOrderBookStreamTestSuite) SetupTest() {
 	}).Once()
 }
 
-func (t *VerifyOrderBookStreamTestSuite) TearDownTest() {
+func (t *VerifyOffersStreamTestSuite) TearDownTest() {
 	t.historyQ.AssertExpectations(t.T())
 	t.graph.AssertExpectations(t.T())
 }
 
-func (t *VerifyOrderBookStreamTestSuite) TestGetAllOffersError() {
+func (t *VerifyOffersStreamTestSuite) TestGetAllOffersError() {
 	t.historyQ.On("GetAllOffers", t.ctx).
 		Return([]history.Offer{}, fmt.Errorf("offers error")).
 		Once()
 
-	t.stream.lastLedger = 300
-	t.stream.verifyAllOffers(t.ctx)
-	t.Assert().Equal(uint32(300), t.stream.lastLedger)
-	t.Assert().True(t.stream.lastVerification.Equal(t.initialTime))
+	offersOk, err := t.stream.verifyAllOffers(t.ctx)
+	t.Assert().EqualError(err, "Error from GetAllOffers: offers error")
+	t.Assert().False(offersOk)
 }
 
-func (t *VerifyOrderBookStreamTestSuite) TestEmptyDBOffers() {
+func (t *VerifyOffersStreamTestSuite) TestEmptyDBOffers() {
 	var offers []history.Offer
 	t.historyQ.On("GetAllOffers", t.ctx).Return(offers, nil).Once()
 
-	t.stream.lastLedger = 300
-	t.stream.verifyAllOffers(t.ctx)
-	t.Assert().Equal(uint32(0), t.stream.lastLedger)
-	t.Assert().False(t.stream.lastVerification.Equal(t.initialTime))
+	offersOk, err := t.stream.verifyAllOffers(t.ctx)
+	t.Assert().NoError(err)
+	t.Assert().False(offersOk)
 }
 
-func (t *VerifyOrderBookStreamTestSuite) TestLengthMismatch() {
+func (t *VerifyOffersStreamTestSuite) TestLengthMismatch() {
 	offers := []history.Offer{
 		{
 			OfferID:            1,
@@ -572,13 +673,12 @@ func (t *VerifyOrderBookStreamTestSuite) TestLengthMismatch() {
 	}
 	t.historyQ.On("GetAllOffers", t.ctx).Return(offers, nil).Once()
 
-	t.stream.lastLedger = 300
-	t.stream.verifyAllOffers(t.ctx)
-	t.Assert().Equal(uint32(0), t.stream.lastLedger)
-	t.Assert().False(t.stream.lastVerification.Equal(t.initialTime))
+	offersOk, err := t.stream.verifyAllOffers(t.ctx)
+	t.Assert().NoError(err)
+	t.Assert().False(offersOk)
 }
 
-func (t *VerifyOrderBookStreamTestSuite) TestContentMismatch() {
+func (t *VerifyOffersStreamTestSuite) TestContentMismatch() {
 	offers := []history.Offer{
 		{
 			OfferID:            1,
@@ -610,12 +710,12 @@ func (t *VerifyOrderBookStreamTestSuite) TestContentMismatch() {
 	t.historyQ.On("GetAllOffers", t.ctx).Return(offers, nil).Once()
 
 	t.stream.lastLedger = 300
-	t.stream.verifyAllOffers(t.ctx)
-	t.Assert().Equal(uint32(0), t.stream.lastLedger)
-	t.Assert().False(t.stream.lastVerification.Equal(t.initialTime))
+	offersOk, err := t.stream.verifyAllOffers(t.ctx)
+	t.Assert().NoError(err)
+	t.Assert().False(offersOk)
 }
 
-func (t *VerifyOrderBookStreamTestSuite) TestSuccess() {
+func (t *VerifyOffersStreamTestSuite) TestSuccess() {
 	offers := []history.Offer{
 		{
 			OfferID:            1,
@@ -646,8 +746,220 @@ func (t *VerifyOrderBookStreamTestSuite) TestSuccess() {
 	}
 	t.historyQ.On("GetAllOffers", t.ctx).Return(offers, nil).Once()
 
-	t.stream.lastLedger = 300
-	t.stream.verifyAllOffers(t.ctx)
-	t.Assert().Equal(uint32(300), t.stream.lastLedger)
-	t.Assert().False(t.stream.lastVerification.Equal(t.initialTime))
+	offersOk, err := t.stream.verifyAllOffers(t.ctx)
+	t.Assert().NoError(err)
+	t.Assert().True(offersOk)
+}
+
+type VerifyLiquidityPoolsStreamTestSuite struct {
+	suite.Suite
+	ctx      context.Context
+	historyQ *mockDBQ
+	graph    *mockOrderBookGraph
+	stream   *OrderBookStream
+}
+
+func TestVerifyLiquidityPoolsStreamTestSuite(t *testing.T) {
+	suite.Run(t, new(VerifyLiquidityPoolsStreamTestSuite))
+}
+
+func (t *VerifyLiquidityPoolsStreamTestSuite) SetupTest() {
+	t.ctx = context.Background()
+	t.historyQ = &mockDBQ{}
+	t.graph = &mockOrderBookGraph{}
+	t.stream = NewOrderBookStream(t.historyQ, t.graph)
+
+	t.graph.On("LiquidityPools").Return([]xdr.LiquidityPoolEntry{
+		{
+			LiquidityPoolId: xdr.PoolId{1, 2, 3},
+			Body: xdr.LiquidityPoolEntryBody{
+				Type: xdr.LiquidityPoolTypeLiquidityPoolConstantProduct,
+				ConstantProduct: &xdr.LiquidityPoolEntryConstantProduct{
+					Params: xdr.LiquidityPoolConstantProductParameters{
+						AssetA: xdr.MustNewNativeAsset(),
+						AssetB: xdr.MustNewCreditAsset("USD", issuer.Address()),
+						Fee:    xdr.LiquidityPoolFeeV18,
+					},
+					ReserveA:                 789,
+					ReserveB:                 456,
+					TotalPoolShares:          11,
+					PoolSharesTrustLineCount: 13,
+				},
+			},
+		},
+		{
+			LiquidityPoolId: xdr.PoolId{4, 5, 6},
+			Body: xdr.LiquidityPoolEntryBody{
+				Type: xdr.LiquidityPoolTypeLiquidityPoolConstantProduct,
+				ConstantProduct: &xdr.LiquidityPoolEntryConstantProduct{
+					Params: xdr.LiquidityPoolConstantProductParameters{
+						AssetA: xdr.MustNewNativeAsset(),
+						AssetB: xdr.MustNewCreditAsset("EUR", issuer.Address()),
+						Fee:    xdr.LiquidityPoolFeeV18,
+					},
+					ReserveA:                 19,
+					ReserveB:                 1234,
+					TotalPoolShares:          456,
+					PoolSharesTrustLineCount: 90,
+				},
+			},
+		},
+	}).Once()
+}
+
+func (t *VerifyLiquidityPoolsStreamTestSuite) TearDownTest() {
+	t.historyQ.AssertExpectations(t.T())
+	t.graph.AssertExpectations(t.T())
+}
+
+func (t *VerifyLiquidityPoolsStreamTestSuite) TestGetAllLiquidityPoolsError() {
+	t.historyQ.MockQLiquidityPools.On("GetAllLiquidityPools", t.ctx).
+		Return([]history.LiquidityPool{}, fmt.Errorf("liquidity pools error")).
+		Once()
+
+	liquidityPoolsOk, err := t.stream.verifyAllLiquidityPools(t.ctx)
+	t.Assert().EqualError(err, "Error from GetAllLiquidityPools: liquidity pools error")
+	t.Assert().False(liquidityPoolsOk)
+}
+
+func (t *VerifyLiquidityPoolsStreamTestSuite) TestEmptyDBOffers() {
+	t.historyQ.MockQLiquidityPools.On("GetAllLiquidityPools", t.ctx).
+		Return([]history.LiquidityPool{}, nil).
+		Once()
+
+	liquidityPoolsOk, err := t.stream.verifyAllLiquidityPools(t.ctx)
+	t.Assert().NoError(err)
+	t.Assert().False(liquidityPoolsOk)
+}
+
+func (t *VerifyLiquidityPoolsStreamTestSuite) TestLengthMismatch() {
+	liquidityPools := []history.LiquidityPool{
+		{
+			PoolID:         processors.PoolIDToString(xdr.PoolId{1, 2, 3}),
+			Type:           xdr.LiquidityPoolTypeLiquidityPoolConstantProduct,
+			Fee:            xdr.LiquidityPoolFeeV18,
+			TrustlineCount: 13,
+			ShareCount:     11,
+			AssetReserves: history.LiquidityPoolAssetReserves{
+				history.LiquidityPoolAssetReserve{
+					Asset:   xdr.MustNewNativeAsset(),
+					Reserve: 789,
+				},
+				history.LiquidityPoolAssetReserve{
+					Asset:   xdr.MustNewCreditAsset("USD", issuer.Address()),
+					Reserve: 456,
+				},
+			},
+			LastModifiedLedger: 100,
+			Deleted:            false,
+		},
+	}
+
+	t.historyQ.MockQLiquidityPools.On("GetAllLiquidityPools", t.ctx).
+		Return(liquidityPools, nil).
+		Once()
+
+	liquidityPoolsOk, err := t.stream.verifyAllLiquidityPools(t.ctx)
+	t.Assert().NoError(err)
+	t.Assert().False(liquidityPoolsOk)
+}
+
+func (t *VerifyLiquidityPoolsStreamTestSuite) TestContentMismatch() {
+	liquidityPools := []history.LiquidityPool{
+		{
+			PoolID:         processors.PoolIDToString(xdr.PoolId{1, 2, 3}),
+			Type:           xdr.LiquidityPoolTypeLiquidityPoolConstantProduct,
+			Fee:            xdr.LiquidityPoolFeeV18,
+			TrustlineCount: 0,
+			ShareCount:     11,
+			AssetReserves: history.LiquidityPoolAssetReserves{
+				history.LiquidityPoolAssetReserve{
+					Asset:   xdr.MustNewNativeAsset(),
+					Reserve: 789,
+				},
+				history.LiquidityPoolAssetReserve{
+					Asset:   xdr.MustNewCreditAsset("USD", issuer.Address()),
+					Reserve: 456,
+				},
+			},
+			LastModifiedLedger: 100,
+			Deleted:            false,
+		},
+		{
+			PoolID:         processors.PoolIDToString(xdr.PoolId{4, 5, 6}),
+			Type:           xdr.LiquidityPoolTypeLiquidityPoolConstantProduct,
+			Fee:            xdr.LiquidityPoolFeeV18,
+			TrustlineCount: 90,
+			ShareCount:     456,
+			AssetReserves: history.LiquidityPoolAssetReserves{
+				history.LiquidityPoolAssetReserve{
+					Asset:   xdr.MustNewNativeAsset(),
+					Reserve: 19,
+				},
+				history.LiquidityPoolAssetReserve{
+					Asset:   xdr.MustNewCreditAsset("EUR", issuer.Address()),
+					Reserve: 1234,
+				},
+			},
+			LastModifiedLedger: 50,
+			Deleted:            false,
+		},
+	}
+	t.historyQ.MockQLiquidityPools.On("GetAllLiquidityPools", t.ctx).
+		Return(liquidityPools, nil).
+		Once()
+
+	liquidityPoolsOk, err := t.stream.verifyAllLiquidityPools(t.ctx)
+	t.Assert().NoError(err)
+	t.Assert().False(liquidityPoolsOk)
+}
+
+func (t *VerifyLiquidityPoolsStreamTestSuite) TestSuccess() {
+	liquidityPools := []history.LiquidityPool{
+		{
+			PoolID:         processors.PoolIDToString(xdr.PoolId{1, 2, 3}),
+			Type:           xdr.LiquidityPoolTypeLiquidityPoolConstantProduct,
+			Fee:            xdr.LiquidityPoolFeeV18,
+			TrustlineCount: 13,
+			ShareCount:     11,
+			AssetReserves: history.LiquidityPoolAssetReserves{
+				history.LiquidityPoolAssetReserve{
+					Asset:   xdr.MustNewNativeAsset(),
+					Reserve: 789,
+				},
+				history.LiquidityPoolAssetReserve{
+					Asset:   xdr.MustNewCreditAsset("USD", issuer.Address()),
+					Reserve: 456,
+				},
+			},
+			LastModifiedLedger: 100,
+			Deleted:            false,
+		},
+		{
+			PoolID:         processors.PoolIDToString(xdr.PoolId{4, 5, 6}),
+			Type:           xdr.LiquidityPoolTypeLiquidityPoolConstantProduct,
+			Fee:            xdr.LiquidityPoolFeeV18,
+			TrustlineCount: 90,
+			ShareCount:     456,
+			AssetReserves: history.LiquidityPoolAssetReserves{
+				history.LiquidityPoolAssetReserve{
+					Asset:   xdr.MustNewNativeAsset(),
+					Reserve: 19,
+				},
+				history.LiquidityPoolAssetReserve{
+					Asset:   xdr.MustNewCreditAsset("EUR", issuer.Address()),
+					Reserve: 1234,
+				},
+			},
+			LastModifiedLedger: 50,
+			Deleted:            false,
+		},
+	}
+	t.historyQ.MockQLiquidityPools.On("GetAllLiquidityPools", t.ctx).
+		Return(liquidityPools, nil).
+		Once()
+
+	offersOk, err := t.stream.verifyAllLiquidityPools(t.ctx)
+	t.Assert().NoError(err)
+	t.Assert().True(offersOk)
 }


### PR DESCRIPTION
Extend the OrderBookStream so that it polls for updated liquidity pools from the DB. The liquidity pool rows from the db will be used to update the in-memory orderbook graph.