### PR TITLE
all: make docker images consistently build from go 1.17

### DIFF
--- a/exp/services/recoverysigner/docker/Dockerfile
+++ b/exp/services/recoverysigner/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as build
+FROM golang:1.17 as build
 
 ADD . /src/recoverysigner
 WORKDIR /src/recoverysigner

--- a/exp/services/webauth/docker/Dockerfile
+++ b/exp/services/webauth/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as build
+FROM golang:1.17 as build
 
 ADD . /src/webauth
 WORKDIR /src/webauth

--- a/services/friendbot/docker/Dockerfile
+++ b/services/friendbot/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as build
+FROM golang:1.17 as build
 
 ADD . /src/friendbot
 WORKDIR /src/friendbot

--- a/services/keystore/docker/Dockerfile
+++ b/services/keystore/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5 as build
+FROM golang:1.17 as build
 
 ADD . /src/keystore
 WORKDIR /src/keystore

--- a/services/regulated-assets-approval-server/docker/Dockerfile
+++ b/services/regulated-assets-approval-server/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5 as build
+FROM golang:1.17 as build
 
 ADD . /src/regulated-assets-approval-server
 WORKDIR /src/regulated-assets-approval-server

--- a/services/ticker/docker/Dockerfile
+++ b/services/ticker/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5 as build
+FROM golang:1.17 as build
 
 ADD . /src/ticker
 WORKDIR /src/ticker

--- a/services/ticker/docker/Dockerfile-dev
+++ b/services/ticker/docker/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM golang:1.16.5-stretch as build
+FROM golang:1.17-stretch as build
 
 LABEL maintainer="Alex Cordeiro <alexc@stellar.org>"
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Make all docker images in this repo consistently build from Go 1.17.

### Why

Some are building from Go 1.16 when we usually target building with the latest version we support, and we currently support 1.16 and 1.17.

Also, some are building from specific minor versions, like 1.16.5, that have been superseded.

### Known limitations

N/A
