### PR TITLE
services/horizon: Change horizon_ingest_state_verify_ledger_entries metric to gauge

### DIFF
--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -128,7 +128,7 @@ type Metrics struct {
 
 	// StateVerifyLedgerEntriesCount exposes total number of ledger entries
 	// checked by the state verifier by type.
-	StateVerifyLedgerEntriesCount *prometheus.SummaryVec
+	StateVerifyLedgerEntriesCount *prometheus.GaugeVec
 
 	// LedgerStatsCounter exposes ledger stats counters (like number of ops/changes).
 	LedgerStatsCounter *prometheus.CounterVec
@@ -323,12 +323,10 @@ func (s *system) initMetrics() {
 		},
 	)
 
-	s.metrics.StateVerifyLedgerEntriesCount = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Namespace: "horizon", Subsystem: "ingest", Name: "state_verify_ledger_entries_count",
+	s.metrics.StateVerifyLedgerEntriesCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "horizon", Subsystem: "ingest", Name: "state_verify_ledger_entries",
 			Help: "number of ledger entries downloaded from buckets in a single state verifier run",
-			// Quantile ranks are not relevant here so pass empty map.
-			Objectives: map[float64]float64{},
 		},
 		[]string{"type"},
 	)

--- a/services/horizon/internal/ingest/verify.go
+++ b/services/horizon/internal/ingest/verify.go
@@ -136,7 +136,7 @@ func (s *system) verifyState(verifyAgainstLatestCheckpoint bool) error {
 				s.Metrics().StateVerifyDuration.Observe(float64(duration))
 				for typ, tot := range totalByType {
 					s.Metrics().StateVerifyLedgerEntriesCount.
-						With(prometheus.Labels{"type": typ}).Observe(float64(tot))
+						With(prometheus.Labels{"type": typ}).Set(float64(tot))
 				}
 			}
 		}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Change the type of `horizon_ingest_state_verify_ledger_entries` metric to gauge.

### Why

In https://github.com/stellar/go/pull/4015 I create a new metric tracking the number of ledger entries in buckets. After writing a few PromQL queries I realized the type would be much easier to query if it was a gauge (instead of summary).

### Known limitations

[TODO or N/A]
