### PR TITLE
ingest: Remove base64 encoding when storing LedgerKey in memory

### DIFF
--- a/ingest/change_compactor.go
+++ b/ingest/change_compactor.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"encoding/base64"
 	"sync"
 
 	"github.com/stellar/go/support/errors"
@@ -85,9 +86,9 @@ func (c *ChangeCompactor) AddChange(change Change) error {
 // addCreatedChange adds a change to the cache, but returns an error if create
 // change is unexpected.
 func (c *ChangeCompactor) addCreatedChange(change Change) error {
-	ledgerKey, err := change.Post.LedgerKey().MarshalBinaryCompress()
+	ledgerKey, err := change.Post.LedgerKey().MarshalBinary()
 	if err != nil {
-		return errors.Wrap(err, "Error MarshalBinaryCompress")
+		return errors.Wrap(err, "Error MarshalBinary")
 	}
 
 	ledgerKeyString := string(ledgerKey)
@@ -102,12 +103,12 @@ func (c *ChangeCompactor) addCreatedChange(change Change) error {
 	case xdr.LedgerEntryChangeTypeLedgerEntryCreated:
 		return NewStateError(errors.Errorf(
 			"can't create an entry that already exists (ledger key = %s)",
-			ledgerKeyString,
+			base64.StdEncoding.EncodeToString(ledgerKey),
 		))
 	case xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
 		return NewStateError(errors.Errorf(
 			"can't create an entry that already exists (ledger key = %s)",
-			ledgerKeyString,
+			base64.StdEncoding.EncodeToString(ledgerKey),
 		))
 	case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:
 		// If existing type is removed it means that this entry does exist
@@ -127,9 +128,9 @@ func (c *ChangeCompactor) addCreatedChange(change Change) error {
 // addUpdatedChange adds a change to the cache, but returns an error if update
 // change is unexpected.
 func (c *ChangeCompactor) addUpdatedChange(change Change) error {
-	ledgerKey, err := change.Post.LedgerKey().MarshalBinaryCompress()
+	ledgerKey, err := change.Post.LedgerKey().MarshalBinary()
 	if err != nil {
-		return errors.Wrap(err, "Error MarshalBinaryCompress")
+		return errors.Wrap(err, "Error MarshalBinary")
 	}
 
 	ledgerKeyString := string(ledgerKey)
@@ -158,7 +159,7 @@ func (c *ChangeCompactor) addUpdatedChange(change Change) error {
 	case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:
 		return NewStateError(errors.Errorf(
 			"can't update an entry that was previously removed (ledger key = %s)",
-			ledgerKeyString,
+			base64.StdEncoding.EncodeToString(ledgerKey),
 		))
 	default:
 		return errors.Errorf("Unknown LedgerEntryChangeType: %d", existingChange.Type)
@@ -170,9 +171,9 @@ func (c *ChangeCompactor) addUpdatedChange(change Change) error {
 // addRemovedChange adds a change to the cache, but returns an error if remove
 // change is unexpected.
 func (c *ChangeCompactor) addRemovedChange(change Change) error {
-	ledgerKey, err := change.Pre.LedgerKey().MarshalBinaryCompress()
+	ledgerKey, err := change.Pre.LedgerKey().MarshalBinary()
 	if err != nil {
-		return errors.Wrap(err, "Error MarshalBinaryCompress")
+		return errors.Wrap(err, "Error MarshalBinary")
 	}
 
 	ledgerKeyString := string(ledgerKey)
@@ -197,7 +198,7 @@ func (c *ChangeCompactor) addRemovedChange(change Change) error {
 	case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:
 		return NewStateError(errors.Errorf(
 			"can't remove an entry that was previously removed (ledger key = %s)",
-			ledgerKeyString,
+			base64.StdEncoding.EncodeToString(ledgerKey),
 		))
 	default:
 		return errors.Errorf("Unknown LedgerEntryChangeType: %d", existingChange.Type)

--- a/ingest/change_compactor.go
+++ b/ingest/change_compactor.go
@@ -85,10 +85,12 @@ func (c *ChangeCompactor) AddChange(change Change) error {
 // addCreatedChange adds a change to the cache, but returns an error if create
 // change is unexpected.
 func (c *ChangeCompactor) addCreatedChange(change Change) error {
-	ledgerKeyString, err := change.Post.LedgerKey().MarshalBinaryBase64()
+	ledgerKey, err := change.Post.LedgerKey().MarshalBinaryCompress()
 	if err != nil {
-		return errors.Wrap(err, "Error MarshalBinaryBase64")
+		return errors.Wrap(err, "Error MarshalBinaryCompress")
 	}
+
+	ledgerKeyString := string(ledgerKey)
 
 	existingChange, exist := c.cache[ledgerKeyString]
 	if !exist {
@@ -125,10 +127,12 @@ func (c *ChangeCompactor) addCreatedChange(change Change) error {
 // addUpdatedChange adds a change to the cache, but returns an error if update
 // change is unexpected.
 func (c *ChangeCompactor) addUpdatedChange(change Change) error {
-	ledgerKeyString, err := change.Post.LedgerKey().MarshalBinaryBase64()
+	ledgerKey, err := change.Post.LedgerKey().MarshalBinaryCompress()
 	if err != nil {
-		return errors.Wrap(err, "Error MarshalBinaryBase64")
+		return errors.Wrap(err, "Error MarshalBinaryCompress")
 	}
+
+	ledgerKeyString := string(ledgerKey)
 
 	existingChange, exist := c.cache[ledgerKeyString]
 	if !exist {
@@ -166,10 +170,12 @@ func (c *ChangeCompactor) addUpdatedChange(change Change) error {
 // addRemovedChange adds a change to the cache, but returns an error if remove
 // change is unexpected.
 func (c *ChangeCompactor) addRemovedChange(change Change) error {
-	ledgerKeyString, err := change.Pre.LedgerKey().MarshalBinaryBase64()
+	ledgerKey, err := change.Pre.LedgerKey().MarshalBinaryCompress()
 	if err != nil {
-		return errors.Wrap(err, "Error MarshalBinaryBase64")
+		return errors.Wrap(err, "Error MarshalBinaryCompress")
 	}
+
+	ledgerKeyString := string(ledgerKey)
 
 	existingChange, exist := c.cache[ledgerKeyString]
 	if !exist {

--- a/ingest/checkpoint_change_reader.go
+++ b/ingest/checkpoint_change_reader.go
@@ -2,7 +2,6 @@ package ingest
 
 import (
 	"context"
-	"encoding/base64"
 	"io"
 	"sync"
 	"time"
@@ -376,7 +375,7 @@ LoopBucketEntry:
 					return false
 				}
 
-				h := base64.StdEncoding.EncodeToString(keyBytes)
+				h := string(keyBytes)
 				preloadKeys = append(preloadKeys, h)
 			}
 
@@ -432,7 +431,7 @@ LoopBucketEntry:
 			return false
 		}
 
-		h := base64.StdEncoding.EncodeToString(keyBytes)
+		h := string(keyBytes)
 
 		switch entry.Type {
 		case xdr.BucketEntryTypeLiveentry, xdr.BucketEntryTypeInitentry:

--- a/services/horizon/internal/ingest/verify/main.go
+++ b/services/horizon/internal/ingest/verify/main.go
@@ -116,7 +116,7 @@ func (v *StateVerifier) Write(entry xdr.LedgerEntry) error {
 		return ingest.NewStateError(errors.Errorf(
 			"Cannot find entry in currentEntries map: %s (key = %s)",
 			base64.StdEncoding.EncodeToString(actualEntryMarshaled),
-			key,
+			base64.StdEncoding.EncodeToString(key),
 		))
 	}
 	delete(v.currentEntries, string(key))

--- a/services/horizon/internal/ingest/verify/main.go
+++ b/services/horizon/internal/ingest/verify/main.go
@@ -78,14 +78,14 @@ func (v *StateVerifier) GetLedgerKeys(count int) ([]xdr.LedgerKey, error) {
 		}
 
 		ledgerKey := entry.LedgerKey()
-		key, err := xdr.MarshalBase64(ledgerKey)
+		key, err := ledgerKey.MarshalBinary()
 		if err != nil {
 			return keys, errors.Wrap(err, "Error marshaling ledgerKey")
 		}
 
 		keys = append(keys, ledgerKey)
 		entry.Normalize()
-		v.currentEntries[key] = entry
+		v.currentEntries[string(key)] = entry
 
 		count--
 		v.readEntries++
@@ -106,12 +106,12 @@ func (v *StateVerifier) Write(entry xdr.LedgerEntry) error {
 		return errors.Wrap(err, "Error marshaling actualEntry")
 	}
 
-	key, err := xdr.MarshalBase64(actualEntry.LedgerKey())
+	key, err := actualEntry.LedgerKey().MarshalBinary()
 	if err != nil {
 		return errors.Wrap(err, "Error marshaling ledgerKey")
 	}
 
-	expectedEntry, exist := v.currentEntries[key]
+	expectedEntry, exist := v.currentEntries[string(key)]
 	if !exist {
 		return ingest.NewStateError(errors.Errorf(
 			"Cannot find entry in currentEntries map: %s (key = %s)",
@@ -119,7 +119,7 @@ func (v *StateVerifier) Write(entry xdr.LedgerEntry) error {
 			key,
 		))
 	}
-	delete(v.currentEntries, key)
+	delete(v.currentEntries, string(key))
 
 	preTransformExpectedEntry := expectedEntry
 	preTransformExpectedEntryMarshaled, err := preTransformExpectedEntry.MarshalBinary()

--- a/services/horizon/internal/ingest/verify/main_test.go
+++ b/services/horizon/internal/ingest/verify/main_test.go
@@ -127,12 +127,12 @@ func (s *StateVerifierTestSuite) TestTransformFunction() {
 	s.Assert().NoError(err)
 
 	// Check currentEntries
-	ledgerKeyBase64, err := xdr.MarshalBase64(accountEntry.LedgerKey())
+	ledgerKey, err := accountEntry.LedgerKey().MarshalBinary()
 	s.Assert().NoError(err)
 
 	// Account entry transformed and offer entry ignored
 	s.Assert().Len(s.verifier.currentEntries, 1)
-	s.Assert().Equal(accountEntry, s.verifier.currentEntries[ledgerKeyBase64])
+	s.Assert().Equal(accountEntry, s.verifier.currentEntries[string(ledgerKey)])
 }
 
 func (s *StateVerifierTestSuite) TestOnlyRequestedNumberOfKeysReturned() {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit changes all key representations of `LedgerKey` from base64 string to raw bytes string. This should lower memory requirements of `ChangeCompactor`, `CheckpointChangeReader` and `StateVerifier` by around 25% (given that base64 encoding is roughly 4/3 of original length).

### Why

According to [Strings, bytes, runes and characters in Go](https://go.dev/blog/strings):
> Some people think Go strings are always UTF-8, but they are not: only string literals are UTF-8. As we showed in the previous section, string values can contain arbitrary bytes; as we showed in this one, string literals always contain UTF-8 text as long as they have no byte-level escapes.
>
> To summarize, strings can contain arbitrary bytes, but when constructed from string literals, those bytes are (almost always) UTF-8.

Because of that we don't need to base64-encode marshalled `LedgerKey` when using it as map key.

### Known limitations

[TODO or N/A]
