### PR TITLE
Add stellar/go-xdr#16 (reduction on XDR encoding/decoding allocations)

### DIFF
--- a/benchmarks/xdr_test.go
+++ b/benchmarks/xdr_test.go
@@ -1,0 +1,89 @@
+package benchmarks
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stellar/go/gxdr"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/require"
+	goxdr "github.com/xdrpp/goxdr/xdr"
+)
+
+const input64 = "AAAAAgAAAACfHrX0tYB0gpXuJYTN9os06cdF62KAaqY9jid+777eyQAAC7gCM9czAAi/DQAAAAEAAAAAAAAAAAAAAABhga2dAAAAAAAAAAMAAAAAAAAADAAAAAAAAAABTU9CSQAAAAA8cTArnmXa4wEQJxDHOw5SwBaDVjBfAP5lRMNZkRtlZAAAAAAG42RBAAf7lQCYloAAAAAAMgbg0AAAAAAAAAADAAAAAU1PQkkAAAAAPHEwK55l2uMBECcQxzsOUsAWg1YwXwD+ZUTDWZEbZWQAAAAAAAAADkpyV7kAARBNABMS0AAAAAAyBuDRAAAAAAAAAAMAAAABTU9CSQAAAAA8cTArnmXa4wEQJxDHOw5SwBaDVjBfAP5lRMNZkRtlZAAAAAAAAAAclOSvewAIl5kAmJaAAAAAADIG4NIAAAAAAAAAAe++3skAAABAs2jt6+cyeyFvXVFphBcwt18GXnj7Jwa+hWQRyaBmPOSR2415GBi8XY3lC4m4aX9S322HvHjrxgQiar7KjgnQDw=="
+
+var input = func() []byte {
+	decoded, err := base64.StdEncoding.DecodeString(input64)
+	if err != nil {
+		panic(err)
+	}
+	return decoded
+}()
+
+func BenchmarkXDRUnmarshal(b *testing.B) {
+	b.StopTimer()
+	te := xdr.TransactionEnvelope{}
+
+	// Make sure the input is valid.
+	err := te.UnmarshalBinary(input)
+	require.NoError(b, err)
+	b.StartTimer()
+	// Benchmark.
+	for i := 0; i < b.N; i++ {
+		_ = te.UnmarshalBinary(input)
+	}
+}
+
+func BenchmarkGXDRUnmarshal(b *testing.B) {
+	b.StopTimer()
+	te := gxdr.TransactionEnvelope{}
+
+	// Make sure the input is valid, note goxdr will panic if there's a
+	// marshaling error.
+	te.XdrMarshal(&goxdr.XdrIn{In: bytes.NewReader(input)}, "")
+	b.StartTimer()
+
+	// Benchmark.
+	r := bytes.NewReader(input)
+	for i := 0; i < b.N; i++ {
+		r.Reset(input)
+		te.XdrMarshal(&goxdr.XdrIn{In: r}, "")
+	}
+}
+
+func BenchmarkXDRMarshal(b *testing.B) {
+	b.StopTimer()
+	te := xdr.TransactionEnvelope{}
+
+	// Make sure the input is valid.
+	err := te.UnmarshalBinary(input)
+	require.NoError(b, err)
+	output, err := te.MarshalBinary()
+	require.NoError(b, err)
+	require.Equal(b, input, output)
+	b.StartTimer()
+
+	// Benchmark.
+	for i := 0; i < b.N; i++ {
+		_, _ = te.MarshalBinary()
+	}
+}
+
+func BenchmarkGXDRMarshal(b *testing.B) {
+	b.StopTimer()
+	te := gxdr.TransactionEnvelope{}
+
+	// Make sure the input is valid, note goxdr will panic if there's a
+	// marshaling error.
+	te.XdrMarshal(&goxdr.XdrIn{In: bytes.NewReader(input)}, "")
+	output := bytes.Buffer{}
+	te.XdrMarshal(&goxdr.XdrOut{Out: &output}, "")
+
+	b.StartTimer()
+	// Benchmark.
+	for i := 0; i < b.N; i++ {
+		output.Reset()
+		te.XdrMarshal(&goxdr.XdrOut{Out: &output}, "")
+	}
+}

--- a/go.list
+++ b/go.list
@@ -70,7 +70,7 @@ github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189
 github.com/stellar/go 
-github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a
+github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible
 github.com/stretchr/objx v0.3.0
 github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431 // indirect
 	github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475
 	github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189
-	github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a
+	github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee
 	github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,8 @@ github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475 h1:RtZIgreTwcayPTOw7G5
 github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189 h1:fvB1AFbBd6SfI9Rd0ooAJp8uLkZDbZaLFHi7ZnNP6uI=
 github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
-github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
-github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
+github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
+github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible h1:jMXXAcz6xTarGDQ4VtVbtERogcmDQw4RaE85Cr9CgoQ=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
This PR incorporates stellar/go-xdr#16  in Horizon.

The benchmarks (copied from https://github.com/stellar/xdrgen/pull/65 but using a larger transaction) show a big improvement in the allocations made by the encoder/decoder.


Before:

```                                                                                                                                                                                                                                                             
goos: darwin
goarch: amd64
pkg: github.com/stellar/go/benchmarks
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkXDRUnmarshal
BenchmarkXDRUnmarshal-8              100             18301 ns/op            5968 B/op        232 allocs/op
BenchmarkGXDRUnmarshal
BenchmarkGXDRUnmarshal-8             100             58419 ns/op           86738 B/op        278 allocs/op
BenchmarkXDRMarshal
BenchmarkXDRMarshal-8                100             13599 ns/op            5248 B/op        194 allocs/op
BenchmarkGXDRMarshal
BenchmarkGXDRMarshal-8               100              8561 ns/op            2152 B/op        157 allocs/op
PASS
```

After:

```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go/benchmarks
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkXDRUnmarshal
BenchmarkXDRUnmarshal-8              100             18851 ns/op            5576 B/op        186 allocs/op
BenchmarkGXDRUnmarshal
BenchmarkGXDRUnmarshal-8             100             51694 ns/op           86736 B/op        278 allocs/op
BenchmarkXDRMarshal
BenchmarkXDRMarshal-8                100             11203 ns/op            5128 B/op        156 allocs/op
BenchmarkGXDRMarshal
BenchmarkGXDRMarshal-8               100              8539 ns/op            2152 B/op        157 allocs/op
PASS
```

Note how the allocations go down:
* from 232 to 186 (~20% reduction) for the decoder
* from 194 to 156 (also ~20% reduction) for the encoder


This should relieve a lot of pressure in the garbage collector ( https://github.com/stellar/go/issues/4022 shows how allocations/garbage collection constitute a big part of Horizon's runtime)