### PR TITLE
services/horizon: Ingest base and counter offer id when offer consumed on creation

### DIFF
--- a/services/horizon/internal/ingest/processors/synt_offer_id.go
+++ b/services/horizon/internal/ingest/processors/synt_offer_id.go
@@ -1,0 +1,39 @@
+package processors
+
+type OfferIDType uint64
+
+const (
+	CoreOfferIDType OfferIDType = 0
+	TOIDType        OfferIDType = 1
+
+	mask uint64 = 0xC000000000000000
+)
+
+// EncodeOfferId creates synthetic offer ids to be used by trade resources
+//
+// This is required because stellar-core does not allocate offer ids for immediately filled offers,
+// while clients expect them for aggregated views.
+//
+// The encoded value is of type int64 for sql compatibility. The 2nd bit is used to differentiate between stellar-core
+// offer ids and operation ids, which are toids.
+//
+// Due to the 2nd bit being used, the largest possible toid is:
+// 0011111111111111111111111111111100000000000000000001000000000001
+// \          ledger              /\    transaction   /\    op    /
+//            = 1073741823
+//              with avg. 5 sec close time will reach in ~170 years
+func EncodeOfferId(id uint64, typ OfferIDType) int64 {
+	// First ensure the bits we're going to change are 0s
+	if id&mask != 0 {
+		panic("Value too big to encode")
+	}
+	return int64(id | uint64(typ)<<62)
+}
+
+// DecodeOfferID performs the reverse operation of EncodeOfferID
+func DecodeOfferID(encodedId int64) (uint64, OfferIDType) {
+	if encodedId < 0 {
+		panic("Negative offer ids can not be decoded")
+	}
+	return uint64(encodedId<<2) >> 2, OfferIDType(encodedId >> 62)
+}

--- a/services/horizon/internal/ingest/processors/trades_processor.go
+++ b/services/horizon/internal/ingest/processors/trades_processor.go
@@ -290,7 +290,9 @@ func (p *TradeProcessor) extractTrades(
 			}
 
 			if buyOfferExists {
-				row.CounterOfferID = null.IntFrom(int64(buyOffer.OfferId))
+				row.CounterOfferID = null.IntFrom(EncodeOfferId(uint64(buyOffer.OfferId), CoreOfferIDType))
+			} else {
+				row.CounterOfferID = null.IntFrom(EncodeOfferId(uint64(opID), TOIDType))
 			}
 
 			var buyerAddress string

