### PR TITLE
exp/orderbook: Exclude arbitrage paths from path finding search

### DIFF
--- a/exp/orderbook/graph_test.go
+++ b/exp/orderbook/graph_test.go
@@ -1472,17 +1472,6 @@ func TestFindPaths(t *testing.T) {
 
 	expectedPaths := []Path{
 		{
-			// arbitrage usd then trade to xlm
-			SourceAmount: 2,
-			SourceAsset:  usdAsset.String(),
-			InteriorNodes: []string{
-				eurAsset.String(),
-				usdAsset.String(),
-			},
-			DestinationAsset:  nativeAsset.String(),
-			DestinationAmount: 20,
-		},
-		{
 			SourceAmount:      5,
 			SourceAsset:       usdAsset.String(),
 			InteriorNodes:     []string{},
@@ -1548,17 +1537,6 @@ func TestFindPaths(t *testing.T) {
 
 	expectedPaths = []Path{
 		{
-			// arbitrage usd then trade to xlm
-			SourceAmount: 2,
-			SourceAsset:  usdAsset.String(),
-			InteriorNodes: []string{
-				eurAsset.String(),
-				usdAsset.String(),
-			},
-			DestinationAsset:  nativeAsset.String(),
-			DestinationAmount: 20,
-		},
-		{
 			SourceAmount:      5,
 			SourceAsset:       usdAsset.String(),
 			InteriorNodes:     []string{},
@@ -1612,17 +1590,6 @@ func TestFindPaths(t *testing.T) {
 	)
 
 	expectedPaths = []Path{
-		{
-			// arbitrage usd then trade to xlm
-			SourceAmount: 2,
-			SourceAsset:  usdAsset.String(),
-			InteriorNodes: []string{
-				eurAsset.String(),
-				usdAsset.String(),
-			},
-			DestinationAsset:  nativeAsset.String(),
-			DestinationAmount: 20,
-		},
 		{
 			SourceAmount:      5,
 			SourceAsset:       usdAsset.String(),
@@ -1751,17 +1718,6 @@ func TestFindPathsStartingAt(t *testing.T) {
 	}
 
 	expectedPaths := []Path{
-		{
-			// arbitrage usd then trade to xlm
-			SourceAmount: 5,
-			SourceAsset:  usdAsset.String(),
-			InteriorNodes: []string{
-				eurAsset.String(),
-				usdAsset.String(),
-			},
-			DestinationAsset:  nativeAsset.String(),
-			DestinationAmount: 60,
-		},
 		{
 			SourceAmount:      5,
 			SourceAsset:       usdAsset.String(),

--- a/exp/orderbook/search.go
+++ b/exp/orderbook/search.go
@@ -89,9 +89,9 @@ type pathNode struct {
 	prev  *pathNode
 }
 
-func (p *pathNode) contains(src, dst int32) bool {
-	for cur := p; cur != nil && cur.prev != nil; cur = cur.prev {
-		if cur.asset == dst && cur.prev.asset == src {
+func (p *pathNode) contains(node int32) bool {
+	for cur := p; cur != nil; cur = cur.prev {
+		if cur.asset == node {
 			return true
 		}
 	}
@@ -159,8 +159,8 @@ func search(
 					continue
 				}
 
-				// Make sure we don't use an edge more than once.
-				if pathToCurrentAsset.contains(currentAsset, nextAsset) {
+				// Make sure we don't visit a node more than once.
+				if pathToCurrentAsset.contains(nextAsset) {
 					continue
 				}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

One of the changes to the path finding algorithm introduced by https://github.com/stellar/go/pull/4096 is that the new algorithm includes paths which take advantage of arbitrage opportunities. In this commit, I have removed that behavior so that no arbitrage paths will be included in the response.

### Why

The horizon v2.12.0 release contains substantial implementation changes to the path finding algorithm. Removing the differences in outputs between the old and new algorithm will make it easier to test. We can always include the arbitrage paths functionality in a future release.

Clients which always pick the first path from the path finding response and use it in a path payment operation might be frustrated when the first path is an arbitrage path which will have a lot of contention. You can imagine a situation where the client submits the path payment but it fails because the offers which lead to the arbitrage have already been consumed by another transaction.

### Known limitations

[N/A]
