### PR TITLE
exp/orderbook:

### DIFF
--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -706,6 +706,7 @@ func (graph *OrderBookGraph) FindPaths(
 	}
 	destinationAssetID, ok := graph.assetStringToID[destinationAssetString]
 	if !ok || len(sourceAssetsMap) == 0 {
+		graph.lock.RUnlock()
 		return []Path{}, graph.lastLedger, nil
 	}
 	searchState := &sellingGraphSearchState{
@@ -787,6 +788,7 @@ func (graph *OrderBookGraph) FindFixedPaths(
 	sourceAssetString := sourceAsset.String()
 	sourceAssetID, ok := graph.assetStringToID[sourceAssetString]
 	if !ok || len(target) == 0 {
+		graph.lock.RUnlock()
 		return []Path{}, graph.lastLedger, nil
 	}
 	searchState := &buyingGraphSearchState{

--- a/exp/orderbook/graph.go
+++ b/exp/orderbook/graph.go
@@ -205,7 +205,12 @@ func (graph *OrderBookGraph) Verify() ([]xdr.OfferEntry, []xdr.LiquidityPoolEntr
 		if len(sellingAssetString) == 0 && len(edges) > 0 {
 			return nil, nil, fmt.Errorf("found vacant id %v with non empty edges %v", sellingAsset, edges)
 		}
-		if id := graph.assetStringToID[sellingAssetString]; id != int32(sellingAsset) {
+		if id, ok := graph.assetStringToID[sellingAssetString]; !ok {
+			return nil, nil, fmt.Errorf(
+				"asset string %v is not in graph.assetStringToID",
+				sellingAssetString,
+			)
+		} else if id != int32(sellingAsset) {
 			return nil, nil, fmt.Errorf(
 				"asset string %v maps to %v , expected %v",
 				sellingAssetString,
@@ -693,9 +698,16 @@ func (graph *OrderBookGraph) FindPaths(
 	sourceAssetsMap := make(map[int32]xdr.Int64, len(sourceAssets))
 	for i, sourceAsset := range sourceAssets {
 		sourceAssetString := sourceAsset.String()
-		sourceAssetsMap[graph.assetStringToID[sourceAssetString]] = sourceAssetBalances[i]
+		sourceAssetID, ok := graph.assetStringToID[sourceAssetString]
+		if !ok {
+			continue
+		}
+		sourceAssetsMap[sourceAssetID] = sourceAssetBalances[i]
 	}
-
+	destinationAssetID, ok := graph.assetStringToID[destinationAssetString]
+	if !ok || len(sourceAssetsMap) == 0 {
+		return []Path{}, graph.lastLedger, nil
+	}
 	searchState := &sellingGraphSearchState{
 		graph:                  graph,
 		destinationAssetString: destinationAssetString,
@@ -710,7 +722,7 @@ func (graph *OrderBookGraph) FindPaths(
 		ctx,
 		searchState,
 		maxPathLength,
-		graph.assetStringToID[destinationAssetString],
+		destinationAssetID,
 		destinationAmount,
 	)
 	lastLedger := graph.lastLedger
@@ -765,10 +777,18 @@ func (graph *OrderBookGraph) FindFixedPaths(
 	target := map[int32]bool{}
 	for _, destinationAsset := range destinationAssets {
 		destinationAssetString := destinationAsset.String()
-		target[graph.assetStringToID[destinationAssetString]] = true
+		destinationAssetID, ok := graph.assetStringToID[destinationAssetString]
+		if !ok {
+			continue
+		}
+		target[destinationAssetID] = true
 	}
 
 	sourceAssetString := sourceAsset.String()
+	sourceAssetID, ok := graph.assetStringToID[sourceAssetString]
+	if !ok || len(target) == 0 {
+		return []Path{}, graph.lastLedger, nil
+	}
 	searchState := &buyingGraphSearchState{
 		graph:             graph,
 		sourceAssetString: sourceAssetString,
@@ -781,7 +801,7 @@ func (graph *OrderBookGraph) FindFixedPaths(
 		ctx,
 		searchState,
 		maxPathLength,
-		graph.assetStringToID[sourceAssetString],
+		sourceAssetID,
 		amountToSpend,
 	)
 	lastLedger := graph.lastLedger

--- a/exp/orderbook/graph_test.go
+++ b/exp/orderbook/graph_test.go
@@ -1623,6 +1623,52 @@ func TestFindPaths(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, 2, lastLedger)
 	assertPathEquals(t, paths, expectedPaths)
+
+	t.Run("find paths starting from non-existent asset", func(t *testing.T) {
+		paths, lastLedger, err = graph.FindPaths(
+			context.TODO(),
+			4,
+			xdr.MustNewCreditAsset("DNE", yenAsset.GetIssuer()),
+			20,
+			&ignoreOffersFrom,
+			[]xdr.Asset{
+				yenAsset,
+				usdAsset,
+			},
+			[]xdr.Int64{
+				100000,
+				60000,
+			},
+			false,
+			5,
+			true,
+		)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 2, lastLedger)
+		assert.Len(t, paths, 0)
+	})
+
+	t.Run("find paths ending at non-existent assets", func(t *testing.T) {
+		paths, lastLedger, err = graph.FindPaths(
+			context.TODO(),
+			4,
+			usdAsset,
+			20,
+			&ignoreOffersFrom,
+			[]xdr.Asset{
+				xdr.MustNewCreditAsset("DNE", yenAsset.GetIssuer()),
+			},
+			[]xdr.Int64{
+				1000000000,
+			},
+			false,
+			5,
+			true,
+		)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 2, lastLedger)
+		assert.Len(t, paths, 0)
+	})
 }
 
 func TestFindPathsStartingAt(t *testing.T) {
@@ -1872,6 +1918,38 @@ func TestFindPathsStartingAt(t *testing.T) {
 		},
 	}
 	assertPathEquals(t, paths, expectedPaths)
+
+	t.Run("find fixed paths starting from non-existent asset", func(t *testing.T) {
+		paths, lastLedger, err = graph.FindFixedPaths(
+			context.TODO(),
+			5,
+			xdr.MustNewCreditAsset("DNE", yenAsset.GetIssuer()),
+			5,
+			[]xdr.Asset{nativeAsset, usdAsset},
+			5,
+			true,
+		)
+
+		assert.NoError(t, err)
+		assert.EqualValues(t, 2, lastLedger)
+		assert.Len(t, paths, 0)
+	})
+
+	t.Run("find fixed paths ending at non-existent assets", func(t *testing.T) {
+		paths, lastLedger, err = graph.FindFixedPaths(
+			context.TODO(),
+			5,
+			usdAsset,
+			5,
+			[]xdr.Asset{xdr.MustNewCreditAsset("DNE", yenAsset.GetIssuer())},
+			5,
+			true,
+		)
+
+		assert.NoError(t, err)
+		assert.EqualValues(t, 2, lastLedger)
+		assert.Len(t, paths, 0)
+	})
 }
 
 func TestPathThroughLiquidityPools(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

There is a bug where if you query for path finding requests starting from or ending at a non-existent asset the path finding algorithm may return invalid paths. There is a mapping between an asset's string representation and its integer id. However, when accessing the map I did not check if the asset string actually exists. So, for non existent keys golang maps will default to the the 0 value.

For example if I search for paths from asset "DNE: GC4YD2I47LT64AFNN67QYG5VVZG32MJHNRD3DJ23FZSN33DIYHMK5QBX" to "XLM" and "DNE: GC4YD2I47LT64AFNN67QYG5VVZG32MJHNRD3DJ23FZSN33DIYHMK5QBX" does not exist, the code will actually search for paths from whichever asset has id 0 to "XLM".

This commit adds the proper check to first determine if the asset exists before doing the path finding search.



### Known limitations

[N/A]
