### PR TITLE
Handle negative transaction sequences gracefully

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -5,6 +5,8 @@ package horizon
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"math"
 	"math/big"
 	"strconv"
 	"time"
@@ -110,8 +112,11 @@ func (a *Account) IncrementSequenceNumber() (int64, error) {
 	if err != nil {
 		return 0, err
 	}
+	if seqNum == int64(math.MaxInt64) {
+		return 0, fmt.Errorf("sequence cannot be increased, it already reached MaxInt64 (%d)", int64(math.MaxInt64))
+	}
 	seqNum++
-	a.Sequence = strconv.FormatInt(int64(seqNum), 10)
+	a.Sequence = strconv.FormatInt(seqNum, 10)
 	return seqNum, nil
 }
 

--- a/services/horizon/internal/integration/negative_seq_txsub_test.go
+++ b/services/horizon/internal/integration/negative_seq_txsub_test.go
@@ -1,0 +1,74 @@
+package integration
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/services/horizon/internal/test/integration"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNegativeSequenceTxSubmission(t *testing.T) {
+	tt := assert.New(t)
+	itest := NewProtocol18Test(t)
+	master := itest.Master()
+
+	// First, bump the sequence to the maximum value -1
+	op := txnbuild.BumpSequence{
+		BumpTo: int64(math.MaxInt64) - 1,
+	}
+	itest.MustSubmitOperations(itest.MasterAccount(), master, &op)
+
+	account := itest.MasterAccount()
+	seqnum, err := account.GetSequenceNumber()
+	tt.NoError(err)
+	tt.Equal(int64(math.MaxInt64)-1, seqnum)
+
+	// Submit a simple payment
+	op2 := txnbuild.Payment{
+		Destination: master.Address(),
+		Amount:      "10",
+		Asset:       txnbuild.NativeAsset{},
+	}
+
+	txResp := itest.MustSubmitOperations(account, master, &op2)
+	tt.Equal(master.Address(), txResp.Account)
+
+	// The transaction should had bumped our sequence to the maximum possible value
+	seqnum, err = account.GetSequenceNumber()
+	tt.NoError(err)
+	tt.Equal(int64(math.MaxInt64), seqnum)
+
+	// Using txnbuild to create another transaction should fail, since it would cause a sequence number overflow
+	txResp, err = itest.SubmitOperations(account, master, &op2)
+	tt.Error(err)
+	tt.Contains(err.Error(), "sequence cannot be increased, it already reached MaxInt64")
+
+	// We can enforce a negative sequence without errors by setting IncrementSequenceNum=false
+	account = &txnbuild.SimpleAccount{
+		AccountID: account.GetAccountID(),
+		Sequence:  math.MinInt64,
+	}
+	txParams := txnbuild.TransactionParams{
+		SourceAccount:        account,
+		Operations:           []txnbuild.Operation{&op2},
+		BaseFee:              txnbuild.MinBaseFee,
+		Timebounds:           txnbuild.NewInfiniteTimeout(),
+		IncrementSequenceNum: false,
+		EnableMuxedAccounts:  true,
+	}
+	tx, err := txnbuild.NewTransaction(txParams)
+	tt.NoError(err)
+	tx, err = tx.Sign(integration.StandaloneNetworkPassphrase, master)
+	tt.NoError(err)
+	txResp, err = itest.Client().SubmitTransaction(tx)
+	tt.Error(err)
+	clientErr, ok := err.(*horizonclient.Error)
+	tt.True(ok)
+	codes, err := clientErr.ResultCodes()
+	tt.NoError(err)
+	tt.Equal("tx_bad_seq", codes.TransactionCode)
+
+}

--- a/services/horizon/internal/txsub/system.go
+++ b/services/horizon/internal/txsub/system.go
@@ -101,6 +101,11 @@ func (sys *System) Submit(
 		"tx":      rawTx,
 	}).Info("Processing transaction")
 
+	if envelope.SeqNum() < 0 {
+		sys.finish(ctx, hash, response, Result{Err: ErrBadSequence})
+		return
+	}
+
 	tx, sequenceNumber, err := checkTxAlreadyExists(ctx, db, hash, sourceAddress)
 	if err == nil {
 		sys.Log.Ctx(ctx).WithField("hash", hash).Info("Found submission result in a DB")


### PR DESCRIPTION
Also: Create integration test for negative tx sequence submission

Closes https://github.com/stellar/go/issues/3982
