### PR TITLE
Revert "exp/orderbook: Use uint128s for pool calculations to improve performance"

### DIFF
--- a/exp/orderbook/pools.go
+++ b/exp/orderbook/pools.go
@@ -2,8 +2,7 @@ package orderbook
 
 import (
 	"math"
-
-	"lukechampine.com/uint128"
+	"math/big"
 
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
@@ -21,7 +20,6 @@ import (
 const (
 	tradeTypeDeposit     = iota // deposit into pool, what's the payout?
 	tradeTypeExpectation = iota // expect payout, what to deposit?
-	maxBips              = 10000
 )
 
 var (
@@ -29,7 +27,6 @@ var (
 	errBadPoolType   = errors.New("Unsupported liquidity pool: must be ConstantProduct")
 	errBadTradeType  = errors.New("Unknown pool exchange type requested")
 	errBadAmount     = errors.New("Exchange amount must be positive")
-	maxBips128       = uint128.From64(maxBips)
 )
 
 // makeTrade simulates execution of an exchange with a liquidity pool.
@@ -94,31 +91,32 @@ func makeTrade(
 //
 // It returns false if the calculation overflows.
 func calculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int32) (xdr.Int64, bool) {
-	X, Y := uint128.From64(uint64(reserveA)), uint128.From64(uint64(reserveB))
-	F, x := uint128.From64(uint64(feeBips)), uint128.From64(uint64(received))
+	X, Y := big.NewInt(int64(reserveA)), big.NewInt(int64(reserveB))
+	F, x := big.NewInt(int64(feeBips)), big.NewInt(int64(received))
 
 	// would this deposit overflow the reserve?
-	// is feeBips within range?
-	if received > math.MaxInt64-reserveA || feeBips > maxBips {
+	if received > math.MaxInt64-reserveA {
 		return 0, false
 	}
 
 	// We do all of the math in bips, so it's all upscaled by this value.
-	f := maxBips128.Sub(F) // upscaled 1 - F
+	maxBips := big.NewInt(10000)
+	f := new(big.Int).Sub(maxBips, F) // upscaled 1 - F
 
 	// right half: X + (1 - F)x
-	denom := X.Mul(maxBips128).Add(x.Mul(f))
-	if denom.IsZero() { // avoid div-by-zero panic
+	denom := X.Mul(X, maxBips).Add(X, new(big.Int).Mul(x, f))
+	if denom.Cmp(big.NewInt(0)) == 0 { // avoid div-by-zero panic
 		return 0, false
 	}
 
 	// left half, a: (1 - F) Yx
-	numer := Y.Mul(x).Mul(f)
+	numer := Y.Mul(Y, x).Mul(Y, f)
 
 	// divide & check overflow
-	result := numer.Div(denom)
+	result := numer.Div(numer, denom)
 
-	return xdr.Int64(result.Lo), result.Hi == 0 && result.Lo <= math.MaxInt64
+	i := xdr.Int64(result.Int64())
+	return i, result.IsInt64() && i > 0
 }
 
 // calculatePoolExpectation determines how much of `reserveA` you would need to
@@ -130,33 +128,34 @@ func calculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int
 func calculatePoolExpectation(
 	reserveA, reserveB, disbursed xdr.Int64, feeBips xdr.Int32,
 ) (xdr.Int64, bool) {
-	X, Y := uint128.From64(uint64(reserveA)), uint128.From64(uint64(reserveB))
-	F, y := uint128.From64(uint64(feeBips)), uint128.From64(uint64(disbursed))
+	X, Y := big.NewInt(int64(reserveA)), big.NewInt(int64(reserveB))
+	F, y := big.NewInt(int64(feeBips)), big.NewInt(int64(disbursed))
 
 	// sanity check: disbursing shouldn't underflow the reserve
-	// and bips should be within the expected range
-	if disbursed >= reserveB || feeBips > maxBips {
+	if disbursed >= reserveB {
 		return 0, false
 	}
 
 	// We do all of the math in bips, so it's all upscaled by this value.
-	f := maxBips128.Sub(F) // upscaled 1 - F
+	maxBips := big.NewInt(10000)
+	f := new(big.Int).Sub(maxBips, F) // upscaled 1 - F
 
-	denom := Y.Sub(y).Mul(f) // right half: (Y - y)(1 - F)
-	if denom.IsZero() {      // avoid div-by-zero panic
+	denom := Y.Sub(Y, y).Mul(Y, f)     // right half: (Y - y)(1 - F)
+	if denom.Cmp(big.NewInt(0)) == 0 { // avoid div-by-zero panic
 		return 0, false
 	}
 
-	numer := X.Mul(y).Mul(maxBips128) // left half: Xy
+	numer := X.Mul(X, y).Mul(X, maxBips) // left half: Xy
 
-	result, rem := numer.QuoRem(denom)
+	result, rem := new(big.Int), new(big.Int)
+	result.DivMod(numer, denom, rem)
 
 	// hacky way to ceil(): if there's a remainder, add 1
-	if rem.Cmp64(0) > 0 {
-		result = result.Add64(1)
+	if rem.Cmp(big.NewInt(0)) > 0 {
+		result.Add(result, big.NewInt(1))
 	}
 
-	return xdr.Int64(result.Lo), result.Hi == 0 && result.Lo <= math.MaxInt64
+	return xdr.Int64(result.Int64()), result.IsInt64()
 }
 
 // getOtherAsset returns the other asset in the liquidity pool. Note that

--- a/exp/orderbook/pools_test.go
+++ b/exp/orderbook/pools_test.go
@@ -166,22 +166,6 @@ func TestLiquidityPoolMath(t *testing.T) {
 		// ceil(10000 / 0.997) = 10031 we need to receive 10000.
 		assertPoolExchange(t, recv, 10000, -1, 20000, 10000, 30, true, 10031, -1)
 	})
-
-	t.Run("Potential Internal Overflow", func(t *testing.T) {
-
-		// Test for internal uint128 underflow/overflow in calculatePoolPayout() and  calculatePoolExpectation() by providing
-		// input values which cause the maximum internal calculations
-
-		assertPoolExchange(t, send, math.MaxInt64, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, false, -1, 10000)
-		assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, 0, false, 2147698418, -1)
-
-		// Check with reserveB < disbursed
-		assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, 0, 1, 0, false, 2147698418, -1)
-
-		// Check with poolFeeBips > 10000
-		assertPoolExchange(t, send, math.MaxInt64, math.MaxInt64, math.MaxInt64, math.MaxInt64, 10001, false, -1, 10000)
-		assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, 10010, false, 2147698418, -1)
-	})
 }
 
 // assertPoolExchange validates that pool inputs match their expected outputs.

--- a/go.list
+++ b/go.list
@@ -103,4 +103,3 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tylerb/graceful.v1 v1.2.13
 gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
-lukechampine.com/uint128 v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -83,5 +83,4 @@ require (
 	gopkg.in/gorp.v1 v1.7.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.4.1
 	gopkg.in/tylerb/graceful.v1 v1.2.13
-	lukechampine.com/uint128 v1.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -748,8 +748,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-lukechampine.com/uint128 v1.1.1 h1:pnxCASz787iMf+02ssImqk6OLt+Z5QHMoZyUXR4z6JU=
-lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
Reverts stellar/go#4104

After replaying some production requests I found some cases where calculatePoolPayout panics with an overflow.
Here is one case which causes a panic:

calculatePoolPayout(92017260901926686, 9157376027422527, 4000000000000000000, 30)