### PR TITLE
xdr: Add AbsBeforeEpoch to ClaimableBalance:Predicate API resource 

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -5,9 +5,6 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-* Generate Http Status code of 499 for Client Disconnects, should propagate into `horizon_http_requests_duration_seconds_count`
-  metric key with status=499 label. ([4098](https://github.com/stellar/go/pull/4098))
-
 * Added `absBeforeEpoch` to ClaimableBalance API Resources. It will contain the Unix epoch representation of absolute before date. ([TBD](TBD))  
 
 ## v2.12.1

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,7 +6,9 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Generate Http Status code of 499 for Client Disconnects, should propagate into `horizon_http_requests_duration_seconds_count`
-  metric key with status=499 label. ([4098](horizon_http_requests_duration_seconds_count))
+  metric key with status=499 label. ([4098](https://github.com/stellar/go/pull/4098))
+
+* Added `absBeforeEpoch` to ClaimableBalance API Resources. It will contain the Unix epoch representation of absolute before date. ([TBD](TBD))  
 
 ## v2.12.1
 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -5,7 +5,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-* Added `absBeforeEpoch` to ClaimableBalance API Resources. It will contain the Unix epoch representation of absolute before date. ([TBD](TBD))  
+* Added `absBeforeEpoch` to ClaimableBalance API Resources. It will contain the Unix epoch representation of absolute before date. ([4148](https://github.com/stellar/go/pull/4148))  
 
 ## v2.12.1
 

--- a/services/horizon/internal/resourceadapter/claimable_balances_test.go
+++ b/services/horizon/internal/resourceadapter/claimable_balances_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPopulateClaimableBalance(t *testing.T) {
+func TestPopulateClaimableBalanceUnconditional(t *testing.T) {
 	tt := assert.New(t)
 	ctx, _ := test.ContextWithLogBuffer()
 	resource := ClaimableBalance{}
@@ -21,6 +21,12 @@ func TestPopulateClaimableBalance(t *testing.T) {
 		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
 		V0:   &xdr.Hash{1, 2, 3},
 	}
+	unconditional := &xdr.ClaimPredicate{
+		Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+	}
+	relBefore := xdr.Int64(12)
+	absBefore := xdr.Int64(1598440539)
+
 	id, err := xdr.MarshalHex(&balanceID)
 	tt.NoError(err)
 	claimableBalance := history.ClaimableBalance{
@@ -32,7 +38,26 @@ func TestPopulateClaimableBalance(t *testing.T) {
 			{
 				Destination: "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 				Predicate: xdr.ClaimPredicate{
-					Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+					Type: xdr.ClaimPredicateTypeClaimPredicateAnd,
+					AndPredicates: &[]xdr.ClaimPredicate{
+						{
+							Type: xdr.ClaimPredicateTypeClaimPredicateOr,
+							OrPredicates: &[]xdr.ClaimPredicate{
+								{
+									Type:      xdr.ClaimPredicateTypeClaimPredicateBeforeRelativeTime,
+									RelBefore: &relBefore,
+								},
+								{
+									Type:      xdr.ClaimPredicateTypeClaimPredicateBeforeAbsoluteTime,
+									AbsBefore: &absBefore,
+								},
+							},
+						},
+						{
+							Type:         xdr.ClaimPredicateTypeClaimPredicateNot,
+							NotPredicate: &unconditional,
+						},
+					},
 				},
 			},
 		},
@@ -74,5 +99,5 @@ func TestPopulateClaimableBalance(t *testing.T) {
 
 	predicate, err := json.Marshal(resource.Claimants[0].Predicate)
 	tt.NoError(err)
-	tt.JSONEq(`{"unconditional":true}`, string(predicate))
+	tt.JSONEq(`{"and":[{"or":[{"rel_before":"12"},{"abs_before":"2020-08-26T11:15:39Z","abs_before_epoch":"1598440539"}]},{"not":{"unconditional":true}}]}`, string(predicate))
 }

--- a/services/horizon/internal/resourceadapter/claimable_balances_test.go
+++ b/services/horizon/internal/resourceadapter/claimable_balances_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPopulateClaimableBalanceUnconditional(t *testing.T) {
+func TestPopulateClaimableBalance(t *testing.T) {
 	tt := assert.New(t)
 	ctx, _ := test.ContextWithLogBuffer()
 	resource := ClaimableBalance{}

--- a/xdr/json.go
+++ b/xdr/json.go
@@ -102,7 +102,7 @@ func (c claimPredicateJSON) toXDR() (ClaimPredicate, error) {
 		result.Type = ClaimPredicateTypeClaimPredicateBeforeRelativeTime
 		result.RelBefore = &relBefore
 	case c.AbsBefore != nil:
-		absBefore := Int64(c.AbsBefore.Epoch())
+		absBefore := Int64(c.AbsBefore.UTC().Unix())
 		result.Type = ClaimPredicateTypeClaimPredicateBeforeAbsoluteTime
 		result.AbsBefore = &absBefore
 	case c.Not != nil:
@@ -161,9 +161,10 @@ func (c ClaimPredicate) toJSON() (claimPredicateJSON, error) {
 		payload.Not = new(claimPredicateJSON)
 		*payload.Not, err = c.MustNotPredicate().toJSON()
 	case ClaimPredicateTypeClaimPredicateBeforeAbsoluteTime:
-		payload.AbsBefore = Newiso8601Time(int64(c.MustAbsBefore()))
+		absBeforeEpoch := int64(c.MustAbsBefore())
+		payload.AbsBefore = Newiso8601Time(absBeforeEpoch)
 		payload.AbsBeforeEpoch = new(int64)
-		*payload.AbsBeforeEpoch = payload.AbsBefore.Epoch()
+		*payload.AbsBeforeEpoch = absBeforeEpoch
 	case ClaimPredicateTypeClaimPredicateBeforeRelativeTime:
 		payload.RelBefore = new(int64)
 		*payload.RelBefore = int64(c.MustRelBefore())

--- a/xdr/json.go
+++ b/xdr/json.go
@@ -60,11 +60,7 @@ func (t *iso8601Time) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (t iso8601Time) Epoch() int64 {
-	return t.UTC().Unix()
-}
-
-func Newiso8601Time(epoch int64) *iso8601Time {
+func newiso8601Time(epoch int64) *iso8601Time {
 	return &iso8601Time{time.Unix(epoch, 0).UTC()}
 }
 
@@ -162,7 +158,7 @@ func (c ClaimPredicate) toJSON() (claimPredicateJSON, error) {
 		*payload.Not, err = c.MustNotPredicate().toJSON()
 	case ClaimPredicateTypeClaimPredicateBeforeAbsoluteTime:
 		absBeforeEpoch := int64(c.MustAbsBefore())
-		payload.AbsBefore = Newiso8601Time(absBeforeEpoch)
+		payload.AbsBefore = newiso8601Time(absBeforeEpoch)
 		payload.AbsBeforeEpoch = &absBeforeEpoch
 	case ClaimPredicateTypeClaimPredicateBeforeRelativeTime:
 		relBefore := int64(c.MustRelBefore())

--- a/xdr/json.go
+++ b/xdr/json.go
@@ -163,11 +163,10 @@ func (c ClaimPredicate) toJSON() (claimPredicateJSON, error) {
 	case ClaimPredicateTypeClaimPredicateBeforeAbsoluteTime:
 		absBeforeEpoch := int64(c.MustAbsBefore())
 		payload.AbsBefore = Newiso8601Time(absBeforeEpoch)
-		payload.AbsBeforeEpoch = new(int64)
-		*payload.AbsBeforeEpoch = absBeforeEpoch
+		payload.AbsBeforeEpoch = &absBeforeEpoch
 	case ClaimPredicateTypeClaimPredicateBeforeRelativeTime:
-		payload.RelBefore = new(int64)
-		*payload.RelBefore = int64(c.MustRelBefore())
+		relBefore := int64(c.MustRelBefore())
+		payload.RelBefore = &relBefore
 	default:
 		err = fmt.Errorf("invalid predicate type: " + c.Type.String())
 	}

--- a/xdr/json_test.go
+++ b/xdr/json_test.go
@@ -46,7 +46,7 @@ func TestClaimPredicateJSON(t *testing.T) {
 	assert.NoError(t, err)
 	assert.JSONEq(
 		t,
-		`{"and":[{"or":[{"rel_before":"12"},{"abs_before":"2020-08-26T11:15:39Z"}]},{"not":{"unconditional":true}}]}`,
+		`{"and":[{"or":[{"rel_before":"12"},{"abs_before":"2020-08-26T11:15:39Z","abs_before_epoch":"1598440539"}]},{"not":{"unconditional":true}}]}`,
 		string(serialized),
 	)
 
@@ -99,28 +99,28 @@ func TestAbsBeforeTimestamps(t *testing.T) {
 	}{
 		{
 			0,
-			`{"abs_before":"1970-01-01T00:00:00Z"}`,
+			`{"abs_before":"1970-01-01T00:00:00Z","abs_before_epoch":"0"}`,
 		},
 		{
 			900 * year,
-			`{"abs_before":"2869-05-27T00:00:00Z"}`,
+			`{"abs_before":"2869-05-27T00:00:00Z","abs_before_epoch":"28382400000"}`,
 		},
 		{
 			math.MaxInt64,
-			`{"abs_before":"+292277026596-12-04T15:30:07Z"}`,
+			`{"abs_before":"+292277026596-12-04T15:30:07Z","abs_before_epoch":"9223372036854775807"}`,
 		},
 		{
 			-10,
-			`{"abs_before":"1969-12-31T23:59:50Z"}`,
+			`{"abs_before":"1969-12-31T23:59:50Z","abs_before_epoch":"-10"}`,
 		},
 		{
 			-9000 * year,
-			`{"abs_before":"-7025-12-23T00:00:00Z"}`,
+			`{"abs_before":"-7025-12-23T00:00:00Z","abs_before_epoch":"-283824000000"}`,
 		},
 		{
 			math.MinInt64,
 			// this serialization doesn't make sense but at least it doesn't crash the marshaller
-			`{"abs_before":"+292277026596-12-04T15:30:08Z"}`,
+			`{"abs_before":"+292277026596-12-04T15:30:08Z","abs_before_epoch":"-9223372036854775808"}`,
 		},
 	} {
 		xdrSec := Int64(testCase.unix)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

added a new optional field `AbsBeforeEpoch` to the API resource `ClaimableBalance:Predicate`, it is the Unix Epoch value represented by the same custom extended ISO date value in the `AbsBefore` field.

### Why

this extra info for Epoch will enable SDK's to use the epoch for absolute before value of claimable balance predicate rather than attempt to parse the ISO, which gets complicated when the date very large, beyond the ISO standard range of year 9999. Some SDK's like the java SDK have bug fix pending on this change, like [Java SDK #354](https://github.com/stellar/java-stellar-sdk/issues/354)

Closes #4095 

### Known limitations


