### PR TITLE
exp/orderbook: Use uint128s for pool calculations to improve performance

### DIFF
--- a/exp/orderbook/pools.go
+++ b/exp/orderbook/pools.go
@@ -106,7 +106,7 @@ func calculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int
 
 	// right half: X + (1 - F)x
 	denom := X.Mul(maxBips).Add(x.Mul(f))
-	if denom.Cmp64(0) == 0 { // avoid div-by-zero panic
+	if denom.IsZero() { // avoid div-by-zero panic
 		return 0, false
 	}
 
@@ -141,7 +141,7 @@ func calculatePoolExpectation(
 	f := maxBips.Sub(F) // upscaled 1 - F
 
 	denom := Y.Sub(y).Mul(f) // right half: (Y - y)(1 - F)
-	if denom.Cmp64(0) == 0 { // avoid div-by-zero panic
+	if denom.IsZero() {      // avoid div-by-zero panic
 		return 0, false
 	}
 

--- a/exp/orderbook/pools.go
+++ b/exp/orderbook/pools.go
@@ -105,7 +105,7 @@ func calculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int
 
 	// right half: X + (1 - F)x
 	denom := X.Mul(X, maxBips).Add(X, new(uint256.Int).Mul(x, f))
-	if denom.Cmp(uint256.NewInt(0)) == 0 { // avoid div-by-zero panic
+	if denom.IsZero() { // avoid div-by-zero panic
 		return 0, false
 	}
 
@@ -140,8 +140,8 @@ func calculatePoolExpectation(
 	maxBips := uint256.NewInt(10000)
 	f := new(uint256.Int).Sub(maxBips, F) // upscaled 1 - F
 
-	denom := Y.Sub(Y, y).Mul(Y, f)         // right half: (Y - y)(1 - F)
-	if denom.Cmp(uint256.NewInt(0)) == 0 { // avoid div-by-zero panic
+	denom := Y.Sub(Y, y).Mul(Y, f) // right half: (Y - y)(1 - F)
+	if denom.IsZero() {            // avoid div-by-zero panic
 		return 0, false
 	}
 
@@ -152,7 +152,7 @@ func calculatePoolExpectation(
 	rem.Mod(numer, denom)
 
 	// hacky way to ceil(): if there's a remainder, add 1
-	if rem.Cmp(uint256.NewInt(0)) > 0 {
+	if !rem.IsZero() {
 		result.AddUint64(result, 1)
 	}
 

--- a/exp/orderbook/pools.go
+++ b/exp/orderbook/pools.go
@@ -2,7 +2,8 @@ package orderbook
 
 import (
 	"math"
-	"math/big"
+
+	"lukechampine.com/uint128"
 
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
@@ -91,8 +92,8 @@ func makeTrade(
 //
 // It returns false if the calculation overflows.
 func calculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int32) (xdr.Int64, bool) {
-	X, Y := big.NewInt(int64(reserveA)), big.NewInt(int64(reserveB))
-	F, x := big.NewInt(int64(feeBips)), big.NewInt(int64(received))
+	X, Y := uint128.From64(uint64(reserveA)), uint128.From64(uint64(reserveB))
+	F, x := uint128.From64(uint64(feeBips)), uint128.From64(uint64(received))
 
 	// would this deposit overflow the reserve?
 	if received > math.MaxInt64-reserveA {
@@ -100,23 +101,22 @@ func calculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int
 	}
 
 	// We do all of the math in bips, so it's all upscaled by this value.
-	maxBips := big.NewInt(10000)
-	f := new(big.Int).Sub(maxBips, F) // upscaled 1 - F
+	maxBips := uint128.From64(10000)
+	f := maxBips.Sub(F) // upscaled 1 - F
 
 	// right half: X + (1 - F)x
-	denom := X.Mul(X, maxBips).Add(X, new(big.Int).Mul(x, f))
-	if denom.Cmp(big.NewInt(0)) == 0 { // avoid div-by-zero panic
+	denom := X.Mul(maxBips).Add(x.Mul(f))
+	if denom.Cmp64(0) == 0 { // avoid div-by-zero panic
 		return 0, false
 	}
 
 	// left half, a: (1 - F) Yx
-	numer := Y.Mul(Y, x).Mul(Y, f)
+	numer := Y.Mul(x).Mul(f)
 
 	// divide & check overflow
-	result := numer.Div(numer, denom)
+	result := numer.Div(denom)
 
-	i := xdr.Int64(result.Int64())
-	return i, result.IsInt64() && i > 0
+	return xdr.Int64(result.Lo), result.Hi == 0 && result.Lo <= math.MaxInt64
 }
 
 // calculatePoolExpectation determines how much of `reserveA` you would need to
@@ -128,8 +128,8 @@ func calculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int
 func calculatePoolExpectation(
 	reserveA, reserveB, disbursed xdr.Int64, feeBips xdr.Int32,
 ) (xdr.Int64, bool) {
-	X, Y := big.NewInt(int64(reserveA)), big.NewInt(int64(reserveB))
-	F, y := big.NewInt(int64(feeBips)), big.NewInt(int64(disbursed))
+	X, Y := uint128.From64(uint64(reserveA)), uint128.From64(uint64(reserveB))
+	F, y := uint128.From64(uint64(feeBips)), uint128.From64(uint64(disbursed))
 
 	// sanity check: disbursing shouldn't underflow the reserve
 	if disbursed >= reserveB {
@@ -137,25 +137,24 @@ func calculatePoolExpectation(
 	}
 
 	// We do all of the math in bips, so it's all upscaled by this value.
-	maxBips := big.NewInt(10000)
-	f := new(big.Int).Sub(maxBips, F) // upscaled 1 - F
+	maxBips := uint128.From64(10000)
+	f := maxBips.Sub(F) // upscaled 1 - F
 
-	denom := Y.Sub(Y, y).Mul(Y, f)     // right half: (Y - y)(1 - F)
-	if denom.Cmp(big.NewInt(0)) == 0 { // avoid div-by-zero panic
+	denom := Y.Sub(y).Mul(f) // right half: (Y - y)(1 - F)
+	if denom.Cmp64(0) == 0 { // avoid div-by-zero panic
 		return 0, false
 	}
 
-	numer := X.Mul(X, y).Mul(X, maxBips) // left half: Xy
+	numer := X.Mul(y).Mul(maxBips) // left half: Xy
 
-	result, rem := new(big.Int), new(big.Int)
-	result.DivMod(numer, denom, rem)
+	result, rem := numer.QuoRem(denom)
 
 	// hacky way to ceil(): if there's a remainder, add 1
-	if rem.Cmp(big.NewInt(0)) > 0 {
-		result.Add(result, big.NewInt(1))
+	if rem.Cmp64(0) > 0 {
+		result = result.Add64(1)
 	}
 
-	return xdr.Int64(result.Int64()), result.IsInt64()
+	return xdr.Int64(result.Lo), result.Hi == 0 && result.Lo <= math.MaxInt64
 }
 
 // getOtherAsset returns the other asset in the liquidity pool. Note that

--- a/exp/orderbook/pools_test.go
+++ b/exp/orderbook/pools_test.go
@@ -166,6 +166,22 @@ func TestLiquidityPoolMath(t *testing.T) {
 		// ceil(10000 / 0.997) = 10031 we need to receive 10000.
 		assertPoolExchange(t, recv, 10000, -1, 20000, 10000, 30, true, 10031, -1)
 	})
+
+	t.Run("Potential Internal Overflow", func(t *testing.T) {
+
+		// Test for internal uint128 underflow/overflow in calculatePoolPayout() and  calculatePoolExpectation() by providing
+		// input values which cause the maximum internal calculations
+
+		assertPoolExchange(t, send, math.MaxInt64, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, false, -1, 10000)
+		assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, 0, false, 2147698418, -1)
+
+		// Check with reserveB < disbursed
+		assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, 0, 1, 0, false, 2147698418, -1)
+
+		// TODO: These cause failures. Is it acceptable to make calls with poolFeeBips > 10000 ?
+		// assertPoolExchange(t, send, math.MaxInt64, math.MaxInt64, math.MaxInt64, math.MaxInt64, 10001, false, -1, 10000)
+		// assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, 10010, false, 2147698418, -1)
+	})
 }
 
 // assertPoolExchange validates that pool inputs match their expected outputs.

--- a/exp/orderbook/pools_test.go
+++ b/exp/orderbook/pools_test.go
@@ -178,9 +178,9 @@ func TestLiquidityPoolMath(t *testing.T) {
 		// Check with reserveB < disbursed
 		assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, 0, 1, 0, false, 2147698418, -1)
 
-		// TODO: These cause failures. Is it acceptable to make calls with poolFeeBips > 10000 ?
-		// assertPoolExchange(t, send, math.MaxInt64, math.MaxInt64, math.MaxInt64, math.MaxInt64, 10001, false, -1, 10000)
-		// assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, 10010, false, 2147698418, -1)
+		// Check with poolFeeBips > 10000
+		assertPoolExchange(t, send, math.MaxInt64, math.MaxInt64, math.MaxInt64, math.MaxInt64, 10001, false, -1, 10000)
+		assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, 10010, false, 2147698418, -1)
 	})
 }
 

--- a/exp/orderbook/pools_test.go
+++ b/exp/orderbook/pools_test.go
@@ -2,6 +2,8 @@ package orderbook
 
 import (
 	"math"
+	"math/big"
+	"math/rand"
 	"testing"
 
 	"github.com/stellar/go/xdr"
@@ -217,4 +219,106 @@ func assertPoolExchange(t *testing.T,
 		assert.EqualValues(t, expectedDisbursed, fromPool, "wrong payout")
 		assert.EqualValues(t, expectedDeposited, toPool, "wrong expectation")
 	}
+}
+
+func TestCalculatePoolExpectations(t *testing.T) {
+	for i := 0; i < 1000000; i++ {
+		reserveA := xdr.Int64(rand.Int63())
+		reserveB := xdr.Int64(rand.Int63())
+		disbursed := xdr.Int64(rand.Int63())
+
+		result, ok := calculatePoolExpectationBig(reserveA, reserveB, disbursed, 30)
+		result1, ok1 := calculatePoolExpectation(reserveA, reserveB, disbursed, 30)
+		if assert.Equal(t, ok, ok1) {
+			assert.Equal(t, result, result1)
+		}
+	}
+}
+
+func TestCalculatePoolPayout(t *testing.T) {
+	for i := 0; i < 1000000; i++ {
+		reserveA := xdr.Int64(rand.Int63())
+		reserveB := xdr.Int64(rand.Int63())
+		received := xdr.Int64(rand.Int63())
+
+		result, ok := calculatePoolPayoutBig(reserveA, reserveB, received, 30)
+		result1, ok1 := calculatePoolPayout(reserveA, reserveB, received, 30)
+		if assert.Equal(t, ok, ok1) {
+			assert.Equal(t, result, result1)
+		}
+	}
+}
+
+// calculatePoolPayout calculates the amount of `reserveB` disbursed from the
+// pool for a `received` amount of `reserveA` . From CAP-38:
+//
+//      y = floor[(1 - F) Yx / (X + x - Fx)]
+//
+// It returns false if the calculation overflows.
+func calculatePoolPayoutBig(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int32) (xdr.Int64, bool) {
+	X, Y := big.NewInt(int64(reserveA)), big.NewInt(int64(reserveB))
+	F, x := big.NewInt(int64(feeBips)), big.NewInt(int64(received))
+
+	// would this deposit overflow the reserve?
+	if received > math.MaxInt64-reserveA {
+		return 0, false
+	}
+
+	// We do all of the math in bips, so it's all upscaled by this value.
+	maxBips := big.NewInt(10000)
+	f := new(big.Int).Sub(maxBips, F) // upscaled 1 - F
+
+	// right half: X + (1 - F)x
+	denom := X.Mul(X, maxBips).Add(X, new(big.Int).Mul(x, f))
+	if denom.Cmp(big.NewInt(0)) == 0 { // avoid div-by-zero panic
+		return 0, false
+	}
+
+	// left half, a: (1 - F) Yx
+	numer := Y.Mul(Y, x).Mul(Y, f)
+
+	// divide & check overflow
+	result := numer.Div(numer, denom)
+
+	i := xdr.Int64(result.Int64())
+	return i, result.IsInt64() && i >= 0
+}
+
+// calculatePoolExpectation determines how much of `reserveA` you would need to
+// put into a pool to get the `disbursed` amount of `reserveB`.
+//
+//      x = ceil[Xy / ((Y - y)(1 - F))]
+//
+// It returns false if the calculation overflows.
+func calculatePoolExpectationBig(
+	reserveA, reserveB, disbursed xdr.Int64, feeBips xdr.Int32,
+) (xdr.Int64, bool) {
+	X, Y := big.NewInt(int64(reserveA)), big.NewInt(int64(reserveB))
+	F, y := big.NewInt(int64(feeBips)), big.NewInt(int64(disbursed))
+
+	// sanity check: disbursing shouldn't underflow the reserve
+	if disbursed >= reserveB {
+		return 0, false
+	}
+
+	// We do all of the math in bips, so it's all upscaled by this value.
+	maxBips := big.NewInt(10000)
+	f := new(big.Int).Sub(maxBips, F) // upscaled 1 - F
+
+	denom := Y.Sub(Y, y).Mul(Y, f)     // right half: (Y - y)(1 - F)
+	if denom.Cmp(big.NewInt(0)) == 0 { // avoid div-by-zero panic
+		return 0, false
+	}
+
+	numer := X.Mul(X, y).Mul(X, maxBips) // left half: Xy
+
+	result, rem := new(big.Int), new(big.Int)
+	result.DivMod(numer, denom, rem)
+
+	// hacky way to ceil(): if there's a remainder, add 1
+	if rem.Cmp(big.NewInt(0)) > 0 {
+		result.Add(result, big.NewInt(1))
+	}
+
+	return xdr.Int64(result.Int64()), result.IsInt64()
 }

--- a/exp/orderbook/pools_test.go
+++ b/exp/orderbook/pools_test.go
@@ -172,15 +172,18 @@ func TestLiquidityPoolMath(t *testing.T) {
 		// Test for internal uint128 underflow/overflow in calculatePoolPayout() and  calculatePoolExpectation() by providing
 		// input values which cause the maximum internal calculations
 
-		assertPoolExchange(t, send, math.MaxInt64, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, false, -1, 10000)
-		assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, 0, false, 2147698418, -1)
+		assertPoolExchange(t, send, math.MaxInt64, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, false, 0, 0)
+		assertPoolExchange(t, send, math.MaxInt64, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, false, 0, 0)
+		assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, 0, false, 0, 0)
 
 		// Check with reserveB < disbursed
-		assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, 0, 1, 0, false, 2147698418, -1)
+		assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, 0, 1, 0, false, 0, 0)
 
 		// Check with poolFeeBips > 10000
-		assertPoolExchange(t, send, math.MaxInt64, math.MaxInt64, math.MaxInt64, math.MaxInt64, 10001, false, -1, 10000)
-		assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, 10010, false, 2147698418, -1)
+		assertPoolExchange(t, send, math.MaxInt64, math.MaxInt64, math.MaxInt64, math.MaxInt64, 10001, false, 0, 0)
+		assertPoolExchange(t, recv, math.MaxInt64, math.MaxInt64, math.MaxInt64, 0, 10010, false, 0, 0)
+
+		assertPoolExchange(t, send, 92017260901926686, 9157376027422527, 4000000000000000000, 30, 1, false, 0, 0)
 	})
 }
 

