### PR TITLE
services/friendbot: remove disabled error messages that is dead code

### DIFF
--- a/services/friendbot/internal/friendbot_handler.go
+++ b/services/friendbot/internal/friendbot_handler.go
@@ -32,12 +32,7 @@ func (handler *FriendbotHandler) Handle(w http.ResponseWriter, r *http.Request) 
 
 // doHandle is just a convenience method that returns the object to be rendered
 func (handler *FriendbotHandler) doHandle(r *http.Request) (*horizon.Transaction, error) {
-	err := handler.checkEnabled()
-	if err != nil {
-		return nil, err
-	}
-
-	err = r.ParseForm()
+	err := r.ParseForm()
 	if err != nil {
 		p := problem.BadRequest
 		p.Detail = "Request parameters are not escaped or incorrectly formatted."
@@ -49,19 +44,6 @@ func (handler *FriendbotHandler) doHandle(r *http.Request) (*horizon.Transaction
 		return nil, problem.MakeInvalidFieldProblem("addr", err)
 	}
 	return handler.Friendbot.Pay(address)
-}
-
-func (handler *FriendbotHandler) checkEnabled() error {
-	if handler.Friendbot != nil {
-		return nil
-	}
-
-	return &problem.P{
-		Type:   "friendbot_disabled",
-		Title:  "Friendbot is disabled",
-		Status: http.StatusForbidden,
-		Detail: "Friendbot is disabled on this network. Contact the server administrator if you believe this to be in error.",
-	}
 }
 
 func (handler *FriendbotHandler) loadAddress(r *http.Request) (string, error) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove the error messages for when friendbot is disabled.

### Why

Friendbot is never disabled. The field that this code checks is always set with a value, and so the error is never triggered. I think this code is old code that is probably from the days when friendbot was a part of Horizon and could be disabled within Horizon. Now the code is always enabled because for networks that don't have friendbot functionality we simply don't deploy friendbot.

### Known limitations

N/A