### PR TITLE
txnbuild: Enable Muxed accounts by default

### DIFF
--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -42,7 +42,7 @@ func (c *Client) checkMemoRequired(transaction *txnbuild.Transaction) error {
 	for i, op := range transaction.Operations() {
 		var destination string
 
-		if err := op.Validate(true); err != nil {
+		if err := op.Validate(); err != nil {
 			return err
 		}
 

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -947,7 +947,6 @@ func TestSubmitTransactionRequestMuxedAccounts(t *testing.T) {
 			Operations:           []txnbuild.Operation{&payment},
 			BaseFee:              txnbuild.MinBaseFee,
 			Timebounds:           txnbuild.NewTimebounds(0, 10),
-			EnableMuxedAccounts:  true,
 		},
 	)
 	assert.NoError(t, err)

--- a/services/horizon/internal/integration/negative_seq_txsub_test.go
+++ b/services/horizon/internal/integration/negative_seq_txsub_test.go
@@ -57,7 +57,6 @@ func TestNegativeSequenceTxSubmission(t *testing.T) {
 		BaseFee:              txnbuild.MinBaseFee,
 		Timebounds:           txnbuild.NewInfiniteTimeout(),
 		IncrementSequenceNum: false,
-		EnableMuxedAccounts:  true,
 	}
 	tx, err := txnbuild.NewTransaction(txParams)
 	tt.NoError(err)

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -690,7 +690,6 @@ func (i *Test) CreateSignedTransaction(
 		BaseFee:              txnbuild.MinBaseFee,
 		Timebounds:           txnbuild.NewInfiniteTimeout(),
 		IncrementSequenceNum: true,
-		EnableMuxedAccounts:  true,
 	}
 
 	tx, err := txnbuild.NewTransaction(txParams)

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -6,7 +6,15 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-
+* Enable Muxed Accounts ([SEP-23](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md)) by default:
+  * Remove `TransactionParams.EnableMuxedAccounts`
+  * Remove `TransactionFromXDROptionEnableMuxedAccounts`
+  * Remove `FeeBumpTransactionParams.EnableMuxedAccounts`
+  * Remove parameter `withMuxedAccounts bool` from all methods/functions.
+  * Remove `options ...TransactionFromXDROption` parameter from `TransactionFromXDR()`
+  * Rename `SetOpSourceMuxedAccount()` to (pre-existing) `SetOpSourceAccount()` which now accepts
+    both `G` and `M` (muxed) account strkeys.
+  
 ## [8.0.0-beta.0](https://github.com/stellar/go/releases/tag/horizonclient-v8.0.0-beta.0) - 2021-10-04
 
 **This release adds support for Protocol 18.**

--- a/txnbuild/account_merge.go
+++ b/txnbuild/account_merge.go
@@ -26,7 +26,7 @@ func (am *AccountMerge) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, am.SourceAccount)
+	SetOpSourceAccount(&op, am.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/account_merge.go
+++ b/txnbuild/account_merge.go
@@ -13,14 +13,9 @@ type AccountMerge struct {
 }
 
 // BuildXDR for AccountMerge returns a fully configured XDR Operation.
-func (am *AccountMerge) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (am *AccountMerge) BuildXDR() (xdr.Operation, error) {
 	var xdrOp xdr.MuxedAccount
-	var err error
-	if withMuxedAccounts {
-		err = xdrOp.SetAddress(am.Destination)
-	} else {
-		err = xdrOp.SetEd25519Address(am.Destination)
-	}
+	err := xdrOp.SetAddress(am.Destination)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "failed to set destination address")
 	}
@@ -31,28 +26,19 @@ func (am *AccountMerge) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) 
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, am.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, am.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, am.SourceAccount)
 	return op, nil
 }
 
 // FromXDR for AccountMerge initialises the txnbuild struct from the corresponding xdr Operation.
-func (am *AccountMerge) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (am *AccountMerge) FromXDR(xdrOp xdr.Operation) error {
 	if xdrOp.Body.Type != xdr.OperationTypeAccountMerge {
 		return errors.New("error parsing account_merge operation from xdr")
 	}
 
-	am.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	am.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	if xdrOp.Body.Destination != nil {
-		if withMuxedAccounts {
-			am.Destination = xdrOp.Body.Destination.Address()
-		} else {
-			aid := xdrOp.Body.Destination.ToAccountId()
-			am.Destination = aid.Address()
-		}
+		am.Destination = xdrOp.Body.Destination.Address()
 	}
 
 	return nil
@@ -60,13 +46,9 @@ func (am *AccountMerge) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) err
 
 // Validate for AccountMerge validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
-func (am *AccountMerge) Validate(withMuxedAccounts bool) error {
+func (am *AccountMerge) Validate() error {
 	var err error
-	if withMuxedAccounts {
-		_, err = xdr.AddressToMuxedAccount(am.Destination)
-	} else {
-		_, err = xdr.AddressToAccountId(am.Destination)
-	}
+	_, err = xdr.AddressToMuxedAccount(am.Destination)
 	if err != nil {
 		return NewValidationError("Destination", err.Error())
 	}

--- a/txnbuild/account_merge_test.go
+++ b/txnbuild/account_merge_test.go
@@ -23,7 +23,7 @@ func TestAccountMergeValidate(t *testing.T) {
 		},
 	)
 	if assert.Error(t, err) {
-		expected := "minimum valid length is 5"
+		expected := "invalid address length"
 		assert.Contains(t, err.Error(), expected)
 	}
 }

--- a/txnbuild/allow_trust.go
+++ b/txnbuild/allow_trust.go
@@ -21,7 +21,7 @@ type AllowTrust struct {
 }
 
 // BuildXDR for AllowTrust returns a fully configured XDR Operation.
-func (at *AllowTrust) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (at *AllowTrust) BuildXDR() (xdr.Operation, error) {
 	var xdrOp xdr.AllowTrustOp
 
 	// Set XDR address associated with the trustline
@@ -56,11 +56,7 @@ func (at *AllowTrust) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, at.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, at.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, at.SourceAccount)
 	return op, nil
 }
 
@@ -79,13 +75,13 @@ func assetCodeToCreditAsset(assetCode xdr.AssetCode) (CreditAsset, error) {
 }
 
 // FromXDR for AllowTrust initialises the txnbuild struct from the corresponding xdr Operation.
-func (at *AllowTrust) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (at *AllowTrust) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetAllowTrustOp()
 	if !ok {
 		return errors.New("error parsing allow_trust operation from xdr")
 	}
 
-	at.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	at.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	at.Trustor = result.Trustor.Address()
 	flag := xdr.TrustLineFlags(result.Authorize)
 	at.Authorize = flag.IsAuthorized()
@@ -101,7 +97,7 @@ func (at *AllowTrust) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error
 
 // Validate for AllowTrust validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
