### PR TITLE
services/horizon/internal/integration: Refactor integration tests

### DIFF
--- a/services/horizon/internal/integration/claimable_balance_ops_test.go
+++ b/services/horizon/internal/integration/claimable_balance_ops_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestClaimableBalanceCreationOperationsAndEffects(t *testing.T) {
 	tt := assert.New(t)
-	itest := integration.NewTest(t, protocol15Config)
+	itest := integration.NewTest(t, integration.Config{})
 	master := itest.Master()
 
 	t.Run("Successful", func(t *testing.T) {

--- a/services/horizon/internal/integration/claimable_balance_test.go
+++ b/services/horizon/internal/integration/claimable_balance_test.go
@@ -17,30 +17,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var protocol15Config = integration.Config{ProtocolVersion: 15}
-
-func TestProtocol15Basics(t *testing.T) {
+func TestClaimableBalanceBasics(t *testing.T) {
 	tt := assert.New(t)
-	itest := integration.NewTest(t, protocol15Config)
+	itest := integration.NewTest(t, integration.Config{})
 	master := itest.Master()
-
-	t.Run("Sanity", func(t *testing.T) {
-		root, err := itest.Client().Root()
-		tt.NoError(err)
-		tt.LessOrEqual(int32(15), root.CoreSupportedProtocolVersion)
-		tt.Equal(int32(15), root.CurrentProtocolVersion)
-
-		// Submit a simple tx
-		op := txnbuild.Payment{
-			Destination: master.Address(),
-			Amount:      "10",
-			Asset:       txnbuild.NativeAsset{},
-		}
-
-		txResp := itest.MustSubmitOperations(itest.MasterAccount(), master, &op)
-		tt.Equal(master.Address(), txResp.Account)
-		tt.Equal("1", txResp.AccountSequence)
-	})
 
 	// Ensure predicting claimable balances works.
 	t.Run("BalanceIDs", func(t *testing.T) {
@@ -91,7 +71,7 @@ func TestProtocol15Basics(t *testing.T) {
 }
 
 func TestHappyClaimableBalances(t *testing.T) {
-	itest := integration.NewTest(t, protocol15Config)
+	itest := integration.NewTest(t, integration.Config{})
 	master, client := itest.Master(), itest.Client()
 
 	keys, accounts := itest.CreateAccounts(3, "1000")
@@ -314,7 +294,7 @@ func TestHappyClaimableBalances(t *testing.T) {
 
 // We want to ensure that users can't claim the same claimable balance twice.
 func TestDoubleClaim(t *testing.T) {
-	itest := integration.NewTest(t, protocol15Config)
+	itest := integration.NewTest(t, integration.Config{})
 	client := itest.Client()
 
 	// Create a couple of accounts to test the interactions.
@@ -374,7 +354,7 @@ func TestDoubleClaim(t *testing.T) {
 }
 
 func TestClaimableBalancePredicates(t *testing.T) {
-	itest := integration.NewTest(t, protocol15Config)
+	itest := integration.NewTest(t, integration.Config{})
 	_, client := itest.Master(), itest.Client()
 
 	// Create a couple of accounts to test the interactions.

--- a/services/horizon/internal/integration/clawback_test.go
+++ b/services/horizon/internal/integration/clawback_test.go
@@ -16,38 +16,9 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-func NewProtocol17Test(t *testing.T) *integration.Test {
-	config := integration.Config{ProtocolVersion: 17}
-	return integration.NewTest(t, config)
-}
-
-func TestProtocol16Basics(t *testing.T) {
-	tt := assert.New(t)
-	itest := NewProtocol17Test(t)
-	master := itest.Master()
-
-	t.Run("Sanity", func(t *testing.T) {
-		root, err := itest.Client().Root()
-		tt.NoError(err)
-		tt.LessOrEqual(int32(17), root.CoreSupportedProtocolVersion)
-		tt.Equal(int32(17), root.CurrentProtocolVersion)
-
-		// Submit a simple tx
-		op := txnbuild.Payment{
-			Destination: master.Address(),
-			Amount:      "10",
-			Asset:       txnbuild.NativeAsset{},
-		}
-
-		txResp := itest.MustSubmitOperations(itest.MasterAccount(), master, &op)
-		tt.Equal(master.Address(), txResp.Account)
-		tt.Equal("1", txResp.AccountSequence)
-	})
-}
-
 func TestHappyClawbackAccount(t *testing.T) {
 	tt := assert.New(t)
-	itest := NewProtocol17Test(t)
+	itest := integration.NewTest(t, integration.Config{})
 	master := itest.Master()
 
 	asset, fromKey, _ := setupClawbackAccountTest(tt, itest, master)
@@ -95,7 +66,7 @@ func TestHappyClawbackAccount(t *testing.T) {
 
 func TestHappyClawbackAccountPartial(t *testing.T) {
 	tt := assert.New(t)
-	itest := NewProtocol17Test(t)
+	itest := integration.NewTest(t, integration.Config{})
 	master := itest.Master()
 
 	asset, fromKey, _ := setupClawbackAccountTest(tt, itest, master)
@@ -112,7 +83,7 @@ func TestHappyClawbackAccountPartial(t *testing.T) {
 
 func TestHappyClawbackAccountSellingLiabilities(t *testing.T) {
 	tt := assert.New(t)
-	itest := NewProtocol17Test(t)
+	itest := integration.NewTest(t, integration.Config{})
 	master := itest.Master()
 
 	asset, fromKey, fromAccount := setupClawbackAccountTest(tt, itest, master)
@@ -151,7 +122,7 @@ func TestHappyClawbackAccountSellingLiabilities(t *testing.T) {
 
 func TestSadClawbackAccountInsufficientFunds(t *testing.T) {
 	tt := assert.New(t)
-	itest := NewProtocol17Test(t)
+	itest := integration.NewTest(t, integration.Config{})
 	master := itest.Master()
 
 	asset, fromKey, _ := setupClawbackAccountTest(tt, itest, master)
@@ -167,7 +138,7 @@ func TestSadClawbackAccountInsufficientFunds(t *testing.T) {
 
 func TestSadClawbackAccountSufficientFundsSellingLiabilities(t *testing.T) {
 	tt := assert.New(t)
-	itest := NewProtocol17Test(t)
+	itest := integration.NewTest(t, integration.Config{})
 	master := itest.Master()
 
 	asset, fromKey, fromAccount := setupClawbackAccountTest(tt, itest, master)
@@ -268,7 +239,7 @@ func assertAccountBalance(tt *assert.Assertions, itest *integration.Test, accoun
 
 func TestHappyClawbackClaimableBalance(t *testing.T) {
 	tt := assert.New(t)
-	itest := NewProtocol17Test(t)
+	itest := integration.NewTest(t, integration.Config{})
 	master := itest.Master()
 
 	// Give the master account the revocable flag (needed to set the clawback flag)
@@ -400,7 +371,7 @@ func TestHappyClawbackClaimableBalance(t *testing.T) {
 
 func TestHappySetTrustLineFlags(t *testing.T) {
 	tt := assert.New(t)
-	itest := NewProtocol17Test(t)
+	itest := integration.NewTest(t, integration.Config{})
 	master := itest.Master()
 
 	// Give the master account the revocable flag (needed to set the clawback flag)

--- a/services/horizon/internal/integration/db_test.go
+++ b/services/horizon/internal/integration/db_test.go
@@ -136,8 +136,7 @@ func generatePaymentOps(itest *integration.Test, tt *assert.Assertions) (lastLed
 }
 
 func initializeDBIntegrationTest(t *testing.T) (itest *integration.Test, reachedLedger int32) {
-	config := integration.Config{ProtocolVersion: 18}
-	itest = integration.NewTest(t, config)
+	itest = integration.NewTest(t, integration.Config{})
 	tt := assert.New(t)
 
 	generatePaymentOps(itest, tt)
@@ -368,10 +367,6 @@ func TestResumeFromInitializedDB(t *testing.T) {
 	tt := assert.New(t)
 
 	// Stop the integration test, and restart it with the same database
-	oldDBURL := itest.GetHorizonConfig().DatabaseURL
-	itestConfig := protocol15Config
-	itestConfig.PostgresURL = oldDBURL
-
 	err := itest.RestartHorizon()
 	tt.NoError(err)
 

--- a/services/horizon/internal/integration/liquidity_pool_test.go
+++ b/services/horizon/internal/integration/liquidity_pool_test.go
@@ -16,38 +16,9 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-func NewProtocol18Test(t *testing.T) *integration.Test {
-	config := integration.Config{ProtocolVersion: 18}
-	return integration.NewTest(t, config)
-}
-
-func TestProtocol18Basics(t *testing.T) {
-	tt := assert.New(t)
-	itest := NewProtocol18Test(t)
-	master := itest.Master()
-
-	t.Run("Sanity", func(t *testing.T) {
-		root, err := itest.Client().Root()
-		tt.NoError(err)
-		tt.LessOrEqual(int32(18), root.CoreSupportedProtocolVersion)
-		tt.Equal(int32(18), root.CurrentProtocolVersion)
-
-		// Submit a simple tx
-		op := txnbuild.Payment{
-			Destination: master.Address(),
-			Amount:      "10",
-			Asset:       txnbuild.NativeAsset{},
-		}
-
-		txResp := itest.MustSubmitOperations(itest.MasterAccount(), master, &op)
-		tt.Equal(master.Address(), txResp.Account)
-		tt.Equal("1", txResp.AccountSequence)
-	})
-}
-
 func TestLiquidityPoolHappyPath(t *testing.T) {
 	tt := assert.New(t)
-	itest := NewProtocol18Test(t)
+	itest := integration.NewTest(t, integration.Config{})
 	master := itest.Master()
 
 	keys, accounts := itest.CreateAccounts(2, "1000")
@@ -448,7 +419,7 @@ func TestLiquidityPoolHappyPath(t *testing.T) {
 
 func TestLiquidityPoolRevoke(t *testing.T) {
 	tt := assert.New(t)
-	itest := NewProtocol18Test(t)
+	itest := integration.NewTest(t, integration.Config{})
 	master := itest.Master()
 
 	keys, accounts := itest.CreateAccounts(2, "1000")
@@ -683,7 +654,7 @@ func TestLiquidityPoolRevoke(t *testing.T) {
 
 func TestLiquidityPoolFailedDepositAndWithdraw(t *testing.T) {
 	tt := assert.New(t)
-	itest := NewProtocol18Test(t)
+	itest := integration.NewTest(t, integration.Config{})
 
 	keys, accounts := itest.CreateAccounts(2, "1000")
 	shareKeys, shareAccount := keys[0], accounts[0]

--- a/services/horizon/internal/integration/muxed_account_details_test.go
+++ b/services/horizon/internal/integration/muxed_account_details_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestMuxedAccountDetails(t *testing.T) {
 	tt := assert.New(t)
-	itest := integration.NewTest(t, integration.Config{ProtocolVersion: 17})
+	itest := integration.NewTest(t, integration.Config{})
 	master := itest.Master()
 	masterStr := master.Address()
 	masterAcID := xdr.MustAddress(masterStr)

--- a/services/horizon/internal/integration/muxed_operations_test.go
+++ b/services/horizon/internal/integration/muxed_operations_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMuxedOperations(t *testing.T) {
-	itest := integration.NewTest(t, integration.Config{ProtocolVersion: 17})
+	itest := integration.NewTest(t, integration.Config{})
 
 	sponsored := keypair.MustRandom()
 	// Is there an easier way?

--- a/services/horizon/internal/integration/negative_seq_txsub_test.go
+++ b/services/horizon/internal/integration/negative_seq_txsub_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNegativeSequenceTxSubmission(t *testing.T) {
 	tt := assert.New(t)
-	itest := NewProtocol18Test(t)
+	itest := integration.NewTest(t, integration.Config{})
 	master := itest.Master()
 
 	// First, bump the sequence to the maximum value -1

--- a/services/horizon/internal/integration/sponsorship_test.go
+++ b/services/horizon/internal/integration/sponsorship_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestSponsorships(t *testing.T) {
 	tt := assert.New(t)
-	itest := integration.NewTest(t, protocol15Config)
+	itest := integration.NewTest(t, integration.Config{})
 	client := itest.Client()
 
 	/* Query helpers that can/should? probably be added to IntegrationTest. */

--- a/services/horizon/internal/integration/state_verifier_test.go
+++ b/services/horizon/internal/integration/state_verifier_test.go
@@ -11,16 +11,13 @@ import (
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/services/horizon/internal/ingest"
 	"github.com/stellar/go/services/horizon/internal/test/integration"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestStateVerifier(t *testing.T) {
-	itest := integration.NewTest(t, integration.Config{
-		ProtocolVersion: ingest.MaxSupportedProtocolVersion,
-	})
+	itest := integration.NewTest(t, integration.Config{})
 
 	sponsored := keypair.MustRandom()
 	sponsoredSource := &txnbuild.SimpleAccount{

--- a/services/horizon/internal/integration/trade_aggregations_test.go
+++ b/services/horizon/internal/integration/trade_aggregations_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/services/horizon/internal/ingest"
 	"github.com/stellar/go/services/horizon/internal/test/integration"
 	strtime "github.com/stellar/go/support/time"
 	"github.com/stellar/go/xdr"
@@ -17,7 +16,7 @@ import (
 )
 
 func TestTradeAggregations(t *testing.T) {
-	itest := integration.NewTest(t, integration.Config{ProtocolVersion: ingest.MaxSupportedProtocolVersion})
+	itest := integration.NewTest(t, integration.Config{})
 	ctx := context.Background()
 	historyQ := itest.Horizon().HistoryQ()
 

--- a/services/horizon/internal/integration/txsub_test.go
+++ b/services/horizon/internal/integration/txsub_test.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stellar/go/services/horizon/internal/ingest"
 	"github.com/stellar/go/services/horizon/internal/test/integration"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stretchr/testify/assert"
@@ -13,7 +12,7 @@ import (
 
 func TestTxsub(t *testing.T) {
 	tt := assert.New(t)
-	itest := integration.NewTest(t, integration.Config{ProtocolVersion: ingest.MaxSupportedProtocolVersion})
+	itest := integration.NewTest(t, integration.Config{})
 	master := itest.Master()
 
 	// Sanity check: create 20 accounts and submit 2 txs from each of them as

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/stellar/go/services/horizon/internal/ingest"
 	"github.com/stretchr/testify/assert"
 
 	sdk "github.com/stellar/go/clients/horizonclient"
@@ -110,6 +111,11 @@ func NewTestForRemoteHorizon(t *testing.T, horizonURL string, passPhrase string,
 func NewTest(t *testing.T, config Config) *Test {
 	if os.Getenv("HORIZON_INTEGRATION_TESTS") == "" {
 		t.Skip("skipping integration test: HORIZON_INTEGRATION_TESTS not set")
+	}
+
+	// If not specific explicitly, set the protocol to the maximum supported version
+	if config.ProtocolVersion == 0 {
+		config.ProtocolVersion = ingest.MaxSupportedProtocolVersion
 	}
 
 	composePath := findDockerComposePath()


### PR DESCRIPTION
* Use the latest protocol version for all tests.
* Set the protocol to the latest version if not specified explicitly.
* Rename tests according to their content, stop using protocol numbers.
* Remove all the sanity tests.

Closes  #3149