### PR TITLE
Create xdr.EncodingBuffer, which reduces buffer allocations

### DIFF
--- a/benchmarks/xdr_test.go
+++ b/benchmarks/xdr_test.go
@@ -35,18 +35,38 @@ var gxdrInput = func() gxdr.TransactionEnvelope {
 	return te
 }()
 
-func BenchmarkXDRUnmarshal(b *testing.B) {
+func BenchmarkXDRUnmarshalWithReflection(b *testing.B) {
+	var (
+		r  bytes.Reader
+		te xdr.TransactionEnvelope
+	)
 	for i := 0; i < b.N; i++ {
-		_ = xdrInput.UnmarshalBinary(input)
+		r.Reset(input)
+		_, _ = xdr.Unmarshal(&r, &te)
+	}
+}
+
+func BenchmarkXDRUnmarshal(b *testing.B) {
+	var te xdr.TransactionEnvelope
+	for i := 0; i < b.N; i++ {
+		_ = te.UnmarshalBinary(input)
 	}
 }
 
 func BenchmarkGXDRUnmarshal(b *testing.B) {
-	var te gxdr.TransactionEnvelope
-	r := bytes.NewReader(input)
+	var (
+		te gxdr.TransactionEnvelope
+		r  bytes.Reader
+	)
 	for i := 0; i < b.N; i++ {
 		r.Reset(input)
-		te.XdrMarshal(&goxdr.XdrIn{In: r}, "")
+		te.XdrMarshal(&goxdr.XdrIn{In: &r}, "")
+	}
+}
+
+func BenchmarkXDRMarshalWithReflection(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = xdr.Marshal(&bytes.Buffer{}, xdrInput)
 	}
 }
 

--- a/benchmarks/xdr_test.go
+++ b/benchmarks/xdr_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stellar/go/gxdr"
 	"github.com/stellar/go/xdr"
-	"github.com/stretchr/testify/require"
 	goxdr "github.com/xdrpp/goxdr/xdr"
 )
 
@@ -21,30 +20,29 @@ var input = func() []byte {
 	return decoded
 }()
 
-func BenchmarkXDRUnmarshal(b *testing.B) {
-	b.StopTimer()
-	te := xdr.TransactionEnvelope{}
+var xdrInput = func() xdr.TransactionEnvelope {
+	var te xdr.TransactionEnvelope
+	if err := te.UnmarshalBinary(input); err != nil {
+		panic(err)
+	}
+	return te
+}()
 
-	// Make sure the input is valid.
-	err := te.UnmarshalBinary(input)
-	require.NoError(b, err)
-	b.StartTimer()
-	// Benchmark.
+var gxdrInput = func() gxdr.TransactionEnvelope {
+	var te gxdr.TransactionEnvelope
+	// note goxdr will panic if there's a marshaling error.
+	te.XdrMarshal(&goxdr.XdrIn{In: bytes.NewReader(input)}, "")
+	return te
+}()
+
+func BenchmarkXDRUnmarshal(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = te.UnmarshalBinary(input)
+		_ = xdrInput.UnmarshalBinary(input)
 	}
 }
 
 func BenchmarkGXDRUnmarshal(b *testing.B) {
-	b.StopTimer()
-	te := gxdr.TransactionEnvelope{}
-
-	// Make sure the input is valid, note goxdr will panic if there's a
-	// marshaling error.
-	te.XdrMarshal(&goxdr.XdrIn{In: bytes.NewReader(input)}, "")
-	b.StartTimer()
-
-	// Benchmark.
+	var te gxdr.TransactionEnvelope
 	r := bytes.NewReader(input)
 	for i := 0; i < b.N; i++ {
 		r.Reset(input)
@@ -53,37 +51,63 @@ func BenchmarkGXDRUnmarshal(b *testing.B) {
 }
 
 func BenchmarkXDRMarshal(b *testing.B) {
-	b.StopTimer()
-	te := xdr.TransactionEnvelope{}
-
-	// Make sure the input is valid.
-	err := te.UnmarshalBinary(input)
-	require.NoError(b, err)
-	output, err := te.MarshalBinary()
-	require.NoError(b, err)
-	require.Equal(b, input, output)
-	b.StartTimer()
-
-	// Benchmark.
 	for i := 0; i < b.N; i++ {
-		_, _ = te.MarshalBinary()
+		_, _ = xdrInput.MarshalBinary()
+	}
+}
+
+func BenchmarkXDRMarshalWithEncoder(b *testing.B) {
+	e := xdr.NewEncoder()
+	for i := 0; i < b.N; i++ {
+		_, _ = e.UnsafeMarshalBinary(xdrInput)
 	}
 }
 
 func BenchmarkGXDRMarshal(b *testing.B) {
-	b.StopTimer()
-	te := gxdr.TransactionEnvelope{}
-
-	// Make sure the input is valid, note goxdr will panic if there's a
-	// marshaling error.
-	te.XdrMarshal(&goxdr.XdrIn{In: bytes.NewReader(input)}, "")
-	output := bytes.Buffer{}
-	te.XdrMarshal(&goxdr.XdrOut{Out: &output}, "")
-
-	b.StartTimer()
+	var output bytes.Buffer
 	// Benchmark.
 	for i := 0; i < b.N; i++ {
 		output.Reset()
-		te.XdrMarshal(&goxdr.XdrOut{Out: &output}, "")
+		gxdrInput.XdrMarshal(&goxdr.XdrOut{Out: &output}, "")
+	}
+}
+
+func BenchmarkXDRMarshalHex(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = xdr.MarshalHex(xdrInput)
+	}
+}
+
+func BenchmarkXDRMarshalHexWithEncoder(b *testing.B) {
+	e := xdr.NewEncoder()
+	for i := 0; i < b.N; i++ {
+		_, _ = e.MarshalHex(xdrInput)
+	}
+}
+
+func BenchmarkXDRUnsafeMarshalHexWithEncoder(b *testing.B) {
+	e := xdr.NewEncoder()
+	for i := 0; i < b.N; i++ {
+		_, _ = e.UnsafeMarshalHex(xdrInput)
+	}
+}
+
+func BenchmarkXDRMarshalBase64(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = xdr.MarshalBase64(xdrInput)
+	}
+}
+
+func BenchmarkXDRMarshalBase64WithEncoder(b *testing.B) {
+	e := xdr.NewEncoder()
+	for i := 0; i < b.N; i++ {
+		_, _ = e.MarshalBase64(xdrInput)
+	}
+}
+
+func BenchmarkXDRUnsafeMarshalBase64WithEncoder(b *testing.B) {
+	e := xdr.NewEncoder()
+	for i := 0; i < b.N; i++ {
+		_, _ = e.UnsafeMarshalBase64(xdrInput)
 	}
 }

