### PR TITLE
exp/orderbook: Represent assets in orderbook graph as int32 instead of strings

### DIFF
--- a/exp/orderbook/edges.go
+++ b/exp/orderbook/edges.go
@@ -6,17 +6,17 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-// edgeSet maintains a mapping of strings (asset keys) to a set of venues, which
+// edgeSet maintains a mapping of assets to a set of venues, which
 // is composed of a sorted lists of offers and, optionally, a liquidity pool.
 // The offers are sorted by ascending price (in terms of the buying asset).
 type edgeSet []edge
 
 type edge struct {
-	key   string
+	key   int32
 	value Venues
 }
 
-func (e edgeSet) find(key string) int {
+func (e edgeSet) find(key int32) int {
 	for i := 0; i < len(e); i++ {
 		if e[i].key == key {
 			return i
@@ -26,7 +26,7 @@ func (e edgeSet) find(key string) int {
 }
 
 // addOffer will insert the given offer into the edge set
-func (e edgeSet) addOffer(key string, offer xdr.OfferEntry) edgeSet {
+func (e edgeSet) addOffer(key int32, offer xdr.OfferEntry) edgeSet {
 	// The list of offers in a venue is sorted by cheapest to most expensive
 	// price to convert buyingAsset to sellingAsset
 	i := e.find(key)
@@ -51,7 +51,7 @@ func (e edgeSet) addOffer(key string, offer xdr.OfferEntry) edgeSet {
 }
 
 // addPool makes `pool` a viable venue at `key`.
-func (e edgeSet) addPool(key string, pool xdr.LiquidityPoolEntry) edgeSet {
+func (e edgeSet) addPool(key int32, pool liquidityPool) edgeSet {
 	i := e.find(key)
 	if i < 0 {
 		return append(e, edge{key: key, value: Venues{pool: pool}})
@@ -62,7 +62,7 @@ func (e edgeSet) addPool(key string, pool xdr.LiquidityPoolEntry) edgeSet {
 
 // removeOffer will delete the given offer from the edge set, returning whether
 // or not the given offer was actually found.
-func (e edgeSet) removeOffer(key string, offerID xdr.Int64) (edgeSet, bool) {
+func (e edgeSet) removeOffer(key int32, offerID xdr.Int64) (edgeSet, bool) {
 	i := e.find(key)
 	if i < 0 {
 		return e, false
@@ -94,7 +94,7 @@ func (e edgeSet) removeOffer(key string, offerID xdr.Int64) (edgeSet, bool) {
 	return e, true
 }
 
-func (e edgeSet) removePool(key string) edgeSet {
+func (e edgeSet) removePool(key int32) edgeSet {
 	i := e.find(key)
 	if i < 0 {
 		return e

--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -49,9 +49,19 @@ type OBGraph interface {
 // OrderBookGraph is an in-memory graph representation of all the offers in the
 // Stellar ledger.
 type OrderBookGraph struct {
-	assetStringToID map[string]int32
+	// idToAssetString maps an int32 asset id to its string representation.
+	// Every asset on the OrderBookGraph has an int32 id which indexes into idToAssetString.
+	// The asset integer ids are largely contiguous. When an asset is completely removed
+	// from the OrderBookGraph the integer id for that asset will be assigned to the next
+	// asset which is added to the OrderBookGraph.
 	idToAssetString []string
-	vacantIDs       []int32
+	// assetStringToID maps an asset string to its int32 id.
+	assetStringToID map[string]int32
+	// vacantIDs is a list of int32 asset ids which can be mapped to new assets.
+	// When a new asset is added to the OrderBookGraph we first check if there are
+	// any available vacantIDs, if so, we will assign the new asset to one of the vacantIDs.
+	// Otherwise, we will add a new entry to idToAssetString for the new asset.
+	vacantIDs []int32
 
 	// venuesForBuyingAsset maps an asset to all of its buying opportunities,
 	// which may be offers (sorted by price) or a liquidity pools.
@@ -200,12 +210,17 @@ func (graph *OrderBookGraph) getOrCreateAssetID(asset xdr.Asset) int32 {
 	if ok {
 		return id
 	}
+	// before creating a new int32 asset id we will try to use
+	// a vacant id so that we can plug any empty cells in the
+	// idToAssetString array.
 	if len(graph.vacantIDs) > 0 {
 		id = graph.vacantIDs[len(graph.vacantIDs)-1]
 		graph.vacantIDs = graph.vacantIDs[:len(graph.vacantIDs)-1]
 		graph.idToAssetString[id] = assetString
 	} else {
+		// idToAssetString never decreases in length unless we call graph.Clear()
 		id = int32(len(graph.idToAssetString))
+		// we assign id to asset
 		graph.idToAssetString = append(graph.idToAssetString, assetString)
 		graph.venuesForBuyingAsset = append(graph.venuesForBuyingAsset, nil)
 		graph.venuesForSellingAsset = append(graph.venuesForSellingAsset, nil)
@@ -221,6 +236,10 @@ func (graph *OrderBookGraph) maybeDeleteAsset(asset int32) {
 
 	if buyingEdgesEmpty && sellingEdgesEmpty {
 		delete(graph.assetStringToID, graph.idToAssetString[asset])
+		// When removing an asset we do not resize the idToAssetString array.
+		// Instead, we allow the cell occupied by the id to be empty.
+		// The next time we will add an asset to the graph we will allocate the
+		// id to the new asset.
 		graph.idToAssetString[asset] = ""
 		graph.vacantIDs = append(graph.vacantIDs, asset)
 	}

--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -28,9 +28,9 @@ const (
 // trading pair represents two assets that can be exchanged if an order is fulfilled
 type tradingPair struct {
 	// buyingAsset corresponds to offer.Buying.String() from an xdr.OfferEntry
-	buyingAsset string
+	buyingAsset int32
 	// sellingAsset corresponds to offer.Selling.String() from an xdr.OfferEntry
-	sellingAsset string
+	sellingAsset int32
 }
 
 // OBGraph is an interface for orderbook graphs
@@ -49,12 +49,16 @@ type OBGraph interface {
 // OrderBookGraph is an in-memory graph representation of all the offers in the
 // Stellar ledger.
 type OrderBookGraph struct {
+	assetStringToID map[string]int32
+	idToAssetString []string
+	vacantIDs       []int32
+
 	// venuesForBuyingAsset maps an asset to all of its buying opportunities,
 	// which may be offers (sorted by price) or a liquidity pools.
-	venuesForBuyingAsset map[string]edgeSet
-	// venuesForBuyingAsset maps an asset to all of its *selling* opportunities,
+	venuesForBuyingAsset []edgeSet
+	// venuesForSellingAsset maps an asset to all of its *selling* opportunities,
 	// which may be offers (sorted by price) or a liquidity pools.
-	venuesForSellingAsset map[string]edgeSet
+	venuesForSellingAsset []edgeSet
 	// liquidityPools associates a particular asset pair (in "asset order", see
 	// xdr.Asset.LessThan) with a liquidity pool.
 	liquidityPools map[tradingPair]xdr.LiquidityPoolEntry
@@ -169,8 +173,11 @@ func (graph *OrderBookGraph) Clear() {
 	graph.lock.Lock()
 	defer graph.lock.Unlock()
 
-	graph.venuesForBuyingAsset = map[string]edgeSet{}
-	graph.venuesForSellingAsset = map[string]edgeSet{}
+	graph.assetStringToID = map[string]int32{}
+	graph.idToAssetString = []string{}
+	graph.vacantIDs = []int32{}
+	graph.venuesForSellingAsset = []edgeSet{}
+	graph.venuesForBuyingAsset = []edgeSet{}
 	graph.tradingPairForOffer = map[xdr.Int64]tradingPair{}
 	graph.liquidityPools = map[tradingPair]xdr.LiquidityPoolEntry{}
 	graph.batchedUpdates = graph.batch()
@@ -187,6 +194,38 @@ func (graph *OrderBookGraph) batch() *orderBookBatchedUpdates {
 	}
 }
 
+func (graph *OrderBookGraph) getOrCreateAssetID(asset xdr.Asset) int32 {
+	assetString := asset.String()
+	id, ok := graph.assetStringToID[assetString]
+	if ok {
+		return id
+	}
+	if len(graph.vacantIDs) > 0 {
+		id = graph.vacantIDs[len(graph.vacantIDs)-1]
+		graph.vacantIDs = graph.vacantIDs[:len(graph.vacantIDs)-1]
+		graph.idToAssetString[id] = assetString
+	} else {
+		id = int32(len(graph.idToAssetString))
+		graph.idToAssetString = append(graph.idToAssetString, assetString)
+		graph.venuesForBuyingAsset = append(graph.venuesForBuyingAsset, nil)
+		graph.venuesForSellingAsset = append(graph.venuesForSellingAsset, nil)
+	}
+
+	graph.assetStringToID[assetString] = id
+	return id
+}
+
+func (graph *OrderBookGraph) maybeDeleteAsset(asset int32) {
+	buyingEdgesEmpty := len(graph.venuesForBuyingAsset[asset]) == 0
+	sellingEdgesEmpty := len(graph.venuesForSellingAsset[asset]) == 0
+
+	if buyingEdgesEmpty && sellingEdgesEmpty {
+		delete(graph.assetStringToID, graph.idToAssetString[asset])
+		graph.idToAssetString[asset] = ""
+		graph.vacantIDs = append(graph.vacantIDs, asset)
+	}
+}
+
 // addOffer inserts a given offer into the order book graph
 func (graph *OrderBookGraph) addOffer(offer xdr.OfferEntry) error {
 	// If necessary, replace any existing offer with a new one.
@@ -196,7 +235,8 @@ func (graph *OrderBookGraph) addOffer(offer xdr.OfferEntry) error {
 		}
 	}
 
-	buying, selling := offer.Buying.String(), offer.Selling.String()
+	buying := graph.getOrCreateAssetID(offer.Buying)
+	selling := graph.getOrCreateAssetID(offer.Selling)
 
 	graph.tradingPairForOffer[offer.OfferId] = tradingPair{
 		buyingAsset: buying, sellingAsset: selling,
@@ -208,19 +248,32 @@ func (graph *OrderBookGraph) addOffer(offer xdr.OfferEntry) error {
 	return nil
 }
 
+func (graph *OrderBookGraph) poolFromEntry(poolXDR xdr.LiquidityPoolEntry) liquidityPool {
+	aXDR, bXDR := getPoolAssets(poolXDR)
+	assetA, assetB := graph.getOrCreateAssetID(aXDR), graph.getOrCreateAssetID(bXDR)
+	return liquidityPool{
+		LiquidityPoolEntry: poolXDR,
+		assetA:             assetA,
+		assetB:             assetB,
+	}
+}
+
 // addPool sets the given pool as the venue for the given trading pair.
-func (graph *OrderBookGraph) addPool(pool xdr.LiquidityPoolEntry) {
+func (graph *OrderBookGraph) addPool(poolEntry xdr.LiquidityPoolEntry) {
 	// Liquidity pools have no concept of a "buying" or "selling" asset,
 	// so we create venues in both directions.
-	x, y := getPoolAssets(pool)
-	graph.liquidityPools[tradingPair{x, y}] = pool
+	pool := graph.poolFromEntry(poolEntry)
+	graph.liquidityPools[tradingPair{
+		buyingAsset:  pool.assetA,
+		sellingAsset: pool.assetB,
+	}] = pool.LiquidityPoolEntry
 
-	for _, table := range []map[string]edgeSet{
+	for _, table := range [][]edgeSet{
 		graph.venuesForBuyingAsset,
 		graph.venuesForSellingAsset,
 	} {
-		table[x] = table[x].addPool(y, pool)
-		table[y] = table[y].addPool(x, pool)
+		table[pool.assetA] = table[pool.assetA].addPool(pool.assetB, pool)
+		table[pool.assetB] = table[pool.assetB].addPool(pool.assetA, pool)
 	}
 }
 
@@ -230,43 +283,37 @@ func (graph *OrderBookGraph) removeOffer(offerID xdr.Int64) error {
 	if !ok {
 		return errOfferNotPresent
 	}
-
 	delete(graph.tradingPairForOffer, offerID)
 
-	if set, ok := graph.venuesForSellingAsset[pair.sellingAsset]; !ok {
+	if set, ok := graph.venuesForSellingAsset[pair.sellingAsset].removeOffer(pair.buyingAsset, offerID); !ok {
 		return errOfferNotPresent
-	} else if set, ok = set.removeOffer(pair.buyingAsset, offerID); !ok {
-		return errOfferNotPresent
-	} else if len(set) == 0 {
-		delete(graph.venuesForSellingAsset, pair.sellingAsset)
 	} else {
 		graph.venuesForSellingAsset[pair.sellingAsset] = set
 	}
 
-	if set, ok := graph.venuesForBuyingAsset[pair.buyingAsset]; !ok {
+	if set, ok := graph.venuesForBuyingAsset[pair.buyingAsset].removeOffer(pair.sellingAsset, offerID); !ok {
 		return errOfferNotPresent
-	} else if set, ok = set.removeOffer(pair.sellingAsset, offerID); !ok {
-		return errOfferNotPresent
-	} else if len(set) == 0 {
-		delete(graph.venuesForBuyingAsset, pair.buyingAsset)
 	} else {
 		graph.venuesForBuyingAsset[pair.buyingAsset] = set
 	}
 
+	graph.maybeDeleteAsset(pair.buyingAsset)
+	graph.maybeDeleteAsset(pair.sellingAsset)
 	return nil
 }
 
 // removePool unsets the pool matching the given asset pair, if it exists.
-func (graph *OrderBookGraph) removePool(pool xdr.LiquidityPoolEntry) {
-	x, y := getPoolAssets(pool)
+func (graph *OrderBookGraph) removePool(poolXDR xdr.LiquidityPoolEntry) {
+	aXDR, bXDR := getPoolAssets(poolXDR)
+	assetA, assetB := graph.getOrCreateAssetID(aXDR), graph.getOrCreateAssetID(bXDR)
 
-	for _, asset := range []string{x, y} {
-		otherAsset := x
-		if asset == x {
-			otherAsset = y
+	for _, asset := range []int32{assetA, assetB} {
+		otherAsset := assetB
+		if asset == assetB {
+			otherAsset = assetA
 		}
 
-		for _, table := range []map[string]edgeSet{
+		for _, table := range [][]edgeSet{
 			graph.venuesForBuyingAsset,
 			graph.venuesForSellingAsset,
 		} {
@@ -274,7 +321,9 @@ func (graph *OrderBookGraph) removePool(pool xdr.LiquidityPoolEntry) {
 		}
 	}
 
-	delete(graph.liquidityPools, tradingPair{x, y})
+	delete(graph.liquidityPools, tradingPair{assetA, assetB})
+	graph.maybeDeleteAsset(assetA)
+	graph.maybeDeleteAsset(assetB)
 }
 
 // IsEmpty returns true if the orderbook graph is not populated
@@ -282,7 +331,7 @@ func (graph *OrderBookGraph) IsEmpty() bool {
 	graph.lock.RLock()
 	defer graph.lock.RUnlock()
 
-	return len(graph.venuesForSellingAsset) == 0
+	return len(graph.liquidityPools) == 0 && len(graph.tradingPairForOffer) == 0
 }
 
 // FindPaths returns a list of payment paths originating from a source account
@@ -300,15 +349,15 @@ func (graph *OrderBookGraph) FindPaths(
 	includePools bool,
 ) ([]Path, uint32, error) {
 	destinationAssetString := destinationAsset.String()
-	sourceAssetsMap := make(map[string]xdr.Int64, len(sourceAssets))
+	sourceAssetsMap := make(map[int32]xdr.Int64, len(sourceAssets))
 	for i, sourceAsset := range sourceAssets {
 		sourceAssetString := sourceAsset.String()
-		sourceAssetsMap[sourceAssetString] = sourceAssetBalances[i]
+		sourceAssetsMap[graph.assetStringToID[sourceAssetString]] = sourceAssetBalances[i]
 	}
 
 	searchState := &sellingGraphSearchState{
 		graph:                  graph,
-		destinationAsset:       destinationAsset,
+		destinationAssetString: destinationAssetString,
 		destinationAssetAmount: destinationAmount,
 		ignoreOffersFrom:       sourceAccountID,
 		targetAssets:           sourceAssetsMap,
@@ -321,8 +370,7 @@ func (graph *OrderBookGraph) FindPaths(
 		ctx,
 		searchState,
 		maxPathLength,
-		destinationAssetString,
-		destinationAsset,
+		graph.assetStringToID[destinationAssetString],
 		destinationAmount,
 	)
 	lastLedger := graph.lastLedger
@@ -356,15 +404,15 @@ func (graph *OrderBookGraph) FindFixedPaths(
 	maxAssetsPerPath int,
 	includePools bool,
 ) ([]Path, uint32, error) {
-	target := map[string]bool{}
+	target := map[int32]bool{}
 	for _, destinationAsset := range destinationAssets {
 		destinationAssetString := destinationAsset.String()
-		target[destinationAssetString] = true
+		target[graph.assetStringToID[destinationAssetString]] = true
 	}
 
 	searchState := &buyingGraphSearchState{
 		graph:             graph,
-		sourceAsset:       sourceAsset,
+		sourceAssetString: sourceAsset.String(),
 		sourceAssetAmount: amountToSpend,
 		targetAssets:      target,
 		paths:             []Path{},
@@ -375,8 +423,7 @@ func (graph *OrderBookGraph) FindFixedPaths(
 		ctx,
 		searchState,
 		maxPathLength,
-		sourceAsset.String(),
-		sourceAsset,
+		graph.assetStringToID[sourceAsset.String()],
 		amountToSpend,
 	)
 	lastLedger := graph.lastLedger
@@ -402,13 +449,13 @@ func (graph *OrderBookGraph) FindFixedPaths(
 // if there are multiple paths which spend the same `SourceAmount` then shorter payment paths
 // will be prioritized
 func compareSourceAsset(allPaths []Path, i, j int) bool {
-	if allPaths[i].SourceAsset.Equals(allPaths[j].SourceAsset) {
+	if allPaths[i].SourceAsset == allPaths[j].SourceAsset {
 		if allPaths[i].SourceAmount == allPaths[j].SourceAmount {
 			return len(allPaths[i].InteriorNodes) < len(allPaths[j].InteriorNodes)
 		}
 		return allPaths[i].SourceAmount < allPaths[j].SourceAmount
 	}
-	return allPaths[i].SourceAssetString() < allPaths[j].SourceAssetString()
+	return allPaths[i].SourceAsset < allPaths[j].SourceAsset
 }
 
 // compareDestinationAsset will group payment paths by `DestinationAsset`. Paths
@@ -416,21 +463,21 @@ func compareSourceAsset(allPaths []Path, i, j int) bool {
 // sorting. If there are multiple paths which deliver the same
 // `DestinationAmount`, then shorter payment paths will be prioritized.
 func compareDestinationAsset(allPaths []Path, i, j int) bool {
-	if allPaths[i].DestinationAsset.Equals(allPaths[j].DestinationAsset) {
+	if allPaths[i].DestinationAsset == allPaths[j].DestinationAsset {
 		if allPaths[i].DestinationAmount == allPaths[j].DestinationAmount {
 			return len(allPaths[i].InteriorNodes) < len(allPaths[j].InteriorNodes)
 		}
 		return allPaths[i].DestinationAmount > allPaths[j].DestinationAmount
 	}
-	return allPaths[i].DestinationAssetString() < allPaths[j].DestinationAssetString()
+	return allPaths[i].DestinationAsset < allPaths[j].DestinationAsset
 }
 
 func sourceAssetEquals(p, otherPath Path) bool {
-	return p.SourceAsset.Equals(otherPath.SourceAsset)
+	return p.SourceAsset == otherPath.SourceAsset
 }
 
 func destinationAssetEquals(p, otherPath Path) bool {
-	return p.DestinationAsset.Equals(otherPath.DestinationAsset)
+	return p.DestinationAsset == otherPath.DestinationAsset
 }
 
 // sortAndFilterPaths sorts the given list of paths using `comparePaths`

--- a/exp/orderbook/graph_benchmark_test.go
+++ b/exp/orderbook/graph_benchmark_test.go
@@ -219,11 +219,18 @@ func BenchmarkTestData(b *testing.B) {
 }
 
 func BenchmarkSingleLiquidityPoolExchange(b *testing.B) {
+	graph := NewOrderBookGraph()
+	pool := graph.poolFromEntry(eurUsdLiquidityPool)
+	asset := graph.getOrCreateAssetID(usdAsset)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
 	b.Run("deposit", func(b *testing.B) {
-		makeTrade(eurUsdLiquidityPool, usdAsset, tradeTypeDeposit, math.MaxInt64/2)
+		makeTrade(pool, asset, tradeTypeDeposit, math.MaxInt64/2)
 	})
 	b.Run("exchange", func(b *testing.B) {
-		makeTrade(eurUsdLiquidityPool, usdAsset, tradeTypeExpectation, math.MaxInt64/2)
+		makeTrade(pool, asset, tradeTypeExpectation, math.MaxInt64/2)
 	})
 }
 
@@ -232,23 +239,29 @@ func BenchmarkSingleLiquidityPoolExchange(b *testing.B) {
 
 func BenchmarkLiquidityPoolDeposits(b *testing.B) {
 	amounts := createRandomAmounts(b.N)
+	graph := NewOrderBookGraph()
+	pool := graph.poolFromEntry(eurUsdLiquidityPool)
+	asset := graph.getOrCreateAssetID(usdAsset)
 
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for _, amount := range amounts {
-		makeTrade(eurUsdLiquidityPool, usdAsset, tradeTypeDeposit, amount)
+		makeTrade(pool, asset, tradeTypeDeposit, amount)
 	}
 }
 
 func BenchmarkLiquidityPoolExpectations(b *testing.B) {
 	amounts := createRandomAmounts(b.N)
+	graph := NewOrderBookGraph()
+	pool := graph.poolFromEntry(eurUsdLiquidityPool)
+	asset := graph.getOrCreateAssetID(usdAsset)
 
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for _, amount := range amounts {
-		makeTrade(eurUsdLiquidityPool, usdAsset, tradeTypeExpectation, amount)
+		makeTrade(pool, asset, tradeTypeExpectation, amount)
 	}
 }
 

--- a/exp/orderbook/pools.go
+++ b/exp/orderbook/pools.go
@@ -43,8 +43,8 @@ var (
 // Warning: If you pass an asset that is NOT one of the pool reserves, the
 // behavior of this function is undefined (for performance).
 func makeTrade(
-	pool xdr.LiquidityPoolEntry,
-	asset xdr.Asset,
+	pool liquidityPool,
+	asset int32,
 	tradeType int,
 	amount xdr.Int64,
 ) (xdr.Int64, error) {
@@ -59,7 +59,7 @@ func makeTrade(
 
 	// determine which asset `amount` corresponds to
 	X, Y := details.ReserveA, details.ReserveB
-	if !details.Params.AssetA.Equals(asset) {
+	if pool.assetA != asset {
 		X, Y = Y, X
 	}
 
@@ -161,10 +161,9 @@ func calculatePoolExpectation(
 // getOtherAsset returns the other asset in the liquidity pool. Note that
 // doesn't check to make sure the passed in `asset` is actually part of the
 // pool; behavior in that case is undefined.
-func getOtherAsset(asset xdr.Asset, pool xdr.LiquidityPoolEntry) xdr.Asset {
-	cp := pool.Body.MustConstantProduct()
-	if cp.Params.AssetA.Equals(asset) {
-		return cp.Params.AssetB
+func getOtherAsset(asset int32, pool liquidityPool) int32 {
+	if pool.assetA == asset {
+		return pool.assetB
 	}
-	return cp.Params.AssetA
+	return pool.assetA
 }

--- a/exp/orderbook/search.go
+++ b/exp/orderbook/search.go
@@ -9,54 +9,41 @@ import (
 
 // Path represents a payment path from a source asset to some destination asset
 type Path struct {
-	SourceAsset       xdr.Asset
+	SourceAsset       string
 	SourceAmount      xdr.Int64
-	DestinationAsset  xdr.Asset
+	DestinationAsset  string
 	DestinationAmount xdr.Int64
 
-	// sourceAssetString and destinationAssetString are included as an
-	// optimization to improve the performance of sorting paths by avoiding
-	// serializing assets to strings repeatedly
-	sourceAssetString      string
-	destinationAssetString string
-
-	InteriorNodes []xdr.Asset
+	InteriorNodes []string
 }
 
-// SourceAssetString returns the string representation of the path's source asset
-func (p *Path) SourceAssetString() string {
-	if p.sourceAssetString == "" {
-		p.sourceAssetString = p.SourceAsset.String()
-	}
-	return p.sourceAssetString
-}
-
-// DestinationAssetString returns the string representation of the path's destination asset
-func (p *Path) DestinationAssetString() string {
-	if p.destinationAssetString == "" {
-		p.destinationAssetString = p.DestinationAsset.String()
-	}
-	return p.destinationAssetString
+type liquidityPool struct {
+	xdr.LiquidityPoolEntry
+	assetA int32
+	assetB int32
 }
 
 type Venues struct {
 	offers []xdr.OfferEntry
-	pool   xdr.LiquidityPoolEntry // can be empty, check body pointer
+	pool   liquidityPool // can be empty, check body pointer
 }
 
 type searchState interface {
+	// totalAssets returns the total number of assets in the search space.
+	totalAssets() int32
+
 	// considerPools returns true if we will consider liquidity pools in our path
 	// finding search.
 	considerPools() bool
 
 	// isTerminalNode returns true if the current asset is a terminal node in our
 	// path finding search.
-	isTerminalNode(asset string) bool
+	isTerminalNode(asset int32) bool
 
 	// includePath returns true if the current path which ends at the given asset
 	// and produces the given amount satisfies our search criteria.
 	includePath(
-		currentAsset string,
+		currentAsset int32,
 		currentAssetAmount xdr.Int64,
 	) bool
 
@@ -68,8 +55,8 @@ type searchState interface {
 
 	// appendToPaths appends the current path to our result list.
 	appendToPaths(
-		path []xdr.Asset,
-		currentAsset string,
+		path []int32,
+		currentAsset int32,
 		currentAssetAmount xdr.Int64,
 	)
 
@@ -78,7 +65,7 @@ type searchState interface {
 	// The result is grouped by the next asset hop, mapping to a sorted list of
 	// offers (by price) and a liquidity pool (if one exists for that trading
 	// pair).
-	venues(currentAsset string) edgeSet
+	venues(currentAsset int32) edgeSet
 
 	// consumeOffers will consume the given set of offers to trade our
 	// current asset for a different asset.
@@ -86,41 +73,40 @@ type searchState interface {
 		currentAssetAmount xdr.Int64,
 		currentBestAmount xdr.Int64,
 		offers []xdr.OfferEntry,
-	) (xdr.Asset, xdr.Int64, error)
+	) (xdr.Int64, error)
 
 	// consumePool will consume the given liquidity pool to trade our
 	// current asset for a different asset.
 	consumePool(
-		pool xdr.LiquidityPoolEntry,
-		currentAsset xdr.Asset,
+		pool liquidityPool,
+		currentAsset int32,
 		currentAssetAmount xdr.Int64,
 	) (xdr.Int64, error)
 }
 
 type pathNode struct {
-	assetString string
-	asset       xdr.Asset
-	prev        *pathNode
+	asset int32
+	prev  *pathNode
 }
 
-func (p *pathNode) contains(src, dst string) bool {
+func (p *pathNode) contains(src, dst int32) bool {
 	for cur := p; cur != nil && cur.prev != nil; cur = cur.prev {
-		if cur.assetString == dst && cur.prev.assetString == src {
+		if cur.asset == dst && cur.prev.asset == src {
 			return true
 		}
 	}
 	return false
 }
 
-func reversePath(path []xdr.Asset) {
+func reversePath(path []int32) {
 	for i := len(path)/2 - 1; i >= 0; i-- {
 		opp := len(path) - 1 - i
 		path[i], path[opp] = path[opp], path[i]
 	}
 }
 
-func (e *pathNode) path() []xdr.Asset {
-	var result []xdr.Asset
+func (e *pathNode) path() []int32 {
+	var result []int32
 	for cur := e; cur != nil; cur = cur.prev {
 		result = append(result, cur.asset)
 	}
@@ -133,45 +119,52 @@ func search(
 	ctx context.Context,
 	state searchState,
 	maxPathLength int,
-	sourceAssetString string,
-	sourceAsset xdr.Asset,
+	sourceAsset int32,
 	sourceAssetAmount xdr.Int64,
 ) error {
-	bestAmount := map[string]xdr.Int64{sourceAssetString: sourceAssetAmount}
-	updateAmount := map[string]xdr.Int64{sourceAssetString: sourceAssetAmount}
-	bestPath := map[string]*pathNode{sourceAssetString: {
-		assetString: sourceAssetString,
-		asset:       sourceAsset,
-		prev:        nil,
-	}}
+	totalAssets := state.totalAssets()
+	bestAmount := make([]xdr.Int64, totalAssets)
+	updateAmount := make([]xdr.Int64, totalAssets)
+	bestPath := make([]*pathNode, totalAssets)
+	updatePath := make([]*pathNode, totalAssets)
+	updatedAssets := make([]int32, 0, totalAssets)
+	bestAmount[sourceAsset] = sourceAssetAmount
+	updateAmount[sourceAsset] = sourceAssetAmount
+	bestPath[sourceAsset] = &pathNode{
+		asset: sourceAsset,
+		prev:  nil,
+	}
 
 	for i := 0; i < maxPathLength; i++ {
-		updatePath := map[string]*pathNode{}
+		updatedAssets = updatedAssets[:0]
 
-		for currentAssetString, currentAmount := range bestAmount {
-			pathToCurrentAsset := bestPath[currentAssetString]
-			currentAsset := pathToCurrentAsset.asset
-			edges := state.venues(currentAssetString)
+		for currentAsset := int32(0); currentAsset < totalAssets; currentAsset++ {
+			currentAmount := bestAmount[currentAsset]
+			if currentAmount == 0 {
+				continue
+			}
+			pathToCurrentAsset := bestPath[currentAsset]
+			edges := state.venues(currentAsset)
 			for j := 0; j < len(edges); j++ {
 				// Exit early if the context was cancelled.
 				if err := ctx.Err(); err != nil {
 					return err
 				}
-				nextAssetString, venues := edges[j].key, edges[j].value
+				nextAsset, venues := edges[j].key, edges[j].value
 
 				// If we're on our last step ignore any edges which don't lead to
 				// our desired destination. This optimization will save us from
 				// doing wasted computation.
-				if i == maxPathLength-1 && !state.isTerminalNode(nextAssetString) {
+				if i == maxPathLength-1 && !state.isTerminalNode(nextAsset) {
 					continue
 				}
 
 				// Make sure we don't use an edge more than once.
-				if pathToCurrentAsset.contains(currentAssetString, nextAssetString) {
+				if pathToCurrentAsset.contains(currentAsset, nextAsset) {
 					continue
 				}
 
-				nextAsset, nextAssetAmount, err := processVenues(state, currentAsset, currentAmount, venues)
+				nextAssetAmount, err := processVenues(state, currentAsset, currentAmount, venues)
 				if err != nil {
 					return err
 				}
@@ -179,26 +172,27 @@ func search(
 					continue
 				}
 
-				if bestNextAssetAmount, ok := updateAmount[nextAssetString]; !ok || state.betterPathAmount(bestNextAssetAmount, nextAssetAmount) {
-					updateAmount[nextAssetString] = nextAssetAmount
+				if state.betterPathAmount(updateAmount[nextAsset], nextAssetAmount) {
+					newEntry := updateAmount[nextAsset] == bestAmount[nextAsset]
+					updateAmount[nextAsset] = nextAssetAmount
 
-					if pathToNext, ok := updatePath[nextAssetString]; ok {
-						pathToNext.prev = pathToCurrentAsset
-					} else {
-						updatePath[nextAssetString] = &pathNode{
-							assetString: nextAssetString,
-							asset:       nextAsset,
-							prev:        pathToCurrentAsset,
+					if newEntry {
+						updatePath[nextAsset] = &pathNode{
+							asset: nextAsset,
+							prev:  pathToCurrentAsset,
 						}
+						updatedAssets = append(updatedAssets, nextAsset)
+					} else {
+						updatePath[nextAsset].prev = pathToCurrentAsset
 					}
 
 					// We could avoid this step until the last iteration, but we would
 					// like to include multiple paths in the response to give the user
 					// other options in case the best path is already consumed.
-					if state.includePath(nextAssetString, nextAssetAmount) {
+					if state.includePath(nextAsset, nextAssetAmount) {
 						state.appendToPaths(
-							append(bestPath[currentAssetString].path(), nextAsset),
-							nextAssetString,
+							append(bestPath[currentAsset].path(), nextAsset),
+							nextAsset,
 							nextAssetAmount,
 						)
 					}
@@ -210,9 +204,9 @@ func search(
 		// the algorithm. This optimization will save us from doing wasted
 		// computation.
 		if i < maxPathLength-1 {
-			for assetString, betterPath := range updatePath {
-				bestPath[assetString] = betterPath
-				bestAmount[assetString] = updateAmount[assetString]
+			for _, asset := range updatedAssets {
+				bestPath[asset] = updatePath[asset]
+				bestAmount[asset] = updateAmount[asset]
 			}
 		}
 	}
@@ -231,53 +225,69 @@ func search(
 //    `targetAssets`
 type sellingGraphSearchState struct {
 	graph                  *OrderBookGraph
-	destinationAsset       xdr.Asset
+	destinationAssetString string
 	destinationAssetAmount xdr.Int64
 	ignoreOffersFrom       *xdr.AccountId
-	targetAssets           map[string]xdr.Int64
+	targetAssets           map[int32]xdr.Int64
 	validateSourceBalance  bool
 	paths                  []Path
 	includePools           bool
 }
 
-func (state *sellingGraphSearchState) isTerminalNode(currentAsset string) bool {
+func (state *sellingGraphSearchState) totalAssets() int32 {
+	return int32(len(state.graph.idToAssetString))
+}
+
+func (state *sellingGraphSearchState) isTerminalNode(currentAsset int32) bool {
 	_, ok := state.targetAssets[currentAsset]
 	return ok
 }
 
-func (state *sellingGraphSearchState) includePath(currentAsset string, currentAssetAmount xdr.Int64) bool {
+func (state *sellingGraphSearchState) includePath(currentAsset int32, currentAssetAmount xdr.Int64) bool {
 	targetAssetBalance, ok := state.targetAssets[currentAsset]
 	return ok && (!state.validateSourceBalance || targetAssetBalance >= currentAssetAmount)
 }
 
 func (state *sellingGraphSearchState) betterPathAmount(currentAmount, alternativeAmount xdr.Int64) bool {
+	if currentAmount == 0 {
+		return true
+	}
+	if alternativeAmount == 0 {
+		return false
+	}
 	return alternativeAmount < currentAmount
 }
 
+func assetIDsToAssetStrings(graph *OrderBookGraph, path []int32) []string {
+	var result []string
+	for _, asset := range path {
+		result = append(result, graph.idToAssetString[asset])
+	}
+	return result
+}
+
 func (state *sellingGraphSearchState) appendToPaths(
-	path []xdr.Asset,
-	currentAssetString string,
+	path []int32,
+	currentAsset int32,
 	currentAssetAmount xdr.Int64,
 ) {
-	currentAsset := path[len(path)-1]
 	if len(path) > 2 {
 		path = path[1 : len(path)-1]
 		reversePath(path)
 	} else {
-		path = []xdr.Asset{}
+		path = []int32{}
 	}
 
 	state.paths = append(state.paths, Path{
-		sourceAssetString: currentAssetString,
 		SourceAmount:      currentAssetAmount,
-		SourceAsset:       currentAsset,
-		InteriorNodes:     path,
-		DestinationAsset:  state.destinationAsset,
+		SourceAsset:       state.graph.idToAssetString[currentAsset],
+		InteriorNodes:     assetIDsToAssetStrings(state.graph, path),
+		DestinationAsset:  state.destinationAssetString,
 		DestinationAmount: state.destinationAssetAmount,
 	})
 }
 
-func (state *sellingGraphSearchState) venues(currentAsset string) edgeSet {
+func (state *sellingGraphSearchState) venues(currentAsset int32) edgeSet {
 	return state.graph.venuesForSellingAsset[currentAsset]
 }
 
@@ -285,16 +295,11 @@ func (state *sellingGraphSearchState) consumeOffers(
 	currentAssetAmount xdr.Int64,
 	currentBestAmount xdr.Int64,
 	offers []xdr.OfferEntry,
-) (xdr.Asset, xdr.Int64, error) {
+) (xdr.Int64, error) {
 	nextAmount, err := consumeOffersForSellingAsset(
 		offers, state.ignoreOffersFrom, currentAssetAmount, currentBestAmount)
 
-	var nextAsset xdr.Asset
-	if len(offers) > 0 {
-		nextAsset = offers[0].Buying
-	}
-
-	return nextAsset, positiveMin(currentBestAmount, nextAmount), err
+	return positiveMin(currentBestAmount, nextAmount), err
 }
 
 func (state *sellingGraphSearchState) considerPools() bool {
@@ -302,8 +307,8 @@ func (state *sellingGraphSearchState) considerPools() bool {
 }
 
 func (state *sellingGraphSearchState) consumePool(
-	pool xdr.LiquidityPoolEntry,
-	currentAsset xdr.Asset,
+	pool liquidityPool,
+	currentAsset int32,
 	currentAssetAmount xdr.Int64,
 ) (xdr.Int64, error) {
 	// How many of the previous hop do we need to get this amount?
@@ -321,18 +326,22 @@ func (state *sellingGraphSearchState) consumePool(
 //  - each payment path must begin with `sourceAsset`
 type buyingGraphSearchState struct {
 	graph             *OrderBookGraph
-	sourceAsset       xdr.Asset
+	sourceAssetString string
 	sourceAssetAmount xdr.Int64
-	targetAssets      map[string]bool
+	targetAssets      map[int32]bool
 	paths             []Path
 	includePools      bool
 }
 
-func (state *buyingGraphSearchState) isTerminalNode(currentAsset string) bool {
+func (state *buyingGraphSearchState) totalAssets() int32 {
+	return int32(len(state.graph.idToAssetString))
+}
+
+func (state *buyingGraphSearchState) isTerminalNode(currentAsset int32) bool {
 	return state.targetAssets[currentAsset]
 }
 
-func (state *buyingGraphSearchState) includePath(currentAsset string, currentAssetAmount xdr.Int64) bool {
+func (state *buyingGraphSearchState) includePath(currentAsset int32, currentAssetAmount xdr.Int64) bool {
 	return state.targetAssets[currentAsset]
 }
 
@@ -341,28 +350,26 @@ func (state *buyingGraphSearchState) betterPathAmount(currentAmount, alternative
 }
 
 func (state *buyingGraphSearchState) appendToPaths(
-	path []xdr.Asset,
-	currentAssetString string,
+	path []int32,
+	currentAsset int32,
 	currentAssetAmount xdr.Int64,
 ) {
-	currentAsset := path[len(path)-1]
 	if len(path) > 2 {
 		path = path[1 : len(path)-1]
 	} else {
-		path = []xdr.Asset{}
+		path = []int32{}
 	}
 
 	state.paths = append(state.paths, Path{
-		SourceAmount:           state.sourceAssetAmount,
-		SourceAsset:            state.sourceAsset,
-		InteriorNodes:          path,
-		DestinationAsset:       currentAsset,
-		DestinationAmount:      currentAssetAmount,
-		destinationAssetString: currentAssetString,
+		SourceAmount:      state.sourceAssetAmount,
+		SourceAsset:       state.sourceAssetString,
+		InteriorNodes:     assetIDsToAssetStrings(state.graph, path),
+		DestinationAsset:  state.graph.idToAssetString[currentAsset],
+		DestinationAmount: currentAssetAmount,
 	})
 }
 
-func (state *buyingGraphSearchState) venues(currentAsset string) edgeSet {
+func (state *buyingGraphSearchState) venues(currentAsset int32) edgeSet {
 	return state.graph.venuesForBuyingAsset[currentAsset]
 }
 
@@ -370,15 +377,10 @@ func (state *buyingGraphSearchState) consumeOffers(
 	currentAssetAmount xdr.Int64,
 	currentBestAmount xdr.Int64,
 	offers []xdr.OfferEntry,
-) (xdr.Asset, xdr.Int64, error) {
+) (xdr.Int64, error) {
 	nextAmount, err := consumeOffersForBuyingAsset(offers, currentAssetAmount)
 
-	var nextAsset xdr.Asset
-	if len(offers) > 0 {
-		nextAsset = offers[0].Selling
-	}
-
-	return nextAsset, max(nextAmount, currentBestAmount), err
+	return max(nextAmount, currentBestAmount), err
 }
 
 func (state *buyingGraphSearchState) considerPools() bool {
@@ -386,8 +388,8 @@ func (state *buyingGraphSearchState) considerPools() bool {
 }
 
 func (state *buyingGraphSearchState) consumePool(
-	pool xdr.LiquidityPoolEntry,
-	currentAsset xdr.Asset,
+	pool liquidityPool,
+	currentAsset int32,
 	currentAssetAmount xdr.Int64,
 ) (xdr.Int64, error) {
 	return makeTrade(pool, currentAsset, tradeTypeDeposit, currentAssetAmount)
@@ -519,14 +521,12 @@ func consumeOffersForBuyingAsset(
 
 func processVenues(
 	state searchState,
-	currentAsset xdr.Asset,
+	currentAsset int32,
 	currentAssetAmount xdr.Int64,
 	venues Venues,
-) (xdr.Asset, xdr.Int64, error) {
-	var nextAsset xdr.Asset
-
+) (xdr.Int64, error) {
 	if currentAssetAmount == 0 {
-		return nextAsset, 0, errAssetAmountIsZero
+		return 0, errAssetAmountIsZero
 	}
 
 	// We evaluate the pool venue (if any) before offers, because pool exchange
@@ -535,26 +535,23 @@ func processVenues(
 	if pool := venues.pool; state.considerPools() && pool.Body.ConstantProduct != nil {
 		amount, err := state.consumePool(pool, currentAsset, currentAssetAmount)
 		if err == nil {
-			nextAsset = getOtherAsset(currentAsset, pool)
 			poolAmount = amount
 		}
 		// It's only a true error if the offers fail later, too
 	}
 
 	if poolAmount == 0 && len(venues.offers) == 0 {
-		return nextAsset, -1, nil // not really an error
+		return -1, nil // not really an error
 	}
 
 	// This will return the pool amount if the LP performs better.
-	offerAsset, nextAssetAmount, err := state.consumeOffers(
+	nextAssetAmount, err := state.consumeOffers(
 		currentAssetAmount, poolAmount, venues.offers)
 
 	// Only error out the offers if the LP trade didn't happen.
 	if err != nil && poolAmount == 0 {
-		return nextAsset, 0, err
-	} else if err == nil {
-		nextAsset = offerAsset
+		return 0, err
 	}
 
-	return nextAsset, nextAssetAmount, nil
+	return nextAssetAmount, nil
 }

--- a/exp/orderbook/utils.go
+++ b/exp/orderbook/utils.go
@@ -5,9 +5,9 @@ import (
 )
 
 // getPoolAssets retrieves string representations of a pool's reserves
-func getPoolAssets(pool xdr.LiquidityPoolEntry) (string, string) {
+func getPoolAssets(pool xdr.LiquidityPoolEntry) (xdr.Asset, xdr.Asset) {
 	params := pool.Body.MustConstantProduct().Params
-	return params.AssetA.String(), params.AssetB.String()
+	return params.AssetA, params.AssetB
 }
 
 func max(a, b xdr.Int64) xdr.Int64 {

--- a/services/horizon/internal/paths/main.go
+++ b/services/horizon/internal/paths/main.go
@@ -20,16 +20,16 @@ type Query struct {
 
 // Path is the result returned by a path finder and is tied to the DestinationAmount used in the input query
 type Path struct {
-	Path              []xdr.Asset
-	Source            xdr.Asset
+	Path              []string
+	Source            string
 	SourceAmount      xdr.Int64
-	Destination       xdr.Asset
+	Destination       string
 	DestinationAmount xdr.Int64
 }
 
 // Finder finds paths.
 type Finder interface {
-	// Return a list of payment paths and the most recent ledger
+	// Find returns a list of payment paths and the most recent ledger
 	// for a Query of a maximum length `maxLength`. The payment paths
 	// are accurate and consistent with the returned ledger sequence number
 	Find(ctx context.Context, q Query, maxLength uint) ([]Path, uint32, error)

--- a/services/horizon/internal/resourceadapter/path.go
+++ b/services/horizon/internal/resourceadapter/path.go
@@ -2,18 +2,36 @@ package resourceadapter
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/stellar/go/amount"
 	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/paths"
 )
 
+func extractAsset(asset string, t, c, i *string) error {
+	if asset == "native" {
+		*t = asset
+		return nil
+	}
+	parts := strings.Split(asset, "/")
+	if len(parts) == 3 {
+		return fmt.Errorf("expected length to be 4 but got %v", parts)
+	}
+	*t = parts[0]
+	*c = parts[1]
+	*i = parts[2]
+	return nil
+}
+
 // PopulatePath converts the paths.Path into a Path
 func PopulatePath(ctx context.Context, dest *horizon.Path, p paths.Path) (err error) {
 	dest.DestinationAmount = amount.String(p.DestinationAmount)
 	dest.SourceAmount = amount.String(p.SourceAmount)
 
-	err = p.Source.Extract(
+	err = extractAsset(
+		p.Source,
 		&dest.SourceAssetType,
 		&dest.SourceAssetCode,
 		&dest.SourceAssetIssuer)
@@ -21,7 +39,8 @@ func PopulatePath(ctx context.Context, dest *horizon.Path, p paths.Path) (err er
 		return
 	}
 
-	err = p.Destination.Extract(
+	err = extractAsset(
+		p.Destination,
 		&dest.DestinationAssetType,
 		&dest.DestinationAssetCode,
 		&dest.DestinationAssetIssuer)
@@ -31,7 +50,8 @@ func PopulatePath(ctx context.Context, dest *horizon.Path, p paths.Path) (err er
 
 	dest.Path = make([]horizon.Asset, len(p.Path))
 	for i, a := range p.Path {
-		err = a.Extract(
+		err = extractAsset(
+			a,
 			&dest.Path[i].Type,
 			&dest.Path[i].Code,
 			&dest.Path[i].Issuer)

--- a/services/horizon/internal/resourceadapter/path.go
+++ b/services/horizon/internal/resourceadapter/path.go
@@ -16,8 +16,8 @@ func extractAsset(asset string, t, c, i *string) error {
 		return nil
 	}
 	parts := strings.Split(asset, "/")
-	if len(parts) == 3 {
-		return fmt.Errorf("expected length to be 4 but got %v", parts)
+	if len(parts) != 3 {
+		return fmt.Errorf("expected length to be 3 but got %v", parts)
 	}
 	*t = parts[0]
 	*c = parts[1]

--- a/services/horizon/internal/resourceadapter/path_test.go
+++ b/services/horizon/internal/resourceadapter/path_test.go
@@ -1,0 +1,50 @@
+package resourceadapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/paths"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPopulatePath(t *testing.T) {
+	native := xdr.MustNewNativeAsset()
+	usdc := xdr.MustNewCreditAsset("USDC", "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML")
+	bingo := xdr.MustNewCreditAsset("BINGO", "GBZ35ZJRIKJGYH5PBKLKOZ5L6EXCNTO7BKIL7DAVVDFQ2ODJEEHHJXIM")
+	p := paths.Path{
+		Path:              []string{bingo.String(), native.String()},
+		Source:            native.String(),
+		SourceAmount:      123,
+		Destination:       usdc.String(),
+		DestinationAmount: 345,
+	}
+
+	var dest horizon.Path
+	assert.NoError(t, PopulatePath(context.Background(), &dest, p))
+
+	assert.Equal(t, horizon.Path{
+		SourceAssetType:        "native",
+		SourceAssetCode:        "",
+		SourceAssetIssuer:      "",
+		SourceAmount:           "0.0000123",
+		DestinationAssetType:   "credit_alphanum4",
+		DestinationAssetCode:   "USDC",
+		DestinationAssetIssuer: "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+		DestinationAmount:      "0.0000345",
+		Path: []horizon.Asset{
+			{
+				Type:   "credit_alphanum12",
+				Code:   "BINGO",
+				Issuer: "GBZ35ZJRIKJGYH5PBKLKOZ5L6EXCNTO7BKIL7DAVVDFQ2ODJEEHHJXIM",
+			},
+			{
+				Type:   "native",
+				Code:   "",
+				Issuer: "",
+			},
+		},
+	}, dest)
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What


Previously we were representing the adjacency list for the graph as a mapping from asset string to the list of offers / pools which buy / sell that asset.

Now, every asset is assigned an integer id and the adjacency list is represented as an array where the integer id is used to index into the array. This new data structure is much more compact because the asset strings were very lengthy. The new data structure is also much faster because array indexing is significantly faster than looking up keys in a map.


### Why

New benchmark:

```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go/exp/orderbook
cpu: Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz
BenchmarkVibrantPath
BenchmarkVibrantPath-12    	     100	  12064900 ns/op	 2811558 B/op	   67441 allocs/op
PASS
```

Old benchmark
```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go/exp/orderbook
cpu: Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz
BenchmarkVibrantPath
BenchmarkVibrantPath-12    	      16	  74524903 ns/op	17888031 B/op	   65145 allocs/op
PASS
```

The new code reduced the latency from 74.5 ms per call to 12 ms per call. Also, it reduced the space from 17.8 mb per call to 2.8mb per call.

### Known limitations

[N/A]
