### PR TITLE
services/horizon: Add metrics to all builders that embed BatchInsertBuilder

### DIFF
--- a/services/horizon/internal/db2/history/account_signers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/account_signers_batch_insert_builder.go
@@ -2,6 +2,8 @@ package history
 
 import (
 	"context"
+
+	"github.com/stellar/go/support/db"
 )
 
 func (i *accountSignersBatchInsertBuilder) Add(ctx context.Context, signer AccountSigner) error {
@@ -14,5 +16,6 @@ func (i *accountSignersBatchInsertBuilder) Add(ctx context.Context, signer Accou
 }
 
 func (i *accountSignersBatchInsertBuilder) Exec(ctx context.Context) error {
+	ctx = context.WithValue(ctx, &db.RouteContextKey, "accountSignersBatchInsertBuilder")
 	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/effect_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/effect_batch_insert_builder.go
@@ -58,5 +58,6 @@ func (i *effectBatchInsertBuilder) Add(
 }
 
 func (i *effectBatchInsertBuilder) Exec(ctx context.Context) error {
+	ctx = context.WithValue(ctx, &db.RouteContextKey, "effectBatchInsertBuilder")
 	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/history_claimable_balances.go
+++ b/services/horizon/internal/db2/history/history_claimable_balances.go
@@ -119,6 +119,7 @@ func (i *operationClaimableBalanceBatchInsertBuilder) Add(ctx context.Context, o
 
 // Exec flushes all pending operation claimable balances to the db
 func (i *operationClaimableBalanceBatchInsertBuilder) Exec(ctx context.Context) error {
+	ctx = context.WithValue(ctx, &db.RouteContextKey, "operationClaimableBalanceBatchInsertBuilder")
 	return i.builder.Exec(ctx)
 }
 
@@ -150,5 +151,6 @@ func (i *transactionClaimableBalanceBatchInsertBuilder) Add(ctx context.Context,
 
 // Exec flushes all pending transaction claimable balances to the db
 func (i *transactionClaimableBalanceBatchInsertBuilder) Exec(ctx context.Context) error {
+	ctx = context.WithValue(ctx, &db.RouteContextKey, "transactionClaimableBalanceBatchInsertBuilder")
 	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/history_liquidity_pools.go
+++ b/services/horizon/internal/db2/history/history_liquidity_pools.go
@@ -128,6 +128,7 @@ func (i *operationLiquidityPoolBatchInsertBuilder) Add(ctx context.Context, oper
 
 // Exec flushes all pending operation claimable balances to the db
 func (i *operationLiquidityPoolBatchInsertBuilder) Exec(ctx context.Context) error {
+	ctx = context.WithValue(ctx, &db.RouteContextKey, "operationLiquidityPoolBatchInsertBuilder")
 	return i.builder.Exec(ctx)
 }
 
@@ -159,5 +160,6 @@ func (i *transactionLiquidityPoolBatchInsertBuilder) Add(ctx context.Context, tr
 
 // Exec flushes all pending transaction claimable balances to the db
 func (i *transactionLiquidityPoolBatchInsertBuilder) Exec(ctx context.Context) error {
+	ctx = context.WithValue(ctx, &db.RouteContextKey, "transactionLiquidityPoolBatchInsertBuilder")
 	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/operation_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/operation_batch_insert_builder.go
@@ -63,5 +63,6 @@ func (i *operationBatchInsertBuilder) Add(
 }
 
 func (i *operationBatchInsertBuilder) Exec(ctx context.Context) error {
+	ctx = context.WithValue(ctx, &db.RouteContextKey, "operationBatchInsertBuilder")
 	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/operation_participant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/operation_participant_batch_insert_builder.go
@@ -45,5 +45,6 @@ func (i *operationParticipantBatchInsertBuilder) Add(
 }
 
 func (i *operationParticipantBatchInsertBuilder) Exec(ctx context.Context) error {
+	ctx = context.WithValue(ctx, &db.RouteContextKey, "operationParticipantBatchInsertBuilder")
 	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/participants.go
+++ b/services/horizon/internal/db2/history/participants.go
@@ -44,5 +44,6 @@ func (i *transactionParticipantsBatchInsertBuilder) Add(ctx context.Context, tra
 
 // Exec flushes all pending transaction participants to the db
 func (i *transactionParticipantsBatchInsertBuilder) Exec(ctx context.Context) error {
+	ctx = context.WithValue(ctx, &db.RouteContextKey, "transactionParticipantsBatchInsertBuilder")
 	return i.builder.Exec(ctx)
 }

--- a/services/horizon/internal/db2/history/trade_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/trade_batch_insert_builder.go
@@ -63,6 +63,7 @@ func (q *Q) NewTradeBatchInsertBuilder(maxBatchSize int) TradeBatchInsertBuilder
 
 // Exec flushes all outstanding trades to the database
 func (i *tradeBatchInsertBuilder) Exec(ctx context.Context) error {
+	ctx = context.WithValue(ctx, &db.RouteContextKey, "tradeBatchInsertBuilder")
 	return i.builder.Exec(ctx)
 }
 

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
@@ -57,6 +57,7 @@ func (i *transactionBatchInsertBuilder) Add(ctx context.Context, transaction ing
 }
 
 func (i *transactionBatchInsertBuilder) Exec(ctx context.Context) error {
+	ctx = context.WithValue(ctx, &db.RouteContextKey, "transactionBatchInsertBuilder")
 	return i.builder.Exec(ctx)
 }
 

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -143,7 +143,7 @@ type Table struct {
 	// Name is the name of the table
 	Name string
 
-	Session *Session
+	Session SessionInterface
 }
 
 func pingDB(db *sqlx.DB) error {

--- a/support/db/metrics.go
+++ b/support/db/metrics.go
@@ -379,6 +379,13 @@ func (s *SessionWithMetrics) GetRaw(ctx context.Context, dest interface{}, query
 	return s.Get(ctx, dest, squirrel.Expr(query, args...))
 }
 
+func (s *SessionWithMetrics) GetTable(name string) *Table {
+	return &Table{
+		Name:    name,
+		Session: s,
+	}
+}
+
 func (s *SessionWithMetrics) Select(ctx context.Context, dest interface{}, query squirrel.Sqlizer) (err error) {
 	queryType := string(getQueryType(ctx, query))
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Reuse `route` label in db metrics to gather metrics for specific queries.

### Why

This is done to understand what's the time spent in specific queries. It helps debugging issues like the slow `TransactionsProcessor`. After gathering new metrics we can see that it's actually DB operations that take significant time in this processor:
```
horizon_db_query_duration_seconds{error="false",query_type="insert",route="transactionBatchInsertBuilder",subservice="ingest",quantile="0.5"} 0.114881944
horizon_db_query_duration_seconds{error="false",query_type="insert",route="transactionBatchInsertBuilder",subservice="ingest",quantile="0.9"} 0.183986877
horizon_db_query_duration_seconds{error="false",query_type="insert",route="transactionBatchInsertBuilder",subservice="ingest",quantile="0.99"} 0.374664138
horizon_db_query_duration_seconds_sum{error="false",query_type="insert",route="transactionBatchInsertBuilder",subservice="ingest"} 34.911868006000006
horizon_db_query_duration_seconds_count{error="false",query_type="insert",route="transactionBatchInsertBuilder",subservice="ingest"} 280

horizon_ingest_processor_run_duration_seconds{name="processors.TransactionProcessor",quantile="0.5"} 0.124784865
horizon_ingest_processor_run_duration_seconds{name="processors.TransactionProcessor",quantile="0.9"} 0.197986801
horizon_ingest_processor_run_duration_seconds{name="processors.TransactionProcessor",quantile="0.99"} 0.386869168
horizon_ingest_processor_run_duration_seconds_sum{name="processors.TransactionProcessor"} 37.35023348499998
horizon_ingest_processor_run_duration_seconds_count{name="processors.TransactionProcessor"} 280
```

### Known limitations

It would be clean to create a new label like `method` or `query` but it will create a new dimension on all existing metrics with `route` set increasing space requirements for metrics.