### PR TITLE
horizon/ingest: Add method to ingest.Change that returns liquidity pool type

### DIFF
--- a/ingest/change.go
+++ b/ingest/change.go
@@ -82,6 +82,34 @@ func (c *Change) LedgerEntryChangeType() xdr.LedgerEntryChangeType {
 	}
 }
 
+// getLiquidityPool gets the most recent state of the LiquidityPool that exists or existed.
+func (c *Change) getLiquidityPool() (*xdr.LiquidityPoolEntry, error) {
+	var pre, post *xdr.LiquidityPoolEntry
+	if c.Pre != nil {
+		pre = c.Pre.Data.LiquidityPool
+	}
+	if c.Post != nil {
+		post = c.Post.Data.LiquidityPool
+	}
+	if pre == nil && post == nil {
+		return &xdr.LiquidityPoolEntry{}, errors.New(
+			"both pre and post entries cannot be nil; this change may not include a liquidity pool")
+	}
+	if post != nil {
+		return post, nil
+	}
+	return pre, nil
+}
+
+// GetLiquidityPoolType returns the liquidity pool type.
+func (c *Change) GetLiquidityPoolType() (xdr.LiquidityPoolType, error) {
+	lp, err := c.getLiquidityPool()
+	if err != nil {
+		return xdr.LiquidityPoolType(0), err
+	}
+	return lp.Body.Type, nil
+}
+
 // AccountChangedExceptSigners returns true if account has changed WITHOUT
 // checking the signers (except master key weight!). In other words, if the only
 // change is connected to signers, this function will return false.

--- a/ingest/change.go
+++ b/ingest/change.go
@@ -84,21 +84,17 @@ func (c *Change) LedgerEntryChangeType() xdr.LedgerEntryChangeType {
 
 // getLiquidityPool gets the most recent state of the LiquidityPool that exists or existed.
 func (c *Change) getLiquidityPool() (*xdr.LiquidityPoolEntry, error) {
-	var pre, post *xdr.LiquidityPoolEntry
+	var entry *xdr.LiquidityPoolEntry
 	if c.Pre != nil {
-		pre = c.Pre.Data.LiquidityPool
+		entry = c.Pre.Data.LiquidityPool
 	}
 	if c.Post != nil {
-		post = c.Post.Data.LiquidityPool
+		entry = c.Post.Data.LiquidityPool
 	}
-	if pre == nil && post == nil {
-		return &xdr.LiquidityPoolEntry{}, errors.New(
-			"both pre and post entries cannot be nil; this change may not include a liquidity pool")
+	if entry == nil {
+		return &xdr.LiquidityPoolEntry{}, errors.New("this change does not include a liquidity pool")
 	}
-	if post != nil {
-		return post, nil
-	}
-	return pre, nil
+	return entry, nil
 }
 
 // GetLiquidityPoolType returns the liquidity pool type.

--- a/services/horizon/internal/ingest/processors/asset_stats_set.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_set.go
@@ -237,12 +237,9 @@ func (s AssetStatSet) AddLiquidityPool(change ingest.Change) error {
 		return ingest.NewStateError(errors.New("both pre and post liquidity pools cannot be nil"))
 	}
 
-	var lpType xdr.LiquidityPoolType
-	if pre != nil {
-		lpType = pre.Body.Type
-	}
-	if post != nil {
-		lpType = post.Body.Type
+	lpType, err := change.GetLiquidityPoolType()
+	if err != nil {
+		return ingest.NewStateError(err)
 	}
 
 	var assetA, assetB xdr.Asset


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add method to `ingest.Change` that extracts liquidity pool type

### Why

This functionality is likely to be used elsewhere while processing liquidity pools.

### Known limitations

