### PR TITLE
services/horizon: Add more verbose logging for horizon start up

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -147,6 +147,7 @@ func (a *App) Serve() error {
 		wg.Done()
 	}()
 
+	log.Infof("Starting to serve requests")
 	err := a.webServer.Serve()
 	if err != nil && err != http.ErrServerClosed {
 		return err

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -509,6 +509,8 @@ func NewAppFromFlags(config *Config, flags support.ConfigOptions) (*App, error) 
 	if config.Ingest && !config.EnableCaptiveCoreIngestion && config.StellarCoreDatabaseURL == "" {
 		return nil, fmt.Errorf("flag --%s cannot be empty", StellarCoreDBURLFlagName)
 	}
+
+	log.Infof("Initializing horizon...")
 	app, err := NewApp(*config)
 	if err != nil {
 		return nil, fmt.Errorf("cannot initialize app: %s", err)
@@ -545,10 +547,12 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 		// only on ingesting instances which are required to have write-access
 		// to the DB.
 		if config.ApplyMigrations {
+			stdLog.Println("Applying DB migrations...")
 			if err := applyMigrations(*config); err != nil {
 				return err
 			}
 		}
+		stdLog.Println("Checking DB migrations...")
 		if err := checkMigrations(*config); err != nil {
 			return err
 		}
@@ -560,6 +564,8 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 		}
 
 		if config.EnableCaptiveCoreIngestion {
+			stdLog.Println("Preparing captive core...")
+
 			binaryPath := viper.GetString(StellarCoreBinaryPathName)
 
 			// If the user didn't specify a Stellar Core binary, we can check the

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -18,6 +18,7 @@ import (
 )
 
 func mustNewDBSession(subservice db.Subservice, databaseURL string, maxIdle, maxOpen int, registry *prometheus.Registry) db.SessionInterface {
+	log.Infof("Establishing database session at %s for %v", databaseURL, subservice)
 	session, err := db.Open("postgres", databaseURL)
 	if err != nil {
 		log.Fatalf("cannot open %v DB: %v", subservice, err)
@@ -29,6 +30,8 @@ func mustNewDBSession(subservice db.Subservice, databaseURL string, maxIdle, max
 }
 
 func mustInitHorizonDB(app *App) {
+	log.Infof("Initializing database...")
+
 	maxIdle := app.config.HorizonDBMaxIdleConnections
 	maxOpen := app.config.HorizonDBMaxOpenConnections
 	if app.config.Ingest {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add more verbose logging to horizon start up. Include lines that signal db migration and captive core set up, which should be logged to stdout since it happens before logging is set up.

### Why

It would make debugging easier.

### Known limitations

