### PR TITLE
protocols/horizon: Represent trade prices as int64 fractions

### DIFF
--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -311,8 +311,8 @@ func assertResponseTradeEqualsDBTrade(ht *HTTPT, row history.Trade, record horiz
 	ht.Assert.Equal(uint32(row.LiquidityPoolFee.Int64), record.LiquidityPoolFeeBP)
 	ht.Assert.Equal(row.PagingToken(), record.PagingToken())
 	ht.Assert.Equal(row.LedgerCloseTime.Unix(), record.LedgerCloseTime.Unix())
-	ht.Assert.Equal(int32(row.PriceN.Int64), record.Price.N)
-	ht.Assert.Equal(int32(row.PriceD.Int64), record.Price.D)
+	ht.Assert.Equal(row.PriceN.Int64, record.Price.N)
+	ht.Assert.Equal(row.PriceD.Int64, record.Price.D)
 
 	if row.BaseLiquidityPoolID.Valid || row.CounterLiquidityPoolID.Valid {
 		ht.Assert.Equal(history.LiquidityPoolTrades, record.TradeType)
@@ -338,7 +338,7 @@ func unsetAssetQuery(q *url.Values, prefix string) {
 }
 
 //testPrice ensures that the price float string is equal to the rational price
-func testPrice(t *HTTPT, priceStr string, priceR xdr.Price) {
+func testPrice(t *HTTPT, priceStr string, priceR horizon.TradePrice) {
 	price, err := strconv.ParseFloat(priceStr, 64)
 	if t.Assert.NoError(err) {
 		t.Assert.Equal(price, float64(priceR.N)/float64(priceR.D))

--- a/services/horizon/internal/db2/history/trade_aggregation.go
+++ b/services/horizon/internal/db2/history/trade_aggregation.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stellar/go/services/horizon/internal/toid"
 	"github.com/stellar/go/support/errors"
 	strtime "github.com/stellar/go/support/time"
-	"github.com/stellar/go/xdr"
 )
 
 // AllowedResolutions is the set of trade aggregation time windows allowed to be used as the
@@ -36,30 +35,14 @@ type TradeAggregation struct {
 	BaseVolume    string  `db:"base_volume"`
 	CounterVolume string  `db:"counter_volume"`
 	Average       float64 `db:"avg"`
-	HighN         int32   `db:"high_n"`
-	HighD         int32   `db:"high_d"`
-	LowN          int32   `db:"low_n"`
-	LowD          int32   `db:"low_d"`
-	OpenN         int32   `db:"open_n"`
-	OpenD         int32   `db:"open_d"`
-	CloseN        int32   `db:"close_n"`
-	CloseD        int32   `db:"close_d"`
-}
-
-func (t TradeAggregation) High() xdr.Price {
-	return xdr.Price{N: xdr.Int32(t.HighN), D: xdr.Int32(t.HighD)}
-}
-
-func (t TradeAggregation) Low() xdr.Price {
-	return xdr.Price{N: xdr.Int32(t.LowN), D: xdr.Int32(t.LowD)}
-}
-
-func (t TradeAggregation) Open() xdr.Price {
-	return xdr.Price{N: xdr.Int32(t.OpenN), D: xdr.Int32(t.OpenD)}
-}
-
-func (t TradeAggregation) Close() xdr.Price {
-	return xdr.Price{N: xdr.Int32(t.CloseN), D: xdr.Int32(t.CloseD)}
+	HighN         int64   `db:"high_n"`
+	HighD         int64   `db:"high_d"`
+	LowN          int64   `db:"low_n"`
+	LowD          int64   `db:"low_d"`
+	OpenN         int64   `db:"open_n"`
+	OpenD         int64   `db:"open_d"`
+	CloseN        int64   `db:"close_n"`
+	CloseD        int64   `db:"close_d"`
 }
 
 // TradeAggregationsQ is a helper struct to aid in configuring queries to

--- a/services/horizon/internal/integration/protocol18_test.go
+++ b/services/horizon/internal/integration/protocol18_test.go
@@ -438,8 +438,8 @@ func TestLiquidityPoolHappyPath(t *testing.T) {
 	tt.Equal("1.0353642", trade1.CounterAmount)
 	tt.Equal("native", trade1.CounterAssetType)
 
-	tt.Equal(int32(10353642), trade1.Price.N)
-	tt.Equal(int32(20000000), trade1.Price.D)
+	tt.Equal(int64(10353642), trade1.Price.N)
+	tt.Equal(int64(20000000), trade1.Price.D)
 }
 
 func TestLiquidityPoolRevoke(t *testing.T) {

--- a/services/horizon/internal/resourceadapter/trade.go
+++ b/services/horizon/internal/resourceadapter/trade.go
@@ -67,9 +67,9 @@ func PopulateTrade(
 	}
 
 	if row.HasPrice() {
-		dest.Price = &protocol.Price{
-			N: int32(row.PriceN.Int64),
-			D: int32(row.PriceD.Int64),
+		dest.Price = protocol.TradePrice{
+			N: row.PriceN.Int64,
+			D: row.PriceD.Int64,
 		}
 	}
 

--- a/services/horizon/internal/resourceadapter/trade_aggregation.go
+++ b/services/horizon/internal/resourceadapter/trade_aggregation.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 )
 
-// Populate fills out the details of a trade using a row from the history_trades
+// PopulateTradeAggregation fills out the details of a trade aggregation using a row from the trade aggregations
 // table.
 func PopulateTradeAggregation(
 	ctx context.Context,
@@ -28,13 +28,25 @@ func PopulateTradeAggregation(
 		return err
 	}
 	dest.Average = price.StringFromFloat64(row.Average)
-	dest.High = row.High().String()
-	dest.HighR = row.High()
-	dest.Low = row.Low().String()
-	dest.LowR = row.Low()
-	dest.Open = row.Open().String()
-	dest.OpenR = row.Open()
-	dest.Close = row.Close().String()
-	dest.CloseR = row.Close()
+	dest.HighR = protocol.TradePrice{
+		N: row.HighN,
+		D: row.HighD,
+	}
+	dest.High = dest.HighR.String()
+	dest.LowR = protocol.TradePrice{
+		N: row.LowN,
+		D: row.LowD,
+	}
+	dest.Low = dest.LowR.String()
+	dest.OpenR = protocol.TradePrice{
+		N: row.OpenN,
+		D: row.OpenD,
+	}
+	dest.Open = dest.OpenR.String()
+	dest.CloseR = protocol.TradePrice{
+		N: row.CloseN,
+		D: row.CloseD,
+	}
+	dest.Close = dest.CloseR.String()
 	return nil
 }

--- a/services/ticker/internal/scraper/trade_scraper_test.go
+++ b/services/ticker/internal/scraper/trade_scraper_test.go
@@ -23,10 +23,10 @@ func TestReverseAssets(t *testing.T) {
 
 	baseIsSeller := true
 
-	n := int32(10)
-	d := int32(50)
+	n := int64(10)
+	d := int64(50)
 
-	price := hProtocol.Price{
+	price := hProtocol.TradePrice{
 		N: n,
 		D: d,
 	}
@@ -43,7 +43,7 @@ func TestReverseAssets(t *testing.T) {
 		CounterAssetType:   counterAssetType,
 		CounterAssetIssuer: counterAssetIssuer,
 		BaseIsSeller:       baseIsSeller,
-		Price:              &price,
+		Price:              price,
 	}
 
 	fmt.Println(trade1)
@@ -92,10 +92,10 @@ func TestNormalizeTradeAssets(t *testing.T) {
 	baseAssetType := "BASEASSETTYPE"
 	baseAssetIssuer := "BASEASSETISSUER"
 
-	n := int32(10)
-	d := int32(50)
+	n := int64(10)
+	d := int64(50)
 
-	price := hProtocol.Price{
+	price := hProtocol.TradePrice{
 		N: n,
 		D: d,
 	}
@@ -107,7 +107,7 @@ func TestNormalizeTradeAssets(t *testing.T) {
 		BaseAssetType:    baseAssetType,
 		BaseAssetIssuer:  baseAssetIssuer,
 		CounterAssetType: "native",
-		Price:            &price,
+		Price:            price,
 	}
 
 	NormalizeTradeAssets(&trade1)
@@ -134,7 +134,7 @@ func TestNormalizeTradeAssets(t *testing.T) {
 		CounterAssetCode:   "AAA",
 		CounterAssetType:   counterAssetType,
 		CounterAssetIssuer: counterAssetIssuer,
-		Price:              &price,
+		Price:              price,
 	}
 	NormalizeTradeAssets(&trade2)
 	assert.Equal(t, baseAmount, trade2.CounterAmount)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Represent trade prices as int64 fractions.

### Why


Prior to protocol 18 we represented trade prices as a fraction where the numerator and denominator took on 32 bit integer values:

```golang
type Price struct {
	N int32 `json:"n"`
	D int32 `json:"d"`
}
```
In protocol 18 we introduce liquidity pools and trades against liquidity pools involve exchanged amount values which can take on 64  bit integer values. We derive the price for a liquidity pool trade by dividing the amounts exchanged. Therefore we can no longer represent trade prices as fractions with 32 bit numerators and denominators.

### Known limitations

This is a breaking change for **both** the trades and the trade aggregations API. We were already expecting this to be a breaking change for the trades API. However, at that time, I did not realize that we would also need to do a breaking change for the trade aggregations API as well. So we will need to communicate this breaking API change to horizon stakeholders.

Luckily we are representing the aggregation values in the `history_trades_60000` table as `numeric` postgres types, so no db migrations are required on the history aggregations table in order to support 64 bit trade prices.