### PR TITLE
exp/orderbook: Adds tests for liquidity pool exchange math.

### DIFF
--- a/exp/orderbook/pools.go
+++ b/exp/orderbook/pools.go
@@ -84,8 +84,8 @@ func makeTrade(
 	return result, nil
 }
 
-// calculatePoolPayout calculates the amount disbursed from the pool for an
-// amount received. From CAP-38:
+// calculatePoolPayout calculates the amount of `reserveB` disbursed from the
+// pool for a `received` amount of `reserveA` . From CAP-38:
 //
 //      y = floor[(1 - F) Yx / (X + x - Fx)]
 //
@@ -95,7 +95,7 @@ func calculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int
 	F, x := big.NewInt(int64(feeBips)), big.NewInt(int64(received))
 
 	// would this deposit overflow the reserve?
-	if math.MaxInt64-received < reserveA {
+	if received > math.MaxInt64-reserveA {
 		return 0, false
 	}
 
@@ -115,13 +115,14 @@ func calculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int
 	// divide & check overflow
 	result := numer.Div(numer, denom)
 
-	return xdr.Int64(result.Int64()), result.IsInt64()
+	// flooring might cause us to return 0, which is invalid
+	return xdr.Int64(result.Int64()), result.IsInt64() && result.Cmp(big.NewInt(0)) > 0
 }
 
-// calculatePoolExpectation determines how much you would need to put into a
-// pool to get a certain amount disbursed.
+// calculatePoolExpectation determines how much of `reserveA` you would need to
+// put into a pool to get the `disbursed` amount of `reserveB`.
 //
