### PR TITLE
xdr and horizon: Optimize compress-marshaling of ledger keys

### DIFF
--- a/benchmarks/xdr_test.go
+++ b/benchmarks/xdr_test.go
@@ -132,3 +132,57 @@ func BenchmarkXDRUnsafeMarshalBase64WithEncodingBuffer(b *testing.B) {
 		_, _ = e.UnsafeMarshalBase64(xdrInput)
 	}
 }
+
+var ledgerKeys = []xdr.LedgerKey{
+	{
+		Type: xdr.LedgerEntryTypeAccount,
+		Account: &xdr.LedgerKeyAccount{
+			AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+		},
+	},
+	{
+		Type: xdr.LedgerEntryTypeTrustline,
+		TrustLine: &xdr.LedgerKeyTrustLine{
+			AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+			Asset:     xdr.MustNewCreditAsset("EUR", "GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB").ToTrustLineAsset(),
+		},
+	},
+	{
+		Type: xdr.LedgerEntryTypeOffer,
+		Offer: &xdr.LedgerKeyOffer{
+			SellerId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+			OfferId:  xdr.Int64(3),
+		},
+	},
+	{
+		Type: xdr.LedgerEntryTypeData,
+		Data: &xdr.LedgerKeyData{
+			AccountId: xdr.MustAddress("GAOQJGUAB7NI7K7I62ORBXMN3J4SSWQUQ7FOEPSDJ322W2HMCNWPHXFB"),
+			DataName:  "foobar",
+		},
+	},
+	{
+		Type: xdr.LedgerEntryTypeClaimableBalance,
+		ClaimableBalance: &xdr.LedgerKeyClaimableBalance{
+			BalanceId: xdr.ClaimableBalanceId{
+				Type: 0,
+				V0:   &xdr.Hash{0xca, 0xfe, 0xba, 0xbe},
+			},
+		},
+	},
+	{
+		Type: xdr.LedgerEntryTypeLiquidityPool,
+		LiquidityPool: &xdr.LedgerKeyLiquidityPool{
+			LiquidityPoolId: xdr.PoolId{0xca, 0xfe, 0xba, 0xbe},
+		},
+	},
+}
+
+func BenchmarkXDRMarshalCompress(b *testing.B) {
+	e := xdr.NewEncodingBuffer()
+	for i := 0; i < b.N; i++ {
+		for _, lk := range ledgerKeys {
+			_, _ = e.LedgerKeyUnsafeMarshalBinaryCompress(lk)
+		}
+	}
+}

