### PR TITLE
services/horizon: Update `asset_type` for trust line sponsorship effects on fly

### DIFF
--- a/services/horizon/internal/db2/history/effect_test.go
+++ b/services/horizon/internal/db2/history/effect_test.go
@@ -135,7 +135,8 @@ func TestEffectsForTrustlinesSponsorshipEmptyAssetType(t *testing.T) {
 	opID := toid.New(sequence, 1, 1).ToInt64()
 
 	for i, test := range tests {
-		bytes, err := json.Marshal(test.details)
+		var bytes []byte
+		bytes, err = json.Marshal(test.details)
 		tt.Require.NoError(err)
 
 		err = builder.Add(tt.Ctx,

--- a/services/horizon/internal/db2/history/effect_test.go
+++ b/services/horizon/internal/db2/history/effect_test.go
@@ -2,9 +2,11 @@ package history
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/guregu/null"
+	"github.com/stellar/go/protocols/horizon/effects"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/services/horizon/internal/toid"
 )
@@ -18,7 +20,7 @@ func TestEffectsForLiquidityPool(t *testing.T) {
 	// Insert Effect
 	address := "GAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSTVY"
 	muxedAddres := "MAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSAAAAAAAAAAE2LP26"
-	accounIDs, err := q.CreateAccounts(tt.Ctx, []string{address}, 1)
+	accountIDs, err := q.CreateAccounts(tt.Ctx, []string{address}, 1)
 	tt.Assert.NoError(err)
 
 	builder := q.NewEffectBatchInsertBuilder(2)
@@ -29,7 +31,7 @@ func TestEffectsForLiquidityPool(t *testing.T) {
 	})
 	opID := toid.New(sequence, 1, 1).ToInt64()
 	err = builder.Add(tt.Ctx,
-		accounIDs[address],
+		accountIDs[address],
 		null.StringFrom(muxedAddres),
 		opID,
 		1,
@@ -61,4 +63,119 @@ func TestEffectsForLiquidityPool(t *testing.T) {
 	tt.Assert.Len(result, 1)
 	tt.Assert.Equal(result[0].Account, address)
 
+}
+
+func TestEffectsForTrustlinesSponsorshipEmptyAssetType(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	address := "GAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSTVY"
+	muxedAddres := "MAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSAAAAAAAAAAE2LP26"
+	accountIDs, err := q.CreateAccounts(tt.Ctx, []string{address}, 1)
+	tt.Assert.NoError(err)
+
+	builder := q.NewEffectBatchInsertBuilder(1)
+	sequence := int32(56)
+	tests := []struct {
+		effectType        EffectType
+		details           map[string]string
+		expectedAssetType string
+	}{
+		{
+			EffectTrustlineSponsorshipCreated,
+			map[string]string{
+				"asset":   "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+				"sponsor": "GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2",
+			},
+			"credit_alphanum4",
+		},
+		{
+			EffectTrustlineSponsorshipCreated,
+			map[string]string{
+				"asset":   "USDCE:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+				"sponsor": "GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2",
+			},
+			"credit_alphanum12",
+		},
+		{
+			EffectTrustlineSponsorshipUpdated,
+			map[string]string{
+				"asset":   "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+				"sponsor": "GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2",
+			},
+			"credit_alphanum4",
+		},
+		{
+			EffectTrustlineSponsorshipUpdated,
+			map[string]string{
+				"asset":   "USDCE:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+				"sponsor": "GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2",
+			},
+			"credit_alphanum12",
+		},
+		{
+			EffectTrustlineSponsorshipRemoved,
+			map[string]string{
+				"asset":   "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+				"sponsor": "GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2",
+			},
+			"credit_alphanum4",
+		},
+		{
+			EffectTrustlineSponsorshipRemoved,
+			map[string]string{
+				"asset":   "USDCE:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+				"sponsor": "GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2",
+			},
+			"credit_alphanum12",
+		},
+	}
+	opID := toid.New(sequence, 1, 1).ToInt64()
+
+	for i, test := range tests {
+		bytes, err := json.Marshal(test.details)
+		tt.Require.NoError(err)
+
+		err = builder.Add(tt.Ctx,
+			accountIDs[address],
+			null.StringFrom(muxedAddres),
+			opID,
+			uint32(i),
+			test.effectType,
+			bytes,
+		)
+		tt.Require.NoError(err)
+	}
+
+	err = builder.Exec(tt.Ctx)
+	tt.Require.NoError(err)
+
+	var results []Effect
+	err = q.Effects().Select(tt.Ctx, &results)
+	tt.Require.NoError(err)
+	tt.Require.Len(results, len(tests))
+
+	for i, test := range tests {
+		switch test.effectType {
+		case EffectTrustlineSponsorshipCreated:
+			var eff effects.TrustlineSponsorshipCreated
+			err := results[i].UnmarshalDetails(&eff)
+			tt.Require.NoError(err)
+			tt.Assert.Equal(test.expectedAssetType, eff.Type)
+		case EffectTrustlineSponsorshipUpdated:
+			var eff effects.TrustlineSponsorshipUpdated
+			err := results[i].UnmarshalDetails(&eff)
+			tt.Require.NoError(err)
+			tt.Assert.Equal(test.expectedAssetType, eff.Type)
+		case EffectTrustlineSponsorshipRemoved:
+			var eff effects.TrustlineSponsorshipRemoved
+			err := results[i].UnmarshalDetails(&eff)
+			tt.Require.NoError(err)
+			tt.Assert.Equal(test.expectedAssetType, eff.Type)
+		default:
+			panic(fmt.Sprintf("Unknown type %v", test.effectType))
+		}
+	}
 }

--- a/services/horizon/internal/ingest/processors/effects_processor.go
+++ b/services/horizon/internal/ingest/processors/effects_processor.go
@@ -424,13 +424,7 @@ func (e *effectsWrapper) addLedgerEntrySponsorshipEffects(change ingest.Change) 
 			details["asset_type"] = "liquidity_pool"
 			details["liquidity_pool_id"] = PoolIDToString(*tl.Asset.LiquidityPoolId)
 		} else {
-			asset := tl.Asset.ToAsset()
-			var assetType string
-			if err := asset.Extract(&assetType, nil, nil); err != nil {
-				return err
-			}
-			details["asset_type"] = assetType
-			details["asset"] = asset.StringCanonical()
+			details["asset"] = tl.Asset.ToAsset().StringCanonical()
 		}
 	case xdr.LedgerEntryTypeData:
 		muxedAccount = e.operation.SourceAccount()

--- a/services/horizon/internal/ingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/ingest/processors/effects_processor_test.go
@@ -2710,9 +2710,9 @@ func TestTrustlineSponsorhipEffects(t *testing.T) {
 			address:     "GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
 			operationID: 4294967297,
 			details: map[string]interface{}{
-				"asset":      "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
-				"asset_type": "credit_alphanum4",
-				"sponsor":    "GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2",
+				"asset": "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+				// `asset_type` set in `Effect.UnmarshalDetails` to prevent reingestion
+				"sponsor": "GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2",
 			},
 		},
 		{
@@ -2721,8 +2721,8 @@ func TestTrustlineSponsorhipEffects(t *testing.T) {
 			address:     "GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
 			operationID: 4294967297,
 			details: map[string]interface{}{
-				"asset":          "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
-				"asset_type":     "credit_alphanum4",
+				"asset": "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+				// `asset_type` set in `Effect.UnmarshalDetails` to prevent reingestion
 				"former_sponsor": "GDMQUXK7ZUCWM5472ZU3YLDP4BMJLQQ76DEMNYDEY2ODEEGGRKLEWGW2",
 				"new_sponsor":    "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
 			},
@@ -2733,8 +2733,8 @@ func TestTrustlineSponsorhipEffects(t *testing.T) {
 			address:     "GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
 			operationID: 4294967297,
 			details: map[string]interface{}{
-				"asset":          "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
-				"asset_type":     "credit_alphanum4",
+				"asset": "USD:GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
+				// `asset_type` set in `Effect.UnmarshalDetails` to prevent reingestion
 				"former_sponsor": "GDRW375MAYR46ODGF2WGANQC2RRZL7O246DYHHCGWTV2RE7IHE2QUQLD",
 			},
 		},

--- a/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
+++ b/services/horizon/internal/integration/protocol14_sponsorship_ops_test.go
@@ -612,6 +612,7 @@ func TestSponsorships(t *testing.T) {
 		effRecords := getEffectsByOp(revokeOp.ID)
 		tt.Len(effRecords, 1)
 		effect := effRecords[0].(effects.TrustlineSponsorshipUpdated)
+		tt.Equal("credit_alphanum4", effect.Type)
 		tt.Equal(sponsorPair.Address(), effect.FormerSponsor)
 		tt.Equal(newSponsorPair.Address(), effect.NewSponsor)
 
@@ -638,6 +639,7 @@ func TestSponsorships(t *testing.T) {
 		effRecords = getEffectsByTx(txResp.ID)
 		tt.Len(effRecords, 1)
 		sponsorshipRemoved := effRecords[0].(effects.TrustlineSponsorshipRemoved)
+		tt.Equal("credit_alphanum4", sponsorshipRemoved.Type)
 		tt.Equal(newSponsorPair.Address(), sponsorshipRemoved.FormerSponsor)
 		tt.Equal(canonicalAsset, sponsorshipRemoved.Asset)
 	})


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

29c16d3 adds a new `asset_type` field to trust line sponsorship effects in order to distinguish asset trust lines from liquidity pool trust lines. There is an issue with this approach: effects ingested before 2.9.0 release will not have these fields set so an effect response will contain empty `asset_type` JSON field. To solve it, we use `asset` value to derive `asset_type` in `Effect.UnmarshalDetails` method.