-//      x = ceil[Xy / (Y - y) / (1 - F)]
+//      x = ceil[Xy / ((Y - y)(1 - F))]
 //
 // It returns false if the calculation overflows.
 func calculatePoolExpectation(
@@ -131,7 +132,7 @@ func calculatePoolExpectation(
 	F, y := big.NewInt(int64(feeBips)), big.NewInt(int64(disbursed))
 
 	// sanity check: disbursing shouldn't underflow the reserve
-	if reserveA-disbursed <= 0 {
+	if disbursed >= reserveB {
 		return 0, false
 	}
 
@@ -139,12 +140,12 @@ func calculatePoolExpectation(
 	maxBips := big.NewInt(10000)
 	f := new(big.Int).Sub(maxBips, F) // upscaled 1 - F
 
-	denom := Y.Sub(Y, y).Mul(Y, f)     // right half:
+	denom := Y.Sub(Y, y).Mul(Y, f)     // right half: (Y - y)(1 - F)
 	if denom.Cmp(big.NewInt(0)) == 0 { // avoid div-by-zero panic
 		return 0, false
 	}
 
-	numer := X.Mul(X, y).Mul(X, maxBips)
+	numer := X.Mul(X, y).Mul(X, maxBips) // left half: Xy
 
 	result, rem := new(big.Int), new(big.Int)
 	result.DivMod(numer, denom, rem)

--- a/exp/orderbook/pools.go
+++ b/exp/orderbook/pools.go
@@ -115,8 +115,8 @@ func calculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int
 	// divide & check overflow
 	result := numer.Div(numer, denom)
 
-	// flooring might cause us to return 0, which is invalid
-	return xdr.Int64(result.Int64()), result.IsInt64() && result.Cmp(big.NewInt(0)) > 0
+	i := xdr.Int64(result.Int64())
+	return i, result.IsInt64() && i > 0
 }
 
 // calculatePoolExpectation determines how much of `reserveA` you would need to

--- a/exp/orderbook/pools_test.go
+++ b/exp/orderbook/pools_test.go
@@ -1,0 +1,182 @@
+package orderbook
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLiquidityPoolExchanges(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		for _, asset := range []xdr.Asset{usdAsset, eurAsset} {
+			payout, err := makeTrade(eurUsdLiquidityPool, asset, tradeTypeDeposit, 500)
+			assert.NoError(t, err)
+			assert.EqualValues(t, 332, int64(payout))
+			// reserves would now be: 668 of A, 1500 of B
+			// note pool object is unchanged so looping is safe
+		}
+
+		for _, asset := range []xdr.Asset{usdAsset, eurAsset} {
+			payout, err := makeTrade(eurUsdLiquidityPool, asset, tradeTypeExpectation, 332)
+			assert.NoError(t, err)
+			assert.EqualValues(t, 499, int64(payout))
+		}
+
+		// More sanity checks; if they fail, something was changed about how
+		// constant product liquidity pools work.
+		//
+		// We use these oddly-specific values because we rely on them again to
+		// validate paths in later tests.
+		testTable := []struct {
+			dstAsset       xdr.Asset
+			pool           xdr.LiquidityPoolEntry
+			expectedPayout xdr.Int64
+			expectedInput  xdr.Int64
+		}{
+			{yenAsset, eurYenLiquidityPool, 100, 112},
+			{eurAsset, eurUsdLiquidityPool, 112, 127},
+			{nativeAsset, nativeUsdPool, 5, 27},
+			{usdAsset, usdChfLiquidityPool, 127, 342},
+			{usdAsset, usdChfLiquidityPool, 27, 58},
+		}
+
+		for _, test := range testTable {
+			needed, err := makeTrade(test.pool, test.dstAsset,
+				tradeTypeExpectation, test.expectedPayout)
+
+			assert.NoError(t, err)
+			assert.EqualValuesf(t, test.expectedInput, needed,
+				"expected exchange of %d %s -> %d %s, got %d",
+				test.expectedInput, getCode(getOtherAsset(test.dstAsset, test.pool)),
+				test.expectedPayout, getCode(test.dstAsset),
+				needed)
+		}
+	})
+
+	t.Run("fail on bad exchange amounts", func(t *testing.T) {
+		badValues := []xdr.Int64{math.MaxInt64, math.MaxInt64 - 99, 0, -100}
+		for _, badValue := range badValues {
+			_, err := makeTrade(eurUsdLiquidityPool, usdAsset, tradeTypeDeposit, badValue)
+			assert.Error(t, err)
+		}
+	})
+}
+
+// TestLiquidityPoolMath is a robust suite of tests to ensure that theliquidity
+// pool calculation functions are correct, taken from Stellar Core's tests here:
+//
+// https://github.com/stellar/stellar-core/blob/master/src/transactions/test/ExchangeTests.cpp#L948
+func TestLiquidityPoolMath(t *testing.T) {
+	iMax := xdr.Int64(math.MaxInt64)
+	send, recv := tradeTypeDeposit, tradeTypeExpectation
+
+	t.Run("deposit edge cases", func(t *testing.T) {
+		// Sending deposit would overflow the reserve:
+		//   low reserves but high deposit
+		assertPoolExchange(t, send, 100, iMax-100, 100, -1, 0, true, -1, 99)
+		assertPoolExchange(t, send, 100, iMax-99, 100, -1, 0, false, -1, -1)
+
+		//   high reserves but low deposit
+		assertPoolExchange(t, send, iMax-100, 100, iMax-100, -1, 0, true, -1, 99)
+		assertPoolExchange(t, send, iMax-99, 100, iMax-100, -1, 0, false, -1, -1)
+
+		// fromPool = 0
+		assertPoolExchange(t, send, 100, 2, 100, -1, 0, true, -1, 1)
+		assertPoolExchange(t, send, 100, 1, 100, -1, 0, false, -1, -1)
+	})
+
+	t.Run("disburse edge cases", func(t *testing.T) {
+		// Receiving maxReceiveFromPool would deplete the reserves entirely:
+		//   low reserves and low maxReceive
+		assertPoolExchange(t, recv, 100, -1, 100, 99, 0, true, 9900, -1)
+		assertPoolExchange(t, recv, 100, -1, 100, 100, 0, false, -1, -1)
+
+		//   high reserves and high maxReceive
+		assertPoolExchange(t, recv, 100, -1, iMax/100, iMax/100-1, 0, true, iMax-107, -1)
+		assertPoolExchange(t, recv, 100, -1, iMax/100, iMax/100, 0, false, -1, -1)
+
+		// If
+		//           fromPool = k*(maxBps - feeBps) and
+		//   reservesFromPool = fromPool + 1
+		// then
+		//     (reservesToPool * fromPool) / (maxBps - feeBps)
+		//         = k * reservesToPool
+		// so if k = 101 and reservesToPool = iMax / 100 then B / C > iMax during division
+		assertPoolExchange(t, recv, iMax/100, -1, 101*10000+1, 101*10000, 0, false, -1, -1)
+
+		// If
+		//            fromPool = maxBps - feeBps and
+		//    reservesFromPool = fromPool + 1
+		// then
+		//      toPool = maxBps * reservesToPool
+		// so if reservesToPool = iMax / 100 then the division overflows.
+		assertPoolExchange(t, recv, iMax/100, -1, 10000+1, 10000, 0, false, -1, -1)
+
+		// Pool receives more than it has available reserves for
+		assertPoolExchange(t, recv, iMax-100, -1, iMax/2, 49, 0, true, 98, -1)
+		assertPoolExchange(t, recv, iMax-100, -1, iMax/2, 50, 0, false, -1, -1)
+	})
+
+	t.Run("No fees", func(t *testing.T) {
+		// Deposits
+		assertPoolExchange(t, send, 100, 100, 100, -1, 0, true, -1, 50)      // work exactly
+		assertPoolExchange(t, send, 100, 50, 100, -1, 0, true, -1, 33)       // require sending
+		assertPoolExchange(t, send, 100, 0, 100, -1, 0, false, -1, -1)       // sending 0
+		assertPoolExchange(t, send, 100, iMax-99, 100, -1, 0, false, -1, -1) // sending too much
+
+		// Disburses
+		assertPoolExchange(t, recv, 100, -1, 100, 50, 0, true, 100, -1)  // work exactly
+		assertPoolExchange(t, recv, 100, -1, 100, 33, 0, true, 50, -1)   // require recving
+		assertPoolExchange(t, recv, 100, -1, 100, 0, 0, true, 0, -1)     // receiving 0
+		assertPoolExchange(t, recv, 100, -1, 100, 100, 0, false, -1, -1) // receiving too much
+	})
+
+	// These test cases look weird because they actually charge 31 bps instead
+	// of 30 bps. But this is expected, because you pay fees on the fees you
+	// provided: I want to send 10000 after fees, so I send 100030.... but that
+	// doesn't work because 0.997 * 10030 = 9999.910 is too low.
+	t.Run("30 bps fee actually charges 30 bps", func(t *testing.T) {
+
+		// With no fee, sending 10000 would receive 10000. So to receive
+		// 1000 we need to send ceil(10000 / 0.997) = 10031.
+		assertPoolExchange(t, send, 10000, 10031, 20000, -1, 30, true, -1, 10000)
+
+		// With no fee, sending 10000 would receive 10000. So to send
+		// ceil(10000 / 0.997) = 10031 we need to receive 10000.
+		assertPoolExchange(t, recv, 10000, -1, 20000, 10000, 30, true, 10031, -1)
+	})
+}
+
+// assertPoolExchange validates that pool inputs match their expected outputs.
+func assertPoolExchange(t *testing.T,
+	exchangeType int,
+	reservesBeingDeposited, deposited xdr.Int64,
+	reservesBeingDisbursed, disbursed xdr.Int64,
+	poolFeeBips xdr.Int32,
+	expectedReturn bool, expectedDeposited, expectedDisbursed xdr.Int64,
+) {
+	var ok bool
+	toPool, fromPool := xdr.Int64(-1), xdr.Int64(-1)
+
+	switch exchangeType {
+	case tradeTypeDeposit:
+		fromPool, ok = calculatePoolPayout(
+			reservesBeingDeposited, reservesBeingDisbursed,
+			deposited, poolFeeBips)
+
+	case tradeTypeExpectation:
+		toPool, ok = calculatePoolExpectation(
+			reservesBeingDeposited, reservesBeingDisbursed,
+			disbursed, poolFeeBips)
+
+	default:
+		t.FailNow()
+	}
+
+	if expectedReturn && assert.Equal(t, expectedReturn, ok, "wrong exchange success state") {
+		assert.EqualValues(t, expectedDisbursed, fromPool, "wrong payout")
+		assert.EqualValues(t, expectedDeposited, toPool, "wrong expectation")
+	}
+}


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Testing various edge and error cases of LP functions. 

It includes an edge case bugfix in which the wrong reserve was checked for underflows:

```diff
-	if reserveA-disbursed <= 0 {
+	if disbursed >= reserveB {
```

and adds a check for payouts being positive:

```diff
-	return xdr.Int64(result.Int64()), result.IsInt64()
+	i := xdr.Int64(result.Int64())
+	return i, result.IsInt64() && i > 0
```

This extra check has a trivial cost (according to benchmarks on my machine) and is technically not necessary (we would just skip zero-payout paths during the DFS), but I included it to conform more strictly to Core's behavior.

### Why
To ensure the validity and stability of any math involving liquidity pool exchanges. These tests come from Stellar Core (e.g. stellar/stellar-core#3216).