### PR TITLE
services/horizon/internal/httpx: Exempt SSE requests from rate limiting middleware

### DIFF
--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -82,6 +82,12 @@ func (suite *RateLimitMiddlewareTestSuite) TestRateLimit_LimitHeaders() {
 
 // Sets X-RateLimit-Remaining headers correctly.
 func (suite *RateLimitMiddlewareTestSuite) TestRateLimit_RemainingHeaders() {
+	// test that SSE requests are ignored
+	for i := 0; i < 10; i++ {
+		w := suite.rh.Get("/", test.RequestHelperStreaming)
+		assert.Equal(suite.T(), "", w.Header().Get("X-RateLimit-Remaining"))
+	}
+
 	for i := 0; i < 10; i++ {
 		w := suite.rh.Get("/")
 		expected := 10 - (i + 1)
@@ -92,6 +98,7 @@ func (suite *RateLimitMiddlewareTestSuite) TestRateLimit_RemainingHeaders() {
 	for i := 0; i < 10; i++ {
 		w := suite.rh.Get("/")
 		assert.Equal(suite.T(), "0", w.Header().Get("X-RateLimit-Remaining"))
+		assert.Equal(suite.T(), http.StatusTooManyRequests, w.Code)
 	}
 }
 

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -86,12 +86,14 @@ func (suite *RateLimitMiddlewareTestSuite) TestRateLimit_RemainingHeaders() {
 	for i := 0; i < 10; i++ {
 		w := suite.rh.Get("/", test.RequestHelperStreaming)
 		assert.Equal(suite.T(), "", w.Header().Get("X-RateLimit-Remaining"))
+		assert.NotEqual(suite.T(), http.StatusTooManyRequests, w.Code)
 	}
 
 	for i := 0; i < 10; i++ {
 		w := suite.rh.Get("/")
 		expected := 10 - (i + 1)
 		assert.Equal(suite.T(), strconv.Itoa(expected), w.Header().Get("X-RateLimit-Remaining"))
+		assert.NotEqual(suite.T(), http.StatusTooManyRequests, w.Code)
 	}
 
 	// confirm remaining stays at 0


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes https://github.com/stellar/go/issues/2852

This commit removes rate limiting on the http middleware for streaming requests.

### Why

Rate limiting is applied on horizon http requests via a middleware. However, for streaming requests, rate limiting is also applied on each execution of the event handler.

See https://github.com/stellar/go/issues/2852 for more details.

### Known limitations

[N/A]