--- a/xdr/account_id.go
+++ b/xdr/account_id.go
@@ -72,20 +72,25 @@ func (aid *AccountId) LedgerKey() (ret LedgerKey) {
 //
 // Warning, do not use UnmarshalBinary() on data encoded using this method!
 func (aid AccountId) MarshalBinaryCompress() ([]byte, error) {
-	m := []byte{byte(aid.Type)}
+	e := NewEncodingBuffer()
+	if err := e.accountIdCompressEncodeTo(aid); err != nil {
+		return nil, err
+	}
+	return e.xdrEncoderBuf.Bytes(), nil
+}
 
+func (e *EncodingBuffer) accountIdCompressEncodeTo(aid AccountId) error {
+	if err := e.xdrEncoderBuf.WriteByte(byte(aid.Type)); err != nil {
+		return err
+	}
 	switch aid.Type {
 	case PublicKeyTypePublicKeyTypeEd25519:
-		pk, err := aid.Ed25519.MarshalBinary()
-		if err != nil {
-			return nil, err
-		}
-		m = append(m, pk...)
+		// TODO: Encoding directly adds a padding (due to invoking EncodeFixedOpaque())
+		//       shouldn't we just write the bytes?
+		return aid.Ed25519.EncodeTo(e.encoder)
 	default:
 		panic("Unknown type")
 	}
-
-	return m, nil
 }
 
 func MustAddress(address string) AccountId {

--- a/xdr/account_id.go
+++ b/xdr/account_id.go
@@ -64,30 +64,14 @@ func (aid *AccountId) LedgerKey() (ret LedgerKey) {
 	return
 }
 
-// MarshalBinaryCompress marshals AccountId to []byte but unlike
-// MarshalBinary() it removes all unnecessary bytes, exploting the fact
-// that XDR is padding data to 4 bytes in union discriminants etc.
-// It's primary use is in ingest/io.StateReader that keep LedgerKeys in
-// memory so this function decrease memory requirements.
-//
-// Warning, do not use UnmarshalBinary() on data encoded using this method!
-func (aid AccountId) MarshalBinaryCompress() ([]byte, error) {
-	e := NewEncodingBuffer()
-	if err := e.accountIdCompressEncodeTo(aid); err != nil {
-		return nil, err
-	}
-	return e.xdrEncoderBuf.Bytes(), nil
-}
-
 func (e *EncodingBuffer) accountIdCompressEncodeTo(aid AccountId) error {
 	if err := e.xdrEncoderBuf.WriteByte(byte(aid.Type)); err != nil {
 		return err
 	}
 	switch aid.Type {
 	case PublicKeyTypePublicKeyTypeEd25519:
-		// TODO: Encoding directly adds a padding (due to invoking EncodeFixedOpaque())
-		//       shouldn't we just write the bytes?
-		return aid.Ed25519.EncodeTo(e.encoder)
+		_, err := e.xdrEncoderBuf.Write(aid.Ed25519[:])
+		return err
 	default:
 		panic("Unknown type")
 	}

--- a/xdr/asset.go
+++ b/xdr/asset.go
@@ -268,32 +268,17 @@ func (a Asset) StringCanonical() string {
 	return fmt.Sprintf("%s:%s", c, i)
 }
 
-// MarshalBinaryCompress marshals Asset to []byte but unlike
-// MarshalBinary() it removes all unnecessary bytes, exploting the fact
-// that XDR is padding data to 4 bytes in union discriminants etc.
-// It's primary use is in ingest/io.StateReader that keep LedgerKeys in
-// memory so this function decrease memory requirements.
-//
-// Warning, do not use UnmarshalBinary() on data encoded using this method!
-func (a Asset) MarshalBinaryCompress() ([]byte, error) {
-	e := NewEncodingBuffer()
-	if err := e.assetCompressEncodeTo(a); err != nil {
-		return nil, err
-	}
-	return e.xdrEncoderBuf.Bytes(), nil
-}
-
 func trimRightZeros(b []byte) []byte {
 	if len(b) == 0 {
 		return b
 	}
-	i := len(b) - 1
-	for ; i >= 0; i-- {
-		if b[i] != 0 {
+	i := len(b)
+	for ; i > 0; i-- {
+		if b[i-1] != 0 {
 			break
 		}
 	}
-	return b[:i+1]
+	return b[:i]
 }
 
 func (e *EncodingBuffer) assetCompressEncodeTo(a Asset) error {
@@ -315,13 +300,10 @@ func (e *EncodingBuffer) assetCompressEncodeTo(a Asset) error {
 		if _, err := e.xdrEncoderBuf.Write(code); err != nil {
 			return err
 		}
-		// TODO: this was panicking before, check with the team
 		return e.accountIdCompressEncodeTo(a.AlphaNum12.Issuer)
 	default:
 		panic(fmt.Errorf("Unknown asset type: %v", a.Type))
 	}
-
-	return nil
 }
 
 // Equals returns true if `other` is equivalent to `a`

--- a/xdr/asset.go
+++ b/xdr/asset.go
@@ -284,12 +284,16 @@ func (a Asset) MarshalBinaryCompress() ([]byte, error) {
 }
 
 func trimRightZeros(b []byte) []byte {
-	for i := len(b) - 1; i >= 0; i-- {
+	if len(b) == 0 {
+		return b
+	}
+	i := len(b) - 1
+	for ; i >= 0; i-- {
 		if b[i] != 0 {
-			return b[:i+1]
+			break
 		}
 	}
-	return b
+	return b[:i+1]
 }
 
 func (e *EncodingBuffer) assetCompressEncodeTo(a Asset) error {

--- a/xdr/asset.go
+++ b/xdr/asset.go
@@ -268,44 +268,6 @@ func (a Asset) StringCanonical() string {
 	return fmt.Sprintf("%s:%s", c, i)
 }
 
-func trimRightZeros(b []byte) []byte {
-	if len(b) == 0 {
-		return b
-	}
-	i := len(b)
-	for ; i > 0; i-- {
-		if b[i-1] != 0 {
-			break
-		}
-	}
-	return b[:i]
-}
-
-func (e *EncodingBuffer) assetCompressEncodeTo(a Asset) error {
-	if err := e.xdrEncoderBuf.WriteByte(byte(a.Type)); err != nil {
-		return err
-	}
-
-	switch a.Type {
-	case AssetTypeAssetTypeNative:
-		return nil
-	case AssetTypeAssetTypeCreditAlphanum4:
-		code := trimRightZeros(a.AlphaNum4.AssetCode[:])
-		if _, err := e.xdrEncoderBuf.Write(code); err != nil {
-			return err
-		}
-		return e.accountIdCompressEncodeTo(a.AlphaNum4.Issuer)
-	case AssetTypeAssetTypeCreditAlphanum12:
-		code := trimRightZeros(a.AlphaNum12.AssetCode[:])
-		if _, err := e.xdrEncoderBuf.Write(code); err != nil {
-			return err
-		}
-		return e.accountIdCompressEncodeTo(a.AlphaNum12.Issuer)
-	default:
-		panic(fmt.Errorf("Unknown asset type: %v", a.Type))
-	}
-}
-
 // Equals returns true if `other` is equivalent to `a`
 func (a Asset) Equals(other Asset) bool {
 	if a.Type != other.Type {

--- a/xdr/asset.go
+++ b/xdr/asset.go
@@ -276,34 +276,48 @@ func (a Asset) StringCanonical() string {
 //
 // Warning, do not use UnmarshalBinary() on data encoded using this method!
 func (a Asset) MarshalBinaryCompress() ([]byte, error) {
-	m := []byte{byte(a.Type)}
+	e := NewEncodingBuffer()
+	if err := e.assetCompressEncodeTo(a); err != nil {
+		return nil, err
+	}
+	return e.xdrEncoderBuf.Bytes(), nil
+}
 
-	var err error
-	var code []byte
-	var issuer []byte
+func trimRightZeros(b []byte) []byte {
+	for i := len(b) - 1; i >= 0; i-- {
+		if b[i] != 0 {
+			return b[:i+1]
+		}
+	}
+	return b
+}
+
+func (e *EncodingBuffer) assetCompressEncodeTo(a Asset) error {
+	if err := e.xdrEncoderBuf.WriteByte(byte(a.Type)); err != nil {
+		return err
+	}
 
 	switch a.Type {
 	case AssetTypeAssetTypeNative:
-		return m, nil
+		return nil
 	case AssetTypeAssetTypeCreditAlphanum4:
-		code = []byte(strings.TrimRight(string(a.AlphaNum4.AssetCode[:]), "\x00"))
-		issuer, err = a.AlphaNum4.Issuer.MarshalBinary()
-		if err != nil {
-			return nil, err
+		code := trimRightZeros(a.AlphaNum4.AssetCode[:])
+		if _, err := e.xdrEncoderBuf.Write(code); err != nil {
+			return err
 		}
+		return e.accountIdCompressEncodeTo(a.AlphaNum4.Issuer)
 	case AssetTypeAssetTypeCreditAlphanum12:
-		code = []byte(strings.TrimRight(string(a.AlphaNum12.AssetCode[:]), "\x00"))
-		issuer, err = a.AlphaNum12.Issuer.MarshalBinary()
-		if err != nil {
-			panic(err)
+		code := trimRightZeros(a.AlphaNum12.AssetCode[:])
+		if _, err := e.xdrEncoderBuf.Write(code); err != nil {
+			return err
 		}
+		// TODO: this was panicking before, check with the team
+		return e.accountIdCompressEncodeTo(a.AlphaNum12.Issuer)
 	default:
 		panic(fmt.Errorf("Unknown asset type: %v", a.Type))
 	}
 
-	m = append(m, code...)
-	m = append(m, issuer...)
-	return m, nil
+	return nil
 }
 
 // Equals returns true if `other` is equivalent to `a`

--- a/xdr/asset_test.go
+++ b/xdr/asset_test.go
@@ -1,4 +1,4 @@
-package xdr_test
+package xdr
 
 import (
 	"testing"
@@ -7,8 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	. "github.com/stellar/go/xdr"
 )
 
 var _ = Describe("xdr.Asset#Extract()", func() {
@@ -111,6 +109,22 @@ func TestStringCanonical(t *testing.T) {
 
 	asset = MustNewCreditAsset("USD", "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
 	require.Equal(t, "USD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H", asset.StringCanonical())
+}
+
+func TestTrimRightZeros(t *testing.T) {
+	require.Equal(t, []byte(nil), trimRightZeros(nil))
+	require.Equal(t, []byte{}, trimRightZeros([]byte{}))
+	require.Equal(t, []byte{}, trimRightZeros([]byte{0x0}))
+	require.Equal(t, []byte{}, trimRightZeros([]byte{0x0, 0x0}))
+	require.Equal(t, []byte{0x1}, trimRightZeros([]byte{0x1}))
+	require.Equal(t, []byte{0x1}, trimRightZeros([]byte{0x1, 0x0}))
+	require.Equal(t, []byte{0x1}, trimRightZeros([]byte{0x1, 0x0, 0x0}))
+	require.Equal(t, []byte{0x1}, trimRightZeros([]byte{0x1, 0x0, 0x0, 0x0}))
+	require.Equal(t, []byte{0x1, 0x2}, trimRightZeros([]byte{0x1, 0x2}))
+	require.Equal(t, []byte{0x1, 0x2}, trimRightZeros([]byte{0x1, 0x2, 0x0}))
+	require.Equal(t, []byte{0x1, 0x2}, trimRightZeros([]byte{0x1, 0x2, 0x0, 0x0}))
+	require.Equal(t, []byte{0x0, 0x2}, trimRightZeros([]byte{0x0, 0x2, 0x0, 0x0}))
+	require.Equal(t, []byte{0x0, 0x2, 0x0, 0x1}, trimRightZeros([]byte{0x0, 0x2, 0x0, 0x1, 0x0}))
 }
 
 var _ = Describe("xdr.Asset#Equals()", func() {

--- a/xdr/asset_test.go
+++ b/xdr/asset_test.go
@@ -1,7 +1,9 @@
-package xdr
+package xdr_test
 
 import (
 	"testing"
+
+	. "github.com/stellar/go/xdr"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -109,22 +111,6 @@ func TestStringCanonical(t *testing.T) {
 
 	asset = MustNewCreditAsset("USD", "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
 	require.Equal(t, "USD:GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H", asset.StringCanonical())
-}
-
-func TestTrimRightZeros(t *testing.T) {
-	require.Equal(t, []byte(nil), trimRightZeros(nil))
-	require.Equal(t, []byte{}, trimRightZeros([]byte{}))
-	require.Equal(t, []byte{}, trimRightZeros([]byte{0x0}))
-	require.Equal(t, []byte{}, trimRightZeros([]byte{0x0, 0x0}))
-	require.Equal(t, []byte{0x1}, trimRightZeros([]byte{0x1}))
-	require.Equal(t, []byte{0x1}, trimRightZeros([]byte{0x1, 0x0}))
-	require.Equal(t, []byte{0x1}, trimRightZeros([]byte{0x1, 0x0, 0x0}))
-	require.Equal(t, []byte{0x1}, trimRightZeros([]byte{0x1, 0x0, 0x0, 0x0}))
-	require.Equal(t, []byte{0x1, 0x2}, trimRightZeros([]byte{0x1, 0x2}))
-	require.Equal(t, []byte{0x1, 0x2}, trimRightZeros([]byte{0x1, 0x2, 0x0}))
-	require.Equal(t, []byte{0x1, 0x2}, trimRightZeros([]byte{0x1, 0x2, 0x0, 0x0}))
-	require.Equal(t, []byte{0x0, 0x2}, trimRightZeros([]byte{0x0, 0x2, 0x0, 0x0}))
-	require.Equal(t, []byte{0x0, 0x2, 0x0, 0x1}, trimRightZeros([]byte{0x0, 0x2, 0x0, 0x1, 0x0}))
 }
 
 var _ = Describe("xdr.Asset#Equals()", func() {

--- a/xdr/claimable_balance_id.go
+++ b/xdr/claimable_balance_id.go
@@ -1,27 +1,14 @@
 package xdr
 
-// MarshalBinaryCompress marshals ClaimableBalanceId to []byte but unlike
-// MarshalBinary() it removes all unnecessary bytes, exploiting the fact
-// that XDR is padding data to 4 bytes in union discriminants etc.
-// It's primary use is in ingest/io.StateReader that keep LedgerKeys in
-// memory so this function decrease memory requirements.
-//
-// Warning, do not use UnmarshalBinary() on data encoded using this method!
-func (cb ClaimableBalanceId) MarshalBinaryCompress() ([]byte, error) {
-	m := []byte{byte(cb.Type)}
-
+func (e *EncodingBuffer) claimableBalanceCompressEncodeTo(cb ClaimableBalanceId) error {
+	if err := e.xdrEncoderBuf.WriteByte(byte(cb.Type)); err != nil {
+		return err
+	}
 	switch cb.Type {
 	case ClaimableBalanceIdTypeClaimableBalanceIdTypeV0:
-		hash, err := cb.V0.MarshalBinary()
-		if err != nil {
-			return nil, err
-		}
-		m = append(m, hash...)
-	// TODO fix before Protocol 18
-	// case ClaimableBalanceIdTypeClaimableBalanceIdTypeFromPoolRevoke:
+		_, err := e.xdrEncoderBuf.Write(cb.V0[:])
+		return err
 	default:
 		panic("Unknown type")
 	}
-
-	return m, nil
 }

--- a/xdr/ledger_key.go
+++ b/xdr/ledger_key.go
@@ -119,25 +119,6 @@ func (key *LedgerKey) SetLiquidityPool(poolID PoolId) error {
 	return nil
 }
 
-// MarshalBinaryCompress marshals LedgerKey to []byte but unlike
-// MarshalBinary() it removes all unnecessary bytes, exploting the fact
-// that XDR is padding data to 4 bytes in union discriminants etc.
-// It's primary use is in ingest/io.StateReader that keep LedgerKeys in
-// memory so this function decrease memory requirements.
-//
-// Warning, do not use UnmarshalBinary() on data encoded using this method!
-//
-// Optimizations:
-// - Writes a single byte for union discriminants vs 4 bytes.
-// - Removes type and code padding for Asset.
-func (key LedgerKey) MarshalBinaryCompress() ([]byte, error) {
-	e := NewEncodingBuffer()
-	if err := e.ledgerKeyCompressEncodeTo(key); err != nil {
-		return nil, err
-	}
-	return e.xdrEncoderBuf.Bytes(), nil
-}
-
 func (e *EncodingBuffer) ledgerKeyCompressEncodeTo(key LedgerKey) error {
 	if err := e.xdrEncoderBuf.WriteByte(byte(key.Type)); err != nil {
 		return err
@@ -152,23 +133,21 @@ func (e *EncodingBuffer) ledgerKeyCompressEncodeTo(key LedgerKey) error {
 		}
 		return e.assetTrustlineCompressEncodeTo(key.TrustLine.Asset)
 	case LedgerEntryTypeOffer:
-		if err := e.accountIdCompressEncodeTo(key.Offer.SellerId); err != nil {
-			return err
-		}
+		// We intentionally don't encode the SellerID since the OfferID is enough
+		// (it's unique to the network)
 		return key.Offer.OfferId.EncodeTo(e.encoder)
 	case LedgerEntryTypeData:
 		if err := e.accountIdCompressEncodeTo(key.Data.AccountId); err != nil {
 			return err
 		}
-		dataName := trimRightZeros(e.scratchBuf)
+		dataName := trimRightZeros([]byte(key.Data.DataName))
 		_, err := e.xdrEncoderBuf.Write(dataName)
 		return err
 	case LedgerEntryTypeClaimableBalance:
-		return key.ClaimableBalance.BalanceId.EncodeTo(e.encoder)
+		return e.claimableBalanceCompressEncodeTo(key.ClaimableBalance.BalanceId)
 	case LedgerEntryTypeLiquidityPool:
-		// TODO: why are we encoding the full pool id (with padding)
-		//       here, in TrustLineAsset we just write the bytes directly?
-		return key.LiquidityPool.LiquidityPoolId.EncodeTo(e.encoder)
+		_, err := e.xdrEncoderBuf.Write(key.LiquidityPool.LiquidityPoolId[:])
+		return err
 	default:
 		panic("Unknown type")
 	}

--- a/xdr/ledger_key.go
+++ b/xdr/ledger_key.go
@@ -3,7 +3,6 @@ package xdr
 import (
 	"encoding/base64"
 	"fmt"
-	"strings"
 )
 
 // LedgerKey implements the `Keyer` interface
@@ -107,7 +106,7 @@ func (key *LedgerKey) SetClaimableBalance(balanceID ClaimableBalanceId) error {
 	return nil
 }
 
-// SetL LquidityPool mutates `key` such that it represents the identity of a
+// SetLiquidityPool mutates `key` such that it represents the identity of a
 // liquidity pool.
 func (key *LedgerKey) SetLiquidityPool(poolID PoolId) error {
 	data := LedgerKeyLiquidityPool{poolID}
@@ -132,62 +131,48 @@ func (key *LedgerKey) SetLiquidityPool(poolID PoolId) error {
 // - Writes a single byte for union discriminants vs 4 bytes.
 // - Removes type and code padding for Asset.
 func (key LedgerKey) MarshalBinaryCompress() ([]byte, error) {
-	m := []byte{byte(key.Type)}
+	e := NewEncodingBuffer()
+	if err := e.ledgerKeyCompressEncodeTo(key); err != nil {
+		return nil, err
+	}
+	return e.xdrEncoderBuf.Bytes(), nil
+}
+
+func (e *EncodingBuffer) ledgerKeyCompressEncodeTo(key LedgerKey) error {
+	if err := e.xdrEncoderBuf.WriteByte(byte(key.Type)); err != nil {
+		return err
+	}
 
 	switch key.Type {
 	case LedgerEntryTypeAccount:
-		account, err := key.Account.AccountId.MarshalBinaryCompress()
-		if err != nil {
-			return nil, err
-		}
-		m = append(m, account...)
+		return e.accountIdCompressEncodeTo(key.Account.AccountId)
 	case LedgerEntryTypeTrustline:
-		account, err := key.TrustLine.AccountId.MarshalBinaryCompress()
-		if err != nil {
-			return nil, err
+		if err := e.accountIdCompressEncodeTo(key.TrustLine.AccountId); err != nil {
+			return err
 		}
-		m = append(m, account...)
-		asset, err := key.TrustLine.Asset.MarshalBinaryCompress()
-		if err != nil {
-			return nil, err
-		}
-		m = append(m, asset...)
+		return e.assetTrustlineCompressEncodeTo(key.TrustLine.Asset)
 	case LedgerEntryTypeOffer:
-		seller, err := key.Offer.SellerId.MarshalBinaryCompress()
-		if err != nil {
-			return nil, err
+		if err := e.accountIdCompressEncodeTo(key.Offer.SellerId); err != nil {
+			return err
 		}
-		m = append(m, seller...)
-		offer, err := key.Offer.OfferId.MarshalBinary()
-		if err != nil {
-			return nil, err
-		}
-		m = append(m, offer...)
+		return key.Offer.OfferId.EncodeTo(e.encoder)
 	case LedgerEntryTypeData:
-		account, err := key.Data.AccountId.MarshalBinaryCompress()
-		if err != nil {
-			return nil, err
+		if err := e.accountIdCompressEncodeTo(key.Data.AccountId); err != nil {
+			return err
 		}
-		m = append(m, account...)
-		dataName := []byte(strings.TrimRight(string(key.Data.DataName), "\x00"))
-		m = append(m, dataName...)
+		dataName := trimRightZeros(e.scratchBuf)
+		_, err := e.xdrEncoderBuf.Write(dataName)
+		return err
 	case LedgerEntryTypeClaimableBalance:
-		cBalance, err := key.ClaimableBalance.BalanceId.MarshalBinaryCompress()
-		if err != nil {
-			return nil, err
-		}
-		m = append(m, cBalance...)
+		return key.ClaimableBalance.BalanceId.EncodeTo(e.encoder)
 	case LedgerEntryTypeLiquidityPool:
-		cBalance, err := key.LiquidityPool.LiquidityPoolId.MarshalBinary()
-		if err != nil {
-			return nil, err
-		}
-		m = append(m, cBalance...)
+		// TODO: why are we encoding the full pool id (with padding)
+		//       here, in TrustLineAsset we just write the bytes directly?
+		return key.LiquidityPool.LiquidityPoolId.EncodeTo(e.encoder)
 	default:
 		panic("Unknown type")
 	}
 
-	return m, nil
 }
 
 // MarshalBinaryBase64 marshals XDR into a binary form and then encodes it

--- a/xdr/ledger_key_test.go
+++ b/xdr/ledger_key_test.go
@@ -1,18 +1,18 @@
-package xdr_test
+package xdr
 
 import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLedgerKeyTrustLineBinaryMaxLength(t *testing.T) {
-	key := &xdr.LedgerKey{}
+	key := &LedgerKey{}
 	err := key.SetTrustline(
-		xdr.MustAddress("GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"),
-		xdr.MustNewCreditAsset("123456789012", "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF").ToTrustLineAsset(),
+		MustAddress("GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF"),
+		MustNewCreditAsset("123456789012", "GBFLTCDLOE6YQ74B66RH3S2UW5I2MKZ5VLTM75F4YMIWUIXRIFVNRNIF").ToTrustLineAsset(),
 	)
 	assert.NoError(t, err)
 
@@ -21,4 +21,20 @@ func TestLedgerKeyTrustLineBinaryMaxLength(t *testing.T) {
 	assert.Equal(t, len(compressed), 92)
 	bcompressed := base64.StdEncoding.EncodeToString(compressed)
 	assert.Equal(t, len(bcompressed), 124)
+}
+
+func TestTrimRightZeros(t *testing.T) {
+	require.Equal(t, []byte(nil), trimRightZeros(nil))
+	require.Equal(t, []byte{}, trimRightZeros([]byte{}))
+	require.Equal(t, []byte{}, trimRightZeros([]byte{0x0}))
+	require.Equal(t, []byte{}, trimRightZeros([]byte{0x0, 0x0}))
+	require.Equal(t, []byte{0x1}, trimRightZeros([]byte{0x1}))
+	require.Equal(t, []byte{0x1}, trimRightZeros([]byte{0x1, 0x0}))
+	require.Equal(t, []byte{0x1}, trimRightZeros([]byte{0x1, 0x0, 0x0}))
+	require.Equal(t, []byte{0x1}, trimRightZeros([]byte{0x1, 0x0, 0x0, 0x0}))
+	require.Equal(t, []byte{0x1, 0x2}, trimRightZeros([]byte{0x1, 0x2}))
+	require.Equal(t, []byte{0x1, 0x2}, trimRightZeros([]byte{0x1, 0x2, 0x0}))
+	require.Equal(t, []byte{0x1, 0x2}, trimRightZeros([]byte{0x1, 0x2, 0x0, 0x0}))
+	require.Equal(t, []byte{0x0, 0x2}, trimRightZeros([]byte{0x0, 0x2, 0x0, 0x0}))
+	require.Equal(t, []byte{0x0, 0x2, 0x0, 0x1}, trimRightZeros([]byte{0x0, 0x2, 0x0, 0x1, 0x0}))
 }

--- a/xdr/main.go
+++ b/xdr/main.go
@@ -177,6 +177,18 @@ func (e *EncodingBuffer) MarshalBinary(encodable XDREncodable) ([]byte, error) {
 	return ret, nil
 }
 
+// LedgerKeyUnsafeMarshalBinaryCompress marshals LedgerKey to []byte but unlike
+// MarshalBinary() it removes all unnecessary bytes, exploting the fact
+// that XDR is padding data to 4 bytes in union discriminants etc.
+// It's primary use is in ingest/io.StateReader that keep LedgerKeys in
+// memory so this function decrease memory requirements.
+//
+// Warning, do not use UnmarshalBinary() on data encoded using this method!
+//
+// Optimizations:
+// - Writes a single byte for union discriminants vs 4 bytes.
+// - Removes type and code padding for Asset.
+// - Removes padding for AccountIds
 func (e *EncodingBuffer) LedgerKeyUnsafeMarshalBinaryCompress(key LedgerKey) ([]byte, error) {
 	e.xdrEncoderBuf.Reset()
 	err := e.ledgerKeyCompressEncodeTo(key)

--- a/xdr/main.go
+++ b/xdr/main.go
@@ -106,9 +106,9 @@ func MarshalHex(v interface{}) (string, error) {
 // EncodingBuffer reuses internal buffers between invocations to minimize allocations.
 // It intentionally only allows EncodeTo method arguments, to guarantee high performance encoding.
 type EncodingBuffer struct {
-	encoder          *xdr.Encoder
-	xdrEncoderBuf    bytes.Buffer
-	otherEncodersBuf []byte
+	encoder       *xdr.Encoder
+	xdrEncoderBuf bytes.Buffer
+	scratchBuf    []byte
 }
 
 func growSlice(old []byte, newSize int) []byte {
@@ -150,9 +150,9 @@ func (e *EncodingBuffer) UnsafeMarshalBase64(encodable XDREncodable) ([]byte, er
 		return nil, err
 	}
 	neededLen := base64.StdEncoding.EncodedLen(len(xdrEncoded))
-	e.otherEncodersBuf = growSlice(e.otherEncodersBuf, neededLen)
-	base64.StdEncoding.Encode(e.otherEncodersBuf, xdrEncoded)
-	return e.otherEncodersBuf, nil
+	e.scratchBuf = growSlice(e.scratchBuf, neededLen)
+	base64.StdEncoding.Encode(e.scratchBuf, xdrEncoded)
+	return e.scratchBuf, nil
 }
 
 // UnsafeMarshalHex is the hex version of UnsafeMarshalBinary
@@ -162,9 +162,9 @@ func (e *EncodingBuffer) UnsafeMarshalHex(encodable XDREncodable) ([]byte, error
 		return nil, err
 	}
 	neededLen := hex.EncodedLen(len(xdrEncoded))
-	e.otherEncodersBuf = growSlice(e.otherEncodersBuf, neededLen)
-	hex.Encode(e.otherEncodersBuf, xdrEncoded)
-	return e.otherEncodersBuf, nil
+	e.scratchBuf = growSlice(e.scratchBuf, neededLen)
+	hex.Encode(e.scratchBuf, xdrEncoded)
+	return e.scratchBuf, nil
 }
 
 func (e *EncodingBuffer) MarshalBinary(encodable XDREncodable) ([]byte, error) {
@@ -175,6 +175,15 @@ func (e *EncodingBuffer) MarshalBinary(encodable XDREncodable) ([]byte, error) {
 	ret := make([]byte, len(xdrEncoded))
 	copy(ret, xdrEncoded)
 	return ret, nil
+}
+
+func (e *EncodingBuffer) LedgerKeyUnsafeMarshalBinaryCompress(key LedgerKey) ([]byte, error) {
+	e.xdrEncoderBuf.Reset()
+	err := e.ledgerKeyCompressEncodeTo(key)
+	if err != nil {
+		return nil, err
+	}
+	return e.xdrEncoderBuf.Bytes(), nil
 }
 
 func (e *EncodingBuffer) MarshalBase64(encodable XDREncodable) (string, error) {

--- a/xdr/trust_line_asset.go
+++ b/xdr/trust_line_asset.go
@@ -42,16 +42,40 @@ func (a TrustLineAsset) MustExtract(typ interface{}, code interface{}, issuer in
 	}
 }
 
+func trimRightZeros(b []byte) []byte {
+	if len(b) == 0 {
+		return b
+	}
+	i := len(b)
+	for ; i > 0; i-- {
+		if b[i-1] != 0 {
+			break
+		}
+	}
+	return b[:i]
+}
+
 func (e *EncodingBuffer) assetTrustlineCompressEncodeTo(a TrustLineAsset) error {
+	if err := e.xdrEncoderBuf.WriteByte(byte(a.Type)); err != nil {
+		return err
+	}
+
 	switch a.Type {
-	case AssetTypeAssetTypeNative,
-		AssetTypeAssetTypeCreditAlphanum4,
-		AssetTypeAssetTypeCreditAlphanum12:
-		return e.assetCompressEncodeTo(a.ToAsset())
-	case AssetTypeAssetTypePoolShare:
-		if err := e.xdrEncoderBuf.WriteByte(byte(a.Type)); err != nil {
+	case AssetTypeAssetTypeNative:
+		return nil
+	case AssetTypeAssetTypeCreditAlphanum4:
+		code := trimRightZeros(a.AlphaNum4.AssetCode[:])
+		if _, err := e.xdrEncoderBuf.Write(code); err != nil {
 			return err
 		}
+		return e.accountIdCompressEncodeTo(a.AlphaNum4.Issuer)
+	case AssetTypeAssetTypeCreditAlphanum12:
+		code := trimRightZeros(a.AlphaNum12.AssetCode[:])
+		if _, err := e.xdrEncoderBuf.Write(code); err != nil {
+			return err
+		}
+		return e.accountIdCompressEncodeTo(a.AlphaNum12.Issuer)
+	case AssetTypeAssetTypePoolShare:
 		_, err := e.xdrEncoderBuf.Write(a.LiquidityPoolId[:])
 		return err
 	default:

--- a/xdr/trust_line_asset.go
+++ b/xdr/trust_line_asset.go
@@ -42,21 +42,6 @@ func (a TrustLineAsset) MustExtract(typ interface{}, code interface{}, issuer in
 	}
 }
 
-// MarshalBinaryCompress marshals TrustLineAsset to []byte but unlike
-// MarshalBinary() it removes all unnecessary bytes, exploting the fact
-// that XDR is padding data to 4 bytes in union discriminants etc.
-// It's primary use is in ingest/io.StateReader that keep LedgerKeys in
-// memory so this function decrease memory requirements.
-//
-// Warning, do not use UnmarshalBinary() on data encoded using this method!
-func (a TrustLineAsset) MarshalBinaryCompress() ([]byte, error) {
-	e := NewEncodingBuffer()
-	if err := e.assetTrustlineCompressEncodeTo(a); err != nil {
-		return nil, err
-	}
-	return e.xdrEncoderBuf.Bytes(), nil
-}
-
 func (e *EncodingBuffer) assetTrustlineCompressEncodeTo(a TrustLineAsset) error {
 	switch a.Type {
 	case AssetTypeAssetTypeNative,
@@ -67,7 +52,7 @@ func (e *EncodingBuffer) assetTrustlineCompressEncodeTo(a TrustLineAsset) error 
 		if err := e.xdrEncoderBuf.WriteByte(byte(a.Type)); err != nil {
 			return err
 		}
-		_, err := e.xdrEncoderBuf.Write((*a.LiquidityPoolId)[:])
+		_, err := e.xdrEncoderBuf.Write(a.LiquidityPoolId[:])
 		return err
 	default:
 		panic(fmt.Errorf("Unknown asset type: %v", a.Type))

--- a/xdr/trust_line_asset.go
+++ b/xdr/trust_line_asset.go
@@ -50,16 +50,25 @@ func (a TrustLineAsset) MustExtract(typ interface{}, code interface{}, issuer in
 //
 // Warning, do not use UnmarshalBinary() on data encoded using this method!
 func (a TrustLineAsset) MarshalBinaryCompress() ([]byte, error) {
+	e := NewEncodingBuffer()
+	if err := e.assetTrustlineCompressEncodeTo(a); err != nil {
+		return nil, err
+	}
+	return e.xdrEncoderBuf.Bytes(), nil
+}
+
+func (e *EncodingBuffer) assetTrustlineCompressEncodeTo(a TrustLineAsset) error {
 	switch a.Type {
 	case AssetTypeAssetTypeNative,
 		AssetTypeAssetTypeCreditAlphanum4,
 		AssetTypeAssetTypeCreditAlphanum12:
-		return a.ToAsset().MarshalBinaryCompress()
+		return e.assetCompressEncodeTo(a.ToAsset())
 	case AssetTypeAssetTypePoolShare:
-		m := []byte{byte(a.Type)}
-		poolId := [32]byte(*a.LiquidityPoolId)
-		m = append(m, poolId[:]...)
-		return m, nil
+		if err := e.xdrEncoderBuf.WriteByte(byte(a.Type)); err != nil {
+			return err
+		}
+		_, err := e.xdrEncoderBuf.Write((*a.LiquidityPoolId)[:])
+		return err
 	default:
 		panic(fmt.Errorf("Unknown asset type: %v", a.Type))
 	}


### PR DESCRIPTION
15x CPU time improvement, all allocations were removed

Before:

```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go/benchmarks
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkXDRMarshalCompress
BenchmarkXDRMarshalCompress-8   	  608031	      1970 ns/op	    2048 B/op	      59 allocs/op
PASS
```

After:

```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go/benchmarks
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkXDRMarshalCompress
BenchmarkXDRMarshalCompress-8   	 8785383	       133.8 ns/op	       0 B/op	       0 allocs/op
PASS
```

~One of the remaning allocations is, in fact, caused by a call to PoolID.Encode which I think can be removed.~