### PR TITLE
doc: use pull request title pattern for issues too

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@ Check out the [Stellar Contribution Guide](https://github.com/stellar/.github/bl
 ### Issues
 
 * Issues and PR titles start with:
-  * The package name most affected, ex. `services/horizon: fix...`.
+  * The package name most affected, ex. `ingest: fix...`.
+  * Or, for services and tools, the service most affected, ex. `services/horizon: fix...`, `services/ticker: add...`
   * Or, multiple package names separated by a comma when the fix addresses multiple packages worth noting, ex. `services/horizon, services/friendbot: fix...`.
   * Or, `all:` when changes are broad, ex. `all: update...`.
   * Or, `doc:` when changes are isolated to non-code documentation not limited to a single package.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ Check out the [Stellar Contribution Guide](https://github.com/stellar/.github/bl
 * Label issues with `feature request` if they're a feature request.
 
 ### Pull Requests
+
 * PR titles follow the same rules as described in the [Issues](#Issues) section above.
 * PRs must update the [CHANGELOG](CHANGELOG.md) with a small description of the change
 * PRs are merged into master or release branch using squash merge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Check out the [Stellar Contribution Guide](https://github.com/stellar/.github/bl
 * Label issues with `feature request` if they're a feature request.
 
 ### Pull Requests
-
+* PR titles follow the same rules as described in the [Issues](#Issues) section above.
 * PRs must update the [CHANGELOG](CHANGELOG.md) with a small description of the change
 * PRs are merged into master or release branch using squash merge
 * Carefully think about where your PR fits according to [semver](https://semver.org). Target it at master if it’s only a patch change, otherwise if it contains breaking change or significant feature additions, set the base branch to the next major or minor release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ Check out the [Stellar Contribution Guide](https://github.com/stellar/.github/bl
   * The package name most affected, ex. `ingest: fix...`.
   * Or, for services and tools, the service most affected, ex. `services/horizon: fix...`, `services/ticker: add...`
   * Or, multiple package names separated by a comma when the fix addresses multiple packages worth noting, ex. `services/horizon, services/friendbot: fix...`.
-  * Or, `all:` when changes are broad, ex. `all: update...`.
-  * Or, `doc:` when changes are isolated to non-code documentation not limited to a single package.
+  * Or, `all:` when changes or an issue are broad, ex. `all: update...`.
+  * Or, `doc:` when changes or an issue are isolated to non-code documentation not limited to a single package.
 * Label issues with `bug` if they're clearly a bug.
 * Label issues with `feature request` if they're a feature request.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,18 @@ Check out the [Stellar Contribution Guide](https://github.com/stellar/.github/bl
 * Use the present tense ("Add feature" not "Added feature")
 * Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
 
-### Pull Requests
+### Issues
 
-* PR titles start with:
+* Issues and PR titles start with:
   * The package name most affected, ex. `services/horizon: fix...`.
   * Or, multiple package names separated by a comma when the fix addresses multiple packages worth noting, ex. `services/horizon, services/friendbot: fix...`.
   * Or, `all:` when changes are broad, ex. `all: update...`.
   * Or, `doc:` when changes are isolated to non-code documentation not limited to a single package.
+* Label issues with `bug` if they're clearly a bug.
+* Label issues with `feature request` if they're a feature request.
+
+### Pull Requests
+
 * PRs must update the [CHANGELOG](CHANGELOG.md) with a small description of the change
 * PRs are merged into master or release branch using squash merge
 * Carefully think about where your PR fits according to [semver](https://semver.org). Target it at master if it’s only a patch change, otherwise if it contains breaking change or significant feature additions, set the base branch to the next major or minor release.


### PR DESCRIPTION
 ### What

Prefix issues by their primarily affected service or area of the monorepo.

### Why

It's difficult to sometimes understand what the scope of an issue is because our issue titles assume the reader has some prior knowledge that the scope relates to the Go SDK, or Horizon, or something else. Sometimes we don't provide this context at all in the title, other times the context can be found in labels, and other times we do mention it in the title but inside the text.

We have a really clear pattern for communicating this in pull requests: we prefix titles with their area most affected. This results in pull requests having titles like `services/ticker: ...` or `ingest: ...`. This pattern can be applied to issues as well.

We have several teams working in this repository and so context is not always obvious to people in other teams.

The Go community also has a well established pattern of using this for issues at pull requests in the golang/go repo, and it shows up in the ecosystem too, and it is a helpful pattern in that much larger complex repo, so should scale well here too.

### Known limitations

N/A