### PR TITLE
services/horizon/internal: Set default for ingest flag to be true

### DIFF
--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -403,20 +403,11 @@ func Flags() (*Config, support.ConfigOptions) {
 			Usage:     "TLS private key file to use for securing connections to horizon",
 		},
 		&support.ConfigOption{
-			Name:      "ingest",
-			ConfigKey: &config.Ingest,
-			OptType:   types.Bool,
-			// Action needed in release: horizon-v2.9.0: make --ingest default true
-			FlagDefault: false,
-			CustomSetValue: func(opt *support.ConfigOption) error {
-				if support.IsExplicitlySet(opt) {
-					*opt.ConfigKey.(*bool) = viper.GetBool(opt.Name)
-				} else {
-					stdLog.Println("WARNING: in the 2.9.0 Horizon release the --ingest flag will default to true. Update your configuration so that --ingest is explicitly set to false.")
-				}
-				return nil
-			},
-			Usage: "causes this horizon process to ingest data from stellar-core into horizon's db",
+			Name:        "ingest",
+			ConfigKey:   &config.Ingest,
+			OptType:     types.Bool,
+			FlagDefault: true,
+			Usage:       "causes this horizon process to ingest data from stellar-core into horizon's db",
 		},
 		&support.ConfigOption{
 			Name:        "cursor-name",


### PR DESCRIPTION
This change has been scheduled for the 2.9.0 release