### PR TITLE
services/horizon: Horizon 2.12.1 CHANGELOG

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -5,6 +5,11 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## v2.12.1
+
+### Fixes
+* Fixes a critical vulnerability in HTTP server of Golang <=1.17.4. An attacker can cause unbounded memory growth in a Go server accepting HTTP/2 requests.
+
 ## v2.12.0
 
 ### Features


### PR DESCRIPTION
Rebuilds Horizon using Go 1.17.5 (pulled automatically because we don't pin to any specific patch release) to mitigate CVE-2021-44716.