### PR TITLE
xdr: update using xdrgen#71

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'xdrgen', git:'https://github.com/stellar/xdrgen.git', ref: 'master'
+gem 'xdrgen', git:'https://github.com/stellar/xdrgen.git', ref: 'generate-decodefrom'
 gem 'pry'
 gem 'octokit'
 gem 'netrc'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'xdrgen', git:'https://github.com/stellar/xdrgen.git', ref: 'generate-decodefrom'
+gem 'xdrgen', git:'https://github.com/stellar/xdrgen.git', ref: 'master'
 gem 'pry'
 gem 'octokit'
 gem 'netrc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/stellar/xdrgen.git
-  revision: b960ce7a979bc64d11f7512962733ee88ea87a2b
-  ref: master
+  revision: c077a53d7c974a5a7cc6db2d8c7ee06ec5efefa2
+  ref: generate-decodefrom
   specs:
     xdrgen (0.1.1)
       activesupport (~> 6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/stellar/xdrgen.git
-  revision: c077a53d7c974a5a7cc6db2d8c7ee06ec5efefa2
-  ref: generate-decodefrom
+  revision: 7d53fb17bcb6155d916db09e48c880aae42f624d
+  ref: master
   specs:
     xdrgen (0.1.1)
       activesupport (~> 6)

--- a/benchmarks/xdr_test.go
+++ b/benchmarks/xdr_test.go
@@ -43,7 +43,7 @@ func BenchmarkXDRUnmarshalWithReflection(b *testing.B) {
 	)
 	for i := 0; i < b.N; i++ {
 		r.Reset(input)
-		_, _ = xdr.Unmarshal(&r, &te)
+		_, _ = xdr3.Unmarshal(&r, &te)
 	}
 }
 

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1879,7 +1879,7 @@ func TestReadChallengeTx_invalidCorrupted(t *testing.T) {
 		t,
 		err,
 		"could not parse challenge: unable to unmarshal transaction envelope: "+
-			"xdr:decode: switch '68174086' is not valid enum value for union",
+			"decoding EnvelopeType: '68174086' is not a valid EnvelopeType enum value",
 	)
 }
 


### PR DESCRIPTION
This PR regenerates the xdr types using https://github.com/stellar/xdrgen/pull/71

There is a dramatic performance improvement. ~13x speedup and and 11x reduction of allocations.

```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go/benchmarks
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkXDRUnmarshalWithReflection
BenchmarkXDRUnmarshalWithReflection-8                 	   70221	     17617 ns/op	    5528 B/op	     185 allocs/op
BenchmarkXDRUnmarshal
BenchmarkXDRUnmarshal-8                               	  762405	      1360 ns/op	    1344 B/op	      17 allocs/op
BenchmarkGXDRUnmarshal
BenchmarkGXDRUnmarshal-8                              	   39950	     28912 ns/op	   86736 B/op	     278 allocs/op
```

This performance can be later improved even further by using the same approach as in https://github.com/stellar/go/pull/4056