--- a/go.list
+++ b/go.list
@@ -103,3 +103,4 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tylerb/graceful.v1 v1.2.13
 gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
+lukechampine.com/uint128 v1.1.1

--- a/go.list
+++ b/go.list
@@ -27,6 +27,7 @@ github.com/gorilla/schema v1.1.0
 github.com/graph-gophers/graphql-go v0.0.0-20190225005345-3e8838d4614c
 github.com/guregu/null v2.1.3-0.20151024101046-79c5bd36b615+incompatible
 github.com/hashicorp/golang-lru v0.5.1
+github.com/holiman/uint256 v1.2.0
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c
 github.com/hpcloud/tail v1.0.0
 github.com/imkira/go-interpol v1.1.0
@@ -103,4 +104,3 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tylerb/graceful.v1 v1.2.13
 gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
-lukechampine.com/uint128 v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -83,4 +83,5 @@ require (
 	gopkg.in/gorp.v1 v1.7.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.4.1
 	gopkg.in/tylerb/graceful.v1 v1.2.13
+	lukechampine.com/uint128 v1.1.1
 )

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/gorilla/schema v1.1.0
 	github.com/graph-gophers/graphql-go v0.0.0-20190225005345-3e8838d4614c
 	github.com/guregu/null v2.1.3-0.20151024101046-79c5bd36b615+incompatible
