### PR TITLE
services/horizon: Batch deletion of offers with offer upserting

### DIFF
--- a/services/horizon/internal/db2/history/mock_q_offers.go
+++ b/services/horizon/internal/db2/history/mock_q_offers.go
@@ -36,11 +36,6 @@ func (m *MockQOffers) UpsertOffers(ctx context.Context, rows []Offer) error {
 	return a.Error(0)
 }
 
-func (m *MockQOffers) RemoveOffers(ctx context.Context, offerIDs []int64, lastModifiedLedger uint32) (int64, error) {
-	a := m.Called(ctx, offerIDs, lastModifiedLedger)
-	return a.Get(0).(int64), a.Error(1)
-}
-
 func (m *MockQOffers) CompactOffers(ctx context.Context, cutOffSequence uint32) (int64, error) {
 	a := m.Called(ctx, cutOffSequence)
 	return a.Get(0).(int64), a.Error(1)

--- a/services/horizon/internal/db2/history/orderbook_test.go
+++ b/services/horizon/internal/db2/history/orderbook_test.go
@@ -269,12 +269,14 @@ func TestGetOrderBookSummaryExcludesRemovedOffers(t *testing.T) {
 
 	assert.NoError(t, q.Rollback())
 
+	var offersToDelete []Offer
 	for i, offer := range offers {
-		var count int64
-		count, err = q.RemoveOffers(tt.Ctx, []int64{offer.OfferID}, uint32(i+2))
-		assert.NoError(t, err)
-		assert.Equal(t, int64(1), count)
+		toDelete := offer
+		toDelete.Deleted = true
+		toDelete.LastModifiedLedger = uint32(i + 2)
+		offersToDelete = append(offersToDelete, toDelete)
 	}
+	assert.NoError(t, q.UpsertOffers(tt.Ctx, offersToDelete))
 
 	assert.NoError(t, q.BeginTx(&sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,


### PR DESCRIPTION
This should remove one DB query per ledger