### PR TITLE
exp/orderbook: Include empty paths in path finding response

### DIFF
--- a/exp/orderbook/graph_test.go
+++ b/exp/orderbook/graph_test.go
@@ -1579,10 +1579,12 @@ func TestFindPaths(t *testing.T) {
 		[]xdr.Asset{
 			yenAsset,
 			usdAsset,
+			nativeAsset,
 		},
 		[]xdr.Int64{
 			100000,
 			60000,
+			100000,
 		},
 		true,
 		5,
@@ -1615,6 +1617,15 @@ func TestFindPaths(t *testing.T) {
 				eurAsset.String(),
 				chfAsset.String(),
 			},
+			DestinationAsset:  nativeAsset.String(),
+			DestinationAmount: 20,
+		},
+		// include the empty path where xlm is transferred without any
+		// conversions
+		{
+			SourceAmount:      20,
+			SourceAsset:       nativeAsset.String(),
+			InteriorNodes:     []string{},
 			DestinationAsset:  nativeAsset.String(),
 			DestinationAmount: 20,
 		},
@@ -1873,7 +1884,7 @@ func TestFindPathsStartingAt(t *testing.T) {
 		5,
 		yenAsset,
 		5,
-		[]xdr.Asset{nativeAsset, usdAsset},
+		[]xdr.Asset{nativeAsset, usdAsset, yenAsset},
 		5,
 		true,
 	)
@@ -1894,6 +1905,15 @@ func TestFindPathsStartingAt(t *testing.T) {
 			},
 			DestinationAsset:  usdAsset.String(),
 			DestinationAmount: 20,
+		},
+		// include the empty path where yen is transferred without any
+		// conversions
+		{
+			SourceAmount:      5,
+			SourceAsset:       yenAsset.String(),
+			InteriorNodes:     []string{},
+			DestinationAsset:  yenAsset.String(),
+			DestinationAmount: 5,
 		},
 		{
 			SourceAmount: 5,

--- a/exp/orderbook/search.go
+++ b/exp/orderbook/search.go
@@ -138,6 +138,17 @@ func search(
 		asset: sourceAsset,
 		prev:  nil,
 	}
+	// Simple payments (e.g. payments where an asset is transferred from
+	// one account to another without any conversions into another asset)
+	// are also valid path payments. If the source asset is a valid
+	// destination asset we include the empty path in the response.
+	if state.includePath(sourceAsset, sourceAssetAmount) {
+		state.appendToPaths(
+			[]int32{sourceAsset},
+			sourceAsset,
+			sourceAssetAmount,
+		)
+	}
 
 	for i := 0; i < maxPathLength; i++ {
 		updatedAssets = updatedAssets[:0]


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes https://github.com/stellar/go/issues/4131

If the source asset is included in the list of destination assets we will include the empty path in the path finding response. For example:

If we receive the following `/paths/strict-send` query:

```
destination_assets=native,BTC:GAUTUYY2THLF7SGITDFMXJVYH3LHDSMGEAKSBU267M2K7A3W543CKUEF

source_asset=BTC:GAUTUYY2THLF7SGITDFMXJVYH3LHDSMGEAKSBU267M2K7A3W543CKUEF

source_amount=0.0005953
```

We will include the following empty path in the response:

```
{
        "source_asset_type": "credit_alphanum4",
        "source_asset_code": "BTC",
        "source_asset_issuer": "GAUTUYY2THLF7SGITDFMXJVYH3LHDSMGEAKSBU267M2K7A3W543CKUEF",
        "source_amount": "0.0005953",
        "destination_asset_type": "credit_alphanum4",
        "destination_asset_code": "BTC",
        "destination_asset_issuer": "GAUTUYY2THLF7SGITDFMXJVYH3LHDSMGEAKSBU267M2K7A3W543CKUEF",
        "destination_amount": "0.0005953",
        "path": []
      }
```
### Why

Simple payments (e.g. payments where an asset is transferred from one account to another without any conversions into another asset) are also valid path payments. Because the path finding endpoint is used to construct path payments we should not omit paths corresponding to simple payments.

### Known limitations

[N/A]
