### PR TITLE
gxdr: generate using go:generate

### DIFF
--- a/gogenerate.sh
+++ b/gogenerate.sh
@@ -13,8 +13,5 @@ command -v go-bindata >/dev/null 2>&1 || (
 printf "Running go generate...\n"
 go generate ./...
 
-printf "Running make gxdr/xdr_generated.go...\n"
-make gxdr/xdr_generated.go
-
 printf "Checking for no diff...\n"
 git diff --exit-code || (echo "Files changed after running go generate. Run go generate ./... locally and update generated files." && exit 1)

--- a/gxdr/generate.go
+++ b/gxdr/generate.go
@@ -1,0 +1,4 @@
+package gxdr
+
+//go:generate rm -f xdr_generated.go
+//go:generate make -C ../ gxdr/xdr_generated.go


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Generate gxdr using go:generate.

### Why

I was modifying the gogenerate.sh script for another reason and noticed we have a generation step that is embedded in the gogenerate.sh script that's job is not to do generation, but primarily to make sure that generation results in no diff. Generation should be specified using the `//go:generate` comments so anyone running `go generate ./...` generates all the things.

Note that I also added a rm step, because as it stands the current make call will only generate the code if the file doesn't exist, which is of little value since the point of gogenerate.sh is to validate generated code, and I imagine was a mistake when it was added to the gogenerate.sh.

### Known limitations

N/A