--- a/services/horizon/internal/ingest/processors/trades_processor_test.go
+++ b/services/horizon/internal/ingest/processors/trades_processor_test.go
@@ -5,9 +5,10 @@ package processors
 import (
 	"context"
 	"fmt"
-	"github.com/guregu/null"
 	"testing"
 	"time"
+
+	"github.com/guregu/null"
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -232,6 +233,7 @@ func (s *TradeProcessorTestSuiteLedger) mockReadTradeTransactions(
 			BaseAmount:         int64(s.strictReceiveTrade.AmountBought()),
 			BaseAccountID:      null.IntFrom(s.unmuxedAccountToID[s.unmuxedOpSourceAccount.Address()]),
 			BaseAssetID:        s.assetToID[s.strictReceiveTrade.AssetBought().String()].ID,
+			BaseOfferID:        null.IntFrom(EncodeOfferId(uint64(toid.New(int32(ledger.Header.LedgerSeq), 1, 2).ToInt64()), TOIDType)),
 			CounterAmount:      int64(s.strictReceiveTrade.AmountSold()),
 			CounterAccountID:   null.IntFrom(s.unmuxedAccountToID[s.strictReceiveTrade.SellerId().Address()]),
 			CounterAssetID:     s.assetToID[s.strictReceiveTrade.AssetSold().String()].ID,
@@ -247,6 +249,7 @@ func (s *TradeProcessorTestSuiteLedger) mockReadTradeTransactions(
 			CounterAmount:      int64(s.strictSendTrade.AmountBought()),
 			CounterAccountID:   null.IntFrom(s.unmuxedAccountToID[s.unmuxedOpSourceAccount.Address()]),
 			CounterAssetID:     s.assetToID[s.strictSendTrade.AssetBought().String()].ID,
+			CounterOfferID:     null.IntFrom(EncodeOfferId(uint64(toid.New(int32(ledger.Header.LedgerSeq), 1, 3).ToInt64()), TOIDType)),
 			BaseAmount:         int64(s.strictSendTrade.AmountSold()),
 			BaseAccountID:      null.IntFrom(s.unmuxedAccountToID[s.strictSendTrade.SellerId().Address()]),
 			BaseAssetID:        s.assetToID[s.strictSendTrade.AssetSold().String()].ID,
@@ -278,6 +281,7 @@ func (s *TradeProcessorTestSuiteLedger) mockReadTradeTransactions(
 			CounterAmount:      int64(s.sellOfferTrade.AmountBought()),
 			CounterAssetID:     s.assetToID[s.sellOfferTrade.AssetBought().String()].ID,
 			CounterAccountID:   null.IntFrom(s.unmuxedAccountToID[s.unmuxedOpSourceAccount.Address()]),
+			CounterOfferID:     null.IntFrom(EncodeOfferId(uint64(toid.New(int32(ledger.Header.LedgerSeq), 1, 5).ToInt64()), TOIDType)),
 			BaseAmount:         int64(s.sellOfferTrade.AmountSold()),
 			BaseAccountID:      null.IntFrom(s.unmuxedAccountToID[s.sellOfferTrade.SellerId().Address()]),
 			BaseAssetID:        s.assetToID[s.sellOfferTrade.AssetSold().String()].ID,
@@ -293,6 +297,7 @@ func (s *TradeProcessorTestSuiteLedger) mockReadTradeTransactions(
 			BaseAmount:         int64(s.passiveSellOfferTrade.AmountBought()),
 			BaseAssetID:        s.assetToID[s.passiveSellOfferTrade.AssetBought().String()].ID,
 			BaseAccountID:      null.IntFrom(s.unmuxedAccountToID[s.unmuxedSourceAccount.Address()]),
+			BaseOfferID:        null.IntFrom(EncodeOfferId(uint64(toid.New(int32(ledger.Header.LedgerSeq), 1, 6).ToInt64()), TOIDType)),
 			CounterAmount:      int64(s.passiveSellOfferTrade.AmountSold()),
 			CounterAccountID:   null.IntFrom(s.unmuxedAccountToID[s.passiveSellOfferTrade.SellerId().Address()]),
 			CounterAssetID:     s.assetToID[s.passiveSellOfferTrade.AssetSold().String()].ID,
@@ -310,6 +315,7 @@ func (s *TradeProcessorTestSuiteLedger) mockReadTradeTransactions(
 			CounterAmount:    int64(s.otherPassiveSellOfferTrade.AmountBought()),
 			CounterAssetID:   s.assetToID[s.otherPassiveSellOfferTrade.AssetBought().String()].ID,
 			CounterAccountID: null.IntFrom(s.unmuxedAccountToID[s.unmuxedOpSourceAccount.Address()]),
+			CounterOfferID:   null.IntFrom(EncodeOfferId(uint64(toid.New(int32(ledger.Header.LedgerSeq), 1, 7).ToInt64()), TOIDType)),
 			BaseAmount:       int64(s.otherPassiveSellOfferTrade.AmountSold()),
 			BaseAccountID:    null.IntFrom(s.unmuxedAccountToID[s.otherPassiveSellOfferTrade.SellerId().Address()]),
 			BaseAssetID:      s.assetToID[s.otherPassiveSellOfferTrade.AssetSold().String()].ID,
@@ -325,6 +331,7 @@ func (s *TradeProcessorTestSuiteLedger) mockReadTradeTransactions(
 			BaseAmount:             int64(s.strictReceiveTradeLP.AmountBought()),
 			BaseAssetID:            s.assetToID[s.strictReceiveTradeLP.AssetBought().String()].ID,
 			BaseAccountID:          null.IntFrom(s.unmuxedAccountToID[s.unmuxedOpSourceAccount.Address()]),
+			BaseOfferID:            null.IntFrom(EncodeOfferId(uint64(toid.New(int32(ledger.Header.LedgerSeq), 1, 8).ToInt64()), TOIDType)),
 			CounterAmount:          int64(s.strictReceiveTradeLP.AmountSold()),
 			CounterLiquidityPoolID: null.IntFrom(s.lpToID[s.strictReceiveTradeLP.MustLiquidityPool().LiquidityPoolId]),
 			CounterAssetID:         s.assetToID[s.strictReceiveTradeLP.AssetSold().String()].ID,
@@ -340,6 +347,7 @@ func (s *TradeProcessorTestSuiteLedger) mockReadTradeTransactions(
 			CounterAmount:       int64(s.strictSendTradeLP.AmountBought()),
 			CounterAssetID:      s.assetToID[s.strictSendTradeLP.AssetBought().String()].ID,
 			CounterAccountID:    null.IntFrom(s.unmuxedAccountToID[s.unmuxedOpSourceAccount.Address()]),
+			CounterOfferID:      null.IntFrom(EncodeOfferId(uint64(toid.New(int32(ledger.Header.LedgerSeq), 1, 9).ToInt64()), TOIDType)),
 			BaseAmount:          int64(s.strictSendTradeLP.AmountSold()),
 			BaseLiquidityPoolID: null.IntFrom(s.lpToID[s.strictSendTradeLP.MustLiquidityPool().LiquidityPoolId]),
 			BaseAssetID:         s.assetToID[s.strictSendTradeLP.AssetSold().String()].ID,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add synthetic offer IDs (removed in #3857) to trades in which a maker offer was not assigned an ID by Stellar-Core.

Fix #3966.

### Why

Removing synthetic IDs is a breaking change but they are used in non-liquidity pool trades.

### Known limitations

[TODO or N/A]