+	github.com/holiman/uint256 v1.2.0
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c
 	github.com/imkira/go-interpol v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
@@ -83,5 +84,4 @@ require (
 	gopkg.in/gorp.v1 v1.7.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.4.1
 	gopkg.in/tylerb/graceful.v1 v1.2.13
-	lukechampine.com/uint128 v1.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -748,6 +748,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+lukechampine.com/uint128 v1.1.1 h1:pnxCASz787iMf+02ssImqk6OLt+Z5QHMoZyUXR4z6JU=
+lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ github.com/guregu/null v2.1.3-0.20151024101046-79c5bd36b615+incompatible/go.mod 
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/holiman/uint256 v1.2.0 h1:gpSYcPLWGv4sG43I2mVLiDZCNDh/EpGjSk8tmtxitHM=
+github.com/holiman/uint256 v1.2.0/go.mod h1:y4ga/t+u+Xwd7CpDgZESaRcWy0I7XMlTMA25ApIH5Jw=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c h1:kQWxfPIHVLbgLzphqk3QUflDy9QdksZR4ygR807bpy0=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -748,8 +750,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-lukechampine.com/uint128 v1.1.1 h1:pnxCASz787iMf+02ssImqk6OLt+Z5QHMoZyUXR4z6JU=
-lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
Second attempt at #4104 by explicitly checking every possible overflow.


Before:

```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go/exp/orderbook
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkVibrantPath
BenchmarkVibrantPath-8   	     100	  10375399 ns/op	 2758209 B/op	   64732 allocs/op
PASS
```

After:

```
goos: darwin
goarch: amd64
pkg: github.com/stellar/go/exp/orderbook
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkVibrantPath
BenchmarkVibrantPath-8   	     127	   9447364 ns/op	 2251733 B/op	   39260 allocs/op
PASS
```