--- a/benchmarks/xdr_test.go
+++ b/benchmarks/xdr_test.go
@@ -76,8 +76,8 @@ func BenchmarkXDRMarshal(b *testing.B) {
 	}
 }
 
-func BenchmarkXDRMarshalWithEncoder(b *testing.B) {
-	e := xdr.NewEncoder()
+func BenchmarkXDRMarshalWithEncodingBuffer(b *testing.B) {
+	e := xdr.NewEncodingBuffer()
 	for i := 0; i < b.N; i++ {
 		_, _ = e.UnsafeMarshalBinary(xdrInput)
 	}
@@ -98,15 +98,15 @@ func BenchmarkXDRMarshalHex(b *testing.B) {
 	}
 }
 
-func BenchmarkXDRMarshalHexWithEncoder(b *testing.B) {
-	e := xdr.NewEncoder()
+func BenchmarkXDRMarshalHexWithEncodingBuffer(b *testing.B) {
+	e := xdr.NewEncodingBuffer()
 	for i := 0; i < b.N; i++ {
 		_, _ = e.MarshalHex(xdrInput)
 	}
 }
 
-func BenchmarkXDRUnsafeMarshalHexWithEncoder(b *testing.B) {
-	e := xdr.NewEncoder()
+func BenchmarkXDRUnsafeMarshalHexWithEncodingBuffer(b *testing.B) {
+	e := xdr.NewEncodingBuffer()
 	for i := 0; i < b.N; i++ {
 		_, _ = e.UnsafeMarshalHex(xdrInput)
 	}
@@ -118,15 +118,15 @@ func BenchmarkXDRMarshalBase64(b *testing.B) {
 	}
 }
 
-func BenchmarkXDRMarshalBase64WithEncoder(b *testing.B) {
-	e := xdr.NewEncoder()
+func BenchmarkXDRMarshalBase64WithEncodingBuffer(b *testing.B) {
+	e := xdr.NewEncodingBuffer()
 	for i := 0; i < b.N; i++ {
 		_, _ = e.MarshalBase64(xdrInput)
 	}
 }
 
-func BenchmarkXDRUnsafeMarshalBase64WithEncoder(b *testing.B) {
-	e := xdr.NewEncoder()
+func BenchmarkXDRUnsafeMarshalBase64WithEncodingBuffer(b *testing.B) {
+	e := xdr.NewEncodingBuffer()
 	for i := 0; i < b.N; i++ {
 		_, _ = e.UnsafeMarshalBase64(xdrInput)
 	}

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
@@ -236,7 +236,7 @@ func (i *transactionBatchInsertBuilder) transactionToRow(transaction ingest.Ledg
 	if err != nil {
 		return TransactionWithoutLedger{}, err
 	}
-	resultBase64, err := i.encodingBuffer.MarshalBase64(transaction.Result.Result)
+	resultBase64, err := i.encodingBuffer.MarshalBase64(&transaction.Result.Result)
 	if err != nil {
 		return TransactionWithoutLedger{}, err
 	}

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
@@ -31,14 +31,14 @@ type TransactionBatchInsertBuilder interface {
 
 // transactionBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
 type transactionBatchInsertBuilder struct {
-	encoder *xdr.Encoder
-	builder db.BatchInsertBuilder
+	encodingBuffer *xdr.EncodingBuffer
+	builder        db.BatchInsertBuilder
 }
 
 // NewTransactionBatchInsertBuilder constructs a new TransactionBatchInsertBuilder instance
 func (q *Q) NewTransactionBatchInsertBuilder(maxBatchSize int) TransactionBatchInsertBuilder {
 	return &transactionBatchInsertBuilder{
-		encoder: xdr.NewEncoder(),
+		encodingBuffer: xdr.NewEncodingBuffer(),
 		builder: db.BatchInsertBuilder{
 			Table:        q.GetTable("history_transactions"),
 			MaxBatchSize: maxBatchSize,
@@ -232,19 +232,19 @@ type TransactionWithoutLedger struct {
 }
 
 func (i *transactionBatchInsertBuilder) transactionToRow(transaction ingest.LedgerTransaction, sequence uint32) (TransactionWithoutLedger, error) {
-	envelopeBase64, err := i.encoder.MarshalBase64(transaction.Envelope)
+	envelopeBase64, err := i.encodingBuffer.MarshalBase64(transaction.Envelope)
 	if err != nil {
 		return TransactionWithoutLedger{}, err
 	}
-	resultBase64, err := i.encoder.MarshalBase64(transaction.Result.Result)
+	resultBase64, err := i.encodingBuffer.MarshalBase64(transaction.Result.Result)
 	if err != nil {
 		return TransactionWithoutLedger{}, err
 	}
-	metaBase64, err := i.encoder.MarshalBase64(transaction.UnsafeMeta)
+	metaBase64, err := i.encodingBuffer.MarshalBase64(transaction.UnsafeMeta)
 	if err != nil {
 		return TransactionWithoutLedger{}, err
 	}
-	feeMetaBase64, err := i.encoder.MarshalBase64(transaction.FeeChanges)
+	feeMetaBase64, err := i.encodingBuffer.MarshalBase64(transaction.FeeChanges)
 	if err != nil {
 		return TransactionWithoutLedger{}, err
 	}

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
@@ -31,12 +31,14 @@ type TransactionBatchInsertBuilder interface {
 
 // transactionBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
 type transactionBatchInsertBuilder struct {
+	encoder *xdr.Encoder
 	builder db.BatchInsertBuilder
 }
 
 // NewTransactionBatchInsertBuilder constructs a new TransactionBatchInsertBuilder instance
 func (q *Q) NewTransactionBatchInsertBuilder(maxBatchSize int) TransactionBatchInsertBuilder {
 	return &transactionBatchInsertBuilder{
+		encoder: xdr.NewEncoder(),
 		builder: db.BatchInsertBuilder{
 			Table:        q.GetTable("history_transactions"),
 			MaxBatchSize: maxBatchSize,
@@ -46,7 +48,7 @@ func (q *Q) NewTransactionBatchInsertBuilder(maxBatchSize int) TransactionBatchI
 
 // Add adds a new transaction to the batch
 func (i *transactionBatchInsertBuilder) Add(ctx context.Context, transaction ingest.LedgerTransaction, sequence uint32) error {
-	row, err := transactionToRow(transaction, sequence)
+	row, err := i.transactionToRow(transaction, sequence)
 	if err != nil {
 		return err
 	}
@@ -229,20 +231,20 @@ type TransactionWithoutLedger struct {
 	InnerSignatures      pq.StringArray `db:"inner_signatures"`
 }
 
-func transactionToRow(transaction ingest.LedgerTransaction, sequence uint32) (TransactionWithoutLedger, error) {
-	envelopeBase64, err := xdr.MarshalBase64(transaction.Envelope)
+func (i *transactionBatchInsertBuilder) transactionToRow(transaction ingest.LedgerTransaction, sequence uint32) (TransactionWithoutLedger, error) {
+	envelopeBase64, err := i.encoder.MarshalBase64(transaction.Envelope)
 	if err != nil {
 		return TransactionWithoutLedger{}, err
 	}
-	resultBase64, err := xdr.MarshalBase64(transaction.Result.Result)
+	resultBase64, err := i.encoder.MarshalBase64(transaction.Result.Result)
 	if err != nil {
 		return TransactionWithoutLedger{}, err
 	}
-	metaBase64, err := xdr.MarshalBase64(transaction.UnsafeMeta)
+	metaBase64, err := i.encoder.MarshalBase64(transaction.UnsafeMeta)
 	if err != nil {
 		return TransactionWithoutLedger{}, err
 	}
-	feeMetaBase64, err := xdr.MarshalBase64(transaction.FeeChanges)
+	feeMetaBase64, err := i.encoder.MarshalBase64(transaction.FeeChanges)
 	if err != nil {
 		return TransactionWithoutLedger{}, err
 	}

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder_test.go
@@ -84,7 +84,10 @@ func TestTransactionToMap_muxed(t *testing.T) {
 			},
 		},
 	}
-	row, err := transactionToRow(tx, 20)
+	b := &transactionBatchInsertBuilder{
+		encoder: xdr.NewEncoder(),
+	}
+	row, err := b.transactionToRow(tx, 20)
 	assert.NoError(t, err)
 
 	assert.Equal(t, innerAccountID.Address(), row.Account)
@@ -165,7 +168,10 @@ func TestTransactionToMap_SourceMuxedAndFeeSourceUnmuxed(t *testing.T) {
 			},
 		},
 	}
-	row, err := transactionToRow(tx, 20)
+	b := &transactionBatchInsertBuilder{
+		encoder: xdr.NewEncoder(),
+	}
+	row, err := b.transactionToRow(tx, 20)
 	assert.NoError(t, err)
 
 	assert.Equal(t, innerAccountID.Address(), row.Account)

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder_test.go
@@ -85,7 +85,7 @@ func TestTransactionToMap_muxed(t *testing.T) {
 		},
 	}
 	b := &transactionBatchInsertBuilder{
-		encoder: xdr.NewEncoder(),
+		encodingBuffer: xdr.NewEncodingBuffer(),
 	}
 	row, err := b.transactionToRow(tx, 20)
 	assert.NoError(t, err)
@@ -169,7 +169,7 @@ func TestTransactionToMap_SourceMuxedAndFeeSourceUnmuxed(t *testing.T) {
 		},
 	}
 	b := &transactionBatchInsertBuilder{
-		encoder: xdr.NewEncoder(),
+		encodingBuffer: xdr.NewEncodingBuffer(),
 	}
 	row, err := b.transactionToRow(tx, 20)
 	assert.NoError(t, err)

--- a/services/horizon/internal/ingest/orderbook.go
+++ b/services/horizon/internal/ingest/orderbook.go
@@ -228,11 +228,11 @@ func (o *OrderBookStream) verifyAllOffers(ctx context.Context) (bool, error) {
 		for i, offerRow := range ingestionOffers {
 			offerEntry := offers[i]
 			offerRowXDR := offerToXDR(offerRow)
-			offerEntryBase64, err := o.encodingBuffer.MarshalBase64(offerEntry)
+			offerEntryBase64, err := o.encodingBuffer.MarshalBase64(&offerEntry)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from marshalling offerEntry")
 			}
-			offerRowBase64, err := o.encodingBuffer.MarshalBase64(offerRowXDR)
+			offerRowBase64, err := o.encodingBuffer.MarshalBase64(&offerRowXDR)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from marshalling offerRowXDR")
 			}
@@ -277,11 +277,11 @@ func (o *OrderBookStream) verifyAllLiquidityPools(ctx context.Context) (bool, er
 			if err != nil {
 				return false, errors.Wrap(err, "Error from converting liquidity pool row to xdr")
 			}
-			liquidityPoolEntryBase64, err := o.encodingBuffer.MarshalBase64(liquidityPoolEntry)
+			liquidityPoolEntryBase64, err := o.encodingBuffer.MarshalBase64(&liquidityPoolEntry)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from marshalling liquidityPoolEntry")
 			}
-			liquidityPoolRowBase64, err := o.encodingBuffer.MarshalBase64(liquidityPoolRowXDR)
+			liquidityPoolRowBase64, err := o.encodingBuffer.MarshalBase64(&liquidityPoolRowXDR)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from marshalling liquidityPoolRowXDR")
 			}

--- a/services/horizon/internal/ingest/orderbook.go
+++ b/services/horizon/internal/ingest/orderbook.go
@@ -35,7 +35,7 @@ type OrderBookStream struct {
 	LatestLedgerGauge prometheus.Gauge
 	lastLedger        uint32
 	lastVerification  time.Time
-	xdrEncoder        *xdr.Encoder
+	encodingBuffer    *xdr.EncodingBuffer
 }
 
 // NewOrderBookStream constructs and initializes an OrderBookStream instance
@@ -47,7 +47,7 @@ func NewOrderBookStream(historyQ history.IngestionQ, graph orderbook.OBGraph) *O
 			Namespace: "horizon", Subsystem: "order_book_stream", Name: "latest_ledger",
 		}),
 		lastVerification: time.Now(),
-		xdrEncoder:       xdr.NewEncoder(),
+		encodingBuffer:   xdr.NewEncodingBuffer(),
 	}
 }
 
@@ -228,11 +228,11 @@ func (o *OrderBookStream) verifyAllOffers(ctx context.Context) (bool, error) {
 		for i, offerRow := range ingestionOffers {
 			offerEntry := offers[i]
 			offerRowXDR := offerToXDR(offerRow)
-			offerEntryBase64, err := o.xdrEncoder.MarshalBase64(offerEntry)
+			offerEntryBase64, err := o.encodingBuffer.MarshalBase64(offerEntry)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from marshalling offerEntry")
 			}
-			offerRowBase64, err := o.xdrEncoder.MarshalBase64(offerRowXDR)
+			offerRowBase64, err := o.encodingBuffer.MarshalBase64(offerRowXDR)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from marshalling offerRowXDR")
 			}
@@ -277,11 +277,11 @@ func (o *OrderBookStream) verifyAllLiquidityPools(ctx context.Context) (bool, er
 			if err != nil {
 				return false, errors.Wrap(err, "Error from converting liquidity pool row to xdr")
 			}
-			liquidityPoolEntryBase64, err := o.xdrEncoder.MarshalBase64(liquidityPoolEntry)
+			liquidityPoolEntryBase64, err := o.encodingBuffer.MarshalBase64(liquidityPoolEntry)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from marshalling liquidityPoolEntry")
 			}
-			liquidityPoolRowBase64, err := o.xdrEncoder.MarshalBase64(liquidityPoolRowXDR)
+			liquidityPoolRowBase64, err := o.encodingBuffer.MarshalBase64(liquidityPoolRowXDR)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from marshalling liquidityPoolRowXDR")
 			}

--- a/services/horizon/internal/ingest/orderbook.go
+++ b/services/horizon/internal/ingest/orderbook.go
@@ -35,6 +35,7 @@ type OrderBookStream struct {
 	LatestLedgerGauge prometheus.Gauge
 	lastLedger        uint32
 	lastVerification  time.Time
+	xdrEncoder        *xdr.Encoder
 }
 
 // NewOrderBookStream constructs and initializes an OrderBookStream instance
@@ -46,6 +47,7 @@ func NewOrderBookStream(historyQ history.IngestionQ, graph orderbook.OBGraph) *O
 			Namespace: "horizon", Subsystem: "order_book_stream", Name: "latest_ledger",
 		}),
 		lastVerification: time.Now(),
+		xdrEncoder:       xdr.NewEncoder(),
 	}
 }
 
@@ -226,11 +228,11 @@ func (o *OrderBookStream) verifyAllOffers(ctx context.Context) (bool, error) {
 		for i, offerRow := range ingestionOffers {
 			offerEntry := offers[i]
 			offerRowXDR := offerToXDR(offerRow)
-			offerEntryBase64, err := xdr.MarshalBase64(offerEntry)
+			offerEntryBase64, err := o.xdrEncoder.MarshalBase64(offerEntry)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from marshalling offerEntry")
 			}
-			offerRowBase64, err := xdr.MarshalBase64(offerRowXDR)
+			offerRowBase64, err := o.xdrEncoder.MarshalBase64(offerRowXDR)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from marshalling offerRowXDR")
 			}
@@ -275,11 +277,11 @@ func (o *OrderBookStream) verifyAllLiquidityPools(ctx context.Context) (bool, er
 			if err != nil {
 				return false, errors.Wrap(err, "Error from converting liquidity pool row to xdr")
 			}
-			liquidityPoolEntryBase64, err := xdr.MarshalBase64(liquidityPoolEntry)
+			liquidityPoolEntryBase64, err := o.xdrEncoder.MarshalBase64(liquidityPoolEntry)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from marshalling liquidityPoolEntry")
 			}
-			liquidityPoolRowBase64, err := xdr.MarshalBase64(liquidityPoolRowXDR)
+			liquidityPoolRowBase64, err := o.xdrEncoder.MarshalBase64(liquidityPoolRowXDR)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from marshalling liquidityPoolRowXDR")
 			}

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
@@ -10,14 +10,14 @@ import (
 )
 
 type ClaimableBalancesChangeProcessor struct {
-	encoder            *xdr.Encoder
+	encodingBuffer     *xdr.EncodingBuffer
 	qClaimableBalances history.QClaimableBalances
 	cache              *ingest.ChangeCompactor
 }
 
 func NewClaimableBalancesChangeProcessor(Q history.QClaimableBalances) *ClaimableBalancesChangeProcessor {
 	p := &ClaimableBalancesChangeProcessor{
-		encoder:            xdr.NewEncoder(),
+		encodingBuffer:     xdr.NewEncodingBuffer(),
 		qClaimableBalances: Q,
 	}
 	p.reset()
@@ -67,7 +67,7 @@ func (p *ClaimableBalancesChangeProcessor) Commit(ctx context.Context) error {
 		case change.Pre != nil && change.Post == nil:
 			// Removed
 			cBalance := change.Pre.Data.MustClaimableBalance()
-			id, err := p.encoder.MarshalHex(cBalance.BalanceId)
+			id, err := p.encodingBuffer.MarshalHex(cBalance.BalanceId)
 			if err != nil {
 				return err
 			}

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
@@ -10,12 +10,14 @@ import (
 )
 
 type ClaimableBalancesChangeProcessor struct {
+	encoder            *xdr.Encoder
 	qClaimableBalances history.QClaimableBalances
 	cache              *ingest.ChangeCompactor
 }
 
 func NewClaimableBalancesChangeProcessor(Q history.QClaimableBalances) *ClaimableBalancesChangeProcessor {
 	p := &ClaimableBalancesChangeProcessor{
+		encoder:            xdr.NewEncoder(),
 		qClaimableBalances: Q,
 	}
 	p.reset()
@@ -65,7 +67,7 @@ func (p *ClaimableBalancesChangeProcessor) Commit(ctx context.Context) error {
 		case change.Pre != nil && change.Post == nil:
 			// Removed
 			cBalance := change.Pre.Data.MustClaimableBalance()
-			id, err := xdr.MarshalHex(cBalance.BalanceId)
+			id, err := p.encoder.MarshalHex(cBalance.BalanceId)
 			if err != nil {
 				return err
 			}

--- a/services/horizon/internal/ingest/verify.go
+++ b/services/horizon/internal/ingest/verify.go
@@ -648,7 +648,7 @@ func addClaimableBalanceToStateVerifier(
 	}
 
 	var idStrings []string
-	e := xdr.NewEncoder()
+	e := xdr.NewEncodingBuffer()
 	for _, id := range ids {
 		idString, err := e.MarshalHex(id)
 		if err != nil {

--- a/services/horizon/internal/ingest/verify.go
+++ b/services/horizon/internal/ingest/verify.go
@@ -648,8 +648,9 @@ func addClaimableBalanceToStateVerifier(
 	}
 
 	var idStrings []string
+	e := xdr.NewEncoder()
 	for _, id := range ids {
-		idString, err := xdr.MarshalHex(id)
+		idString, err := e.MarshalHex(id)
 		if err != nil {
 			return err
 		}

--- a/xdr/main.go
+++ b/xdr/main.go
@@ -84,18 +84,18 @@ func SafeUnmarshal(data []byte, dest interface{}) error {
 }
 
 func MarshalBase64(v interface{}) (string, error) {
-	e := NewEncoder()
+	e := NewEncodingBuffer()
 	return e.MarshalBase64(v)
 }
 
 func MarshalHex(v interface{}) (string, error) {
-	e := NewEncoder()
+	e := NewEncodingBuffer()
 	return e.MarshalHex(v)
 }
 
-// Encoder reuses internal buffers between invocations
+// EncodingBuffer reuses internal buffers between invocations
 // to minimize allocations.
-type Encoder struct {
+type EncodingBuffer struct {
 	encoder          *xdr.Encoder
 	xdrEncoderBuf    bytes.Buffer
 	otherEncodersBuf []byte
@@ -115,17 +115,17 @@ type xdrEncodable interface {
 	EncodeTo(e *xdr.Encoder) error
 }
 
-func NewEncoder() *Encoder {
-	var ret Encoder
+func NewEncodingBuffer() *EncodingBuffer {
+	var ret EncodingBuffer
 	ret.encoder = xdr.NewEncoder(&ret.xdrEncoderBuf)
 	return &ret
 }
 
 // UnsafeMarshalBinary marshals the input XDR binary, returning
-// a slice pointing to the internal encoder's buffer. Handled with care, this saves
-// allows copying the buffer (e.g. like when returning a string).
+// a slice pointing to the internal buffer. Handled with care this improveds
+// performance since copying is not required.
 // Subsequent calls to marshalling methods will overwrite the returned buffer.
-func (e *Encoder) UnsafeMarshalBinary(v interface{}) ([]byte, error) {
+func (e *EncodingBuffer) UnsafeMarshalBinary(v interface{}) ([]byte, error) {
 	e.xdrEncoderBuf.Reset()
 	if encodable, ok := v.(xdrEncodable); ok {
 		// higher performance
@@ -141,7 +141,7 @@ func (e *Encoder) UnsafeMarshalBinary(v interface{}) ([]byte, error) {
 }
 
 // UnsafeMarshalBase64 is the base64 version of UnsafeMarshalBinary
-func (e *Encoder) UnsafeMarshalBase64(v interface{}) ([]byte, error) {
+func (e *EncodingBuffer) UnsafeMarshalBase64(v interface{}) ([]byte, error) {
 	xdrEncoded, err := e.UnsafeMarshalBinary(v)
 	if err != nil {
 		return nil, err
@@ -153,7 +153,7 @@ func (e *Encoder) UnsafeMarshalBase64(v interface{}) ([]byte, error) {
 }
 
 // UnsafeMarshalHex is the hex version of UnsafeMarshalBinary
-func (e *Encoder) UnsafeMarshalHex(v interface{}) ([]byte, error) {
+func (e *EncodingBuffer) UnsafeMarshalHex(v interface{}) ([]byte, error) {
 	xdrEncoded, err := e.UnsafeMarshalBinary(v)
 	if err != nil {
 		return nil, err
@@ -164,7 +164,7 @@ func (e *Encoder) UnsafeMarshalHex(v interface{}) ([]byte, error) {
 	return e.otherEncodersBuf, nil
 }
 
-func (e *Encoder) MarshalBase64(v interface{}) (string, error) {
+func (e *EncodingBuffer) MarshalBase64(v interface{}) (string, error) {
 	b, err := e.UnsafeMarshalBase64(v)
 	if err != nil {
 		return "", err
@@ -172,7 +172,7 @@ func (e *Encoder) MarshalBase64(v interface{}) (string, error) {
 	return string(b), nil
 }
 
-func (e *Encoder) MarshalHex(v interface{}) (string, error) {
+func (e *EncodingBuffer) MarshalHex(v interface{}) (string, error) {
 	b, err := e.UnsafeMarshalHex(v)
 	if err != nil {
 		return "", err

--- a/xdr/main.go
+++ b/xdr/main.go
@@ -121,6 +121,10 @@ func growSlice(old []byte, newSize int) []byte {
 	return make([]byte, newSize, 2*newSize)
 }
 
+type xdrEncodable interface {
+	EncodeTo(e *xdr.Encoder) error
+}
+
 func NewEncoder() *Encoder {
 	var ret Encoder
 	ret.encoder = xdr.NewEncoder(&ret.xdrEncoderBuf)
@@ -133,8 +137,15 @@ func NewEncoder() *Encoder {
 // Subsequent calls to marshalling methods will overwrite the returned buffer.
 func (e *Encoder) UnsafeMarshalBinary(v interface{}) ([]byte, error) {
 	e.xdrEncoderBuf.Reset()
-	if _, err := e.encoder.Encode(v); err != nil {
-		return nil, err
+	if encodable, ok := v.(xdrEncodable); ok {
+		// higher performance
+		if err := encodable.EncodeTo(e.encoder); err != nil {
+			return nil, err
+		}
+	} else {
+		if _, err := e.encoder.Encode(v); err != nil {
+			return nil, err
+		}
 	}
 	return e.xdrEncoderBuf.Bytes(), nil
 }

--- a/xdr/main.go
+++ b/xdr/main.go
@@ -47,7 +47,7 @@ func safeUnmarshalString(decoder func(reader io.Reader) io.Reader, data string, 
 }
 
 // SafeUnmarshalBase64 first decodes the provided reader from base64 before
-// decoding the xdr into the provided destination.  Also ensures that the reader
+// decoding the xdr into the provided destination. Also ensures that the reader
 // is fully consumed.
 func SafeUnmarshalBase64(data string, dest interface{}) error {
 	return safeUnmarshalString(
@@ -60,7 +60,7 @@ func SafeUnmarshalBase64(data string, dest interface{}) error {
 }
 
 // SafeUnmarshalHex first decodes the provided reader from hex before
-// decoding the xdr into the provided destination.  Also ensures that the reader
+// decoding the xdr into the provided destination. Also ensures that the reader
 // is fully consumed.
 func SafeUnmarshalHex(data string, dest interface{}) error {
 	return safeUnmarshalString(hex.NewDecoder, data, dest)
@@ -101,6 +101,82 @@ func MarshalBase64(v interface{}) (string, error) {
 
 func MarshalHex(v interface{}) (string, error) {
 	return marshalString(hex.EncodeToString, v)
+}
+
+// Encoder reuses internal buffers between invocations
+// to minimize allocations.
+type Encoder struct {
+	encoder          *xdr.Encoder
+	xdrEncoderBuf    bytes.Buffer
+	otherEncodersBuf []byte
+}
+
+func growSlice(old []byte, newSize int) []byte {
+	oldCap := cap(old)
+	if newSize <= oldCap {
+		return old[:newSize]
+	}
+	// the array doesn't fit, lets return a new one with double the capacity
+	// to avoid further resizing
+	return make([]byte, newSize, 2*newSize)
+}
+
+func NewEncoder() *Encoder {
+	var ret Encoder
+	ret.encoder = xdr.NewEncoder(&ret.xdrEncoderBuf)
+	return &ret
+}
+
+// UnsafeMarshalBinary marshals the input XDR binary, returning
+// a slice pointing to the internal encoder's buffer. Handled with care, this saves
+// allows copying the buffer (e.g. like when returning a string).
+// Subsequent calls to marshalling methods will overwrite the returned buffer.
+func (e *Encoder) UnsafeMarshalBinary(v interface{}) ([]byte, error) {
+	e.xdrEncoderBuf.Reset()
+	if _, err := e.encoder.Encode(v); err != nil {
+		return nil, err
+	}
+	return e.xdrEncoderBuf.Bytes(), nil
+}
+
+// UnsafeMarshalBase64 is the base64 version of UnsafeMarshalBinary
+func (e *Encoder) UnsafeMarshalBase64(v interface{}) ([]byte, error) {
+	xdrEncoded, err := e.UnsafeMarshalBinary(v)
+	if err != nil {
+		return nil, err
+	}
+	neededLen := base64.StdEncoding.EncodedLen(len(xdrEncoded))
+	e.otherEncodersBuf = growSlice(e.otherEncodersBuf, neededLen)
+	base64.StdEncoding.Encode(e.otherEncodersBuf, xdrEncoded)
+	return e.otherEncodersBuf, nil
+}
+
+// UnsafeMarshalHex is the hex version of UnsafeMarshalBinary
+func (e *Encoder) UnsafeMarshalHex(v interface{}) ([]byte, error) {
+	xdrEncoded, err := e.UnsafeMarshalBinary(v)
+	if err != nil {
+		return nil, err
+	}
+	neededLen := hex.EncodedLen(len(xdrEncoded))
+	e.otherEncodersBuf = growSlice(e.otherEncodersBuf, neededLen)
+	hex.Encode(e.otherEncodersBuf, xdrEncoded)
+	return e.otherEncodersBuf, nil
+}
+
+func (e *Encoder) MarshalBase64(v interface{}) (string, error) {
+	b, err := e.UnsafeMarshalBase64(v)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func (e *Encoder) MarshalHex(v interface{}) (string, error) {
+	b, err := e.UnsafeMarshalHex(v)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 func MarshalFramed(w io.Writer, v interface{}) error {

--- a/xdr/main.go
+++ b/xdr/main.go
@@ -83,24 +83,14 @@ func SafeUnmarshal(data []byte, dest interface{}) error {
 	return nil
 }
 
-func marshalString(encoder func([]byte) string, v interface{}) (string, error) {
-	var raw bytes.Buffer
-
-	_, err := Marshal(&raw, v)
-
-	if err != nil {
-		return "", err
-	}
-
-	return encoder(raw.Bytes()), nil
-}
-
 func MarshalBase64(v interface{}) (string, error) {
-	return marshalString(base64.StdEncoding.EncodeToString, v)
+	e := NewEncoder()
+	return e.MarshalBase64(v)
 }
 
 func MarshalHex(v interface{}) (string, error) {
-	return marshalString(hex.EncodeToString, v)
+	e := NewEncoder()
+	return e.MarshalHex(v)
 }
 
 // Encoder reuses internal buffers between invocations

--- a/xdr/main.go
+++ b/xdr/main.go
@@ -83,18 +83,28 @@ func SafeUnmarshal(data []byte, dest interface{}) error {
 	return nil
 }
 
+func marshalString(encoder func([]byte) string, v interface{}) (string, error) {
+	var raw bytes.Buffer
+
+	_, err := Marshal(&raw, v)
+
+	if err != nil {
+		return "", err
+	}
+
+	return encoder(raw.Bytes()), nil
+}
+
 func MarshalBase64(v interface{}) (string, error) {
-	e := NewEncodingBuffer()
-	return e.MarshalBase64(v)
+	return marshalString(base64.StdEncoding.EncodeToString, v)
 }
 
 func MarshalHex(v interface{}) (string, error) {
-	e := NewEncodingBuffer()
-	return e.MarshalHex(v)
+	return marshalString(hex.EncodeToString, v)
 }
 
-// EncodingBuffer reuses internal buffers between invocations
-// to minimize allocations.
+// EncodingBuffer reuses internal buffers between invocations to minimize allocations.
+// It intentionally only allows EncodeTo method arguments, to guarantee high performance encoding.
 type EncodingBuffer struct {
 	encoder          *xdr.Encoder
 	xdrEncoderBuf    bytes.Buffer
@@ -111,7 +121,7 @@ func growSlice(old []byte, newSize int) []byte {
 	return make([]byte, newSize, 2*newSize)
 }
 
-type xdrEncodable interface {
+type XDREncodable interface {
 	EncodeTo(e *xdr.Encoder) error
 }
 
@@ -125,24 +135,17 @@ func NewEncodingBuffer() *EncodingBuffer {
 // a slice pointing to the internal buffer. Handled with care this improveds
 // performance since copying is not required.
 // Subsequent calls to marshalling methods will overwrite the returned buffer.
-func (e *EncodingBuffer) UnsafeMarshalBinary(v interface{}) ([]byte, error) {
+func (e *EncodingBuffer) UnsafeMarshalBinary(encodable XDREncodable) ([]byte, error) {
 	e.xdrEncoderBuf.Reset()
-	if encodable, ok := v.(xdrEncodable); ok {
-		// higher performance
-		if err := encodable.EncodeTo(e.encoder); err != nil {
-			return nil, err
-		}
-	} else {
-		if _, err := e.encoder.Encode(v); err != nil {
-			return nil, err
-		}
+	if err := encodable.EncodeTo(e.encoder); err != nil {
+		return nil, err
 	}
 	return e.xdrEncoderBuf.Bytes(), nil
 }
 
 // UnsafeMarshalBase64 is the base64 version of UnsafeMarshalBinary
-func (e *EncodingBuffer) UnsafeMarshalBase64(v interface{}) ([]byte, error) {
-	xdrEncoded, err := e.UnsafeMarshalBinary(v)
+func (e *EncodingBuffer) UnsafeMarshalBase64(encodable XDREncodable) ([]byte, error) {
+	xdrEncoded, err := e.UnsafeMarshalBinary(encodable)
 	if err != nil {
 		return nil, err
 	}
@@ -153,8 +156,8 @@ func (e *EncodingBuffer) UnsafeMarshalBase64(v interface{}) ([]byte, error) {
 }
 
 // UnsafeMarshalHex is the hex version of UnsafeMarshalBinary
-func (e *EncodingBuffer) UnsafeMarshalHex(v interface{}) ([]byte, error) {
-	xdrEncoded, err := e.UnsafeMarshalBinary(v)
+func (e *EncodingBuffer) UnsafeMarshalHex(encodable XDREncodable) ([]byte, error) {
+	xdrEncoded, err := e.UnsafeMarshalBinary(encodable)
 	if err != nil {
 		return nil, err
 	}
@@ -164,16 +167,16 @@ func (e *EncodingBuffer) UnsafeMarshalHex(v interface{}) ([]byte, error) {
 	return e.otherEncodersBuf, nil
 }
 
-func (e *EncodingBuffer) MarshalBase64(v interface{}) (string, error) {
-	b, err := e.UnsafeMarshalBase64(v)
+func (e *EncodingBuffer) MarshalBase64(encodable XDREncodable) (string, error) {
+	b, err := e.UnsafeMarshalBase64(encodable)
 	if err != nil {
 		return "", err
 	}
 	return string(b), nil
 }
 
-func (e *EncodingBuffer) MarshalHex(v interface{}) (string, error) {
-	b, err := e.UnsafeMarshalHex(v)
+func (e *EncodingBuffer) MarshalHex(encodable XDREncodable) (string, error) {
+	b, err := e.UnsafeMarshalHex(encodable)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The improvement is considerable. It reduces the allocations (and CPU consumption) by roughly half.

```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go/benchmarks
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkXDRMarshal
BenchmarkXDRMarshal-8                          	 1000000	      1050 ns/op	    1352 B/op	      14 allocs/op
BenchmarkXDRMarshalWithEncoder
BenchmarkXDRMarshalWithEncoder-8               	 1909111	       619.1 ns/op	     176 B/op	       9 allocs/op
BenchmarkGXDRMarshal
BenchmarkGXDRMarshal-8                         	  151929	      7880 ns/op	    2152 B/op	     157 allocs/op
BenchmarkXDRMarshalHex
BenchmarkXDRMarshalHex-8                       	  473662	      2199 ns/op	    3640 B/op	      19 allocs/op
BenchmarkXDRMarshalHexWithEncoder
BenchmarkXDRMarshalHexWithEncoder-8            	  846926	      1406 ns/op	    1072 B/op	      10 allocs/op
BenchmarkXDRUnsafeMarshalHexWithEncoder
BenchmarkXDRUnsafeMarshalHexWithEncoder-8      	 1000000	      1137 ns/op	     176 B/op	       9 allocs/op
BenchmarkXDRMarshalBase64
BenchmarkXDRMarshalBase64-8                    	  555267	      1918 ns/op	    3000 B/op	      19 allocs/op
BenchmarkXDRMarshalBase64WithEncoder
BenchmarkXDRMarshalBase64WithEncoder-8         	  998617	      1217 ns/op	     752 B/op	      10 allocs/op
BenchmarkXDRUnsafeMarshalBase64WithEncoder
BenchmarkXDRUnsafeMarshalBase64WithEncoder-8   	 1000000	      1048 ns/op	     176 B/op	       9 allocs/op
PASS
```

Note how xdr encoding now smashes the performance of the gxdr encoder (which used to be better than the xdr encoder).