### PR TITLE
txnbuild, clients/horizonclient: Release v8.0.0-beta.0.

### DIFF
--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -3,11 +3,21 @@
 All notable changes to this project will be documented in this
 file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
+
 ## Unreleased
 
-* The restriction that `Fund` can only be called on the DefaultTestNetClient has
-been removed. Any horizonclient.Client may now call Fund. Horizon instances not
-supporting Fund will error with a resource not found error.
+
+## [8.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v8.0.0) - 2021-10-04
+
+**This release adds support for Protocol 18.**
+
+* The restriction that `Fund` can only be called on the DefaultTestNetClient has been removed. Any `horizonclient.Client` may now call Fund. Horizon instances not supporting funding will error with a resource not found error.
+* Change `AccountRequest` to accept `Sponsor` and `LiquidityPool` filters
+* Change `EffectRequest`, `TransactionRequest`, and `OperationRequest` to accept a `ForLiquidityPool` filter
+* Change `TradeRequest` to accept both a `ForLiquidityPool` filter or a `TradeType` filter
+* Add `LiquidityPoolsRequest` for getting details about liquidity pools, with an optional `Reserves` field to filter by pools' reserve asset(s).
+* Add `LiquidityPoolRequest` for getting details about a _specific_ liquidity pool via the `LiquidityPoolID` filter.
+
 
 ## [v7.1.1](https://github.com/stellar/go/releases/tag/horizonclient-v7.1.1) - 2021-06-25
 

--- a/clients/horizonclient/CHANGELOG.md
+++ b/clients/horizonclient/CHANGELOG.md
@@ -7,7 +7,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 
-## [8.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v8.0.0) - 2021-10-04
+## [8.0.0-beta.0](https://github.com/stellar/go/releases/tag/horizonclient-v8.0.0-beta.0) - 2021-10-04
 
 **This release adds support for Protocol 18.**
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -7,7 +7,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 
-## [8.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v8.0.0) - 2021-10-04
+## [8.0.0-beta.0](https://github.com/stellar/go/releases/tag/horizonclient-v8.0.0-beta.0) - 2021-10-04
 
 **This release adds support for Protocol 18.**
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -6,9 +6,30 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-* GenericTransaction, Transaction, and FeeBumpTransaction now implement
-encoding.TextMarshaler and encoding.TextUnmarshaler.
-* Adds 5-minute grace period to `transaction.ReadChallengeTx`'s minimum time bound constraint. ([#3824](https://github.com/stellar/go/pull/3824))
+
+## [8.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v7.2.0) - 2021-10-04
+
+**This release adds support for Protocol 18.**
+
+### New features
+* `GenericTransaction`, `Transaction`, and `FeeBumpTransaction` now implement
+`encoding.TextMarshaler` and `encoding.TextUnmarshaler`.
+* New asset structures that conform to the new ChangeTrust and New assets: 
+* Support for the core liquidity pool XDR types: `LiquidityPoolId`, `LiquidityPoolParameters`, `LiquidityPoolDeposit`, and `LiquidityPoolWithdraw`.
+* Support for the new asset structures: `ChangeTrustAsset` and `TrustLineAsset`.
+
+### Changes
+* There's now a 5-minute grace period to `transaction.ReadChallengeTx`'s minimum time bound constraint ([#3824](https://github.com/stellar/go/pull/3824)).
+* Assets can now be liquidity pool shares (`AssetTypePoolShare`).
+* All asset objects can now be converted to the new `ChangeTrustAsset` and `TrustLineAsset` objects.
+* Assets can now be compared in accordance with the protocol, see their respective `LessThan()` implementations.
+
+### Breaking changes
+* `ChangeTrust` requires a `ChangeTrustAsset`.
+* `RevokeSponsorship` requires a `TrustLineAsset` when revoking trustlines.
+* `RemoveTrustlineOp` helper now requires a `ChangeTrustAsset`
+* `validate*Asset` helpers now require more-specific asset types.
+
 
 ## [v7.1.1](https://github.com/stellar/go/releases/tag/horizonclient-v7.1.1) - 2021-06-25
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -7,7 +7,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 
-## [8.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v7.2.0) - 2021-10-04
+## [8.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v8.0.0) - 2021-10-04
 
 **This release adds support for Protocol 18.**
 


### PR DESCRIPTION
I tried to be comprehensive in the CHANGELOGs but the [diff is massive](https://github.com/stellar/go/compare/horizonclient-v7.1.1...master), plus you can't filter by path in the GitHub UI:

 - for horizonclient: `git diff horizonclient-v7.1.1..master clients/horizonclient/`
 - for txnbuild: `git diff horizonclient-v7.1.1..master txnbuild/`

(Note: tagging all committers to these releases.)