### PR TITLE
services/horizon: Change `ProcessorsRunDuration` metric type from counter to summary

### DIFF
--- a/services/horizon/internal/ingest/fsm.go
+++ b/services/horizon/internal/ingest/fsm.go
@@ -523,6 +523,8 @@ func (r resumeState) addProcessorDurationsMetricFromMap(s *system, m map[string]
 		processorName = strings.Replace(processorName, "*", "", -1)
 		s.Metrics().ProcessorsRunDuration.
 			With(prometheus.Labels{"name": processorName}).Add(value.Seconds())
+		s.Metrics().ProcessorsRunDurationSummary.
+			With(prometheus.Labels{"name": processorName}).Observe(value.Seconds())
 	}
 }
 

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -129,7 +129,11 @@ type Metrics struct {
 	LedgerStatsCounter *prometheus.CounterVec
 
 	// ProcessorsRunDuration exposes processors run durations.
+	// Deprecated in favour of: ProcessorsRunDurationSummary.
 	ProcessorsRunDuration *prometheus.CounterVec
+
+	// ProcessorsRunDurationSummary exposes processors run durations.
+	ProcessorsRunDurationSummary *prometheus.SummaryVec
 
 	// CaptiveStellarCoreSynced exposes synced status of Captive Stellar-Core.
 	// 1 if sync, 0 if not synced, -1 if unable to connect or HTTP server disabled.
@@ -323,6 +327,14 @@ func (s *system) initMetrics() {
 		prometheus.CounterOpts{
 			Namespace: "horizon", Subsystem: "ingest", Name: "processor_run_duration_seconds_total",
 			Help: "run durations of ingestion processors",
+		},
+		[]string{"name"},
+	)
+
+	s.metrics.ProcessorsRunDurationSummary = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace: "horizon", Subsystem: "ingest", Name: "processor_run_duration_seconds",
+			Help: "run durations of ingestion processors, sliding window = 10m",
 		},
 		[]string{"name"},
 	)

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -263,6 +263,7 @@ func initIngestMetrics(app *App) {
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().StateInvalidGauge)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().LedgerStatsCounter)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().ProcessorsRunDuration)
+	app.prometheusRegistry.MustRegister(app.ingester.Metrics().ProcessorsRunDurationSummary)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().CaptiveStellarCoreSynced)
 	app.prometheusRegistry.MustRegister(app.ingester.Metrics().CaptiveCoreSupportedProtocolVersion)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add a new metric `ProcessorsRunDurationSummary` (`processor_run_duration_seconds`) to replace existing `ProcessorsRunDuration` (`processor_run_duration_seconds_total`). The old metric is now deprecated.

### Why

The `ProcessorsRunDuration` is a counter. While it allows estimating and comparing actual duration of processors it's impossible to calculate average per ledger run duration because number of events are not counted.

### Known limitations

[TODO or N/A]
