### PR TITLE
services/horizon: Implement horizon db fill-gaps command

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -9,6 +9,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Add a new horizon flag `--max-assets-per-path-request` (`15` by default) that sets the number of assets to consider for strict-send and strict-recieve ([4046](https://github.com/stellar/go/pull/4046))
 * Add an endpoint that allows querying for which liquidity pools an account is participating in [4043](https://github.com/stellar/go/pull/4043)
+* Add a new horizon command `horizon db fill-gaps` which fills any gaps in history in the horizon db. The command takes optional start and end ledger parameters. If the start and end ledger is provided then horizon will only fill the gaps found within the given ledger range [4060](https://github.com/stellar/go/pull/4060)
 
 ## v2.10.0
 

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -302,7 +302,12 @@ var dbReingestRangeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return runDBReingestRange([][2]uint32{{argsUInt32[0], argsUInt32[1]}}, reingestForce, parallelWorkers, *config)
+		return runDBReingestRange(
+			[]history.LedgerRange{{StartSequence: argsUInt32[0], EndSequence: argsUInt32[1]}},
+			reingestForce,
+			parallelWorkers,
+			*config,
+		)
 	},
 }
 
@@ -344,7 +349,7 @@ var dbFillGapsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		var gaps []history.LedgerGap
+		var gaps []history.LedgerRange
 		if withRange {
 			gaps, err = runDBDetectGapsInRange(*config, uint32(start), uint32(end))
 			if err != nil {
@@ -359,15 +364,11 @@ var dbFillGapsCmd = &cobra.Command{
 			hlog.Infof("found gaps %v", gaps)
 		}
 
-		var ledgerRanges [][2]uint32
-		for _, gap := range gaps {
-			ledgerRanges = append(ledgerRanges, [2]uint32{gap.StartSequence, gap.EndSequence})
-		}
-		return runDBReingestRange(ledgerRanges, reingestForce, parallelWorkers, *config)
+		return runDBReingestRange(gaps, reingestForce, parallelWorkers, *config)
 	},
 }
 
-func runDBReingestRange(ledgerRanges [][2]uint32, reingestForce bool, parallelWorkers uint, config horizon.Config) error {
+func runDBReingestRange(ledgerRanges []history.LedgerRange, reingestForce bool, parallelWorkers uint, config horizon.Config) error {
 	if reingestForce && parallelWorkers > 1 {
 		return errors.New("--force is incompatible with --parallel-workers > 1")
 	}
@@ -466,7 +467,7 @@ var dbDetectGapsCmd = &cobra.Command{
 	},
 }
 
-func runDBDetectGaps(config horizon.Config) ([]history.LedgerGap, error) {
+func runDBDetectGaps(config horizon.Config) ([]history.LedgerRange, error) {
 	horizonSession, err := db.Open("postgres", config.DatabaseURL)
 	if err != nil {
 		return nil, err
@@ -475,7 +476,7 @@ func runDBDetectGaps(config horizon.Config) ([]history.LedgerGap, error) {
 	return q.GetLedgerGaps(context.Background())
 }
 
-func runDBDetectGapsInRange(config horizon.Config, start, end uint32) ([]history.LedgerGap, error) {
+func runDBDetectGapsInRange(config horizon.Config, start, end uint32) ([]history.LedgerRange, error) {
 	horizonSession, err := db.Open("postgres", config.DatabaseURL)
 	if err != nil {
 		return nil, err

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -292,7 +292,7 @@ var dbReingestRangeCmd = &cobra.Command{
 		for i, arg := range args {
 			if seq, err := strconv.ParseUint(arg, 10, 32); err != nil {
 				cmd.Usage()
-				return fmt.Errorf(`Invalid sequence number "%s"`, arg)
+				return fmt.Errorf(`invalid sequence number "%s"`, arg)
 			} else {
 				argsUInt32[i] = uint32(seq)
 			}
@@ -302,26 +302,72 @@ var dbReingestRangeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = runDBReingestRange(argsUInt32[0], argsUInt32[1], reingestForce, parallelWorkers, *config)
-		if err != nil {
-			if _, ok := errors.Cause(err).(ingest.ErrReingestRangeConflict); ok {
-				return fmt.Errorf(`The range you have provided overlaps with Horizon's most recently ingested ledger.
-It is not possible to run the reingest command on this range in parallel with
-Horizon's ingestion system.
-Either reduce the range so that it doesn't overlap with Horizon's ingestion system,
-or, use the force flag to ensure that Horizon's ingestion system is blocked until
-the reingest command completes.`)
-			}
-
-			return err
-		}
-
-		hlog.Info("Range run successfully!")
-		return nil
+		return runDBReingestRange([][2]uint32{{argsUInt32[0], argsUInt32[1]}}, reingestForce, parallelWorkers, *config)
 	},
 }
 
-func runDBReingestRange(from, to uint32, reingestForce bool, parallelWorkers uint, config horizon.Config) error {
+var dbFillGapsCmd = &cobra.Command{
+	Use:   "fill-gaps [Start sequence number] [End sequence number]",
+	Short: "Ingests any gaps found in the horizon db",
+	Long:  "Ingests any gaps found in the horizon db. The command takes an optional start and end parameters which restrict the range of ledgers ingested.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		for _, co := range reingestRangeCmdOpts {
+			if err := co.RequireE(); err != nil {
+				return err
+			}
+			co.SetValue()
+		}
+
+		if len(args) != 0 && len(args) != 2 {
+			hlog.Errorf("Expected either 0 arguments or 2 but found %v arguments", len(args))
+			return ErrUsage{cmd}
+		}
+
+		var start, end uint64
+		var withRange bool
+		if len(args) == 2 {
+			var err error
+			start, err = strconv.ParseUint(args[0], 10, 32)
+			if err != nil {
+				cmd.Usage()
+				return fmt.Errorf(`invalid sequence number "%s"`, args[0])
+			}
+			end, err = strconv.ParseUint(args[1], 10, 32)
+			if err != nil {
+				cmd.Usage()
+				return fmt.Errorf(`invalid sequence number "%s"`, args[1])
+			}
+			withRange = true
+		}
+
+		err := horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true})
+		if err != nil {
+			return err
+		}
+		var gaps []history.LedgerGap
+		if withRange {
+			gaps, err = runDBDetectGapsInRange(*config, uint32(start), uint32(end))
+			if err != nil {
+				return err
+			}
+			hlog.Infof("found gaps %v within range [%v, %v]", gaps, start, end)
+		} else {
+			gaps, err = runDBDetectGaps(*config)
+			if err != nil {
+				return err
+			}
+			hlog.Infof("found gaps %v", gaps)
+		}
+
+		var ledgerRanges [][2]uint32
+		for _, gap := range gaps {
+			ledgerRanges = append(ledgerRanges, [2]uint32{gap.StartSequence, gap.EndSequence})
+		}
+		return runDBReingestRange(ledgerRanges, reingestForce, parallelWorkers, *config)
+	},
+}
+
+func runDBReingestRange(ledgerRanges [][2]uint32, reingestForce bool, parallelWorkers uint, config horizon.Config) error {
 	if reingestForce && parallelWorkers > 1 {
 		return errors.New("--force is incompatible with --parallel-workers > 1")
 	}
@@ -364,8 +410,7 @@ func runDBReingestRange(from, to uint32, reingestForce bool, parallelWorkers uin
 		}
 
 		return system.ReingestRange(
-			from,
-			to,
+			ledgerRanges,
 			parallelJobSize,
 		)
 	}
@@ -375,11 +420,21 @@ func runDBReingestRange(from, to uint32, reingestForce bool, parallelWorkers uin
 		return systemErr
 	}
 
-	return system.ReingestRange(
-		from,
-		to,
-		reingestForce,
-	)
+	err = system.ReingestRange(ledgerRanges, reingestForce)
+	if err != nil {
+		if _, ok := errors.Cause(err).(ingest.ErrReingestRangeConflict); ok {
+			return fmt.Errorf(`The range you have provided overlaps with Horizon's most recently ingested ledger.
+It is not possible to run the reingest command on this range in parallel with
+Horizon's ingestion system.
+Either reduce the range so that it doesn't overlap with Horizon's ingestion system,
+or, use the force flag to ensure that Horizon's ingestion system is blocked until
+the reingest command completes.`)
+		}
+
+		return err
+	}
+	hlog.Info("Range run successfully!")
+	return nil
 }
 
 var dbDetectGapsCmd = &cobra.Command{
@@ -420,15 +475,29 @@ func runDBDetectGaps(config horizon.Config) ([]history.LedgerGap, error) {
 	return q.GetLedgerGaps(context.Background())
 }
 
+func runDBDetectGapsInRange(config horizon.Config, start, end uint32) ([]history.LedgerGap, error) {
+	horizonSession, err := db.Open("postgres", config.DatabaseURL)
+	if err != nil {
+		return nil, err
+	}
+	q := &history.Q{horizonSession}
+	return q.GetLedgerGapsInRange(context.Background(), start, end)
+}
+
 func init() {
 	for _, co := range reingestRangeCmdOpts {
 		err := co.Init(dbReingestRangeCmd)
 		if err != nil {
 			log.Fatal(err.Error())
 		}
+		err = co.Init(dbFillGapsCmd)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
 	}
 
 	viper.BindPFlags(dbReingestRangeCmd.PersistentFlags())
+	viper.BindPFlags(dbFillGapsCmd.PersistentFlags())
 
 	RootCmd.AddCommand(dbCmd)
 	dbCmd.AddCommand(
@@ -437,6 +506,7 @@ func init() {
 		dbReapCmd,
 		dbReingestCmd,
 		dbDetectGapsCmd,
+		dbFillGapsCmd,
 	)
 	dbMigrateCmd.AddCommand(
 		dbMigrateDownCmd,

--- a/services/horizon/internal/db2/history/ledger.go
+++ b/services/horizon/internal/db2/history/ledger.go
@@ -130,11 +130,11 @@ func (q *Q) InsertLedger(ctx context.Context,
 	return result.RowsAffected()
 }
 
-// GetLedgerGaps, obtains ingestion gaps in the history_ledgers table.
+// GetLedgerGaps obtains ingestion gaps in the history_ledgers table.
 // Returns the gaps and error.
 func (q *Q) GetLedgerGaps(ctx context.Context) ([]LedgerGap, error) {
-	var result []LedgerGap
-	err := q.SelectRaw(ctx, &result, `
+	var gaps []LedgerGap
+	query := `
     SELECT sequence + 1 AS gap_start,
 		next_number - 1 AS gap_end
 	FROM (
@@ -142,8 +142,79 @@ func (q *Q) GetLedgerGaps(ctx context.Context) ([]LedgerGap, error) {
 		LEAD(sequence) OVER (ORDER BY sequence) AS next_number
 	FROM history_ledgers
 	) number
-	WHERE sequence + 1 <> next_number;`)
-	return result, err
+	WHERE sequence + 1 <> next_number;`
+	if err := q.SelectRaw(ctx, &gaps, query); err != nil {
+		return nil, err
+	}
+	return gaps, nil
+}
+
+func max(a, b uint32) uint32 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b uint32) uint32 {
+	if a > b {
+		return b
+	}
+	return a
+}
+
+// GetLedgerGapsInRange obtains ingestion gaps in the history_ledgers table within the given range.
+// Returns the gaps and error.
+func (q *Q) GetLedgerGapsInRange(ctx context.Context, start, end uint32) ([]LedgerGap, error) {
+	var result []LedgerGap
+	var oldestLedger, latestLedger uint32
+
+	if err := q.ElderLedger(ctx, &oldestLedger); err != nil {
+		return nil, errors.Wrap(err, "Could not query elder ledger")
+	} else if oldestLedger == 0 {
+		return []LedgerGap{{
+			StartSequence: start,
+			EndSequence:   end,
+		}}, nil
+	}
+
+	if err := q.LatestLedger(ctx, &latestLedger); err != nil {
+		return nil, errors.Wrap(err, "Could not query latest ledger")
+	}
+
+	if start < oldestLedger {
+		result = append(result, LedgerGap{
+			StartSequence: start,
+			EndSequence:   min(end, oldestLedger-1),
+		})
+	}
+
+	gaps, err := q.GetLedgerGaps(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, gap := range gaps {
+		if gap.EndSequence < start {
+			continue
+		}
+		if gap.StartSequence > end {
+			break
+		}
+		result = append(result, LedgerGap{
+			StartSequence: max(gap.StartSequence, start),
+			EndSequence:   min(gap.EndSequence, end),
+		})
+	}
+
+	if latestLedger < end {
+		result = append(result, LedgerGap{
+			StartSequence: max(latestLedger+1, start),
+			EndSequence:   end,
+		})
+	}
+
+	return result, nil
 }
 
 func ledgerHeaderToMap(

--- a/services/horizon/internal/db2/history/ledger.go
+++ b/services/horizon/internal/db2/history/ledger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -132,11 +133,11 @@ func (q *Q) InsertLedger(ctx context.Context,
 
 // GetLedgerGaps obtains ingestion gaps in the history_ledgers table.
 // Returns the gaps and error.
-func (q *Q) GetLedgerGaps(ctx context.Context) ([]LedgerGap, error) {
-	var gaps []LedgerGap
+func (q *Q) GetLedgerGaps(ctx context.Context) ([]LedgerRange, error) {
+	var gaps []LedgerRange
 	query := `
-    SELECT sequence + 1 AS gap_start,
-		next_number - 1 AS gap_end
+    SELECT sequence + 1 AS start,
+		next_number - 1 AS end
 	FROM (
 		SELECT sequence,
 		LEAD(sequence) OVER (ORDER BY sequence) AS next_number
@@ -146,6 +147,9 @@ func (q *Q) GetLedgerGaps(ctx context.Context) ([]LedgerGap, error) {
 	if err := q.SelectRaw(ctx, &gaps, query); err != nil {
 		return nil, err
 	}
+	sort.Slice(gaps, func(i, j int) bool {
+		return gaps[i].StartSequence < gaps[j].StartSequence
+	})
 	return gaps, nil
 }
 
@@ -165,14 +169,14 @@ func min(a, b uint32) uint32 {
 
 // GetLedgerGapsInRange obtains ingestion gaps in the history_ledgers table within the given range.
 // Returns the gaps and error.
-func (q *Q) GetLedgerGapsInRange(ctx context.Context, start, end uint32) ([]LedgerGap, error) {
-	var result []LedgerGap
+func (q *Q) GetLedgerGapsInRange(ctx context.Context, start, end uint32) ([]LedgerRange, error) {
+	var result []LedgerRange
 	var oldestLedger, latestLedger uint32
 
 	if err := q.ElderLedger(ctx, &oldestLedger); err != nil {
 		return nil, errors.Wrap(err, "Could not query elder ledger")
 	} else if oldestLedger == 0 {
-		return []LedgerGap{{
+		return []LedgerRange{{
 			StartSequence: start,
 			EndSequence:   end,
 		}}, nil
@@ -183,10 +187,13 @@ func (q *Q) GetLedgerGapsInRange(ctx context.Context, start, end uint32) ([]Ledg
 	}
 
 	if start < oldestLedger {
-		result = append(result, LedgerGap{
+		result = append(result, LedgerRange{
 			StartSequence: start,
 			EndSequence:   min(end, oldestLedger-1),
 		})
+	}
+	if end <= oldestLedger {
+		return result, nil
 	}
 
 	gaps, err := q.GetLedgerGaps(ctx)
@@ -201,14 +208,14 @@ func (q *Q) GetLedgerGapsInRange(ctx context.Context, start, end uint32) ([]Ledg
 		if gap.StartSequence > end {
 			break
 		}
-		result = append(result, LedgerGap{
+		result = append(result, LedgerRange{
 			StartSequence: max(gap.StartSequence, start),
 			EndSequence:   min(gap.EndSequence, end),
 		})
 	}
 
 	if latestLedger < end {
-		result = append(result, LedgerGap{
+		result = append(result, LedgerRange{
 			StartSequence: max(latestLedger+1, start),
 			EndSequence:   end,
 		})

--- a/services/horizon/internal/db2/history/ledger_test.go
+++ b/services/horizon/internal/db2/history/ledger_test.go
@@ -236,7 +236,7 @@ func TestGetLedgerGaps(t *testing.T) {
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 1, 100)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 1, EndSequence: 100}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 1, EndSequence: 100}}, gaps)
 
 	// Lets insert a few gaps and make sure they are detected incrementally
 	insertLedgerWithSequence(tt, q, 4)
@@ -252,19 +252,19 @@ func TestGetLedgerGaps(t *testing.T) {
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 1, 2)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 1, EndSequence: 2}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 1, EndSequence: 2}}, gaps)
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 1, 3)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 1, EndSequence: 3}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 1, EndSequence: 3}}, gaps)
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 1, 6)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 1, EndSequence: 3}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 1, EndSequence: 3}}, gaps)
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 3, 5)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 3, EndSequence: 3}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 3, EndSequence: 3}}, gaps)
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 4, 6)
 	tt.Assert.NoError(err)
@@ -272,21 +272,21 @@ func TestGetLedgerGaps(t *testing.T) {
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 4, 8)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 8, EndSequence: 8}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 8, EndSequence: 8}}, gaps)
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 4, 10)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 8, EndSequence: 10}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 8, EndSequence: 10}}, gaps)
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 8, 10)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 8, EndSequence: 10}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 8, EndSequence: 10}}, gaps)
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 9, 11)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 9, EndSequence: 11}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 9, EndSequence: 11}}, gaps)
 
-	var expectedGaps []LedgerGap
+	var expectedGaps []LedgerRange
 
 	insertLedgerWithSequence(tt, q, 99)
 	insertLedgerWithSequence(tt, q, 100)
@@ -295,45 +295,45 @@ func TestGetLedgerGaps(t *testing.T) {
 
 	gaps, err = q.GetLedgerGaps(context.Background())
 	tt.Assert.NoError(err)
-	expectedGaps = append(expectedGaps, LedgerGap{8, 98})
+	expectedGaps = append(expectedGaps, LedgerRange{8, 98})
 	tt.Assert.Equal(expectedGaps, gaps)
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 10, 11)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 10, EndSequence: 11}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 10, EndSequence: 11}}, gaps)
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 4, 11)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 8, EndSequence: 11}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 8, EndSequence: 11}}, gaps)
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 1, 11)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 1, EndSequence: 3}, {StartSequence: 8, EndSequence: 11}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 1, EndSequence: 3}, {StartSequence: 8, EndSequence: 11}}, gaps)
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 10, 105)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 10, EndSequence: 98}, {StartSequence: 103, EndSequence: 105}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 10, EndSequence: 98}, {StartSequence: 103, EndSequence: 105}}, gaps)
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 100, 105)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 103, EndSequence: 105}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 103, EndSequence: 105}}, gaps)
 
 	gaps, err = q.GetLedgerGapsInRange(context.Background(), 105, 110)
 	tt.Assert.NoError(err)
-	tt.Assert.Equal([]LedgerGap{{StartSequence: 105, EndSequence: 110}}, gaps)
+	tt.Assert.Equal([]LedgerRange{{StartSequence: 105, EndSequence: 110}}, gaps)
 
 	// Yet another gap, this time to a single-ledger cluster
 	insertLedgerWithSequence(tt, q, 1000)
 
 	gaps, err = q.GetLedgerGaps(context.Background())
 	tt.Assert.NoError(err)
-	expectedGaps = append(expectedGaps, LedgerGap{103, 999})
+	expectedGaps = append(expectedGaps, LedgerRange{103, 999})
 	tt.Assert.Equal(expectedGaps, gaps)
 
 	// Yet another gap, this time the gap only contains a ledger
 	insertLedgerWithSequence(tt, q, 1002)
 	gaps, err = q.GetLedgerGaps(context.Background())
 	tt.Assert.NoError(err)
-	expectedGaps = append(expectedGaps, LedgerGap{1001, 1001})
+	expectedGaps = append(expectedGaps, LedgerRange{1001, 1001})
 	tt.Assert.Equal(expectedGaps, gaps)
 }

--- a/services/horizon/internal/db2/history/ledger_test.go
+++ b/services/horizon/internal/db2/history/ledger_test.go
@@ -234,6 +234,10 @@ func TestGetLedgerGaps(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Len(gaps, 0)
 
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 1, 100)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 1, EndSequence: 100}}, gaps)
+
 	// Lets insert a few gaps and make sure they are detected incrementally
 	insertLedgerWithSequence(tt, q, 4)
 	insertLedgerWithSequence(tt, q, 5)
@@ -246,6 +250,42 @@ func TestGetLedgerGaps(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Len(gaps, 0)
 
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 1, 2)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 1, EndSequence: 2}}, gaps)
+
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 1, 3)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 1, EndSequence: 3}}, gaps)
+
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 1, 6)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 1, EndSequence: 3}}, gaps)
+
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 3, 5)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 3, EndSequence: 3}}, gaps)
+
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 4, 6)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(gaps, 0)
+
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 4, 8)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 8, EndSequence: 8}}, gaps)
+
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 4, 10)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 8, EndSequence: 10}}, gaps)
+
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 8, 10)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 8, EndSequence: 10}}, gaps)
+
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 9, 11)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 9, EndSequence: 11}}, gaps)
+
 	var expectedGaps []LedgerGap
 
 	insertLedgerWithSequence(tt, q, 99)
@@ -257,6 +297,30 @@ func TestGetLedgerGaps(t *testing.T) {
 	tt.Assert.NoError(err)
 	expectedGaps = append(expectedGaps, LedgerGap{8, 98})
 	tt.Assert.Equal(expectedGaps, gaps)
+
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 10, 11)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 10, EndSequence: 11}}, gaps)
+
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 4, 11)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 8, EndSequence: 11}}, gaps)
+
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 1, 11)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 1, EndSequence: 3}, {StartSequence: 8, EndSequence: 11}}, gaps)
+
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 10, 105)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 10, EndSequence: 98}, {StartSequence: 103, EndSequence: 105}}, gaps)
+
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 100, 105)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 103, EndSequence: 105}}, gaps)
+
+	gaps, err = q.GetLedgerGapsInRange(context.Background(), 105, 110)
+	tt.Assert.NoError(err)
+	tt.Assert.Equal([]LedgerGap{{StartSequence: 105, EndSequence: 110}}, gaps)
 
 	// Yet another gap, this time to a single-ledger cluster
 	insertLedgerWithSequence(tt, q, 1000)
@@ -272,5 +336,4 @@ func TestGetLedgerGaps(t *testing.T) {
 	tt.Assert.NoError(err)
 	expectedGaps = append(expectedGaps, LedgerGap{1001, 1001})
 	tt.Assert.Equal(expectedGaps, gaps)
-
 }

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -576,9 +576,9 @@ type LedgerCache struct {
 	queued map[int32]struct{}
 }
 
-type LedgerGap struct {
-	StartSequence uint32 `db:"gap_start"`
-	EndSequence   uint32 `db:"gap_end"`
+type LedgerRange struct {
+	StartSequence uint32 `db:"start"`
+	EndSequence   uint32 `db:"end"`
 }
 
 // LedgersQ is a helper struct to aid in configuring queries that loads

--- a/services/horizon/internal/ingest/ingest_history_range_state_test.go
+++ b/services/horizon/internal/ingest/ingest_history_range_state_test.go
@@ -309,19 +309,18 @@ func (s *ReingestHistoryRangeStateTestSuite) TearDownTest() {
 func (s *ReingestHistoryRangeStateTestSuite) TestInvalidRange() {
 	// Recreate mock in this single test to remove Rollback assertion.
 	*s.historyQ = mockDBQ{}
-	s.historyQ.On("GetTx").Return(nil)
 
-	err := s.system.ReingestRange(0, 0, false)
-	s.Assert().EqualError(err, "invalid range: [0, 0]")
+	err := s.system.ReingestRange([][2]uint32{{0, 0}}, false)
+	s.Assert().EqualError(err, "Invalid range: [0 0] genesis ledger starts at 1")
 
-	err = s.system.ReingestRange(0, 100, false)
-	s.Assert().EqualError(err, "invalid range: [0, 100]")
+	err = s.system.ReingestRange([][2]uint32{{0, 100}}, false)
+	s.Assert().EqualError(err, "Invalid range: [0 100] genesis ledger starts at 1")
 
-	err = s.system.ReingestRange(100, 0, false)
-	s.Assert().EqualError(err, "invalid range: [100, 0]")
+	err = s.system.ReingestRange([][2]uint32{{100, 0}}, false)
+	s.Assert().EqualError(err, "Invalid range: [100 0] from > to")
 
-	err = s.system.ReingestRange(100, 99, false)
-	s.Assert().EqualError(err, "invalid range: [100, 99]")
+	err = s.system.ReingestRange([][2]uint32{{100, 99}}, false)
+	s.Assert().EqualError(err, "Invalid range: [100 99] from > to")
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestBeginReturnsError() {
@@ -332,7 +331,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestBeginReturnsError() {
 
 	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
 
-	err := s.system.ReingestRange(100, 200, false)
+	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
 	s.Assert().EqualError(err, "Error starting a transaction: my error")
 }
 
@@ -342,7 +341,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestGetLastLedgerIngestNonBlockingE
 
 	s.historyQ.On("GetLastLedgerIngestNonBlocking", s.ctx).Return(uint32(0), errors.New("my error")).Once()
 
-	err := s.system.ReingestRange(100, 200, false)
+	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
 	s.Assert().EqualError(err, "Error getting last ingested ledger: my error")
 }
 
@@ -352,7 +351,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeOverlaps() {
 
 	s.historyQ.On("GetLastLedgerIngestNonBlocking", s.ctx).Return(uint32(190), nil).Once()
 
-	err := s.system.ReingestRange(100, 200, false)
+	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
 	s.Assert().Equal(ErrReingestRangeConflict{190}, err)
 }
 
@@ -362,7 +361,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeOverlapsAtEnd() {
 
 	s.historyQ.On("GetLastLedgerIngestNonBlocking", s.ctx).Return(uint32(200), nil).Once()
 
-	err := s.system.ReingestRange(100, 200, false)
+	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
 	s.Assert().Equal(ErrReingestRangeConflict{200}, err)
 }
 
@@ -381,7 +380,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestClearHistoryFails() {
 
 	s.historyQ.On("Rollback").Return(nil).Once()
 
-	err := s.system.ReingestRange(100, 200, false)
+	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
 	s.Assert().EqualError(err, "error in DeleteRangeAll: my error")
 }
 
@@ -417,7 +416,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedge
 		).Once()
 	s.historyQ.On("Rollback").Return(nil).Once()
 
-	err := s.system.ReingestRange(100, 200, false)
+	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
 	s.Assert().EqualError(err, "error processing ledger sequence=100: my error")
 }
 
@@ -454,7 +453,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestCommitFails() {
 	s.historyQ.On("Commit").Return(errors.New("my error")).Once()
 	s.historyQ.On("Rollback").Return(nil).Once()
 
-	err := s.system.ReingestRange(100, 200, false)
+	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
 	s.Assert().EqualError(err, "Error committing db transaction: my error")
 }
 
@@ -495,7 +494,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestSuccess() {
 	}
 	s.historyQ.On("RebuildTradeAggregationBuckets", s.ctx, uint32(100), uint32(200)).Return(nil).Once()
 
-	err := s.system.ReingestRange(100, 200, false)
+	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
 	s.Assert().NoError(err)
 }
 
@@ -532,14 +531,14 @@ func (s *ReingestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
 	s.ledgerBackend.On("PrepareRange", s.ctx, ledgerbackend.BoundedRange(100, 100)).Return(nil).Once()
 	s.ledgerBackend.On("GetLedger", s.ctx, uint32(100)).Return(meta, nil).Once()
 
-	err := s.system.ReingestRange(100, 100, false)
+	err := s.system.ReingestRange([][2]uint32{{100, 100}}, false)
 	s.Assert().NoError(err)
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestGetLastLedgerIngestError() {
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), errors.New("my error")).Once()
 
-	err := s.system.ReingestRange(100, 200, true)
+	err := s.system.ReingestRange([][2]uint32{{100, 200}}, true)
 	s.Assert().EqualError(err, "Error getting last ingested ledger: my error")
 }
 
@@ -577,6 +576,6 @@ func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeForce() {
 
 	s.historyQ.On("RebuildTradeAggregationBuckets", s.ctx, uint32(100), uint32(200)).Return(nil).Once()
 
-	err := s.system.ReingestRange(100, 200, true)
+	err := s.system.ReingestRange([][2]uint32{{100, 200}}, true)
 	s.Assert().NoError(err)
 }

--- a/services/horizon/internal/ingest/ingest_history_range_state_test.go
+++ b/services/horizon/internal/ingest/ingest_history_range_state_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/stellar/go/ingest/ledgerbackend"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/ingest/processors"
 	"github.com/stellar/go/services/horizon/internal/toid"
 	"github.com/stellar/go/support/errors"
@@ -310,17 +311,17 @@ func (s *ReingestHistoryRangeStateTestSuite) TestInvalidRange() {
 	// Recreate mock in this single test to remove Rollback assertion.
 	*s.historyQ = mockDBQ{}
 
-	err := s.system.ReingestRange([][2]uint32{{0, 0}}, false)
-	s.Assert().EqualError(err, "Invalid range: [0 0] genesis ledger starts at 1")
+	err := s.system.ReingestRange([]history.LedgerRange{{0, 0}}, false)
+	s.Assert().EqualError(err, "Invalid range: {0 0} genesis ledger starts at 1")
 
-	err = s.system.ReingestRange([][2]uint32{{0, 100}}, false)
-	s.Assert().EqualError(err, "Invalid range: [0 100] genesis ledger starts at 1")
+	err = s.system.ReingestRange([]history.LedgerRange{{0, 100}}, false)
+	s.Assert().EqualError(err, "Invalid range: {0 100} genesis ledger starts at 1")
 
-	err = s.system.ReingestRange([][2]uint32{{100, 0}}, false)
-	s.Assert().EqualError(err, "Invalid range: [100 0] from > to")
+	err = s.system.ReingestRange([]history.LedgerRange{{100, 0}}, false)
+	s.Assert().EqualError(err, "Invalid range: {100 0} from > to")
 
-	err = s.system.ReingestRange([][2]uint32{{100, 99}}, false)
-	s.Assert().EqualError(err, "Invalid range: [100 99] from > to")
+	err = s.system.ReingestRange([]history.LedgerRange{{100, 99}}, false)
+	s.Assert().EqualError(err, "Invalid range: {100 99} from > to")
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestBeginReturnsError() {
@@ -331,7 +332,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestBeginReturnsError() {
 
 	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
 
-	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
+	err := s.system.ReingestRange([]history.LedgerRange{{100, 200}}, false)
 	s.Assert().EqualError(err, "Error starting a transaction: my error")
 }
 
@@ -341,7 +342,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestGetLastLedgerIngestNonBlockingE
 
 	s.historyQ.On("GetLastLedgerIngestNonBlocking", s.ctx).Return(uint32(0), errors.New("my error")).Once()
 
-	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
+	err := s.system.ReingestRange([]history.LedgerRange{{100, 200}}, false)
 	s.Assert().EqualError(err, "Error getting last ingested ledger: my error")
 }
 
@@ -351,7 +352,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeOverlaps() {
 
 	s.historyQ.On("GetLastLedgerIngestNonBlocking", s.ctx).Return(uint32(190), nil).Once()
 
-	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
+	err := s.system.ReingestRange([]history.LedgerRange{{100, 200}}, false)
 	s.Assert().Equal(ErrReingestRangeConflict{190}, err)
 }
 
@@ -361,7 +362,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeOverlapsAtEnd() {
 
 	s.historyQ.On("GetLastLedgerIngestNonBlocking", s.ctx).Return(uint32(200), nil).Once()
 
-	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
+	err := s.system.ReingestRange([]history.LedgerRange{{100, 200}}, false)
 	s.Assert().Equal(ErrReingestRangeConflict{200}, err)
 }
 
@@ -380,7 +381,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestClearHistoryFails() {
 
 	s.historyQ.On("Rollback").Return(nil).Once()
 
-	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
+	err := s.system.ReingestRange([]history.LedgerRange{{100, 200}}, false)
 	s.Assert().EqualError(err, "error in DeleteRangeAll: my error")
 }
 
@@ -416,7 +417,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedge
 		).Once()
 	s.historyQ.On("Rollback").Return(nil).Once()
 
-	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
+	err := s.system.ReingestRange([]history.LedgerRange{{100, 200}}, false)
 	s.Assert().EqualError(err, "error processing ledger sequence=100: my error")
 }
 
@@ -453,7 +454,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestCommitFails() {
 	s.historyQ.On("Commit").Return(errors.New("my error")).Once()
 	s.historyQ.On("Rollback").Return(nil).Once()
 
-	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
+	err := s.system.ReingestRange([]history.LedgerRange{{100, 200}}, false)
 	s.Assert().EqualError(err, "Error committing db transaction: my error")
 }
 
@@ -494,7 +495,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestSuccess() {
 	}
 	s.historyQ.On("RebuildTradeAggregationBuckets", s.ctx, uint32(100), uint32(200)).Return(nil).Once()
 
-	err := s.system.ReingestRange([][2]uint32{{100, 200}}, false)
+	err := s.system.ReingestRange([]history.LedgerRange{{100, 200}}, false)
 	s.Assert().NoError(err)
 }
 
@@ -531,14 +532,14 @@ func (s *ReingestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
 	s.ledgerBackend.On("PrepareRange", s.ctx, ledgerbackend.BoundedRange(100, 100)).Return(nil).Once()
 	s.ledgerBackend.On("GetLedger", s.ctx, uint32(100)).Return(meta, nil).Once()
 
-	err := s.system.ReingestRange([][2]uint32{{100, 100}}, false)
+	err := s.system.ReingestRange([]history.LedgerRange{{100, 100}}, false)
 	s.Assert().NoError(err)
 }
 
 func (s *ReingestHistoryRangeStateTestSuite) TestGetLastLedgerIngestError() {
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), errors.New("my error")).Once()
 
-	err := s.system.ReingestRange([][2]uint32{{100, 200}}, true)
+	err := s.system.ReingestRange([]history.LedgerRange{{100, 200}}, true)
 	s.Assert().EqualError(err, "Error getting last ingested ledger: my error")
 }
 
@@ -576,6 +577,6 @@ func (s *ReingestHistoryRangeStateTestSuite) TestReingestRangeForce() {
 
 	s.historyQ.On("RebuildTradeAggregationBuckets", s.ctx, uint32(100), uint32(200)).Return(nil).Once()
 
-	err := s.system.ReingestRange([][2]uint32{{100, 200}}, true)
+	err := s.system.ReingestRange([]history.LedgerRange{{100, 200}}, true)
 	s.Assert().NoError(err)
 }

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -158,7 +158,7 @@ type System interface {
 	Metrics() Metrics
 	StressTest(numTransactions, changesPerTransaction int) error
 	VerifyRange(fromLedger, toLedger uint32, verifyState bool) error
-	ReingestRange(ledgerRanges [][2]uint32, force bool) error
+	ReingestRange(ledgerRanges []history.LedgerRange, force bool) error
 	BuildGenesisState() error
 	Shutdown()
 }
@@ -486,21 +486,20 @@ func (s *system) VerifyRange(fromLedger, toLedger uint32, verifyState bool) erro
 	})
 }
 
-func validateRanges(ledgerRanges [][2]uint32) error {
-	for i, pair := range ledgerRanges {
-		from, to := pair[0], pair[1]
-		if from > to {
-			return errors.Errorf("Invalid range: %v from > to", pair)
+func validateRanges(ledgerRanges []history.LedgerRange) error {
+	for i, cur := range ledgerRanges {
+		if cur.StartSequence > cur.EndSequence {
+			return errors.Errorf("Invalid range: %v from > to", cur)
 		}
-		if from == 0 {
-			return errors.Errorf("Invalid range: %v genesis ledger starts at 1", pair)
+		if cur.StartSequence == 0 {
+			return errors.Errorf("Invalid range: %v genesis ledger starts at 1", cur)
 		}
 		if i == 0 {
 			continue
 		}
 		prev := ledgerRanges[i-1]
-		if prev[1] >= from {
-			return errors.Errorf("ranges are not sorted prevRange %v curRange %v", prev, pair)
+		if prev.EndSequence >= cur.StartSequence {
+			return errors.Errorf("ranges are not sorted prevRange %v curRange %v", prev, cur)
 		}
 	}
 	return nil
@@ -508,22 +507,21 @@ func validateRanges(ledgerRanges [][2]uint32) error {
 
 // ReingestRange runs the ingestion pipeline on the range of ledgers ingesting
 // history data only.
-func (s *system) ReingestRange(ledgerRanges [][2]uint32, force bool) error {
+func (s *system) ReingestRange(ledgerRanges []history.LedgerRange, force bool) error {
 	if err := validateRanges(ledgerRanges); err != nil {
 		return err
 	}
-	for _, pair := range ledgerRanges {
-		fromLedger, toLedger := pair[0], pair[1]
+	for _, cur := range ledgerRanges {
 		run := func() error {
 			return s.runStateMachine(reingestHistoryRangeState{
-				fromLedger: fromLedger,
-				toLedger:   toLedger,
+				fromLedger: cur.StartSequence,
+				toLedger:   cur.EndSequence,
 				force:      force,
 			})
 		}
 		err := run()
 		for retry := 0; err != nil && retry < s.maxReingestRetries; retry++ {
-			log.Warnf("reingest range [%d, %d] failed (%s), retrying", fromLedger, toLedger, err.Error())
+			log.Warnf("reingest range [%d, %d] failed (%s), retrying", cur.StartSequence, cur.EndSequence, err.Error())
 			time.Sleep(time.Second * time.Duration(s.reingestRetryBackoffSeconds))
 			err = run()
 		}

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -158,7 +158,7 @@ type System interface {
 	Metrics() Metrics
 	StressTest(numTransactions, changesPerTransaction int) error
 	VerifyRange(fromLedger, toLedger uint32, verifyState bool) error
-	ReingestRange(fromLedger, toLedger uint32, force bool) error
+	ReingestRange(ledgerRanges [][2]uint32, force bool) error
 	BuildGenesisState() error
 	Shutdown()
 }
@@ -486,23 +486,52 @@ func (s *system) VerifyRange(fromLedger, toLedger uint32, verifyState bool) erro
 	})
 }
 
+func validateRanges(ledgerRanges [][2]uint32) error {
+	for i, pair := range ledgerRanges {
+		from, to := pair[0], pair[1]
+		if from > to {
+			return errors.Errorf("Invalid range: %v from > to", pair)
+		}
+		if from == 0 {
+			return errors.Errorf("Invalid range: %v genesis ledger starts at 1", pair)
+		}
+		if i == 0 {
+			continue
+		}
+		prev := ledgerRanges[i-1]
+		if prev[1] >= from {
+			return errors.Errorf("ranges are not sorted prevRange %v  curRange %v", prev, pair)
+		}
+	}
+	return nil
+}
+
 // ReingestRange runs the ingestion pipeline on the range of ledgers ingesting
 // history data only.
-func (s *system) ReingestRange(fromLedger, toLedger uint32, force bool) error {
-	run := func() error {
-		return s.runStateMachine(reingestHistoryRangeState{
-			fromLedger: fromLedger,
-			toLedger:   toLedger,
-			force:      force,
-		})
+func (s *system) ReingestRange(ledgerRanges [][2]uint32, force bool) error {
+	if err := validateRanges(ledgerRanges); err != nil {
+		return err
 	}
-	err := run()
-	for retry := 0; err != nil && retry < s.maxReingestRetries; retry++ {
-		log.Warnf("reingest range [%d, %d] failed (%s), retrying", fromLedger, toLedger, err.Error())
-		time.Sleep(time.Second * time.Duration(s.reingestRetryBackoffSeconds))
-		err = run()
+	for _, pair := range ledgerRanges {
+		fromLedger, toLedger := pair[0], pair[1]
+		run := func() error {
+			return s.runStateMachine(reingestHistoryRangeState{
+				fromLedger: fromLedger,
+				toLedger:   toLedger,
+				force:      force,
+			})
+		}
+		err := run()
+		for retry := 0; err != nil && retry < s.maxReingestRetries; retry++ {
+			log.Warnf("reingest range [%d, %d] failed (%s), retrying", fromLedger, toLedger, err.Error())
+			time.Sleep(time.Second * time.Duration(s.reingestRetryBackoffSeconds))
+			err = run()
+		}
+		if err != nil {
+			return err
+		}
 	}
-	return err
+	return nil
 }
 
 // BuildGenesisState runs the ingestion pipeline on genesis ledger. Transitions

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -500,7 +500,7 @@ func validateRanges(ledgerRanges [][2]uint32) error {
 		}
 		prev := ledgerRanges[i-1]
 		if prev[1] >= from {
-			return errors.Errorf("ranges are not sorted prevRange %v  curRange %v", prev, pair)
+			return errors.Errorf("ranges are not sorted prevRange %v curRange %v", prev, pair)
 		}
 	}
 	return nil

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -495,7 +495,7 @@ func (m *mockSystem) VerifyRange(fromLedger, toLedger uint32, verifyState bool) 
 	return args.Error(0)
 }
 
-func (m *mockSystem) ReingestRange(ledgerRanges [][2]uint32, force bool) error {
+func (m *mockSystem) ReingestRange(ledgerRanges []history.LedgerRange, force bool) error {
 	args := m.Called(ledgerRanges, force)
 	return args.Error(0)
 }

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -495,8 +495,8 @@ func (m *mockSystem) VerifyRange(fromLedger, toLedger uint32, verifyState bool) 
 	return args.Error(0)
 }
 
-func (m *mockSystem) ReingestRange(fromLedger, toLedger uint32, force bool) error {
-	args := m.Called(fromLedger, toLedger, force)
+func (m *mockSystem) ReingestRange(ledgerRanges [][2]uint32, force bool) error {
+	args := m.Called(ledgerRanges, force)
 	return args.Error(0)
 }
 

--- a/services/horizon/internal/ingest/parallel.go
+++ b/services/horizon/internal/ingest/parallel.go
@@ -58,7 +58,7 @@ func (ps *ParallelSystems) runReingestWorker(s System, stop <-chan struct{}, rei
 		case <-stop:
 			return rangeError{}
 		case reingestRange := <-reingestJobQueue:
-			err := s.ReingestRange(reingestRange.from, reingestRange.to, false)
+			err := s.ReingestRange([][2]uint32{{reingestRange.from, reingestRange.to}}, false)
 			if err != nil {
 				return rangeError{
 					err:         err,
@@ -66,6 +66,25 @@ func (ps *ParallelSystems) runReingestWorker(s System, stop <-chan struct{}, rei
 				}
 			}
 			log.WithFields(logpkg.F{"from": reingestRange.from, "to": reingestRange.to}).Info("successfully reingested range")
+		}
+	}
+}
+
+func enqueueReingestTasks(ledgerRanges [][2]uint32, batchSize uint32, stop <-chan struct{}, reingestJobQueue chan<- ledgerRange) {
+	for _, pair := range ledgerRanges {
+		fromLedger, toLedger := pair[0], pair[1]
+		for subRangeFrom := fromLedger; subRangeFrom < toLedger; {
+			// job queuing
+			subRangeTo := subRangeFrom + (batchSize - 1) // we subtract one because both from and to are part of the batch
+			if subRangeTo > toLedger {
+				subRangeTo = toLedger
+			}
+			select {
+			case <-stop:
+				return
+			case reingestJobQueue <- ledgerRange{subRangeFrom, subRangeTo}:
+			}
+			subRangeFrom = subRangeTo + 1
 		}
 	}
 }
@@ -85,9 +104,17 @@ func calculateParallelLedgerBatchSize(rangeSize uint32, batchSizeSuggestion uint
 	return (batchSize / historyCheckpointLedgerInterval) * historyCheckpointLedgerInterval
 }
 
-func (ps *ParallelSystems) ReingestRange(fromLedger, toLedger uint32, batchSizeSuggestion uint32) error {
+func totalRangeSize(ledgerRanges [][2]uint32) uint32 {
+	var sum uint32
+	for _, pair := range ledgerRanges {
+		sum += pair[1] - pair[0]
+	}
+	return sum
+}
+
+func (ps *ParallelSystems) ReingestRange(ledgerRanges [][2]uint32, batchSizeSuggestion uint32) error {
 	var (
-		batchSize        = calculateParallelLedgerBatchSize(toLedger-fromLedger, batchSizeSuggestion, ps.workerCount)
+		batchSize        = calculateParallelLedgerBatchSize(totalRangeSize(ledgerRanges), batchSizeSuggestion, ps.workerCount)
 		reingestJobQueue = make(chan ledgerRange)
 		wg               sync.WaitGroup
 
@@ -106,6 +133,9 @@ func (ps *ParallelSystems) ReingestRange(fromLedger, toLedger uint32, batchSizeS
 		// the user needs to start again to prevent the gaps.
 		lowestRangeErr *rangeError
 	)
+	if err := validateRanges(ledgerRanges); err != nil {
+		return err
+	}
 
 	for i := uint(0); i < ps.workerCount; i++ {
 		wg.Add(1)
@@ -131,20 +161,7 @@ func (ps *ParallelSystems) ReingestRange(fromLedger, toLedger uint32, batchSizeS
 		}()
 	}
 
-rangeQueueLoop:
-	for subRangeFrom := fromLedger; subRangeFrom < toLedger; {
-		// job queuing
-		subRangeTo := subRangeFrom + (batchSize - 1) // we subtract one because both from and to are part of the batch
-		if subRangeTo > toLedger {
-			subRangeTo = toLedger
-		}
-		select {
-		case <-stop:
-			break rangeQueueLoop
-		case reingestJobQueue <- ledgerRange{subRangeFrom, subRangeTo}:
-		}
-		subRangeFrom = subRangeTo + 1
-	}
+	enqueueReingestTasks(ledgerRanges, batchSize, stop, reingestJobQueue)
 
 	stopOnce.Do(func() {
 		close(stop)
@@ -153,7 +170,8 @@ rangeQueueLoop:
 	close(reingestJobQueue)
 
 	if lowestRangeErr != nil {
-		return errors.Wrapf(lowestRangeErr, "job failed, recommended restart range: [%d, %d]", lowestRangeErr.ledgerRange.from, toLedger)
+		lastLedger := ledgerRanges[len(ledgerRanges)-1][1]
+		return errors.Wrapf(lowestRangeErr, "job failed, recommended restart range: [%d, %d]", lowestRangeErr.ledgerRange.from, lastLedger)
 	}
 	return nil
 }

--- a/services/horizon/internal/ingest/parallel.go
+++ b/services/horizon/internal/ingest/parallel.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/errors"
 	logpkg "github.com/stellar/go/support/log"
 )
@@ -13,18 +14,13 @@ const (
 	minBatchSize                    = historyCheckpointLedgerInterval
 )
 
-type ledgerRange struct {
-	from uint32
-	to   uint32
-}
-
 type rangeError struct {
 	err         error
-	ledgerRange ledgerRange
+	ledgerRange history.LedgerRange
 }
 
 func (e rangeError) Error() string {
-	return fmt.Sprintf("error when processing [%d, %d] range: %s", e.ledgerRange.from, e.ledgerRange.to, e.err)
+	return fmt.Sprintf("error when processing [%d, %d] range: %s", e.ledgerRange.StartSequence, e.ledgerRange.EndSequence, e.err)
 }
 
 type ParallelSystems struct {
@@ -51,38 +47,37 @@ func newParallelSystems(config Config, workerCount uint, systemFactory func(Conf
 	}, nil
 }
 
-func (ps *ParallelSystems) runReingestWorker(s System, stop <-chan struct{}, reingestJobQueue <-chan ledgerRange) rangeError {
+func (ps *ParallelSystems) runReingestWorker(s System, stop <-chan struct{}, reingestJobQueue <-chan history.LedgerRange) rangeError {
 
 	for {
 		select {
 		case <-stop:
 			return rangeError{}
 		case reingestRange := <-reingestJobQueue:
-			err := s.ReingestRange([][2]uint32{{reingestRange.from, reingestRange.to}}, false)
+			err := s.ReingestRange([]history.LedgerRange{reingestRange}, false)
 			if err != nil {
 				return rangeError{
 					err:         err,
 					ledgerRange: reingestRange,
 				}
 			}
-			log.WithFields(logpkg.F{"from": reingestRange.from, "to": reingestRange.to}).Info("successfully reingested range")
+			log.WithFields(logpkg.F{"from": reingestRange.StartSequence, "to": reingestRange.EndSequence}).Info("successfully reingested range")
 		}
 	}
 }
 
-func enqueueReingestTasks(ledgerRanges [][2]uint32, batchSize uint32, stop <-chan struct{}, reingestJobQueue chan<- ledgerRange) {
-	for _, pair := range ledgerRanges {
-		fromLedger, toLedger := pair[0], pair[1]
-		for subRangeFrom := fromLedger; subRangeFrom < toLedger; {
+func enqueueReingestTasks(ledgerRanges []history.LedgerRange, batchSize uint32, stop <-chan struct{}, reingestJobQueue chan<- history.LedgerRange) {
+	for _, cur := range ledgerRanges {
+		for subRangeFrom := cur.StartSequence; subRangeFrom < cur.EndSequence; {
 			// job queuing
 			subRangeTo := subRangeFrom + (batchSize - 1) // we subtract one because both from and to are part of the batch
-			if subRangeTo > toLedger {
-				subRangeTo = toLedger
+			if subRangeTo > cur.EndSequence {
+				subRangeTo = cur.EndSequence
 			}
 			select {
 			case <-stop:
 				return
-			case reingestJobQueue <- ledgerRange{subRangeFrom, subRangeTo}:
+			case reingestJobQueue <- history.LedgerRange{StartSequence: subRangeFrom, EndSequence: subRangeTo}:
 			}
 			subRangeFrom = subRangeTo + 1
 		}
@@ -104,18 +99,18 @@ func calculateParallelLedgerBatchSize(rangeSize uint32, batchSizeSuggestion uint
 	return (batchSize / historyCheckpointLedgerInterval) * historyCheckpointLedgerInterval
 }
 
-func totalRangeSize(ledgerRanges [][2]uint32) uint32 {
+func totalRangeSize(ledgerRanges []history.LedgerRange) uint32 {
 	var sum uint32
-	for _, pair := range ledgerRanges {
-		sum += pair[1] - pair[0] + 1
+	for _, ledgerRange := range ledgerRanges {
+		sum += ledgerRange.EndSequence - ledgerRange.StartSequence + 1
 	}
 	return sum
 }
 
-func (ps *ParallelSystems) ReingestRange(ledgerRanges [][2]uint32, batchSizeSuggestion uint32) error {
+func (ps *ParallelSystems) ReingestRange(ledgerRanges []history.LedgerRange, batchSizeSuggestion uint32) error {
 	var (
 		batchSize        = calculateParallelLedgerBatchSize(totalRangeSize(ledgerRanges), batchSizeSuggestion, ps.workerCount)
-		reingestJobQueue = make(chan ledgerRange)
+		reingestJobQueue = make(chan history.LedgerRange)
 		wg               sync.WaitGroup
 
 		// stopOnce is used to close the stop channel once: closing a closed channel panics and it can happen in case
@@ -149,7 +144,7 @@ func (ps *ParallelSystems) ReingestRange(ledgerRanges [][2]uint32, batchSizeSugg
 			if rangeErr.err != nil {
 				log.WithError(rangeErr).Error("error in reingest worker")
 				lowestRangeErrMutex.Lock()
-				if lowestRangeErr == nil || lowestRangeErr.ledgerRange.from > rangeErr.ledgerRange.from {
+				if lowestRangeErr == nil || lowestRangeErr.ledgerRange.StartSequence > rangeErr.ledgerRange.StartSequence {
 					lowestRangeErr = &rangeErr
 				}
 				lowestRangeErrMutex.Unlock()
@@ -170,8 +165,8 @@ func (ps *ParallelSystems) ReingestRange(ledgerRanges [][2]uint32, batchSizeSugg
 	close(reingestJobQueue)
 
 	if lowestRangeErr != nil {
-		lastLedger := ledgerRanges[len(ledgerRanges)-1][1]
-		return errors.Wrapf(lowestRangeErr, "job failed, recommended restart range: [%d, %d]", lowestRangeErr.ledgerRange.from, lastLedger)
+		lastLedger := ledgerRanges[len(ledgerRanges)-1].EndSequence
+		return errors.Wrapf(lowestRangeErr, "job failed, recommended restart range: [%d, %d]", lowestRangeErr.ledgerRange.StartSequence, lastLedger)
 	}
 	return nil
 }

--- a/services/horizon/internal/ingest/parallel.go
+++ b/services/horizon/internal/ingest/parallel.go
@@ -107,7 +107,7 @@ func calculateParallelLedgerBatchSize(rangeSize uint32, batchSizeSuggestion uint
 func totalRangeSize(ledgerRanges [][2]uint32) uint32 {
 	var sum uint32
 	for _, pair := range ledgerRanges {
-		sum += pair[1] - pair[0]
+		sum += pair[1] - pair[0] + 1
 	}
 	return sum
 }

--- a/services/horizon/internal/ingest/parallel_test.go
+++ b/services/horizon/internal/ingest/parallel_test.go
@@ -35,43 +35,42 @@ func TestParallelReingestRange(t *testing.T) {
 		rangesCalled sorteableRanges
 		m            sync.Mutex
 	)
+	result := &mockSystem{}
+	result.On("ReingestRange", mock.AnythingOfType("[][2]uint32"), mock.AnythingOfType("bool")).Run(
+		func(args mock.Arguments) {
+			m.Lock()
+			defer m.Unlock()
+			for _, pair := range args.Get(0).([][2]uint32) {
+				rangesCalled = append(rangesCalled, ledgerRange{from: pair[0], to: pair[1]})
+			}
+			// simulate call
+			time.Sleep(time.Millisecond * time.Duration(10+rand.Int31n(50)))
+		}).Return(error(nil))
 	factory := func(c Config) (System, error) {
-		result := &mockSystem{}
-		result.On("ReingestRange", mock.AnythingOfType("uint32"), mock.AnythingOfType("uint32"), mock.AnythingOfType("bool")).Run(
-			func(args mock.Arguments) {
-				r := ledgerRange{
-					from: args.Get(0).(uint32),
-					to:   args.Get(1).(uint32),
-				}
-				m.Lock()
-				defer m.Unlock()
-				rangesCalled = append(rangesCalled, r)
-				// simulate call
-				time.Sleep(time.Millisecond * time.Duration(10+rand.Int31n(50)))
-			}).Return(error(nil))
 		return result, nil
 	}
 	system, err := newParallelSystems(config, 3, factory)
 	assert.NoError(t, err)
-	err = system.ReingestRange(0, 2050, 258)
+	err = system.ReingestRange([][2]uint32{{1, 2050}}, 258)
 	assert.NoError(t, err)
 
 	sort.Sort(rangesCalled)
 	expected := sorteableRanges{
-		{from: 0, to: 255}, {from: 256, to: 511}, {from: 512, to: 767}, {from: 768, to: 1023}, {from: 1024, to: 1279},
-		{from: 1280, to: 1535}, {from: 1536, to: 1791}, {from: 1792, to: 2047}, {from: 2048, to: 2050},
+		{from: 1, to: 256}, {from: 257, to: 512}, {from: 513, to: 768}, {from: 769, to: 1024}, {from: 1025, to: 1280},
+		{from: 1281, to: 1536}, {from: 1537, to: 1792}, {from: 1793, to: 2048}, {from: 2049, to: 2050},
 	}
 	assert.Equal(t, expected, rangesCalled)
 
 	rangesCalled = nil
 	system, err = newParallelSystems(config, 1, factory)
 	assert.NoError(t, err)
-	err = system.ReingestRange(0, 1024, 64)
+	err = system.ReingestRange([][2]uint32{{1, 1024}}, 64)
+	result.AssertExpectations(t)
 	expected = sorteableRanges{
-		{from: 0, to: 63}, {from: 64, to: 127}, {from: 128, to: 191}, {from: 192, to: 255}, {from: 256, to: 319},
-		{from: 320, to: 383}, {from: 384, to: 447}, {from: 448, to: 511}, {from: 512, to: 575}, {from: 576, to: 639},
-		{from: 640, to: 703}, {from: 704, to: 767}, {from: 768, to: 831}, {from: 832, to: 895}, {from: 896, to: 959},
-		{from: 960, to: 1023},
+		{from: 1, to: 64}, {from: 65, to: 128}, {from: 129, to: 192}, {from: 193, to: 256}, {from: 257, to: 320},
+		{from: 321, to: 384}, {from: 385, to: 448}, {from: 449, to: 512}, {from: 513, to: 576}, {from: 577, to: 640},
+		{from: 641, to: 704}, {from: 705, to: 768}, {from: 769, to: 832}, {from: 833, to: 896}, {from: 897, to: 960},
+		{from: 961, to: 1024},
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, expected, rangesCalled)
@@ -79,45 +78,47 @@ func TestParallelReingestRange(t *testing.T) {
 
 func TestParallelReingestRangeError(t *testing.T) {
 	config := Config{}
+	result := &mockSystem{}
+	// Fail on the second range
+	result.On("ReingestRange", [][2]uint32{{1537, 1792}}, mock.AnythingOfType("bool")).Return(errors.New("failed because of foo"))
+	result.On("ReingestRange", mock.AnythingOfType("[][2]uint32"), mock.AnythingOfType("bool")).Return(error(nil))
 	factory := func(c Config) (System, error) {
-		result := &mockSystem{}
-		// Fail on the second range
-		result.On("ReingestRange", uint32(1536), uint32(1791), mock.AnythingOfType("bool")).Return(errors.New("failed because of foo"))
-		result.On("ReingestRange", mock.AnythingOfType("uint32"), mock.AnythingOfType("uint32"), mock.AnythingOfType("bool")).Return(error(nil))
 		return result, nil
 	}
 	system, err := newParallelSystems(config, 3, factory)
 	assert.NoError(t, err)
-	err = system.ReingestRange(0, 2050, 258)
+	err = system.ReingestRange([][2]uint32{{1, 2050}}, 258)
+	result.AssertExpectations(t)
 	assert.Error(t, err)
-	assert.Equal(t, "job failed, recommended restart range: [1536, 2050]: error when processing [1536, 1791] range: failed because of foo", err.Error())
-
+	assert.Equal(t, "job failed, recommended restart range: [1537, 2050]: error when processing [1537, 1792] range: failed because of foo", err.Error())
 }
 
 func TestParallelReingestRangeErrorInEarlierJob(t *testing.T) {
 	config := Config{}
 	var wg sync.WaitGroup
 	wg.Add(1)
+	result := &mockSystem{}
+	// Fail on an lower subrange after the first error
+	result.On("ReingestRange", [][2]uint32{{1025, 1280}}, mock.AnythingOfType("bool")).Run(func(mock.Arguments) {
+		// Wait for a more recent range to error
+		wg.Wait()
+		// This sleep should help making sure the result of this range is processed later than the one below
+		// (there are no guarantees without instrumenting ReingestRange(), but that's too complicated)
+		time.Sleep(50 * time.Millisecond)
+	}).Return(errors.New("failed because of foo"))
+	result.On("ReingestRange", [][2]uint32{{1537, 1792}}, mock.AnythingOfType("bool")).Run(func(mock.Arguments) {
+		wg.Done()
+	}).Return(errors.New("failed because of bar"))
+	result.On("ReingestRange", mock.AnythingOfType("[][2]uint32"), mock.AnythingOfType("bool")).Return(error(nil))
+
 	factory := func(c Config) (System, error) {
-		result := &mockSystem{}
-		// Fail on an lower subrange after the first error
-		result.On("ReingestRange", uint32(1024), uint32(1279), mock.AnythingOfType("bool")).Run(func(mock.Arguments) {
-			// Wait for a more recent range to error
-			wg.Wait()
-			// This sleep should help making sure the result of this range is processed later than the one below
-			// (there are no guarantees without instrumenting ReingestRange(), but that's too complicated)
-			time.Sleep(50 * time.Millisecond)
-		}).Return(errors.New("failed because of foo"))
-		result.On("ReingestRange", uint32(1536), uint32(1791), mock.AnythingOfType("bool")).Run(func(mock.Arguments) {
-			wg.Done()
-		}).Return(errors.New("failed because of bar"))
-		result.On("ReingestRange", mock.AnythingOfType("uint32"), mock.AnythingOfType("uint32"), mock.AnythingOfType("bool")).Return(error(nil))
 		return result, nil
 	}
 	system, err := newParallelSystems(config, 3, factory)
 	assert.NoError(t, err)
-	err = system.ReingestRange(0, 2050, 258)
+	err = system.ReingestRange([][2]uint32{{1, 2050}}, 258)
+	result.AssertExpectations(t)
 	assert.Error(t, err)
-	assert.Equal(t, "job failed, recommended restart range: [1024, 2050]: error when processing [1024, 1279] range: failed because of foo", err.Error())
+	assert.Equal(t, "job failed, recommended restart range: [1025, 2050]: error when processing [1025, 1280] range: failed because of foo", err.Error())
 
 }

--- a/services/horizon/internal/ingest/parallel_test.go
+++ b/services/horizon/internal/ingest/parallel_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/errors"
 )
 
@@ -23,26 +24,18 @@ func TestCalculateParallelLedgerBatchSize(t *testing.T) {
 	assert.Equal(t, uint32(64), calculateParallelLedgerBatchSize(20096, 64, 1))
 }
 
-type sorteableRanges []ledgerRange
-
-func (s sorteableRanges) Len() int           { return len(s) }
-func (s sorteableRanges) Less(i, j int) bool { return s[i].from < s[j].from }
-func (s sorteableRanges) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-
 func TestParallelReingestRange(t *testing.T) {
 	config := Config{}
 	var (
-		rangesCalled sorteableRanges
+		rangesCalled []history.LedgerRange
 		m            sync.Mutex
 	)
 	result := &mockSystem{}
-	result.On("ReingestRange", mock.AnythingOfType("[][2]uint32"), mock.AnythingOfType("bool")).Run(
+	result.On("ReingestRange", mock.AnythingOfType("[]history.LedgerRange"), mock.AnythingOfType("bool")).Run(
 		func(args mock.Arguments) {
 			m.Lock()
 			defer m.Unlock()
-			for _, pair := range args.Get(0).([][2]uint32) {
-				rangesCalled = append(rangesCalled, ledgerRange{from: pair[0], to: pair[1]})
-			}
+			rangesCalled = append(rangesCalled, args.Get(0).([]history.LedgerRange)...)
 			// simulate call
 			time.Sleep(time.Millisecond * time.Duration(10+rand.Int31n(50)))
 		}).Return(error(nil))
@@ -51,26 +44,28 @@ func TestParallelReingestRange(t *testing.T) {
 	}
 	system, err := newParallelSystems(config, 3, factory)
 	assert.NoError(t, err)
-	err = system.ReingestRange([][2]uint32{{1, 2050}}, 258)
+	err = system.ReingestRange([]history.LedgerRange{{1, 2050}}, 258)
 	assert.NoError(t, err)
 
-	sort.Sort(rangesCalled)
-	expected := sorteableRanges{
-		{from: 1, to: 256}, {from: 257, to: 512}, {from: 513, to: 768}, {from: 769, to: 1024}, {from: 1025, to: 1280},
-		{from: 1281, to: 1536}, {from: 1537, to: 1792}, {from: 1793, to: 2048}, {from: 2049, to: 2050},
+	sort.Slice(rangesCalled, func(i, j int) bool {
+		return rangesCalled[i].StartSequence < rangesCalled[j].StartSequence
+	})
+	expected := []history.LedgerRange{
+		{StartSequence: 1, EndSequence: 256}, {StartSequence: 257, EndSequence: 512}, {StartSequence: 513, EndSequence: 768}, {StartSequence: 769, EndSequence: 1024}, {StartSequence: 1025, EndSequence: 1280},
+		{StartSequence: 1281, EndSequence: 1536}, {StartSequence: 1537, EndSequence: 1792}, {StartSequence: 1793, EndSequence: 2048}, {StartSequence: 2049, EndSequence: 2050},
 	}
 	assert.Equal(t, expected, rangesCalled)
 
 	rangesCalled = nil
 	system, err = newParallelSystems(config, 1, factory)
 	assert.NoError(t, err)
-	err = system.ReingestRange([][2]uint32{{1, 1024}}, 64)
+	err = system.ReingestRange([]history.LedgerRange{{1, 1024}}, 64)
 	result.AssertExpectations(t)
-	expected = sorteableRanges{
-		{from: 1, to: 64}, {from: 65, to: 128}, {from: 129, to: 192}, {from: 193, to: 256}, {from: 257, to: 320},
-		{from: 321, to: 384}, {from: 385, to: 448}, {from: 449, to: 512}, {from: 513, to: 576}, {from: 577, to: 640},
-		{from: 641, to: 704}, {from: 705, to: 768}, {from: 769, to: 832}, {from: 833, to: 896}, {from: 897, to: 960},
-		{from: 961, to: 1024},
+	expected = []history.LedgerRange{
+		{StartSequence: 1, EndSequence: 64}, {StartSequence: 65, EndSequence: 128}, {StartSequence: 129, EndSequence: 192}, {StartSequence: 193, EndSequence: 256}, {StartSequence: 257, EndSequence: 320},
+		{StartSequence: 321, EndSequence: 384}, {StartSequence: 385, EndSequence: 448}, {StartSequence: 449, EndSequence: 512}, {StartSequence: 513, EndSequence: 576}, {StartSequence: 577, EndSequence: 640},
+		{StartSequence: 641, EndSequence: 704}, {StartSequence: 705, EndSequence: 768}, {StartSequence: 769, EndSequence: 832}, {StartSequence: 833, EndSequence: 896}, {StartSequence: 897, EndSequence: 960},
+		{StartSequence: 961, EndSequence: 1024},
 	}
 	assert.NoError(t, err)
 	assert.Equal(t, expected, rangesCalled)
@@ -80,14 +75,14 @@ func TestParallelReingestRangeError(t *testing.T) {
 	config := Config{}
 	result := &mockSystem{}
 	// Fail on the second range
-	result.On("ReingestRange", [][2]uint32{{1537, 1792}}, mock.AnythingOfType("bool")).Return(errors.New("failed because of foo"))
-	result.On("ReingestRange", mock.AnythingOfType("[][2]uint32"), mock.AnythingOfType("bool")).Return(error(nil))
+	result.On("ReingestRange", []history.LedgerRange{{1537, 1792}}, mock.AnythingOfType("bool")).Return(errors.New("failed because of foo"))
+	result.On("ReingestRange", mock.AnythingOfType("[]history.LedgerRange"), mock.AnythingOfType("bool")).Return(error(nil))
 	factory := func(c Config) (System, error) {
 		return result, nil
 	}
 	system, err := newParallelSystems(config, 3, factory)
 	assert.NoError(t, err)
-	err = system.ReingestRange([][2]uint32{{1, 2050}}, 258)
+	err = system.ReingestRange([]history.LedgerRange{{1, 2050}}, 258)
 	result.AssertExpectations(t)
 	assert.Error(t, err)
 	assert.Equal(t, "job failed, recommended restart range: [1537, 2050]: error when processing [1537, 1792] range: failed because of foo", err.Error())
@@ -99,24 +94,24 @@ func TestParallelReingestRangeErrorInEarlierJob(t *testing.T) {
 	wg.Add(1)
 	result := &mockSystem{}
 	// Fail on an lower subrange after the first error
-	result.On("ReingestRange", [][2]uint32{{1025, 1280}}, mock.AnythingOfType("bool")).Run(func(mock.Arguments) {
+	result.On("ReingestRange", []history.LedgerRange{{1025, 1280}}, mock.AnythingOfType("bool")).Run(func(mock.Arguments) {
 		// Wait for a more recent range to error
 		wg.Wait()
 		// This sleep should help making sure the result of this range is processed later than the one below
 		// (there are no guarantees without instrumenting ReingestRange(), but that's too complicated)
 		time.Sleep(50 * time.Millisecond)
 	}).Return(errors.New("failed because of foo"))
-	result.On("ReingestRange", [][2]uint32{{1537, 1792}}, mock.AnythingOfType("bool")).Run(func(mock.Arguments) {
+	result.On("ReingestRange", []history.LedgerRange{{1537, 1792}}, mock.AnythingOfType("bool")).Run(func(mock.Arguments) {
 		wg.Done()
 	}).Return(errors.New("failed because of bar"))
-	result.On("ReingestRange", mock.AnythingOfType("[][2]uint32"), mock.AnythingOfType("bool")).Return(error(nil))
+	result.On("ReingestRange", mock.AnythingOfType("[]history.LedgerRange"), mock.AnythingOfType("bool")).Return(error(nil))
 
 	factory := func(c Config) (System, error) {
 		return result, nil
 	}
 	system, err := newParallelSystems(config, 3, factory)
 	assert.NoError(t, err)
-	err = system.ReingestRange([][2]uint32{{1, 2050}}, 258)
+	err = system.ReingestRange([]history.LedgerRange{{1, 2050}}, 258)
 	result.AssertExpectations(t)
 	assert.Error(t, err)
 	assert.Equal(t, "job failed, recommended restart range: [1025, 2050]: error when processing [1025, 1280] range: failed because of foo", err.Error())

--- a/services/horizon/internal/integration/db_test.go
+++ b/services/horizon/internal/integration/db_test.go
@@ -1,7 +1,10 @@
 package integration
 
 import (
+	"context"
 	"fmt"
+	horizon "github.com/stellar/go/services/horizon/internal"
+	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -93,7 +96,19 @@ func TestReingestDB(t *testing.T) {
 		"captive-core-reingest-range-integration-tests.cfg",
 	)
 
-	horizoncmd.RootCmd.SetArgs([]string{
+	horizoncmd.RootCmd.SetArgs(command(horizonConfig, "db",
+		"reingest",
+		"range",
+		"1",
+		fmt.Sprintf("%d", toLedger),
+	))
+
+	// Reingest into the DB
+	tt.NoError(horizoncmd.RootCmd.Execute())
+}
+
+func command(horizonConfig horizon.Config, args ...string) []string {
+	return append([]string{
 		"--stellar-core-url",
 		horizonConfig.StellarCoreURL,
 		"--history-archive-urls",
@@ -112,16 +127,108 @@ func TestReingestDB(t *testing.T) {
 		// due to ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING
 		"--checkpoint-frequency",
 		"8",
-		"db",
-		"reingest",
-		"range",
-		"1",
-		fmt.Sprintf("%d", toLedger),
-	})
+	}, args...)
+}
 
-	err = horizoncmd.RootCmd.Execute()
-	// Reingest into the DB
+func TestFillGaps(t *testing.T) {
+	itest, reachedLedger := initializeDBIntegrationTest(t)
+	tt := assert.New(t)
+
+	// Create a fresh Horizon database
+	newDB := dbtest.Postgres(t)
+	// TODO: Unfortunately Horizon's ingestion System leaves open sessions behind,leading to
+	//       a "database  is being accessed by other users" error when trying to drop it
+	// defer newDB.Close()
+	freshHorizonPostgresURL := newDB.DSN
+	horizonConfig := itest.GetHorizonConfig()
+	horizonConfig.DatabaseURL = freshHorizonPostgresURL
+	// Initialize the DB schema
+	dbConn, err := db.Open("postgres", freshHorizonPostgresURL)
+	defer dbConn.Close()
+	_, err = schema.Migrate(dbConn.DB.DB, schema.MigrateUp, 0)
 	tt.NoError(err)
+
+	// cap reachedLedger to the nearest checkpoint ledger because reingest range cannot ingest past the most
+	// recent checkpoint ledger when using captive core
+	toLedger := uint32(reachedLedger)
+	archive, err := historyarchive.Connect(horizonConfig.HistoryArchiveURLs[0], historyarchive.ConnectOptions{
+		NetworkPassphrase:   horizonConfig.NetworkPassphrase,
+		CheckpointFrequency: horizonConfig.CheckpointFrequency,
+	})
+	tt.NoError(err)
+
+	// make sure a full checkpoint has elapsed otherwise there will be nothing to reingest
+	var latestCheckpoint uint32
+	publishedFirstCheckpoint := func() bool {
+		has, requestErr := archive.GetRootHAS()
+		tt.NoError(requestErr)
+		latestCheckpoint = has.CurrentLedger
+		return latestCheckpoint > 1
+	}
+	tt.Eventually(publishedFirstCheckpoint, 10*time.Second, time.Second)
+
+	if toLedger > latestCheckpoint {
+		toLedger = latestCheckpoint
+	}
+
+	// We just want to test reingestion, so there's no reason for a background
+	// Horizon to run. Keeping it running will actually cause the Captive Core
+	// subprocesses to conflict.
+	itest.StopHorizon()
+
+	historyQ := history.Q{dbConn}
+	var oldestLedger, latestLedger int64
+	tt.NoError(historyQ.ElderLedger(context.Background(), &oldestLedger))
+	tt.NoError(historyQ.LatestLedger(context.Background(), &latestLedger))
+	tt.NoError(historyQ.DeleteRangeAll(context.Background(), oldestLedger, latestLedger))
+
+	horizonConfig.CaptiveCoreConfigPath = filepath.Join(
+		filepath.Dir(horizonConfig.CaptiveCoreConfigPath),
+		"captive-core-reingest-range-integration-tests.cfg",
+	)
+	horizoncmd.RootCmd.SetArgs(command(horizonConfig, "db", "fill-gaps"))
+	tt.NoError(horizoncmd.RootCmd.Execute())
+
+	tt.NoError(historyQ.LatestLedger(context.Background(), &latestLedger))
+	tt.Equal(int64(0), latestLedger)
+
+	horizoncmd.RootCmd.SetArgs(command(horizonConfig, "db", "fill-gaps", "3", "4"))
+	tt.NoError(horizoncmd.RootCmd.Execute())
+	tt.NoError(historyQ.LatestLedger(context.Background(), &latestLedger))
+	tt.NoError(historyQ.ElderLedger(context.Background(), &oldestLedger))
+	tt.Equal(int64(3), oldestLedger)
+	tt.Equal(int64(4), latestLedger)
+
+	horizoncmd.RootCmd.SetArgs(command(horizonConfig, "db", "fill-gaps", "6", "7"))
+	tt.NoError(horizoncmd.RootCmd.Execute())
+	tt.NoError(historyQ.LatestLedger(context.Background(), &latestLedger))
+	tt.NoError(historyQ.ElderLedger(context.Background(), &oldestLedger))
+	tt.Equal(int64(3), oldestLedger)
+	tt.Equal(int64(7), latestLedger)
+	var gaps []history.LedgerGap
+	gaps, err = historyQ.GetLedgerGaps(context.Background())
+	tt.NoError(err)
+	tt.Equal([]history.LedgerGap{{StartSequence: 5, EndSequence: 5}}, gaps)
+
+	horizoncmd.RootCmd.SetArgs(command(horizonConfig, "db", "fill-gaps"))
+	tt.NoError(horizoncmd.RootCmd.Execute())
+	tt.NoError(historyQ.LatestLedger(context.Background(), &latestLedger))
+	tt.NoError(historyQ.ElderLedger(context.Background(), &oldestLedger))
+	tt.Equal(int64(3), oldestLedger)
+	tt.Equal(int64(7), latestLedger)
+	gaps, err = historyQ.GetLedgerGaps(context.Background())
+	tt.NoError(err)
+	tt.Empty(gaps)
+
+	horizoncmd.RootCmd.SetArgs(command(horizonConfig, "db", "fill-gaps", "2", "8"))
+	tt.NoError(horizoncmd.RootCmd.Execute())
+	tt.NoError(historyQ.LatestLedger(context.Background(), &latestLedger))
+	tt.NoError(historyQ.ElderLedger(context.Background(), &oldestLedger))
+	tt.Equal(int64(2), oldestLedger)
+	tt.Equal(int64(8), latestLedger)
+	gaps, err = historyQ.GetLedgerGaps(context.Background())
+	tt.NoError(err)
+	tt.Empty(gaps)
 }
 
 func TestResumeFromInitializedDB(t *testing.T) {

--- a/services/horizon/internal/integration/db_test.go
+++ b/services/horizon/internal/integration/db_test.go
@@ -205,10 +205,10 @@ func TestFillGaps(t *testing.T) {
 	tt.NoError(historyQ.ElderLedger(context.Background(), &oldestLedger))
 	tt.Equal(int64(3), oldestLedger)
 	tt.Equal(int64(7), latestLedger)
-	var gaps []history.LedgerGap
+	var gaps []history.LedgerRange
 	gaps, err = historyQ.GetLedgerGaps(context.Background())
 	tt.NoError(err)
-	tt.Equal([]history.LedgerGap{{StartSequence: 5, EndSequence: 5}}, gaps)
+	tt.Equal([]history.LedgerRange{{StartSequence: 5, EndSequence: 5}}, gaps)
 
 	horizoncmd.RootCmd.SetArgs(command(horizonConfig, "db", "fill-gaps"))
 	tt.NoError(horizoncmd.RootCmd.Execute())


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close https://github.com/stellar/go/issues/4010

`horizon db fill-gaps` can be called with no parameters in which case it queries for any existing gaps in the horizon db and then proceeds to ingest history to fill the gaps.

The command can also be called with a start and end ledger parameter. In which case, the command will only query for gaps within the provided range.

`horizon db fill-gaps 1 1000` will fill any gaps occurring within the range 1-1000

It is also possible to configure the same parallel worker command line parameters that are used by horizon db reingest range so that fill-gaps can be also take advantage of concurrency.


### Known limitations

[N/A]
