### PR TITLE
services/horizon/internal/db2/schema: Remove migration to fix fee account transactions

### DIFF
--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -45,7 +45,6 @@
 // migrations/48_rebuild_trade_aggregations.sql (1.243kB)
 // migrations/49_add_brin_index_trade_aggregations.sql (206B)
 // migrations/4_add_protocol_version.sql (188B)
-// migrations/50_fix_fee_account_muxed.sql (154B)
 // migrations/5_create_trades_table.sql (1.1kB)
 // migrations/6_create_assets_table.sql (366B)
 // migrations/7_modify_trades_table.sql (2.303kB)
@@ -1020,26 +1019,6 @@ func migrations4_add_protocol_versionSql() (*asset, error) {
 	return a, nil
 }
 
-var _migrations50_fix_fee_account_muxedSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xd2\xd5\x55\xd0\xce\xcd\x4c\x2f\x4a\x2c\x49\x55\x08\x2d\xe0\xe2\x0a\x0d\x70\x71\x0c\x71\x55\xc8\xc8\x2c\x2e\xc9\x2f\xaa\x8c\x2f\x29\x4a\xcc\x2b\x4e\x4c\x2e\xc9\xcc\xcf\x2b\x56\x08\x76\x0d\x51\x48\x4b\x4d\x8d\x4f\x4c\x4e\xce\x2f\xcd\x2b\x89\xcf\x2d\xad\x48\x4d\x51\xb0\x55\xf0\x0b\xf5\xf1\x51\x08\xf7\x70\x0d\x72\x45\x96\x56\xf0\x0c\x56\xf0\xf3\x0f\x81\xc8\x3a\xfa\xb9\x60\xd1\xea\xe3\xe9\xed\xaa\xa0\xee\xae\xaa\x6e\xcd\xc5\x85\xec\x10\x97\xfc\xf2\x3c\x2e\x40\x00\x00\x00\xff\xff\x9f\x47\xcf\x4e\x9a\x00\x00\x00")
-
-func migrations50_fix_fee_account_muxedSqlBytes() ([]byte, error) {
-	return bindataRead(
-		_migrations50_fix_fee_account_muxedSql,
-		"migrations/50_fix_fee_account_muxed.sql",
-	)
-}
-
-func migrations50_fix_fee_account_muxedSql() (*asset, error) {
-	bytes, err := migrations50_fix_fee_account_muxedSqlBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	info := bindataFileInfo{name: "migrations/50_fix_fee_account_muxed.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
-	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xf5, 0x79, 0x41, 0xbe, 0x9e, 0x48, 0xcf, 0x66, 0x8b, 0x9a, 0x64, 0x41, 0x20, 0xe3, 0x15, 0xd8, 0xd, 0x20, 0x1, 0x17, 0x68, 0x9f, 0x6, 0x4, 0xad, 0xf9, 0x85, 0x3a, 0x49, 0x5d, 0x13, 0x2a}}
-	return a, nil
-}
-
 var _migrations5_create_trades_tableSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x94\x94\x51\x6f\xaa\x40\x10\x85\xdf\xf9\x15\x13\x9f\x30\x17\x93\x7b\x6f\x5a\x5f\x4c\x9a\x58\x25\xad\xa9\xc1\xd6\x4a\xd2\x37\xb2\xb0\x23\x6c\xa2\x2c\x99\x1d\xda\xf0\xef\x1b\x68\x69\x10\x57\xad\xaf\x9c\x39\x67\x38\xbb\x5f\x76\x34\x82\x3f\x7b\x95\x92\x60\x84\xb0\x70\x66\x6b\x7f\xba\xf1\x61\x33\xbd\x5f\xfa\x90\x29\xc3\x9a\xaa\x88\x49\x48\x34\xe0\x3a\x00\xf0\xf3\x51\x17\x48\x82\x95\xce\x23\x25\x21\x56\xa9\xca\x19\x82\xd5\x06\x82\x70\xb9\xf4\x9a\xc9\x81\x26\x89\x34\x00\x95\x33\xa6\x48\x1d\xb5\x91\xf5\x76\x8b\x64\x35\x37\xb2\xc1\xdd\xee\x84\x5e\xcb\x71\x59\x9d\x75\xeb\x9d\x8c\x84\x31\xc8\x11\x57\x05\x42\x92\x09\x12\x09\x23\xc1\xbb\xa0\x4a\xe5\xa9\x3b\xbe\x19\xf6\x22\x3b\x1e\x65\x4c\x89\x64\x71\xdd\x8e\xcf\xb8\x12\x2d\x6d\x9b\xfe\xfd\xb7\x7b\xf6\xba\xcc\xb9\xff\xff\x30\x7b\xf4\x67\x4f\xe0\x76\x47\xee\xe0\xef\xf0\xbb\x57\xac\xcb\x34\xe3\x6b\x9b\x1d\xb8\xae\xe8\x76\xe0\xfb\x75\xbb\xd6\x75\xb6\xdf\xe1\x50\xdd\xd0\x19\x4e\x9c\x96\xbf\x30\x58\xbc\x84\x3e\x2c\x82\xb9\xff\x06\x19\x93\x8c\x0a\x25\x61\x15\xf4\x91\x0c\x5f\x17\xc1\x03\xc4\x4c\x88\xe0\xda\xc8\xf4\x5a\x0a\x3b\xe1\x9d\xd4\xb8\x8a\x1a\x0c\x2f\x45\xb7\xac\xda\x52\xea\x90\xfa\xb6\x2e\x65\xf4\x90\xf4\xfa\xe4\x78\xc7\x00\x9e\x5a\xf7\x75\x78\x97\x16\x1e\xb1\xe2\x1d\x5f\xa8\x67\x63\xa3\x5e\xdb\x7d\x17\xe6\xfa\x23\x77\xe6\xeb\xd5\xb3\xfd\x5d\x48\x84\x49\x84\xc4\x89\xf3\x19\x00\x00\xff\xff\x79\x87\x24\x6b\x4c\x04\x00\x00")
 
 func migrations5_create_trades_tableSqlBytes() ([]byte, error) {
@@ -1296,7 +1275,6 @@ var _bindata = map[string]func() (*asset, error){
 	"migrations/48_rebuild_trade_aggregations.sql":                       migrations48_rebuild_trade_aggregationsSql,
 	"migrations/49_add_brin_index_trade_aggregations.sql":                migrations49_add_brin_index_trade_aggregationsSql,
 	"migrations/4_add_protocol_version.sql":                              migrations4_add_protocol_versionSql,
-	"migrations/50_fix_fee_account_muxed.sql":                            migrations50_fix_fee_account_muxedSql,
 	"migrations/5_create_trades_table.sql":                               migrations5_create_trades_tableSql,
 	"migrations/6_create_assets_table.sql":                               migrations6_create_assets_tableSql,
 	"migrations/7_modify_trades_table.sql":                               migrations7_modify_trades_tableSql,
@@ -1392,7 +1370,6 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"48_rebuild_trade_aggregations.sql":                       &bintree{migrations48_rebuild_trade_aggregationsSql, map[string]*bintree{}},
 		"49_add_brin_index_trade_aggregations.sql":                &bintree{migrations49_add_brin_index_trade_aggregationsSql, map[string]*bintree{}},
 		"4_add_protocol_version.sql":                              &bintree{migrations4_add_protocol_versionSql, map[string]*bintree{}},
-		"50_fix_fee_account_muxed.sql":                            &bintree{migrations50_fix_fee_account_muxedSql, map[string]*bintree{}},
 		"5_create_trades_table.sql":                               &bintree{migrations5_create_trades_tableSql, map[string]*bintree{}},
 		"6_create_assets_table.sql":                               &bintree{migrations6_create_assets_tableSql, map[string]*bintree{}},
 		"7_modify_trades_table.sql":                               &bintree{migrations7_modify_trades_tableSql, map[string]*bintree{}},

--- a/services/horizon/internal/db2/schema/migrations/50_fix_fee_account_muxed.sql
+++ b/services/horizon/internal/db2/schema/migrations/50_fix_fee_account_muxed.sql
@@ -1,5 +1,0 @@
--- +migrate Up
-
-UPDATE history_transactions SET fee_account_muxed = NULL WHERE fee_account IS NOT NULL AND fee_account_muxed LIKE 'G%';
-
--- +migrate Down


### PR DESCRIPTION
It seems like we will need to reingest anyways so there is no use in having this migration