### PR TITLE
services/horizon: Return both inner and outer result codes for fee bump transactions.

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -605,8 +605,9 @@ func (t Transaction) PagingToken() string {
 // TransactionResultCodes represent a summary of result codes returned from
 // a single xdr TransactionResult
 type TransactionResultCodes struct {
-	TransactionCode string   `json:"transaction"`
-	OperationCodes  []string `json:"operations,omitempty"`
+	TransactionCode      string   `json:"transaction"`
+	InnerTransactionCode string   `json:"inner_transaction,omitempty"`
+	OperationCodes       []string `json:"operations,omitempty"`
 }
 
 // KeyTypeFromAddress converts the version byte of the provided strkey encoded

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this
 file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changes
+* Return inner and outer result codes for fee bump transactions ([4081](https://github.com/stellar/go/pull/4081))
+
 ## v2.11.0
 
 ### Changes

--- a/services/horizon/internal/actions_transaction_test.go
+++ b/services/horizon/internal/actions_transaction_test.go
@@ -413,7 +413,7 @@ func TestPostFailedFeeBumpTransaction(t *testing.T) {
 	w := ht.Post("/transactions", form)
 	ht.Assert.Equal(400, w.Code)
 	ht.Assert.Contains(string(w.Body.Bytes()), "tx_fee_bump_inner_failed")
-	ht.Assert.NotContains(string(w.Body.Bytes()), "tx_bad_auth")
+	ht.Assert.Contains(string(w.Body.Bytes()), "tx_bad_auth")
 
 	innerTxEnvelope, err := xdr.MarshalBase64(fixture.Envelope.FeeBump.Tx.InnerTx.V1)
 	ht.Assert.NoError(err)

--- a/services/horizon/internal/resourceadapter/transaction_result_codes.go
+++ b/services/horizon/internal/resourceadapter/transaction_result_codes.go
@@ -2,6 +2,7 @@ package resourceadapter
 
 import (
 	"context"
+
 	protocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/txsub"
 )
@@ -13,10 +14,12 @@ func PopulateTransactionResultCodes(ctx context.Context,
 	fail *txsub.FailedTransactionError,
 ) (err error) {
 
-	dest.TransactionCode, err = fail.TransactionResultCode(transactionHash)
+	results, err := fail.TransactionResultCodes(transactionHash)
 	if err != nil {
 		return
 	}
+	dest.TransactionCode = results.Code
+	dest.InnerTransactionCode = results.InnerCode
 
 	dest.OperationCodes, err = fail.OperationResultCodes()
 	if err != nil {

--- a/services/regulated-assets-approval-server/internal/serve/httperror/http_error_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/httperror/http_error_test.go
@@ -25,7 +25,8 @@ func TestParseHorizonError(t *testing.T) {
 			Status: http.StatusBadRequest,
 			Extras: map[string]interface{}{
 				"result_codes": hProtocol.TransactionResultCodes{
-					TransactionCode: "tx_code_here",
+					TransactionCode:      "tx_code_here",
+					InnerTransactionCode: "",
 					OperationCodes: []string{
 						"op_success",
 						"op_bad_auth",
@@ -35,5 +36,5 @@ func TestParseHorizonError(t *testing.T) {
 		},
 	}
 	err = ParseHorizonError(horizonError)
-	require.EqualError(t, err, "error submitting transaction: problem: bad_request, &{TransactionCode:tx_code_here OperationCodes:[op_success op_bad_auth]}\n: horizon error: \"Bad Request\" (tx_code_here, op_success, op_bad_auth) - check horizon.Error.Problem for more information")
+	require.EqualError(t, err, "error submitting transaction: problem: bad_request, &{TransactionCode:tx_code_here InnerTransactionCode: OperationCodes:[op_success op_bad_auth]}\n: horizon error: \"Bad Request\" (tx_code_here, op_success, op_bad_auth) - check horizon.Error.Problem for more information")
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Return both inner and outer result codes for fee bump transactions.

### Why

Currently only the outer code is returned for fee bump transactions

### Known limitations

N/A