### PR TITLE
xdr: Improve performance of StringCanonical() and add asset string benchmarks

### DIFF
--- a/xdr/asset.go
+++ b/xdr/asset.go
@@ -265,7 +265,7 @@ func (a Asset) StringCanonical() string {
 		return t
 	}
 
-	return fmt.Sprintf("%s:%s", c, i)
+	return c + ":" + i
 }
 
 // Equals returns true if `other` is equivalent to `a`

--- a/xdr/asset_test.go
+++ b/xdr/asset_test.go
@@ -474,3 +474,33 @@ func TestAssetLessThan(t *testing.T) {
 		assert.False(t, assetIssuerB.LessThan(assetIssuerB))
 	})
 }
+
+func BenchmarkAssetString(b *testing.B) {
+	n := MustNewNativeAsset()
+	a, err := NewCreditAsset(
+		"ARST",
+		"GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO",
+	)
+	require.NoError(b, err)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = n.String()
+		_ = a.String()
+	}
+}
+
+func BenchmarkAssetStringCanonical(b *testing.B) {
+	n := MustNewNativeAsset()
+	a, err := NewCreditAsset(
+		"ARST",
+		"GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO",
+	)
+	require.NoError(b, err)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = n.StringCanonical()
+		_ = a.StringCanonical()
+	}
+}


### PR DESCRIPTION
Yet another leftover branch I had hanging around from optimizing path finding.

Not a critical optimization, but it doesn't hurt either.