### PR TITLE
keypair: add test coverage for hint functions

### DIFF
--- a/keypair/from_address_test.go
+++ b/keypair/from_address_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFromAddress_Hint(t *testing.T) {
+	kp := MustParseAddress("GAYUB4KATGTUZEGUMJEOZDPPWM4MQLHCIKC4T55YSXHN234WI6BJMIY2")
+	assert.Equal(t, [4]byte{0x96, 0x47, 0x82, 0x96}, kp.Hint())
+}
+
 func TestFromAddress_Equal(t *testing.T) {
 	// A nil FromAddress.
 	var kp0 *FromAddress

--- a/keypair/full_test.go
+++ b/keypair/full_test.go
@@ -10,6 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFull_Hint(t *testing.T) {
+	kp := MustParseFull("SBFGFF27Y64ZUGFAIG5AMJGQODZZKV2YQKAVUUN4HNE24XZXD2OEUVUP")
+	assert.Equal(t, [4]byte{0x96, 0x47, 0x82, 0x96}, kp.Hint())
+	assert.Equal(t, [4]byte{0x96, 0x47, 0x82, 0x96}, kp.FromAddress().Hint())
+}
+
 func TestFull_Equal(t *testing.T) {
 	// A nil Full.
 	var kp0 *Full


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add test coverage for the Hint functions of the keypair.FromAddress and keypair.Full types.

### Why

Those functions aren't tested, and I'm iterating on the keypair code in https://github.com/stellar/go/pull/3914 that involves changing the Hint functions, so I'd like test coverage present before hand. 

### Known limitations

N/A
