### PR TITLE
exp/orderbook: Improve path finding algorithm

### DIFF
--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -317,13 +317,10 @@ func (graph *OrderBookGraph) FindPaths(
 		includePools:           includePools,
 	}
 	graph.lock.RLock()
-	err := dfs(
+	err := search(
 		ctx,
 		searchState,
 		maxPathLength,
-		[]xdr.Asset{},
-		[]string{},
-		len(sourceAssets),
 		destinationAssetString,
 		destinationAsset,
 		destinationAmount,
@@ -374,13 +371,10 @@ func (graph *OrderBookGraph) FindFixedPaths(
 		includePools:      includePools,
 	}
 	graph.lock.RLock()
-	err := dfs(
+	err := search(
 		ctx,
 		searchState,
 		maxPathLength,
-		[]xdr.Asset{},
-		[]string{},
-		len(destinationAssets),
 		sourceAsset.String(),
 		sourceAsset,
 		amountToSpend,

--- a/exp/orderbook/graph_test.go
+++ b/exp/orderbook/graph_test.go
@@ -210,24 +210,24 @@ func assertPathEquals(t *testing.T, a, b []Path) {
 
 	for i := 0; i < len(a); i++ {
 		assert.Equalf(t, a[i].SourceAmount, b[i].SourceAmount,
-			"expected src amounts to be same got %v %v", a, b)
+			"expected src amounts to be same got %v %v", a[i], b[i])
 
 		assert.Equalf(t, a[i].DestinationAmount, b[i].DestinationAmount,
-			"expected dest amounts to be same got %v %v", a, b)
+			"expected dest amounts to be same got %v %v", a[i], b[i])
 
 		assert.Truef(t, a[i].DestinationAsset.Equals(b[i].DestinationAsset),
-			"expected dest assets to be same got %v %v", a, b)
+			"expected dest assets to be same got %v %v", a[i], b[i])
 
 		assert.Truef(t, a[i].SourceAsset.Equals(b[i].SourceAsset),
-			"expected source assets to be same got %v %v", a, b)
+			"expected source assets to be same got %v %v", a[i], b[i])
 
 		assert.Equalf(t, len(a[i].InteriorNodes), len(b[i].InteriorNodes),
-			"expected interior nodes have same length got %v %v", a, b)
+			"expected interior nodes have same length got %v %v", a[i], b[i])
 
 		for j := 0; j > len(a[i].InteriorNodes); j++ {
 			assert.Truef(t,
 				a[i].InteriorNodes[j].Equals(b[i].InteriorNodes[j]),
-				"expected interior nodes to be same got %v %v", a, b)
+				"expected interior nodes to be same got %v %v", a[i], b[i])
 		}
 	}
 }
