### PR TITLE
xdr and historyarchive: Remove XDR decoder allocations from XdrStream

### DIFF
--- a/historyarchive/json.go
+++ b/historyarchive/json.go
@@ -17,7 +17,7 @@ import (
 )
 
 func DumpXdrAsJson(args []string) error {
-	var tmp interface{}
+	var tmp xdr.DecoderFrom
 	var rdr io.ReadCloser
 	var err error
 
@@ -58,7 +58,7 @@ func DumpXdrAsJson(args []string) error {
 				return fmt.Errorf("Error: unrecognized XDR file type %s", base)
 			}
 
-			if err = xr.ReadOne(&tmp); err != nil {
+			if err = xr.ReadOne(tmp); err != nil {
 				if err == io.EOF {
 					break
 				} else {

--- a/historyarchive/verify.go
+++ b/historyarchive/verify.go
@@ -9,10 +9,11 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"hash"
 	"io"
 	"sort"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/stellar/go/xdr"
 )
@@ -138,7 +139,7 @@ func (arch *Archive) VerifyCategoryCheckpoint(cat string, chk uint32) error {
 	}
 	defer rdr.Close()
 
-	var tmp interface{}
+	var tmp xdr.DecoderFrom
 	var step func() error
 	var reset func()
 
@@ -177,7 +178,7 @@ func (arch *Archive) VerifyCategoryCheckpoint(cat string, chk uint32) error {
 
 	for {
 		reset()
-		if err = rdr.ReadOne(&tmp); err != nil {
+		if err = rdr.ReadOne(tmp); err != nil {
 			if err == io.EOF {
 				break
 			} else {

--- a/xdr/go_string_test.go
+++ b/xdr/go_string_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Uint32Ptr(val uint32) *xdr.Uint32 {
+	pval := xdr.Uint32(val)
+	return &pval
+}
+
 func TestAssetGoStringerNative(t *testing.T) {
 	asset, err := xdr.NewAsset(xdr.AssetTypeAssetTypeNative, nil)
 	assert.NoError(t, err)
@@ -107,12 +112,12 @@ func TestOperationBodyGoStringerSetOptions(t *testing.T) {
 		Type: xdr.OperationTypeSetOptions,
 		SetOptionsOp: &xdr.SetOptionsOp{
 			InflationDest: xdr.MustAddressPtr("GC7ERFCD7QLDFRSEPLYB3GYSWX6GYMCHLDL45N4S5Q2N5EJDOMOJ63V4"),
-			ClearFlags:    xdr.Uint32Ptr(0),
-			SetFlags:      xdr.Uint32Ptr(1),
-			MasterWeight:  xdr.Uint32Ptr(2),
-			LowThreshold:  xdr.Uint32Ptr(3),
-			MedThreshold:  xdr.Uint32Ptr(4),
-			HighThreshold: xdr.Uint32Ptr(5),
+			ClearFlags:    Uint32Ptr(0),
+			SetFlags:      Uint32Ptr(1),
+			MasterWeight:  Uint32Ptr(2),
+			LowThreshold:  Uint32Ptr(3),
+			MedThreshold:  Uint32Ptr(4),
+			HighThreshold: Uint32Ptr(5),
 			HomeDomain:    xdr.String32Ptr("stellar.org"),
 			Signer: &xdr.Signer{
 				Key:    xdr.MustSigner("GC7ERFCD7QLDFRSEPLYB3GYSWX6GYMCHLDL45N4S5Q2N5EJDOMOJ63V4"),


### PR DESCRIPTION
Also:
* Move Uint32Ptr into test file (it was only used for testing)
* Tidy up EncoderTo and DecoderFrom interfaces
