### PR TITLE
txnbuild: add ClearSignatures functions to Transaction and FeeBumpTransaction

### DIFF
--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -323,6 +323,12 @@ func (t *Transaction) SignHashX(preimage []byte) (*Transaction, error) {
 	return t.clone(extendedSignatures), nil
 }
 
+// ClearSignatures returns a new Transaction instance which extends the current instance
+// with signatures removed.
+func (t *Transaction) ClearSignatures() (*Transaction, error) {
+	return t.clone(nil), nil
+}
+
 // AddSignatureDecorated returns a new Transaction instance which extends the current instance
 // with an additional decorated signature(s).
 func (t *Transaction) AddSignatureDecorated(signature ...xdr.DecoratedSignature) (*Transaction, error) {
@@ -517,6 +523,12 @@ func (t *FeeBumpTransaction) SignHashX(preimage []byte) (*FeeBumpTransaction, er
 	}
 
 	return t.clone(extendedSignatures), nil
+}
+
+// ClearSignatures returns a new Transaction instance which extends the current instance
+// with signatures removed.
+func (t *FeeBumpTransaction) ClearSignatures() (*FeeBumpTransaction, error) {
+	return t.clone(nil), nil
 }
 
 // AddSignatureBase64 returns a new FeeBumpTransaction instance which extends the current instance

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -3,13 +3,13 @@ package txnbuild
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"github.com/stellar/go/price"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/price"
 	"github.com/stellar/go/strkey"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
@@ -1690,6 +1690,83 @@ func TestAddSignatureBase64(t *testing.T) {
 	actual, err := tx1.Base64()
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual, "base64 xdr should match")
+}
+
+func TestTransaction_ClearSignatures(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+
+	tx, err := NewTransaction(
+		TransactionParams{
+			SourceAccount: &SimpleAccount{AccountID: kp0.Address(), Sequence: int64(9605939170639898)},
+			Operations: []Operation{&CreateAccount{
+				Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
+				Amount:        "10",
+				SourceAccount: kp1.Address(),
+			}},
+			BaseFee:    MinBaseFee,
+			Timebounds: NewInfiniteTimeout(),
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, tx.Signatures(), 0)
+
+	txWithSig, err := tx.Sign(network.TestNetworkPassphrase, kp0)
+	require.NoError(t, err)
+	require.Len(t, txWithSig.Signatures(), 1)
+
+	txSigCleared, err := txWithSig.ClearSignatures()
+	require.NoError(t, err)
+	require.Len(t, txSigCleared.Signatures(), 0)
+
+	expected, err := tx.Base64()
+	assert.NoError(t, err)
+	actual, err := txSigCleared.Base64()
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestFeeBumpTransaction_ClearSignatures(t *testing.T) {
+	kp0 := newKeypair0()
+	kp1 := newKeypair1()
+
+	tx, err := NewTransaction(TransactionParams{
+		SourceAccount: &SimpleAccount{AccountID: kp0.Address(), Sequence: int64(9605939170639898)},
+		Operations: []Operation{&CreateAccount{
+			Destination:   "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
+			Amount:        "10",
+			SourceAccount: kp1.Address(),
+		}},
+		BaseFee:    MinBaseFee,
+		Timebounds: NewInfiniteTimeout(),
+	})
+	require.NoError(t, err)
+	require.Len(t, tx.Signatures(), 0)
+	txWithSig, err := tx.Sign(network.TestNetworkPassphrase, kp0)
+	require.NoError(t, err)
+	require.Len(t, txWithSig.Signatures(), 1)
+
+	fbtx, err := NewFeeBumpTransaction(FeeBumpTransactionParams{
+		Inner:      txWithSig,
+		FeeAccount: kp0.Address(),
+		BaseFee:    MinBaseFee,
+	})
+	require.NoError(t, err)
+	require.Len(t, fbtx.Signatures(), 0)
+
+	fbtxWithSig, err := fbtx.Sign(network.TestNetworkPassphrase, kp0)
+	require.NoError(t, err)
+	require.Len(t, fbtxWithSig.Signatures(), 1)
+
+	fbtxSigCleared, err := fbtxWithSig.ClearSignatures()
+	require.NoError(t, err)
+	require.Len(t, fbtxSigCleared.Signatures(), 0)
+
+	expected, err := fbtx.Base64()
+	assert.NoError(t, err)
+	actual, err := fbtxSigCleared.Base64()
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
 }
 
 func TestReadChallengeTx_validSignedByServerAndClient(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add `ClearSignatures` functions to `Transaction` and `FeeBumpTransaction`.

### Why

`Transaction` and `FeeBumpTransaction` have functions for adding signatures, but not for clearing them to get back the original transaction without signatures attached. Without these functions the only way to remove signatures is to get the envelope and fiddle with the internals of the envelope, which seems not ideal. I need these functions for some code I'm writing using the Go SDK.

### Known limitations

N/A