@@ -1404,18 +1404,20 @@ func TestFindPaths(t *testing.T) {
 
 	expectedPaths := []Path{
 		{
-			SourceAmount:      5,
-			SourceAsset:       usdAsset,
-			InteriorNodes:     []xdr.Asset{},
+			// arbitrage usd then trade to xlm
+			SourceAmount: 2,
+			SourceAsset:  usdAsset,
+			InteriorNodes: []xdr.Asset{
+				eurAsset,
+				usdAsset,
+			},
 			DestinationAsset:  nativeAsset,
 			DestinationAmount: 20,
 		},
 		{
-			SourceAmount: 7,
-			SourceAsset:  usdAsset,
-			InteriorNodes: []xdr.Asset{
-				eurAsset,
-			},
+			SourceAmount:      5,
+			SourceAsset:       usdAsset,
+			InteriorNodes:     []xdr.Asset{},
 			DestinationAsset:  nativeAsset,
 			DestinationAmount: 20,
 		},
@@ -1478,18 +1480,20 @@ func TestFindPaths(t *testing.T) {
 
 	expectedPaths = []Path{
 		{
-			SourceAmount:      5,
-			SourceAsset:       usdAsset,
-			InteriorNodes:     []xdr.Asset{},
+			// arbitrage usd then trade to xlm
+			SourceAmount: 2,
+			SourceAsset:  usdAsset,
+			InteriorNodes: []xdr.Asset{
+				eurAsset,
+				usdAsset,
+			},
 			DestinationAsset:  nativeAsset,
 			DestinationAmount: 20,
 		},
 		{
-			SourceAmount: 7,
-			SourceAsset:  usdAsset,
-			InteriorNodes: []xdr.Asset{
-				eurAsset,
-			},
+			SourceAmount:      5,
+			SourceAsset:       usdAsset,
+			InteriorNodes:     []xdr.Asset{},
 			DestinationAsset:  nativeAsset,
 			DestinationAmount: 20,
 		},
@@ -1541,18 +1545,20 @@ func TestFindPaths(t *testing.T) {
 
 	expectedPaths = []Path{
 		{
-			SourceAmount:      5,
-			SourceAsset:       usdAsset,
-			InteriorNodes:     []xdr.Asset{},
+			// arbitrage usd then trade to xlm
+			SourceAmount: 2,
+			SourceAsset:  usdAsset,
+			InteriorNodes: []xdr.Asset{
+				eurAsset,
+				usdAsset,
+			},
 			DestinationAsset:  nativeAsset,
 			DestinationAmount: 20,
 		},
 		{
-			SourceAmount: 7,
-			SourceAsset:  usdAsset,
-			InteriorNodes: []xdr.Asset{
-				eurAsset,
-			},
+			SourceAmount:      5,
+			SourceAsset:       usdAsset,
+			InteriorNodes:     []xdr.Asset{},
 			DestinationAsset:  nativeAsset,
 			DestinationAmount: 20,
 		},
@@ -1678,20 +1684,22 @@ func TestFindPathsStartingAt(t *testing.T) {
 
 	expectedPaths := []Path{
 		{
+			// arbitrage usd then trade to xlm
+			SourceAmount: 5,
+			SourceAsset:  usdAsset,
+			InteriorNodes: []xdr.Asset{
+				eurAsset,
+				usdAsset,
+			},
+			DestinationAsset:  nativeAsset,
+			DestinationAmount: 60,
+		},
+		{
 			SourceAmount:      5,
 			SourceAsset:       usdAsset,
 			InteriorNodes:     []xdr.Asset{},
 			DestinationAsset:  nativeAsset,
 			DestinationAmount: 20,
-		},
-		{
-			SourceAmount: 5,
-			SourceAsset:  usdAsset,
-			InteriorNodes: []xdr.Asset{
-				eurAsset,
-			},
-			DestinationAsset:  nativeAsset,
-			DestinationAmount: 15,
 		},
 	}
 
@@ -2108,12 +2116,6 @@ func TestInterleavedFixedPaths(t *testing.T) {
 			DestinationAsset:  chfAsset,
 			DestinationAmount: 13,
 			InteriorNodes:     []xdr.Asset{usdAsset},
-		}, {
-			SourceAsset:       nativeAsset,
-			SourceAmount:      1234,
-			DestinationAsset:  chfAsset,
-			DestinationAmount: 5,
-			InteriorNodes:     []xdr.Asset{eurAsset, usdAsset},
 		},
 	}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

In the Stellar protocol it is possible to perform a path payment where some amount of an asset is converted into a different asset through a series of trades and then delivered to a recipient. In order to submit a path payment you need to specify the source asset, the source amount, the destination asset, and, crucially, the list of intermediate assets to reach your destination asset.

Given a source asset, source amount, and destination asset, Horizon provides an endpoint to determine the paths which would maximize the amount of the destination asset delivered to the recipient. The algorithm used to implement this endpoint models path payments as a graph problem.

The nodes in the graph represents assets. A directed edges between nodes represents a trade to sell the source asset in exchange for the destination asset. These trades can occur on the orderbook or against liquidity pools. We also add the restriction that we can perform at most `k` trades in a path payment. In other words, we only consider paths which have `k` or less edges.

The current implementation of the path finding algorithm does a depth first search algorithm which examines all possible simple paths (a simple path does not contain any repeated nodes) of length up to `k` from the source asset to the destination asset. Once all the paths are discovered, the algorithm picks paths which maximize the destination amount.

The algorithm recurses up to a depth of `k`. At a depth of `i`, the dfs function call itself on at most `n-i-1` other nodes as a possibility for the next node in the path (where `n` is the total number of nodes in the graph).  The time complexity of this algorithm is approximately `O(n^(k+2))` because the total number of function calls is bounded by `n^(k+1)` and each function call will examine at most `n` other nodes.

This PR implements a more efficient algorithm using dynamic programming which is described below:

Given a source asset `s`, a source amount `a`, and a destination asset `d`, we want to transform `a` units of `s` into the maximum amount of `d` using at most `k` trades.

`dp[i][j]` is the maximum amount of asset `i` that can be obtained starting with `a` units of asset `s` using at  most `j` trades.

When we initialize `dp` we set `dp[s][0] = a` and for every other cell `dp[i][j] = 0`.

Once we have computed `dp` for all assets `i` using at most `j` trades, we can compute `dp[i][j+1]` by examining all edges in the graph to see which trades would produce a higher destination amount.

```golang
for j := 1; j <= k; j++ {
     for _, edge := range graph {
          src, dst := edge[0], edge[1]
          srcAmount := dp[src][j-1]
          dstAmount := executeTrade(src, srcAmount, dst)
          dp[dst][j] = max(dp[dst][j-1], dstAmount)
     }
}
```


The algorithm runs in `O(k*e)` time where `e` is the number of edges (in the worst case `O(k * n^2)` because a dense graph can have at most `n^2` edges). The correctness of this algorithm can be proven by induction (intuitively, the optimal path of length `k+1` must first begin with an optimal path of length `k` to some other node and from that node we can take an edge to the destination).

However, there is one problem with this algorithm. If there are arbitrage opportunities then it is possible that edges are reused in the optimal path. For example, if we have an arbitrage opportunity where we can convert USD to EUR and from EUR back to USD where we make a profit, then the optimal path is to iterate over the cycle as many times as possible and then convert into our destination asset.

This is problematic because when we execute a trade the offers that we used are no longer there. So if we try to execute the same trade again the calculation will be different. The algorithm above does not take into account that the offers can change. So we need to modify the algorithm so that we don't consider edges that would be visited more than once in a given path.

With that modification, the algorithm runs in `O(k^2*e)` because the duplicate edge check takes at most `O(k)` time.

---
Benchmarks on dfs:

```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go/exp/orderbook
cpu: Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz
BenchmarkVibrantPath
BenchmarkVibrantPath-12    	       1	2663075250 ns/op	61439896 B/op	 2817685 allocs/op
PASS
```

Benchmark on new code:

```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go/exp/orderbook
cpu: Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz
BenchmarkVibrantPath
BenchmarkVibrantPath-12    	      16	  74524903 ns/op	17888031 B/op	   65145 allocs/op
PASS
```

It looks to be substantially better in both runtime and memory.

### Known limitations

The previous dfs algorithm included much more paths in the result. This algorithm will include the optimal path using 1 edge, the optimal path using 2 edges, .., the optimal path using `k` edges.