### PR TITLE
services/horizon: Avoid docker-compose side-effects during integration tests cleanup

### DIFF
--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -204,7 +204,8 @@ func (i *Test) prepareShutdownHandlers() {
 			if i.app != nil {
 				i.app.Close()
 			}
-			i.runComposeCommand("down", "-v", "--remove-orphans")
+			i.runComposeCommand("rm", "-fvs", "core")
+			i.runComposeCommand("rm", "-fvs", "core-postgres")
 		},
 		i.environment.Restore,
 	)


### PR DESCRIPTION
Using a generic `docker-compose down` command for stopping the Horizon
integration test containers causes every docker-compose container to
be brought down (including other containers, like the Horizon database
container which can be started using docker-compose).

This change makes sure we only destroy the containers brought up
during integration testing.
