### PR TITLE
keypair: add BinaryMarsheler support to FromAddress

### DIFF
--- a/keypair/from_address.go
+++ b/keypair/from_address.go
@@ -102,3 +102,31 @@ func (kp *FromAddress) UnmarshalText(text []byte) error {
 func (kp *FromAddress) MarshalText() ([]byte, error) {
 	return []byte(kp.address), nil
 }
+
+var (
+	_ = encoding.BinaryMarshaler(&FromAddress{})
+	_ = encoding.BinaryUnmarshaler(&FromAddress{})
+)
+
+func (kp *FromAddress) UnmarshalBinary(b []byte) error {
+	accountID := xdr.AccountId{}
+	err := xdr.SafeUnmarshal(b, &accountID)
+	if err != nil {
+		return err
+	}
+	address := accountID.Address()
+	binKP, err := ParseAddress(address)
+	if err != nil {
+		return err
+	}
+	*kp = *binKP
+	return nil
+}
+
+func (kp *FromAddress) MarshalBinary() ([]byte, error) {
+	accountID, err := xdr.AddressToAccountId(kp.address)
+	if err != nil {
+		return nil, err
+	}
+	return accountID.MarshalBinary()
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Make `FromAddress` compatible with the `BinaryMarshaler` interface.

### Why

It makes the type compatible with encoders/decoders that support the `BinaryMarshaler` interface such as the `encoding/gob` package.

### Known limitations

N/A
