### PR TITLE
services/horizon: Fix stream parsing error printing in captive core

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -558,7 +558,10 @@ func (c *CaptiveStellarCore) checkMetaPipeResult(result metaResult, ok bool) err
 		return err
 	}
 	if !ok || result.err != nil {
-		if exited, err := c.stellarCoreRunner.getProcessExitError(); exited {
+		if result.err != nil {
+			// Case 3 - Some error was encountered while consuming the ledger stream emitted by captive core.
+			return result.err
+		} else if exited, err := c.stellarCoreRunner.getProcessExitError(); exited {
 			// Case 2 - The stellar core process exited unexpectedly
 			if err == nil {
 				return errors.Errorf("stellar core exited unexpectedly")
@@ -570,9 +573,6 @@ func (c *CaptiveStellarCore) checkMetaPipeResult(result metaResult, ok bool) err
 			// if and only if the process exits or the context is cancelled.
 			// However, we add this check for the sake of completeness
 			return errors.Errorf("meta pipe closed unexpectedly")
-		} else {
-			// Case 3 - Some error was encountered while consuming the ledger stream emitted by captive core.
-			return result.err
 		}
 	}
 	return nil

--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -871,7 +871,6 @@ func TestCaptiveGetLedger_ErrReadingMetaResult(t *testing.T) {
 	mockRunner.On("getMetaPipe").Return((<-chan metaResult)(metaChan))
 	ctx, cancel := context.WithCancel(ctx)
 	mockRunner.On("context").Return(ctx)
-	mockRunner.On("getProcessExitError").Return(false, nil)
 	mockRunner.On("close").Return(nil).Run(func(args mock.Arguments) {
 		cancel()
 	}).Once()
@@ -1071,7 +1070,7 @@ func TestCaptiveGetLedgerTerminatedUnexpectedly(t *testing.T) {
 		{
 			"stellar core exited unexpectedly without error",
 			context.Background(),
-			[]metaResult{{LedgerCloseMeta: &ledger64}, {err: fmt.Errorf("transient error")}},
+			[]metaResult{{LedgerCloseMeta: &ledger64}},
 			true,
 			nil,
 			"stellar core exited unexpectedly",
@@ -1079,7 +1078,7 @@ func TestCaptiveGetLedgerTerminatedUnexpectedly(t *testing.T) {
 		{
 			"stellar core exited unexpectedly with an error",
 			context.Background(),
-			[]metaResult{{LedgerCloseMeta: &ledger64}, {err: fmt.Errorf("transient error")}},
+			[]metaResult{{LedgerCloseMeta: &ledger64}},
 			true,
 			fmt.Errorf("signal kill"),
 			"stellar core exited unexpectedly: signal kill",


### PR DESCRIPTION
We were not printing parsing errors properly if captive core exits right away.

Without the fix https://app.circleci.com/pipelines/github/stellar/go/9834/workflows/44ff1f80-b9fe-4787-8783-711d6cd0b8e8/jobs/57566

With the fix https://app.circleci.com/pipelines/github/stellar/go/9842/workflows/718f86b9-1495-4851-a51b-21af6a3c16d4/jobs/57633