-func (at *AllowTrust) Validate(withMuxedAccounts bool) error {
+func (at *AllowTrust) Validate() error {
 	err := validateStellarPublicKey(at.Trustor)
 	if err != nil {
 		return NewValidationError("Trustor", err.Error())

--- a/txnbuild/allow_trust.go
+++ b/txnbuild/allow_trust.go
@@ -56,7 +56,7 @@ func (at *AllowTrust) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, at.SourceAccount)
+	SetOpSourceAccount(&op, at.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/begin_sponsoring_future_reserves.go
+++ b/txnbuild/begin_sponsoring_future_reserves.go
@@ -15,7 +15,7 @@ type BeginSponsoringFutureReserves struct {
 }
 
 // BuildXDR for BeginSponsoringFutureReserves returns a fully configured XDR Operation.
-func (bs *BeginSponsoringFutureReserves) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (bs *BeginSponsoringFutureReserves) BuildXDR() (xdr.Operation, error) {
 	xdrOp := xdr.BeginSponsoringFutureReservesOp{}
 	err := xdrOp.SponsoredId.SetAddress(bs.SponsoredID)
 	if err != nil {
@@ -32,12 +32,12 @@ func (bs *BeginSponsoringFutureReserves) BuildXDR(withMuxedAccounts bool) (xdr.O
 }
 
 // FromXDR for BeginSponsoringFutureReserves initializes the txnbuild struct from the corresponding xdr Operation.
-func (bs *BeginSponsoringFutureReserves) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (bs *BeginSponsoringFutureReserves) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetBeginSponsoringFutureReservesOp()
 	if !ok {
 		return errors.New("error parsing begin_sponsoring_future_reserves operation from xdr")
 	}
-	bs.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	bs.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	bs.SponsoredID = result.SponsoredId.Address()
 
 	return nil
@@ -45,7 +45,7 @@ func (bs *BeginSponsoringFutureReserves) FromXDR(xdrOp xdr.Operation, withMuxedA
 
 // Validate for BeginSponsoringFutureReserves validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
-func (bs *BeginSponsoringFutureReserves) Validate(withMuxedAccounts bool) error {
+func (bs *BeginSponsoringFutureReserves) Validate() error {
 	err := validateStellarPublicKey(bs.SponsoredID)
 	if err != nil {
 		return NewValidationError("SponsoredID", err.Error())

--- a/txnbuild/bump_sequence.go
+++ b/txnbuild/bump_sequence.go
@@ -21,7 +21,7 @@ func (bs *BumpSequence) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, bs.SourceAccount)
+	SetOpSourceAccount(&op, bs.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/bump_sequence.go
+++ b/txnbuild/bump_sequence.go
@@ -13,7 +13,7 @@ type BumpSequence struct {
 }
 
 // BuildXDR for BumpSequence returns a fully configured XDR Operation.
-func (bs *BumpSequence) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (bs *BumpSequence) BuildXDR() (xdr.Operation, error) {
 	opType := xdr.OperationTypeBumpSequence
 	xdrOp := xdr.BumpSequenceOp{BumpTo: xdr.SequenceNumber(bs.BumpTo)}
 	body, err := xdr.NewOperationBody(opType, xdrOp)
@@ -21,29 +21,25 @@ func (bs *BumpSequence) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) 
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, bs.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, bs.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, bs.SourceAccount)
 	return op, nil
 }
 
 // FromXDR for BumpSequence initialises the txnbuild struct from the corresponding xdr Operation.
-func (bs *BumpSequence) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (bs *BumpSequence) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetBumpSequenceOp()
 	if !ok {
 		return errors.New("error parsing bump_sequence operation from xdr")
 	}
 
-	bs.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	bs.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	bs.BumpTo = int64(result.BumpTo)
 	return nil
 }
 
 // Validate for BumpSequence validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
-func (bs *BumpSequence) Validate(withMuxedAccounts bool) error {
+func (bs *BumpSequence) Validate() error {
 	err := validateAmount(bs.BumpTo)
 	if err != nil {
 		return NewValidationError("BumpTo", err.Error())

--- a/txnbuild/change_trust.go
+++ b/txnbuild/change_trust.go
@@ -58,7 +58,7 @@ func (ct *ChangeTrust) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, ct.SourceAccount)
+	SetOpSourceAccount(&op, ct.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/change_trust.go
+++ b/txnbuild/change_trust.go
@@ -30,7 +30,7 @@ func RemoveTrustlineOp(issuedAsset ChangeTrustAsset) ChangeTrust {
 }
 
 // BuildXDR for ChangeTrust returns a fully configured XDR Operation.
-func (ct *ChangeTrust) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (ct *ChangeTrust) BuildXDR() (xdr.Operation, error) {
 	if ct.Line.IsNative() {
 		return xdr.Operation{}, errors.New("trustline cannot be extended to a native (XLM) asset")
 	}
@@ -58,22 +58,18 @@ func (ct *ChangeTrust) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, ct.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, ct.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, ct.SourceAccount)
 	return op, nil
 }
 
 // FromXDR for ChangeTrust initialises the txnbuild struct from the corresponding xdr Operation.
-func (ct *ChangeTrust) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (ct *ChangeTrust) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetChangeTrustOp()
 	if !ok {
 		return errors.New("error parsing change_trust operation from xdr")
 	}
 
-	ct.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	ct.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	ct.Limit = amount.String(result.Limit)
 	asset, err := assetFromChangeTrustAssetXDR(result.Line)
 	if err != nil {
@@ -85,7 +81,7 @@ func (ct *ChangeTrust) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) erro
 
 // Validate for ChangeTrust validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
-func (ct *ChangeTrust) Validate(withMuxedAccounts bool) error {
+func (ct *ChangeTrust) Validate() error {
 	// only validate limit if it has a value. Empty limit is set to the max trustline limit.
 	if ct.Limit != "" {
 		err := validateAmount(ct.Limit)

--- a/txnbuild/claim_claimable_balance.go
+++ b/txnbuild/claim_claimable_balance.go
@@ -31,7 +31,7 @@ func (cb *ClaimClaimableBalance) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, cb.SourceAccount)
+	SetOpSourceAccount(&op, cb.SourceAccount)
 
 	return op, nil
 }

--- a/txnbuild/claim_claimable_balance.go
+++ b/txnbuild/claim_claimable_balance.go
@@ -15,7 +15,7 @@ type ClaimClaimableBalance struct {
 }
 
 // BuildXDR for ClaimClaimableBalance returns a fully configured XDR Operation.
-func (cb *ClaimClaimableBalance) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (cb *ClaimClaimableBalance) BuildXDR() (xdr.Operation, error) {
 	var xdrBalanceID xdr.ClaimableBalanceId
 	err := xdr.SafeUnmarshalHex(cb.BalanceID, &xdrBalanceID)
 	if err != nil {
@@ -31,22 +31,19 @@ func (cb *ClaimClaimableBalance) BuildXDR(withMuxedAccounts bool) (xdr.Operation
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, cb.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, cb.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, cb.SourceAccount)
+
 	return op, nil
 }
 
 // FromXDR for ClaimClaimableBalance initializes the txnbuild struct from the corresponding xdr Operation.
-func (cb *ClaimClaimableBalance) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (cb *ClaimClaimableBalance) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetClaimClaimableBalanceOp()
 	if !ok {
 		return errors.New("error parsing claim_claimable_balance operation from xdr")
 	}
 
-	cb.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	cb.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	balanceID, err := xdr.MarshalHex(result.BalanceId)
 	if err != nil {
 		return errors.New("error parsing BalanceID in claim_claimable_balance operation from xdr")
@@ -58,7 +55,7 @@ func (cb *ClaimClaimableBalance) FromXDR(xdrOp xdr.Operation, withMuxedAccounts 
 
 // Validate for ClaimClaimableBalance validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
-func (cb *ClaimClaimableBalance) Validate(withMuxedAccounts bool) error {
+func (cb *ClaimClaimableBalance) Validate() error {
 	var xdrBalanceID xdr.ClaimableBalanceId
 	err := xdr.SafeUnmarshalHex(cb.BalanceID, &xdrBalanceID)
 	if err != nil {

--- a/txnbuild/clawback.go
+++ b/txnbuild/clawback.go
@@ -54,7 +54,7 @@ func (cb *Clawback) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR Operation")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, cb.SourceAccount)
+	SetOpSourceAccount(&op, cb.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/clawback.go
+++ b/txnbuild/clawback.go
@@ -17,14 +17,10 @@ type Clawback struct {
 }
 
 // BuildXDR for Clawback returns a fully configured XDR Operation.
-func (cb *Clawback) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (cb *Clawback) BuildXDR() (xdr.Operation, error) {
 	var fromMuxedAccount xdr.MuxedAccount
-	var err error
-	if withMuxedAccounts {
-		err = fromMuxedAccount.SetAddress(cb.From)
-	} else {
-		err = fromMuxedAccount.SetEd25519Address(cb.From)
-	}
+	err := fromMuxedAccount.SetAddress(cb.From)
+
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "failed to set from address")
 	}
@@ -58,23 +54,19 @@ func (cb *Clawback) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR Operation")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, cb.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, cb.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, cb.SourceAccount)
 	return op, nil
 }
 
 // FromXDR for Clawback initialises the txnbuild struct from the corresponding xdr Operation.
-func (cb *Clawback) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (cb *Clawback) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetClawbackOp()
 	if !ok {
 		return errors.New("error parsing clawback operation from xdr")
 	}
 
-	cb.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
-	cb.From = accountFromXDR(&result.From, withMuxedAccounts)
+	cb.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	cb.From = accountFromXDR(&result.From)
 	cb.Amount = amount.String(result.Amount)
 	asset, err := assetFromXDR(result.Asset)
 	if err != nil {
@@ -87,13 +79,10 @@ func (cb *Clawback) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
 
 // Validate for Clawback validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
-func (cb *Clawback) Validate(withMuxedAccounts bool) error {
+func (cb *Clawback) Validate() error {
 	var err error
-	if withMuxedAccounts {
-		_, err = xdr.AddressToMuxedAccount(cb.From)
-	} else {
-		_, err = xdr.AddressToAccountId(cb.From)
-	}
+	_, err = xdr.AddressToMuxedAccount(cb.From)
+
 	if err != nil {
 		return NewValidationError("From", err.Error())
 	}

--- a/txnbuild/clawback_claimable_balance.go
+++ b/txnbuild/clawback_claimable_balance.go
@@ -14,7 +14,7 @@ type ClawbackClaimableBalance struct {
 }
 
 // BuildXDR for ClawbackClaimableBalance returns a fully configured XDR Operation.
-func (cb *ClawbackClaimableBalance) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (cb *ClawbackClaimableBalance) BuildXDR() (xdr.Operation, error) {
 	var xdrBalanceID xdr.ClaimableBalanceId
 	err := xdr.SafeUnmarshalHex(cb.BalanceID, &xdrBalanceID)
 	if err != nil {
@@ -30,22 +30,19 @@ func (cb *ClawbackClaimableBalance) BuildXDR(withMuxedAccounts bool) (xdr.Operat
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, cb.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, cb.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, cb.SourceAccount)
+
 	return op, nil
 }
 
 // FromXDR for ClawbackClaimableBalance initializes the txnbuild struct from the corresponding xdr Operation.
-func (cb *ClawbackClaimableBalance) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (cb *ClawbackClaimableBalance) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetClawbackClaimableBalanceOp()
 	if !ok {
 		return errors.New("error parsing clawback_claimable_balance operation from xdr")
 	}
 
-	cb.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	cb.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	balanceID, err := xdr.MarshalHex(result.BalanceId)
 	if err != nil {
 		return errors.New("error parsing BalanceID in claim_claimable_balance operation from xdr")
@@ -57,7 +54,7 @@ func (cb *ClawbackClaimableBalance) FromXDR(xdrOp xdr.Operation, withMuxedAccoun
 
 // Validate for ClawbackClaimableBalance validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
-func (cb *ClawbackClaimableBalance) Validate(withMuxedAccounts bool) error {
+func (cb *ClawbackClaimableBalance) Validate() error {
 	var xdrBalanceID xdr.ClaimableBalanceId
 	err := xdr.SafeUnmarshalHex(cb.BalanceID, &xdrBalanceID)
 	if err != nil {

--- a/txnbuild/clawback_claimable_balance.go
+++ b/txnbuild/clawback_claimable_balance.go
@@ -30,7 +30,7 @@ func (cb *ClawbackClaimableBalance) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, cb.SourceAccount)
+	SetOpSourceAccount(&op, cb.SourceAccount)
 
 	return op, nil
 }

--- a/txnbuild/create_account.go
+++ b/txnbuild/create_account.go
@@ -15,7 +15,7 @@ type CreateAccount struct {
 }
 
 // BuildXDR for CreateAccount returns a fully configured XDR Operation.
-func (ca *CreateAccount) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (ca *CreateAccount) BuildXDR() (xdr.Operation, error) {
 	var xdrOp xdr.CreateAccountOp
 
 	err := xdrOp.Destination.SetAddress(ca.Destination)
@@ -34,22 +34,19 @@ func (ca *CreateAccount) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error)
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, ca.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, ca.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, ca.SourceAccount)
+
 	return op, nil
 }
 
 // FromXDR for CreateAccount initialises the txnbuild struct from the corresponding xdr Operation.
-func (ca *CreateAccount) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (ca *CreateAccount) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetCreateAccountOp()
 	if !ok {
 		return errors.New("error parsing create_account operation from xdr")
 	}
 
-	ca.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	ca.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	ca.Destination = result.Destination.Address()
 	ca.Amount = amount.String(result.StartingBalance)
 
@@ -58,7 +55,7 @@ func (ca *CreateAccount) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) er
 
 // Validate for CreateAccount validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
-func (ca *CreateAccount) Validate(withMuxedAccounts bool) error {
+func (ca *CreateAccount) Validate() error {
 	err := validateStellarPublicKey(ca.Destination)
 	if err != nil {
 		return NewValidationError("Destination", err.Error())

--- a/txnbuild/create_account.go
+++ b/txnbuild/create_account.go
@@ -34,7 +34,7 @@ func (ca *CreateAccount) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, ca.SourceAccount)
+	SetOpSourceAccount(&op, ca.SourceAccount)
 
 	return op, nil
 }

--- a/txnbuild/create_claimable_balance.go
+++ b/txnbuild/create_claimable_balance.go
@@ -96,7 +96,7 @@ func BeforeRelativeTimePredicate(secondsBefore int64) xdr.ClaimPredicate {
 }
 
 // BuildXDR for CreateClaimableBalance returns a fully configured XDR Operation.
-func (cb *CreateClaimableBalance) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (cb *CreateClaimableBalance) BuildXDR() (xdr.Operation, error) {
 	xdrAsset, err := cb.Asset.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "failed to set XDR 'Asset' field")
@@ -134,22 +134,18 @@ func (cb *CreateClaimableBalance) BuildXDR(withMuxedAccounts bool) (xdr.Operatio
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, cb.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, cb.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, cb.SourceAccount)
 	return op, nil
 }
 
 // FromXDR for CreateClaimableBalance initializes the txnbuild struct from the corresponding xdr Operation.
-func (cb *CreateClaimableBalance) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (cb *CreateClaimableBalance) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetCreateClaimableBalanceOp()
 	if !ok {
 		return errors.New("error parsing create_claimable_balance operation from xdr")
 	}
 
-	cb.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	cb.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	for _, c := range result.Claimants {
 		claimant := c.MustV0()
 		cb.Destinations = append(cb.Destinations, Claimant{
@@ -170,7 +166,7 @@ func (cb *CreateClaimableBalance) FromXDR(xdrOp xdr.Operation, withMuxedAccounts
 
 // Validate for CreateClaimableBalance validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
-func (cb *CreateClaimableBalance) Validate(withMuxedAccounts bool) error {
+func (cb *CreateClaimableBalance) Validate() error {
 	for _, d := range cb.Destinations {
 		err := validateStellarPublicKey(d.Destination)
 		if err != nil {

--- a/txnbuild/create_claimable_balance.go
+++ b/txnbuild/create_claimable_balance.go
@@ -134,7 +134,7 @@ func (cb *CreateClaimableBalance) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, cb.SourceAccount)
+	SetOpSourceAccount(&op, cb.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/create_passive_offer.go
+++ b/txnbuild/create_passive_offer.go
@@ -51,7 +51,7 @@ func (cpo *CreatePassiveSellOffer) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, cpo.SourceAccount)
+	SetOpSourceAccount(&op, cpo.SourceAccount)
 
 	return op, nil
 }

--- a/txnbuild/create_passive_offer.go
+++ b/txnbuild/create_passive_offer.go
@@ -18,7 +18,7 @@ type CreatePassiveSellOffer struct {
 }
 
 // BuildXDR for CreatePassiveSellOffer returns a fully configured XDR Operation.
-func (cpo *CreatePassiveSellOffer) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (cpo *CreatePassiveSellOffer) BuildXDR() (xdr.Operation, error) {
 	xdrSelling, err := cpo.Selling.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "failed to set XDR 'Selling' field")
@@ -51,22 +51,19 @@ func (cpo *CreatePassiveSellOffer) BuildXDR(withMuxedAccounts bool) (xdr.Operati
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, cpo.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, cpo.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, cpo.SourceAccount)
+
 	return op, nil
 }
 
 // FromXDR for CreatePassiveSellOffer initialises the txnbuild struct from the corresponding xdr Operation.
-func (cpo *CreatePassiveSellOffer) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (cpo *CreatePassiveSellOffer) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetCreatePassiveSellOfferOp()
 	if !ok {
 		return errors.New("error parsing create_passive_sell_offer operation from xdr")
 	}
 
-	cpo.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	cpo.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	cpo.Amount = amount.String(result.Amount)
 	if result.Price != (xdr.Price{}) {
 		cpo.price.fromXDR(result.Price)
@@ -88,7 +85,7 @@ func (cpo *CreatePassiveSellOffer) FromXDR(xdrOp xdr.Operation, withMuxedAccount
 
 // Validate for CreatePassiveSellOffer validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
-func (cpo *CreatePassiveSellOffer) Validate(withMuxedAccounts bool) error {
+func (cpo *CreatePassiveSellOffer) Validate() error {
 	return validatePassiveOffer(cpo.Buying, cpo.Selling, cpo.Amount, cpo.Price)
 }
 

--- a/txnbuild/create_passive_offer_test.go
+++ b/txnbuild/create_passive_offer_test.go
@@ -125,7 +125,7 @@ func TestCreatePassiveSellOfferPrice(t *testing.T) {
 		SourceAccount: kp0.Address(),
 	}
 
-	xdrOp, err := offer.BuildXDR(false)
+	xdrOp, err := offer.BuildXDR()
 	assert.NoError(t, err)
 	expectedPrice := xdr.Price{N: 1, D: 1000000000}
 	assert.Equal(t, expectedPrice, xdrOp.Body.CreatePassiveSellOfferOp.Price)
@@ -133,7 +133,7 @@ func TestCreatePassiveSellOfferPrice(t *testing.T) {
 	assert.Equal(t, expectedPrice, offer.price.toXDR())
 
 	parsed := CreatePassiveSellOffer{}
-	assert.NoError(t, parsed.FromXDR(xdrOp, false))
+	assert.NoError(t, parsed.FromXDR(xdrOp))
 	assert.Equal(t, offer.Price, parsed.Price)
 	assert.Equal(t, offer.price, parsed.price)
 }

--- a/txnbuild/end_sponsoring_future_reserves.go
+++ b/txnbuild/end_sponsoring_future_reserves.go
@@ -14,34 +14,31 @@ type EndSponsoringFutureReserves struct {
 }
 
 // BuildXDR for EndSponsoringFutureReserves returns a fully configured XDR Operation.
-func (es *EndSponsoringFutureReserves) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (es *EndSponsoringFutureReserves) BuildXDR() (xdr.Operation, error) {
 	opType := xdr.OperationTypeEndSponsoringFutureReserves
 	body, err := xdr.NewOperationBody(opType, nil)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, es.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, es.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, es.SourceAccount)
+
 	return op, nil
 }
 
 // FromXDR for EndSponsoringFutureReserves initializes the txnbuild struct from the corresponding xdr Operation.
-func (es *EndSponsoringFutureReserves) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (es *EndSponsoringFutureReserves) FromXDR(xdrOp xdr.Operation) error {
 	if xdrOp.Body.Type != xdr.OperationTypeEndSponsoringFutureReserves {
 		return errors.New("error parsing end_sponsoring_future_reserves operation from xdr")
 	}
 
-	es.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	es.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	return nil
 }
 
 // Validate for EndSponsoringFutureReserves validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
-func (es *EndSponsoringFutureReserves) Validate(withMuxedAccounts bool) error {
+func (es *EndSponsoringFutureReserves) Validate() error {
 	return nil
 }
 

--- a/txnbuild/end_sponsoring_future_reserves.go
+++ b/txnbuild/end_sponsoring_future_reserves.go
@@ -21,7 +21,7 @@ func (es *EndSponsoringFutureReserves) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, es.SourceAccount)
+	SetOpSourceAccount(&op, es.SourceAccount)
 
 	return op, nil
 }

--- a/txnbuild/fee_bump_test.go
+++ b/txnbuild/fee_bump_test.go
@@ -360,11 +360,10 @@ func TestFeeBumpMuxedAccounts(t *testing.T) {
 	sourceAccount := NewSimpleAccount(mx0.Address(), 1)
 	tx, err := NewTransaction(
 		TransactionParams{
-			SourceAccount:       &sourceAccount,
-			Operations:          []Operation{&Inflation{}},
-			BaseFee:             MinBaseFee,
-			Timebounds:          NewInfiniteTimeout(),
-			EnableMuxedAccounts: true,
+			SourceAccount: &sourceAccount,
+			Operations:    []Operation{&Inflation{}},
+			BaseFee:       MinBaseFee,
+			Timebounds:    NewInfiniteTimeout(),
 		},
 	)
 	assert.NoError(t, err)
@@ -381,25 +380,12 @@ func TestFeeBumpMuxedAccounts(t *testing.T) {
 	}
 	feeBumpTx, err := NewFeeBumpTransaction(
 		FeeBumpTransactionParams{
-			FeeAccount:          mx1.Address(),
-			BaseFee:             2 * MinBaseFee,
-			Inner:               tx,
-			EnableMuxedAccounts: true,
+			FeeAccount: mx1.Address(),
+			BaseFee:    2 * MinBaseFee,
+			Inner:      tx,
 		},
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, mx0.Address(), feeBumpTx.InnerTransaction().sourceAccount.AccountID)
 	assert.Equal(t, mx1.Address(), feeBumpTx.FeeAccount())
-
-	// It fails when not enabling muxed accounts
-	_, err = NewFeeBumpTransaction(
-		FeeBumpTransactionParams{
-			FeeAccount:          mx1.Address(),
-			BaseFee:             2 * MinBaseFee,
-			Inner:               tx,
-			EnableMuxedAccounts: false,
-		},
-	)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid version byte")
 }

--- a/txnbuild/inflation.go
+++ b/txnbuild/inflation.go
@@ -12,33 +12,29 @@ type Inflation struct {
 }
 
 // BuildXDR for Inflation returns a fully configured XDR Operation.
-func (inf *Inflation) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (inf *Inflation) BuildXDR() (xdr.Operation, error) {
 	opType := xdr.OperationTypeInflation
 	body, err := xdr.NewOperationBody(opType, nil)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, inf.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, inf.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, inf.SourceAccount)
 	return op, nil
 }
 
 // FromXDR for Inflation initialises the txnbuild struct from the corresponding xdr Operation.
-func (inf *Inflation) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (inf *Inflation) FromXDR(xdrOp xdr.Operation) error {
 	if xdrOp.Body.Type != xdr.OperationTypeInflation {
 		return errors.New("error parsing inflation operation from xdr")
 	}
-	inf.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	inf.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	return nil
 }
 
 // Validate for Inflation is just a method that implements the Operation interface. No logic is actually performed
 // because the inflation operation does not have any required field. Nil is always returned.
-func (inf *Inflation) Validate(withMuxedAccounts bool) error {
+func (inf *Inflation) Validate() error {
 	// no required fields, return nil.
 	return nil
 }

--- a/txnbuild/inflation.go
+++ b/txnbuild/inflation.go
@@ -19,7 +19,7 @@ func (inf *Inflation) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, inf.SourceAccount)
+	SetOpSourceAccount(&op, inf.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/liquidity_pool_deposit.go
+++ b/txnbuild/liquidity_pool_deposit.go
@@ -48,7 +48,7 @@ func NewLiquidityPoolDeposit(
 }
 
 // BuildXDR for LiquidityPoolDeposit returns a fully configured XDR Operation.
-func (lpd *LiquidityPoolDeposit) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (lpd *LiquidityPoolDeposit) BuildXDR() (xdr.Operation, error) {
 	xdrLiquidityPoolId, err := lpd.LiquidityPoolID.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "couldn't build liquidity pool ID XDR")
@@ -88,16 +88,12 @@ func (lpd *LiquidityPoolDeposit) BuildXDR(withMuxedAccounts bool) (xdr.Operation
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, lpd.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, lpd.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, lpd.SourceAccount)
 	return op, nil
 }
 
 // FromXDR for LiquidityPoolDeposit initializes the txnbuild struct from the corresponding xdr Operation.
-func (lpd *LiquidityPoolDeposit) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (lpd *LiquidityPoolDeposit) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetLiquidityPoolDepositOp()
 	if !ok {
 		return errors.New("error parsing liquidity_pool_deposit operation from xdr")
@@ -109,7 +105,7 @@ func (lpd *LiquidityPoolDeposit) FromXDR(xdrOp xdr.Operation, withMuxedAccounts 
 	}
 	lpd.LiquidityPoolID = liquidityPoolID
 
-	lpd.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	lpd.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	lpd.MaxAmountA = amount.String(result.MaxAmountA)
 	lpd.MaxAmountB = amount.String(result.MaxAmountB)
 	if result.MinPrice != (xdr.Price{}) {
@@ -124,7 +120,7 @@ func (lpd *LiquidityPoolDeposit) FromXDR(xdrOp xdr.Operation, withMuxedAccounts 
 
 // Validate for LiquidityPoolDeposit validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
-func (lpd *LiquidityPoolDeposit) Validate(withMuxedAccounts bool) error {
+func (lpd *LiquidityPoolDeposit) Validate() error {
 	err := validateAmount(lpd.MaxAmountA)
 	if err != nil {
 		return NewValidationError("MaxAmountA", err.Error())

--- a/txnbuild/liquidity_pool_deposit.go
+++ b/txnbuild/liquidity_pool_deposit.go
@@ -88,7 +88,7 @@ func (lpd *LiquidityPoolDeposit) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, lpd.SourceAccount)
+	SetOpSourceAccount(&op, lpd.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/liquidity_pool_withdraw.go
+++ b/txnbuild/liquidity_pool_withdraw.go
@@ -45,7 +45,7 @@ func NewLiquidityPoolWithdraw(
 }
 
 // BuildXDR for LiquidityPoolWithdraw returns a fully configured XDR Operation.
-func (lpd *LiquidityPoolWithdraw) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (lpd *LiquidityPoolWithdraw) BuildXDR() (xdr.Operation, error) {
 	xdrLiquidityPoolId, err := lpd.LiquidityPoolID.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "couldn't build liquidity pool ID XDR")
@@ -79,16 +79,12 @@ func (lpd *LiquidityPoolWithdraw) BuildXDR(withMuxedAccounts bool) (xdr.Operatio
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, lpd.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, lpd.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, lpd.SourceAccount)
 	return op, nil
 }
 
 // FromXDR for LiquidityPoolWithdraw initializes the txnbuild struct from the corresponding xdr Operation.
-func (lpd *LiquidityPoolWithdraw) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (lpd *LiquidityPoolWithdraw) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetLiquidityPoolWithdrawOp()
 	if !ok {
 		return errors.New("error parsing liquidity_pool_withdraw operation from xdr")
@@ -100,7 +96,7 @@ func (lpd *LiquidityPoolWithdraw) FromXDR(xdrOp xdr.Operation, withMuxedAccounts
 	}
 	lpd.LiquidityPoolID = liquidityPoolID
 
-	lpd.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	lpd.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	lpd.Amount = amount.String(result.Amount)
 	lpd.MinAmountA = amount.String(result.MinAmountA)
 	lpd.MinAmountB = amount.String(result.MinAmountB)
@@ -110,7 +106,7 @@ func (lpd *LiquidityPoolWithdraw) FromXDR(xdrOp xdr.Operation, withMuxedAccounts
 
 // Validate for LiquidityPoolWithdraw validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
-func (lpd *LiquidityPoolWithdraw) Validate(withMuxedAccounts bool) error {
+func (lpd *LiquidityPoolWithdraw) Validate() error {
 	err := validateAmount(lpd.Amount)
 	if err != nil {
 		return NewValidationError("Amount", err.Error())

--- a/txnbuild/liquidity_pool_withdraw.go
+++ b/txnbuild/liquidity_pool_withdraw.go
@@ -79,7 +79,7 @@ func (lpd *LiquidityPoolWithdraw) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, lpd.SourceAccount)
+	SetOpSourceAccount(&op, lpd.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/manage_buy_offer.go
+++ b/txnbuild/manage_buy_offer.go
@@ -53,7 +53,7 @@ func (mo *ManageBuyOffer) BuildXDR() (xdr.Operation, error) {
 	}
 
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, mo.SourceAccount)
+	SetOpSourceAccount(&op, mo.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/manage_buy_offer.go
+++ b/txnbuild/manage_buy_offer.go
@@ -19,7 +19,7 @@ type ManageBuyOffer struct {
 }
 
 // BuildXDR for ManageBuyOffer returns a fully configured XDR Operation.
-func (mo *ManageBuyOffer) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (mo *ManageBuyOffer) BuildXDR() (xdr.Operation, error) {
 	xdrSelling, err := mo.Selling.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "failed to set XDR 'Selling' field")
@@ -53,22 +53,18 @@ func (mo *ManageBuyOffer) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error
 	}
 
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, mo.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, mo.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, mo.SourceAccount)
 	return op, nil
 }
 
 // FromXDR for ManageBuyOffer initialises the txnbuild struct from the corresponding xdr Operation.
-func (mo *ManageBuyOffer) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (mo *ManageBuyOffer) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetManageBuyOfferOp()
 	if !ok {
 		return errors.New("error parsing manage_buy_offer operation from xdr")
 	}
 
-	mo.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	mo.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	mo.OfferID = int64(result.OfferId)
 	mo.Amount = amount.String(result.BuyAmount)
 	if result.Price != (xdr.Price{}) {
@@ -91,7 +87,7 @@ func (mo *ManageBuyOffer) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) e
 
 // Validate for ManageBuyOffer validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
-func (mo *ManageBuyOffer) Validate(withMuxedAccounts bool) error {
+func (mo *ManageBuyOffer) Validate() error {
 	return validateOffer(mo.Buying, mo.Selling, mo.Amount, mo.Price, mo.OfferID)
 }
 

--- a/txnbuild/manage_buy_offer_test.go
+++ b/txnbuild/manage_buy_offer_test.go
@@ -158,7 +158,7 @@ func TestManageBuyOfferPrice(t *testing.T) {
 		OfferID: 1,
 	}
 
-	xdrOp, err := mbo.BuildXDR(false)
+	xdrOp, err := mbo.BuildXDR()
 	assert.NoError(t, err)
 	expectedPrice := xdr.Price{N: 1, D: 1000000000}
 	assert.Equal(t, expectedPrice, xdrOp.Body.ManageBuyOfferOp.Price)
@@ -166,7 +166,7 @@ func TestManageBuyOfferPrice(t *testing.T) {
 	assert.Equal(t, expectedPrice, mbo.price.toXDR())
 
 	parsed := ManageBuyOffer{}
-	assert.NoError(t, parsed.FromXDR(xdrOp, false))
+	assert.NoError(t, parsed.FromXDR(xdrOp))
 	assert.Equal(t, mbo.Price, parsed.Price)
 	assert.Equal(t, mbo.price, parsed.price)
 }

--- a/txnbuild/manage_data.go
+++ b/txnbuild/manage_data.go
@@ -14,7 +14,7 @@ type ManageData struct {
 }
 
 // BuildXDR for ManageData returns a fully configured XDR Operation.
-func (md *ManageData) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (md *ManageData) BuildXDR() (xdr.Operation, error) {
 	xdrOp := xdr.ManageDataOp{DataName: xdr.String64(md.Name)}
 
 	// No data value clears the named data entry on the account
@@ -31,22 +31,18 @@ func (md *ManageData) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, md.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, md.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, md.SourceAccount)
 	return op, nil
 }
 
 // FromXDR for ManageData initialises the txnbuild struct from the corresponding xdr Operation.
-func (md *ManageData) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (md *ManageData) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetManageDataOp()
 	if !ok {
 		return errors.New("error parsing create_account operation from xdr")
 	}
 
-	md.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	md.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	md.Name = string(result.DataName)
 	if result.DataValue != nil {
 		md.Value = *result.DataValue
@@ -58,7 +54,7 @@ func (md *ManageData) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error
 
 // Validate for ManageData validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
-func (md *ManageData) Validate(withMuxedAccounts bool) error {
+func (md *ManageData) Validate() error {
 	if len(md.Name) > 64 {
 		return NewValidationError("Name", "maximum length is 64 characters")
 	}

--- a/txnbuild/manage_data.go
+++ b/txnbuild/manage_data.go
@@ -31,7 +31,7 @@ func (md *ManageData) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, md.SourceAccount)
+	SetOpSourceAccount(&op, md.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/manage_offer.go
+++ b/txnbuild/manage_offer.go
@@ -83,7 +83,7 @@ type ManageSellOffer struct {
 }
 
 // BuildXDR for ManageSellOffer returns a fully configured XDR Operation.
-func (mo *ManageSellOffer) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (mo *ManageSellOffer) BuildXDR() (xdr.Operation, error) {
 	xdrSelling, err := mo.Selling.ToXDR()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "failed to set XDR 'Selling' field")
@@ -117,22 +117,18 @@ func (mo *ManageSellOffer) BuildXDR(withMuxedAccounts bool) (xdr.Operation, erro
 	}
 
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, mo.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, mo.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, mo.SourceAccount)
 	return op, nil
 }
 
 // FromXDR for ManageSellOffer initialises the txnbuild struct from the corresponding xdr Operation.
-func (mo *ManageSellOffer) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (mo *ManageSellOffer) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetManageSellOfferOp()
 	if !ok {
 		return errors.New("error parsing manage_sell_offer operation from xdr")
 	}
 
-	mo.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	mo.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	mo.OfferID = int64(result.OfferId)
 	mo.Amount = amount.String(result.Amount)
 	if result.Price != (xdr.Price{}) {
@@ -155,7 +151,7 @@ func (mo *ManageSellOffer) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) 
 
 // Validate for ManageSellOffer validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
-func (mo *ManageSellOffer) Validate(withMuxedAccounts bool) error {
+func (mo *ManageSellOffer) Validate() error {
 	return validateOffer(mo.Buying, mo.Selling, mo.Amount, mo.Price, mo.OfferID)
 }
 

--- a/txnbuild/manage_offer.go
+++ b/txnbuild/manage_offer.go
@@ -117,7 +117,7 @@ func (mo *ManageSellOffer) BuildXDR() (xdr.Operation, error) {
 	}
 
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, mo.SourceAccount)
+	SetOpSourceAccount(&op, mo.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/manage_offer_test.go
+++ b/txnbuild/manage_offer_test.go
@@ -154,7 +154,7 @@ func TestManageSellOfferPrice(t *testing.T) {
 		OfferID: 1,
 	}
 
-	xdrOp, err := mso.BuildXDR(false)
+	xdrOp, err := mso.BuildXDR()
 	assert.NoError(t, err)
 	expectedPrice := xdr.Price{N: 1, D: 1000000000}
 	assert.Equal(t, expectedPrice, xdrOp.Body.ManageSellOfferOp.Price)
@@ -162,7 +162,7 @@ func TestManageSellOfferPrice(t *testing.T) {
 	assert.Equal(t, expectedPrice, mso.price.toXDR())
 
 	parsed := ManageSellOffer{}
-	assert.NoError(t, parsed.FromXDR(xdrOp, false))
+	assert.NoError(t, parsed.FromXDR(xdrOp))
 	assert.Equal(t, mso.Price, parsed.Price)
 	assert.Equal(t, mso.price, parsed.price)
 }

--- a/txnbuild/operation.go
+++ b/txnbuild/operation.go
@@ -14,18 +14,8 @@ type Operation interface {
 	GetSourceAccount() string
 }
 
-// SetOpSourceAccount sets the source account ID on an Operation.
-func SetOpSourceAccount(op *xdr.Operation, sourceAccount string) {
-	if sourceAccount == "" {
-		return
-	}
-	var opSourceAccountID xdr.MuxedAccount
-	opSourceAccountID.SetEd25519Address(sourceAccount)
-	op.SourceAccount = &opSourceAccountID
-}
-
 // SetOpSourceAccount sets the source account ID on an Operation, allowing M-strkeys (as defined in SEP23).
-func SetOpSourceMuxedAccount(op *xdr.Operation, sourceAccount string) {
+func SetOpSourceAccount(op *xdr.Operation, sourceAccount string) {
 	if sourceAccount == "" {
 		return
 	}

--- a/txnbuild/operation.go
+++ b/txnbuild/operation.go
@@ -8,9 +8,9 @@ import (
 
 // Operation represents the operation types of the Stellar network.
 type Operation interface {
-	BuildXDR(withMuxedAccounts bool) (xdr.Operation, error)
-	FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error
-	Validate(withMuxedAccounts bool) error
+	BuildXDR() (xdr.Operation, error)
+	FromXDR(xdrOp xdr.Operation) error
+	Validate() error
 	GetSourceAccount() string
 }
 
@@ -35,7 +35,7 @@ func SetOpSourceMuxedAccount(op *xdr.Operation, sourceAccount string) {
 }
 
 // operationFromXDR returns a txnbuild Operation from its corresponding XDR operation
-func operationFromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) (Operation, error) {
+func operationFromXDR(xdrOp xdr.Operation) (Operation, error) {
 	var newOp Operation
 	switch xdrOp.Body.Type {
 	case xdr.OperationTypeCreateAccount:
@@ -90,18 +90,13 @@ func operationFromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) (Operation, e
 		return nil, fmt.Errorf("unknown operation type: %d", xdrOp.Body.Type)
 	}
 
-	err := newOp.FromXDR(xdrOp, withMuxedAccounts)
+	err := newOp.FromXDR(xdrOp)
 	return newOp, err
 }
 
-func accountFromXDR(account *xdr.MuxedAccount, withMuxedAccounts bool) string {
+func accountFromXDR(account *xdr.MuxedAccount) string {
 	if account != nil {
-		if withMuxedAccounts {
-			return account.Address()
-		} else {
-			aid := account.ToAccountId()
-			return aid.Address()
-		}
+		return account.Address()
 	}
 	return ""
 }

--- a/txnbuild/operation_test.go
+++ b/txnbuild/operation_test.go
@@ -15,7 +15,7 @@ func TestCreateAccountFromXDR(t *testing.T) {
 	xdrEnv, err := unmarshalBase64(txeB64)
 	if assert.NoError(t, err) {
 		var ca CreateAccount
-		err = ca.FromXDR(xdrEnv.Operations()[0], false)
+		err = ca.FromXDR(xdrEnv.Operations()[0])
 		if assert.NoError(t, err) {
 			assert.Equal(t, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR", ca.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GCPHE7DYMAUAY4UWA6OIYDFGLKRXGLLEMT6MVETC36L7LW4Z3A37EJW5", ca.Destination, "destination should match")
@@ -27,7 +27,7 @@ func TestCreateAccountFromXDR(t *testing.T) {
 	xdrEnv, err = unmarshalBase64(txeB64NoSource)
 	if assert.NoError(t, err) {
 		var ca CreateAccount
-		err = ca.FromXDR(xdrEnv.Operations()[0], false)
+		err = ca.FromXDR(xdrEnv.Operations()[0])
 		if assert.NoError(t, err) {
 			assert.Equal(t, "", ca.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR", ca.Destination, "destination should match")
@@ -69,7 +69,7 @@ func TestPaymentFromXDR(t *testing.T) {
 	xdrEnv, err := unmarshalBase64(txeB64)
 	if assert.NoError(t, err) {
 		var p Payment
-		err = p.FromXDR(xdrEnv.Operations()[0], false)
+		err = p.FromXDR(xdrEnv.Operations()[0])
 		if assert.NoError(t, err) {
 			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", p.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR", p.Destination, "destination should match")
@@ -77,7 +77,7 @@ func TestPaymentFromXDR(t *testing.T) {
 			assert.Equal(t, true, p.Asset.IsNative(), "Asset should be native")
 		}
 
-		err = p.FromXDR(xdrEnv.Operations()[1], false)
+		err = p.FromXDR(xdrEnv.Operations()[1])
 		if assert.NoError(t, err) {
 			assert.Equal(t, "", p.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR", p.Destination, "destination should match")
@@ -97,7 +97,7 @@ func TestPathPaymentFromXDR(t *testing.T) {
 	xdrEnv, err := unmarshalBase64(txeB64)
 	if assert.NoError(t, err) {
 		var pp PathPayment
-		err = pp.FromXDR(xdrEnv.Operations()[0], false)
+		err = pp.FromXDR(xdrEnv.Operations()[0])
 		if assert.NoError(t, err) {
 			assert.Equal(t, "", pp.SourceAccount, "source accounts should match")
 			assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", pp.Destination, "destination should match")
@@ -120,7 +120,7 @@ func TestManageSellOfferFromXDR(t *testing.T) {
 	xdrEnv, err := unmarshalBase64(txeB64)
 	if assert.NoError(t, err) {
 		var mso ManageSellOffer
-		err = mso.FromXDR(xdrEnv.Operations()[0], false)
+		err = mso.FromXDR(xdrEnv.Operations()[0])
 		if assert.NoError(t, err) {
 			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", mso.SourceAccount, "source accounts should match")
 			assert.Equal(t, int64(0), mso.OfferID, "OfferID should match")
@@ -134,7 +134,7 @@ func TestManageSellOfferFromXDR(t *testing.T) {
 			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", mso.Buying.GetIssuer(), "Asset issuer should match")
 		}
 
-		err = mso.FromXDR(xdrEnv.Operations()[1], false)
+		err = mso.FromXDR(xdrEnv.Operations()[1])
 		if assert.NoError(t, err) {
 			assert.Equal(t, "", mso.SourceAccount, "source accounts should match")
 			assert.Equal(t, int64(0), mso.OfferID, "OfferID should match")
@@ -157,7 +157,7 @@ func TestManageBuyOfferFromXDR(t *testing.T) {
 	xdrEnv, err := unmarshalBase64(txeB64)
 	if assert.NoError(t, err) {
 		var mbo ManageBuyOffer
-		err = mbo.FromXDR(xdrEnv.Operations()[0], false)
+		err = mbo.FromXDR(xdrEnv.Operations()[0])
 		if assert.NoError(t, err) {
 			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", mbo.SourceAccount, "source accounts should match")
 			assert.Equal(t, int64(0), mbo.OfferID, "OfferID should match")
@@ -171,7 +171,7 @@ func TestManageBuyOfferFromXDR(t *testing.T) {
 			assert.Equal(t, "GBUKBCG5VLRKAVYAIREJRUJHOKLIADZJOICRW43WVJCLES52BDOTCQZU", mbo.Buying.GetIssuer(), "Asset issuer should match")
 		}
 
-		err = mbo.FromXDR(xdrEnv.Operations()[1], false)
+		err = mbo.FromXDR(xdrEnv.Operations()[1])
 		if assert.NoError(t, err) {
 			assert.Equal(t, "", mbo.SourceAccount, "source accounts should match")
 			assert.Equal(t, int64(0), mbo.OfferID, "OfferID should match")
@@ -194,7 +194,7 @@ func TestCreatePassiveSellOfferFromXDR(t *testing.T) {
 	xdrEnv, err := unmarshalBase64(txeB64)
 	if assert.NoError(t, err) {
 		var cpo CreatePassiveSellOffer
-		err = cpo.FromXDR(xdrEnv.Operations()[0], false)
+		err = cpo.FromXDR(xdrEnv.Operations()[0])
 		if assert.NoError(t, err) {
 			assert.Equal(t, "", cpo.SourceAccount, "source accounts should match")
 			assert.Equal(t, "10.0000000", cpo.Amount, "Amount should match")
@@ -251,7 +251,7 @@ func TestSetOptionsFromXDR(t *testing.T) {
 	}
 
 	var so SetOptions
-	err = so.FromXDR(xdrOp, false)
+	err = so.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
 		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", so.SourceAccount, "source accounts should match")
 		assert.Equal(t, Threshold(7), *so.MasterWeight, "master weight should match")
@@ -295,7 +295,7 @@ func TestChangeTrustFromXDR(t *testing.T) {
 	}
 
 	var ct ChangeTrust
-	err = ct.FromXDR(xdrOp, false)
+	err = ct.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
 		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", ct.SourceAccount, "source accounts should match")
 		assetType, e := ct.Line.GetType()
@@ -336,7 +336,7 @@ func TestAllowTrustFromXDR(t *testing.T) {
 	}
 
 	var at AllowTrust
-	err = at.FromXDR(xdrOp, false)
+	err = at.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
 		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", at.SourceAccount, "source accounts should match")
 
@@ -367,7 +367,7 @@ func TestAccountMergeFromXDR(t *testing.T) {
 	}
 
 	var am AccountMerge
-	err = am.FromXDR(xdrOp, false)
+	err = am.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
 		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", am.SourceAccount, "source accounts should match")
 		assert.Equal(t, "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3", am.Destination, "destination accounts should match")
@@ -385,7 +385,7 @@ func TestInflationFromXDR(t *testing.T) {
 	}
 
 	var inf Inflation
-	err = inf.FromXDR(xdrOp, false)
+	err = inf.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
 		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", inf.SourceAccount, "source accounts should match")
 	}
@@ -412,7 +412,7 @@ func TestManageDataFromXDR(t *testing.T) {
 	}
 
 	var md ManageData
-	err = md.FromXDR(xdrOp, false)
+	err = md.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
 		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", md.SourceAccount, "source accounts should match")
 		assert.Equal(t, "data", md.Name, "Name should match")
@@ -438,7 +438,7 @@ func TestBumpSequenceFromXDR(t *testing.T) {
 	}
 
 	var bs BumpSequence
-	err = bs.FromXDR(xdrOp, false)
+	err = bs.FromXDR(xdrOp)
 	if assert.NoError(t, err) {
 		assert.Equal(t, "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H", bs.SourceAccount, "source accounts should match")
 		assert.Equal(t, int64(45), bs.BumpTo, "BumpTo should match")
@@ -464,11 +464,10 @@ func testOperationsMarshallingRoundtrip(t *testing.T, operations []Operation, wi
 
 	tx, err := NewTransaction(
 		TransactionParams{
-			SourceAccount:       &sourceAccount,
-			Operations:          operations,
-			Timebounds:          NewInfiniteTimeout(),
-			BaseFee:             MinBaseFee,
-			EnableMuxedAccounts: withMuxedAccounts,
+			SourceAccount: &sourceAccount,
+			Operations:    operations,
+			Timebounds:    NewInfiniteTimeout(),
+			BaseFee:       MinBaseFee,
 		},
 	)
 	assert.NoError(t, err)
@@ -479,7 +478,7 @@ func testOperationsMarshallingRoundtrip(t *testing.T, operations []Operation, wi
 
 	var parsedTx *GenericTransaction
 	if withMuxedAccounts {
-		parsedTx, err = TransactionFromXDR(b64, TransactionFromXDROptionEnableMuxedAccounts)
+		parsedTx, err = TransactionFromXDR(b64)
 	} else {
 		parsedTx, err = TransactionFromXDR(b64)
 	}

--- a/txnbuild/path_payment.go
+++ b/txnbuild/path_payment.go
@@ -25,7 +25,7 @@ type PathPaymentStrictReceive struct {
 }
 
 // BuildXDR for PathPaymentStrictReceive returns a fully configured XDR Operation.
-func (pp *PathPaymentStrictReceive) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (pp *PathPaymentStrictReceive) BuildXDR() (xdr.Operation, error) {
 	// Set XDR send asset
 	if pp.SendAsset == nil {
 		return xdr.Operation{}, errors.New("you must specify an asset to send for payment")
@@ -43,11 +43,7 @@ func (pp *PathPaymentStrictReceive) BuildXDR(withMuxedAccounts bool) (xdr.Operat
 
 	// Set XDR destination
 	var xdrDestination xdr.MuxedAccount
-	if withMuxedAccounts {
-		err = xdrDestination.SetAddress(pp.Destination)
-	} else {
-		err = xdrDestination.SetEd25519Address(pp.Destination)
-	}
+	err = xdrDestination.SetAddress(pp.Destination)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "failed to set destination address")
 	}
@@ -92,28 +88,20 @@ func (pp *PathPaymentStrictReceive) BuildXDR(withMuxedAccounts bool) (xdr.Operat
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, pp.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, pp.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, pp.SourceAccount)
 	return op, nil
 }
 
 // FromXDR for PathPaymentStrictReceive initialises the txnbuild struct from the corresponding xdr Operation.
-func (pp *PathPaymentStrictReceive) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (pp *PathPaymentStrictReceive) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetPathPaymentStrictReceiveOp()
 	if !ok {
 		return errors.New("error parsing path_payment operation from xdr")
 	}
 
-	pp.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
-	if withMuxedAccounts {
-		pp.Destination = result.Destination.Address()
-	} else {
-		destAID := result.Destination.ToAccountId()
-		pp.Destination = destAID.Address()
-	}
+	pp.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	pp.Destination = result.Destination.Address()
+
 	pp.DestAmount = amount.String(result.DestAmount)
 	pp.SendMax = amount.String(result.SendMax)
 
@@ -143,14 +131,8 @@ func (pp *PathPaymentStrictReceive) FromXDR(xdrOp xdr.Operation, withMuxedAccoun
 
 // Validate for PathPaymentStrictReceive validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
-func (pp *PathPaymentStrictReceive) Validate(withMuxedAccounts bool) error {
-	var err error
-	if withMuxedAccounts {
-		_, err = xdr.AddressToMuxedAccount(pp.Destination)
-	} else {
-		_, err = xdr.AddressToAccountId(pp.Destination)
-	}
-
+func (pp *PathPaymentStrictReceive) Validate() error {
+	_, err := xdr.AddressToMuxedAccount(pp.Destination)
 	if err != nil {
 		return NewValidationError("Destination", err.Error())
 	}

--- a/txnbuild/path_payment.go
+++ b/txnbuild/path_payment.go
@@ -88,7 +88,7 @@ func (pp *PathPaymentStrictReceive) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, pp.SourceAccount)
+	SetOpSourceAccount(&op, pp.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/path_payment_strict_send.go
+++ b/txnbuild/path_payment_strict_send.go
@@ -82,7 +82,7 @@ func (pp *PathPaymentStrictSend) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, pp.SourceAccount)
+	SetOpSourceAccount(&op, pp.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/path_payment_strict_send.go
+++ b/txnbuild/path_payment_strict_send.go
@@ -19,7 +19,7 @@ type PathPaymentStrictSend struct {
 }
 
 // BuildXDR for Payment returns a fully configured XDR Operation.
-func (pp *PathPaymentStrictSend) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (pp *PathPaymentStrictSend) BuildXDR() (xdr.Operation, error) {
 	// Set XDR send asset
 	if pp.SendAsset == nil {
 		return xdr.Operation{}, errors.New("you must specify an asset to send for payment")
@@ -37,11 +37,7 @@ func (pp *PathPaymentStrictSend) BuildXDR(withMuxedAccounts bool) (xdr.Operation
 
 	// Set XDR destination
 	var xdrDestination xdr.MuxedAccount
-	if withMuxedAccounts {
-		err = xdrDestination.SetAddress(pp.Destination)
-	} else {
-		err = xdrDestination.SetEd25519Address(pp.Destination)
-	}
+	err = xdrDestination.SetAddress(pp.Destination)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "failed to set destination address")
 	}
@@ -86,28 +82,19 @@ func (pp *PathPaymentStrictSend) BuildXDR(withMuxedAccounts bool) (xdr.Operation
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, pp.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, pp.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, pp.SourceAccount)
 	return op, nil
 }
 
 // FromXDR for PathPaymentStrictSend initialises the txnbuild struct from the corresponding xdr Operation.
-func (pp *PathPaymentStrictSend) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (pp *PathPaymentStrictSend) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetPathPaymentStrictSendOp()
 	if !ok {
 		return errors.New("error parsing path_payment operation from xdr")
 	}
 
-	pp.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
-	if withMuxedAccounts {
-		pp.Destination = result.Destination.Address()
-	} else {
-		destAID := result.Destination.ToAccountId()
-		pp.Destination = destAID.Address()
-	}
+	pp.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	pp.Destination = result.Destination.Address()
 	pp.SendAmount = amount.String(result.SendAmount)
 	pp.DestMin = amount.String(result.DestMin)
 
@@ -137,13 +124,8 @@ func (pp *PathPaymentStrictSend) FromXDR(xdrOp xdr.Operation, withMuxedAccounts 
 
 // Validate for PathPaymentStrictSend validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
-func (pp *PathPaymentStrictSend) Validate(withMuxedAccounts bool) error {
-	var err error
-	if withMuxedAccounts {
-		_, err = xdr.AddressToMuxedAccount(pp.Destination)
-	} else {
-		_, err = xdr.AddressToAccountId(pp.Destination)
-	}
+func (pp *PathPaymentStrictSend) Validate() error {
+	_, err := xdr.AddressToMuxedAccount(pp.Destination)
 	if err != nil {
 		return NewValidationError("Destination", err.Error())
 	}

--- a/txnbuild/payment.go
+++ b/txnbuild/payment.go
@@ -49,7 +49,7 @@ func (p *Payment) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR Operation")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, p.SourceAccount)
+	SetOpSourceAccount(&op, p.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/payment.go
+++ b/txnbuild/payment.go
@@ -17,15 +17,10 @@ type Payment struct {
 
 // BuildXDR for Payment returns a fully configured XDR Operation.
 
-func (p *Payment) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (p *Payment) BuildXDR() (xdr.Operation, error) {
 	var destMuxedAccount xdr.MuxedAccount
 
-	var err error
-	if withMuxedAccounts {
-		err = destMuxedAccount.SetAddress(p.Destination)
-	} else {
-		err = destMuxedAccount.SetEd25519Address(p.Destination)
-	}
+	err := destMuxedAccount.SetAddress(p.Destination)
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "failed to set destination address")
 	}
@@ -54,28 +49,19 @@ func (p *Payment) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR Operation")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, p.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, p.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, p.SourceAccount)
 	return op, nil
 }
 
 // FromXDR for Payment initialises the txnbuild struct from the corresponding xdr Operation.
-func (p *Payment) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (p *Payment) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetPaymentOp()
 	if !ok {
 		return errors.New("error parsing payment operation from xdr")
 	}
 
-	p.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
-	if withMuxedAccounts {
-		p.Destination = result.Destination.Address()
-	} else {
-		destAID := result.Destination.ToAccountId()
-		p.Destination = destAID.Address()
-	}
+	p.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
+	p.Destination = result.Destination.Address()
 
 	p.Amount = amount.String(result.Amount)
 
@@ -90,13 +76,8 @@ func (p *Payment) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
 
 // Validate for Payment validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
-func (p *Payment) Validate(withMuxedAccounts bool) error {
-	var err error
-	if withMuxedAccounts {
-		_, err = xdr.AddressToMuxedAccount(p.Destination)
-	} else {
-		_, err = xdr.AddressToAccountId(p.Destination)
-	}
+func (p *Payment) Validate() error {
+	_, err := xdr.AddressToMuxedAccount(p.Destination)
 
 	if err != nil {
 		return NewValidationError("Destination", err.Error())

--- a/txnbuild/revoke_sponsorship.go
+++ b/txnbuild/revoke_sponsorship.go
@@ -55,7 +55,7 @@ type SignerID struct {
 	SignerAddress string
 }
 
-func (r *RevokeSponsorship) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (r *RevokeSponsorship) BuildXDR() (xdr.Operation, error) {
 	xdrOp := xdr.RevokeSponsorshipOp{}
 	switch r.SponsorshipType {
 	case RevokeSponsorshipTypeAccount:
@@ -153,16 +153,13 @@ func (r *RevokeSponsorship) BuildXDR(withMuxedAccounts bool) (xdr.Operation, err
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, r.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, r.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, r.SourceAccount)
+
 	return op, nil
 }
 
-func (r *RevokeSponsorship) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
-	r.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+func (r *RevokeSponsorship) FromXDR(xdrOp xdr.Operation) error {
+	r.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	op, ok := xdrOp.Body.GetRevokeSponsorshipOp()
 	if !ok {
 		return errors.New("error parsing revoke_sponsorhip operation from xdr")
@@ -226,7 +223,7 @@ func (r *RevokeSponsorship) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool)
 	return nil
 }
 
-func (r *RevokeSponsorship) Validate(withMuxedAccounts bool) error {
+func (r *RevokeSponsorship) Validate() error {
 	switch r.SponsorshipType {
 	case RevokeSponsorshipTypeAccount:
 		if r.Account == nil {

--- a/txnbuild/revoke_sponsorship.go
+++ b/txnbuild/revoke_sponsorship.go
@@ -153,7 +153,7 @@ func (r *RevokeSponsorship) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, r.SourceAccount)
+	SetOpSourceAccount(&op, r.SourceAccount)
 
 	return op, nil
 }

--- a/txnbuild/revoke_sponsorship_test.go
+++ b/txnbuild/revoke_sponsorship_test.go
@@ -88,15 +88,15 @@ func TestRevokeSponsorship(t *testing.T) {
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			op := testcase.op
-			assert.NoError(t, op.Validate(false))
-			xdrOp, err := op.BuildXDR(false)
+			assert.NoError(t, op.Validate())
+			xdrOp, err := op.BuildXDR()
 			assert.NoError(t, err)
 			xdrBin, err := xdrOp.MarshalBinary()
 			assert.NoError(t, err)
 			var xdrOp2 xdr.Operation
 			assert.NoError(t, xdr.SafeUnmarshal(xdrBin, &xdrOp2))
 			var op2 RevokeSponsorship
-			assert.NoError(t, op2.FromXDR(xdrOp2, false))
+			assert.NoError(t, op2.FromXDR(xdrOp2))
 			assert.Equal(t, op, op2)
 			testOperationsMarshallingRoundtrip(t, []Operation{&testcase.op}, false)
 		})

--- a/txnbuild/set_options.go
+++ b/txnbuild/set_options.go
@@ -95,7 +95,7 @@ func (so *SetOptions) BuildXDR() (xdr.Operation, error) {
 	}
 
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, so.SourceAccount)
+	SetOpSourceAccount(&op, so.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/set_options.go
+++ b/txnbuild/set_options.go
@@ -67,7 +67,7 @@ type SetOptions struct {
 }
 
 // BuildXDR for SetOptions returns a fully configured XDR Operation.
-func (so *SetOptions) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (so *SetOptions) BuildXDR() (xdr.Operation, error) {
 	err := so.handleInflation()
 	if err != nil {
 		return xdr.Operation{}, errors.Wrap(err, "failed to set inflation destination address")
@@ -95,11 +95,7 @@ func (so *SetOptions) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
 	}
 
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, so.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, so.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, so.SourceAccount)
 	return op, nil
 }
 
@@ -297,13 +293,13 @@ func (so *SetOptions) handleSignerXDR(xSigner *xdr.Signer) {
 }
 
 // FromXDR for SetOptions initialises the txnbuild struct from the corresponding xdr Operation.
-func (so *SetOptions) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (so *SetOptions) FromXDR(xdrOp xdr.Operation) error {
 	result, ok := xdrOp.Body.GetSetOptionsOp()
 	if !ok {
 		return errors.New("error parsing set_options operation from xdr")
 	}
 
-	so.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	so.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	so.handleInflationXDR(result.InflationDest)
 	so.handleClearFlagsXDR(result.ClearFlags)
 	so.handleSetFlagsXDR(result.SetFlags)
@@ -319,7 +315,7 @@ func (so *SetOptions) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error
 
 // Validate for SetOptions validates the required struct fields. It returns an error if any
 // of the fields are invalid. Otherwise, it returns nil.
-func (so *SetOptions) Validate(withMuxedAccounts bool) error {
+func (so *SetOptions) Validate() error {
 	// skipping checks here because the individual methods above already check for required fields.
 	// Refactoring is out of the scope of this issue(https://github.com/stellar/go/issues/1041) so will leave as is for now.
 	return nil

--- a/txnbuild/set_options_test.go
+++ b/txnbuild/set_options_test.go
@@ -131,7 +131,7 @@ func TestEmptyHomeDomainOK(t *testing.T) {
 	options := SetOptions{
 		HomeDomain: NewHomeDomain(""),
 	}
-	options.BuildXDR(false)
+	options.BuildXDR()
 
 	assert.Equal(t, string(*options.xdrOp.HomeDomain), "", "empty string home domain is set")
 

--- a/txnbuild/set_trust_line_flags.go
+++ b/txnbuild/set_trust_line_flags.go
@@ -57,7 +57,7 @@ func (stf *SetTrustLineFlags) BuildXDR() (xdr.Operation, error) {
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	SetOpSourceMuxedAccount(&op, stf.SourceAccount)
+	SetOpSourceAccount(&op, stf.SourceAccount)
 	return op, nil
 }
 

--- a/txnbuild/set_trust_line_flags.go
+++ b/txnbuild/set_trust_line_flags.go
@@ -29,7 +29,7 @@ type SetTrustLineFlags struct {
 }
 
 // BuildXDR for SetTrustLineFlags  returns a fully configured XDR Operation.
-func (stf *SetTrustLineFlags) BuildXDR(withMuxedAccounts bool) (xdr.Operation, error) {
+func (stf *SetTrustLineFlags) BuildXDR() (xdr.Operation, error) {
 	var xdrOp xdr.SetTrustLineFlagsOp
 
 	// Set XDR address associated with the trustline
@@ -57,11 +57,7 @@ func (stf *SetTrustLineFlags) BuildXDR(withMuxedAccounts bool) (xdr.Operation, e
 		return xdr.Operation{}, errors.Wrap(err, "failed to build XDR OperationBody")
 	}
 	op := xdr.Operation{Body: body}
-	if withMuxedAccounts {
-		SetOpSourceMuxedAccount(&op, stf.SourceAccount)
-	} else {
-		SetOpSourceAccount(&op, stf.SourceAccount)
-	}
+	SetOpSourceMuxedAccount(&op, stf.SourceAccount)
 	return op, nil
 }
 
@@ -74,13 +70,13 @@ func trustLineFlagsToXDR(flags []TrustLineFlag) xdr.Uint32 {
 }
 
 // FromXDR for SetTrustLineFlags  initialises the txnbuild struct from the corresponding xdr Operation.
-func (stf *SetTrustLineFlags) FromXDR(xdrOp xdr.Operation, withMuxedAccounts bool) error {
+func (stf *SetTrustLineFlags) FromXDR(xdrOp xdr.Operation) error {
 	op, ok := xdrOp.Body.GetSetTrustLineFlagsOp()
 	if !ok {
 		return errors.New("error parsing allow_trust operation from xdr")
 	}
 
-	stf.SourceAccount = accountFromXDR(xdrOp.SourceAccount, withMuxedAccounts)
+	stf.SourceAccount = accountFromXDR(xdrOp.SourceAccount)
 	stf.Trustor = op.Trustor.Address()
 	asset, err := assetFromXDR(op.Asset)
 	if err != nil {
@@ -110,7 +106,7 @@ func fromXDRTrustlineFlag(flags xdr.Uint32) []TrustLineFlag {
 
 // Validate for SetTrustLineFlags  validates the required struct fields. It returns an error if any of the fields are
 // invalid. Otherwise, it returns nil.
-func (stf *SetTrustLineFlags) Validate(withMuxedAccounts bool) error {
+func (stf *SetTrustLineFlags) Validate() error {
 	err := validateStellarPublicKey(stf.Trustor)
 	if err != nil {
 		return NewValidationError("Trustor", err.Error())

--- a/txnbuild/set_trustline_flags_test.go
+++ b/txnbuild/set_trustline_flags_test.go
@@ -78,15 +78,15 @@ func TestSetTrustLineFlags(t *testing.T) {
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			op := testcase.op
-			assert.NoError(t, op.Validate(false))
-			xdrOp, err := op.BuildXDR(false)
+			assert.NoError(t, op.Validate())
+			xdrOp, err := op.BuildXDR()
 			assert.NoError(t, err)
 			xdrBin, err := xdrOp.MarshalBinary()
 			assert.NoError(t, err)
 			var xdrOp2 xdr.Operation
 			assert.NoError(t, xdr.SafeUnmarshal(xdrBin, &xdrOp2))
 			var op2 SetTrustLineFlags
-			assert.NoError(t, op2.FromXDR(xdrOp2, false))
+			assert.NoError(t, op2.FromXDR(xdrOp2))
 			assert.Equal(t, op, op2)
 			testOperationsMarshallingRoundtrip(t, []Operation{&testcase.op}, false)
 		})

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -663,33 +663,18 @@ func (t *GenericTransaction) UnmarshalText(b []byte) error {
 	return nil
 }
 
-type TransactionFromXDROption int
-
-const (
-	TransactionFromXDROptionEnableMuxedAccounts TransactionFromXDROption = iota
-)
-
-func areMuxedAccountsEnabled(options []TransactionFromXDROption) bool {
-	for _, opt := range options {
-		if opt == TransactionFromXDROptionEnableMuxedAccounts {
-			return true
-		}
-	}
-	return false
-}
-
 // TransactionFromXDR parses the supplied transaction envelope in base64 XDR
 // and returns a GenericTransaction instance.
-func TransactionFromXDR(txeB64 string, options ...TransactionFromXDROption) (*GenericTransaction, error) {
+func TransactionFromXDR(txeB64 string) (*GenericTransaction, error) {
 	var xdrEnv xdr.TransactionEnvelope
 	err := xdr.SafeUnmarshalBase64(txeB64, &xdrEnv)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to unmarshal transaction envelope")
 	}
-	return transactionFromParsedXDR(xdrEnv, areMuxedAccountsEnabled(options))
+	return transactionFromParsedXDR(xdrEnv)
 }
 
-func transactionFromParsedXDR(xdrEnv xdr.TransactionEnvelope, withMuxedAccounts bool) (*GenericTransaction, error) {
+func transactionFromParsedXDR(xdrEnv xdr.TransactionEnvelope) (*GenericTransaction, error) {
 	var err error
 	newTx := &GenericTransaction{}
 
@@ -698,18 +683,12 @@ func transactionFromParsedXDR(xdrEnv xdr.TransactionEnvelope, withMuxedAccounts 
 		innerTx, err = transactionFromParsedXDR(xdr.TransactionEnvelope{
 			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
 			V1:   xdrEnv.FeeBump.Tx.InnerTx.V1,
-		}, withMuxedAccounts)
+		})
 		if err != nil {
 			return newTx, errors.New("could not parse inner transaction")
 		}
-		var feeAccount string
-		if withMuxedAccounts {
-			feeBumpAccount := xdrEnv.FeeBumpAccount()
-			feeAccount = feeBumpAccount.Address()
-		} else {
-			feeBumpAccount := xdrEnv.FeeBumpAccount().ToAccountId()
-			feeAccount = feeBumpAccount.Address()
-		}
+		feeBumpAccount := xdrEnv.FeeBumpAccount()
+		feeAccount := feeBumpAccount.Address()
 
 		newTx.feeBump = &FeeBumpTransaction{
 			envelope: xdrEnv,
@@ -725,14 +704,8 @@ func transactionFromParsedXDR(xdrEnv xdr.TransactionEnvelope, withMuxedAccounts 
 
 		return newTx, nil
 	}
-	var accountID string
-	if withMuxedAccounts {
-		sourceAccount := xdrEnv.SourceAccount()
-		accountID = sourceAccount.Address()
-	} else {
-		sourceAccount := xdrEnv.SourceAccount().ToAccountId()
-		accountID = sourceAccount.Address()
-	}
+	sourceAccount := xdrEnv.SourceAccount()
+	accountID := sourceAccount.Address()
 
 	totalFee := int64(xdrEnv.Fee())
 	baseFee := totalFee
@@ -764,7 +737,7 @@ func transactionFromParsedXDR(xdrEnv xdr.TransactionEnvelope, withMuxedAccounts 
 
 	operations := xdrEnv.Operations()
 	for _, op := range operations {
-		newOp, err := operationFromXDR(op, withMuxedAccounts)
+		newOp, err := operationFromXDR(op)
 		if err != nil {
 			return nil, err
 		}
@@ -783,7 +756,6 @@ type TransactionParams struct {
 	BaseFee              int64
 	Memo                 Memo
 	Timebounds           Timebounds
-	EnableMuxedAccounts  bool
 }
 
 // NewTransaction returns a new Transaction instance
@@ -815,18 +787,9 @@ func NewTransaction(params TransactionParams) (*Transaction, error) {
 		timebounds: params.Timebounds,
 	}
 	var sourceAccount xdr.MuxedAccount
-	if params.EnableMuxedAccounts {
-		if err = sourceAccount.SetAddress(tx.sourceAccount.AccountID); err != nil {
-			return nil, errors.Wrap(err, "account id is not valid")
-		}
-	} else {
-		accountID, err2 := xdr.AddressToAccountId(tx.sourceAccount.AccountID)
-		if err2 != nil {
-			return nil, errors.Wrap(err2, "account id is not valid")
-		}
-		sourceAccount = accountID.ToMuxedAccount()
+	if err = sourceAccount.SetAddress(tx.sourceAccount.AccountID); err != nil {
+		return nil, errors.Wrap(err, "account id is not valid")
 	}
-
 	if tx.baseFee < 0 {
 		return nil, errors.Errorf("base fee cannot be negative")
 	}
@@ -876,10 +839,10 @@ func NewTransaction(params TransactionParams) (*Transaction, error) {
 	}
 
 	for _, op := range tx.operations {
-		if verr := op.Validate(params.EnableMuxedAccounts); verr != nil {
+		if verr := op.Validate(); verr != nil {
 			return nil, errors.Wrap(verr, fmt.Sprintf("validation failed for %T operation", op))
 		}
-		xdrOperation, err2 := op.BuildXDR(params.EnableMuxedAccounts)
+		xdrOperation, err2 := op.BuildXDR()
 		if err2 != nil {
 			return nil, errors.Wrap(err2, fmt.Sprintf("failed to build operation %T", op))
 		}
@@ -893,10 +856,9 @@ func NewTransaction(params TransactionParams) (*Transaction, error) {
 // FeeBumpTransactionParams is a container for parameters
 // which are used to construct new FeeBumpTransaction instances
 type FeeBumpTransactionParams struct {
-	Inner               *Transaction
-	FeeAccount          string
-	BaseFee             int64
-	EnableMuxedAccounts bool
+	Inner      *Transaction
+	FeeAccount string
+	BaseFee    int64
 }
 
 func convertToV1(tx *Transaction) (*Transaction, error) {
@@ -968,17 +930,10 @@ func NewFeeBumpTransaction(params FeeBumpTransactionParams) (*FeeBumpTransaction
 	}
 
 	var feeSource xdr.MuxedAccount
-	if params.EnableMuxedAccounts {
-		if err := feeSource.SetAddress(tx.feeAccount); err != nil {
-			return tx, errors.Wrap(err, "fee account is not a valid address")
-		}
-	} else {
-		accountID, err := xdr.AddressToAccountId(tx.feeAccount)
-		if err != nil {
-			return tx, errors.Wrap(err, "fee account is not a valid address")
-		}
-		feeSource = accountID.ToMuxedAccount()
+	if err := feeSource.SetAddress(tx.feeAccount); err != nil {
+		return tx, errors.Wrap(err, "fee account is not a valid address")
 	}
+
 	tx.envelope = xdr.TransactionEnvelope{
 		Type: xdr.EnvelopeTypeEnvelopeTypeTxFeeBump,
 		FeeBump: &xdr.FeeBumpTransactionEnvelope{

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -222,7 +222,6 @@ func TestPaymentMuxedAccounts(t *testing.T) {
 			Operations:           []Operation{&payment},
 			BaseFee:              MinBaseFee,
 			Timebounds:           NewInfiniteTimeout(),
-			EnableMuxedAccounts:  true,
 		},
 		network.TestNetworkPassphrase,
 		kp0,
@@ -231,39 +230,6 @@ func TestPaymentMuxedAccounts(t *testing.T) {
 
 	expected := "AAAAAgAAAQAAAAAAyv66vuDcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAiII0AAAAbAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAEAAAEAAAAAAMr+ur7g3G3hclysZlFitS+s5zWyiiJD5B0STWy5LXCj6i5yxQAAAAEAAAEAgAAAAAAAAAA/DDS/k60NmXHQTMyQ9wVRHIOKrZc0pKL7DXoD/H/omgAAAAAAAAAABfXhAAAAAAAAAAAB6i5yxQAAAED4Wkvwf/BJV+fqa6Kvi+T/7ZL82pOinN68GlvEi9qK4klH+qITyvN3jRj5Nfz0+VrE2xBJPVc8sS/qN9LlznoC"
 	assert.Equal(t, expected, received, "Base 64 XDR should match")
-}
-
-func TestPaymentFailsMuxedAccountsIfNotEnabled(t *testing.T) {
-	kp0 := newKeypair0()
-	accountID := xdr.MustAddress(kp0.Address())
-	mx := xdr.MuxedAccount{
-		Type: xdr.CryptoKeyTypeKeyTypeMuxedEd25519,
-		Med25519: &xdr.MuxedAccountMed25519{
-			Id:      0xcafebabe,
-			Ed25519: *accountID.Ed25519,
-		},
-	}
-	sourceAccount := NewSimpleAccount(mx.Address(), int64(9605939170639898))
-
-	payment := Payment{
-		Destination: "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK",
-		Amount:      "10",
-		Asset:       NativeAsset{},
-	}
-
-	_, err := newSignedTransaction(
-		TransactionParams{
-			SourceAccount:        &sourceAccount,
-			IncrementSequenceNum: true,
-			Operations:           []Operation{&payment},
-			BaseFee:              MinBaseFee,
-			Timebounds:           NewInfiniteTimeout(),
-			EnableMuxedAccounts:  false,
-		},
-		network.TestNetworkPassphrase,
-		kp0,
-	)
-	assert.Error(t, err)
 }
 
 func TestPaymentFailsIfNoAssetSpecified(t *testing.T) {
@@ -1424,7 +1390,7 @@ func TestFromXDR(t *testing.T) {
 	txB64WithMuxedAccounts := "AAAAAgAAAQAAAAAAyv66vuDcbeFyXKxmUWK1L6znNbKKIkPkHRJNbLktcKPqLnLFAAAAZAAiII0AAAAbAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAEAAAEAAAAAAMr+ur7g3G3hclysZlFitS+s5zWyiiJD5B0STWy5LXCj6i5yxQAAAAEAAAEAgAAAAAAAAAA/DDS/k60NmXHQTMyQ9wVRHIOKrZc0pKL7DXoD/H/omgAAAAAAAAAABfXhAAAAAAAAAAAB6i5yxQAAAED4Wkvwf/BJV+fqa6Kvi+T/7ZL82pOinN68GlvEi9qK4klH+qITyvN3jRj5Nfz0+VrE2xBJPVc8sS/qN9LlznoC"
 
 	// It provides M-addreses when enabling muxed accounts
-	tx3, err := TransactionFromXDR(txB64WithMuxedAccounts, TransactionFromXDROptionEnableMuxedAccounts)
+	tx3, err := TransactionFromXDR(txB64WithMuxedAccounts)
 	assert.NoError(t, err)
 	newTx3, ok := tx3.Transaction()
 	assert.True(t, ok)
@@ -1433,17 +1399,6 @@ func TestFromXDR(t *testing.T) {
 	assert.True(t, ok3)
 	assert.Equal(t, "MDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKAAAAAAMV7V2XYGQO", op3.SourceAccount)
 	assert.Equal(t, "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK", op3.Destination)
-
-	// It does provide G-addreses when not enabling muxed accounts
-	tx3, err = TransactionFromXDR(txB64WithMuxedAccounts)
-	assert.NoError(t, err)
-	newTx3, ok = tx3.Transaction()
-	assert.True(t, ok)
-	assert.Equal(t, "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3", newTx3.sourceAccount.AccountID)
-	op3, ok3 = newTx3.Operations()[0].(*Payment)
-	assert.True(t, ok3)
-	assert.Equal(t, "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3", op3.SourceAccount)
-	assert.Equal(t, "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ", op3.Destination)
 
 }
 
@@ -4469,7 +4424,6 @@ func TestClaimableBalanceIds(t *testing.T) {
 			BaseFee:              MinBaseFee,
 			Timebounds:           NewInfiniteTimeout(),
 			Operations:           []Operation{&claimableBalanceEntry},
-			EnableMuxedAccounts:  true,
 		},
 	)
 	assert.NoError(t, err)


### PR DESCRIPTION
Closes #4164 


Enable Muxed Accounts ([SEP-23](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md)) by default:
  * Remove `TransactionParams.EnableMuxedAccounts`
  * Remove `TransactionFromXDROptionEnableMuxedAccounts`
  * Remove `FeeBumpTransactionParams.EnableMuxedAccounts`
  * Remove parameter `withMuxedAccounts bool` from all methods/functions.
  * Remove `options ...TransactionFromXDROption` parameter from `TransactionFromXDR()`
  * Rename `SetOpSourceMuxedAccount()` to (pre-existing) `SetOpSourceAccount()` which now accepts
    both `G` and `M` (muxed) account strkeys.
