### PR TITLE
services/horizon/../sse:  Stop counting the SSE preamble as an event

### DIFF
--- a/services/horizon/internal/render/sse/stream.go
+++ b/services/horizon/internal/render/sse/stream.go
@@ -18,11 +18,12 @@ var (
 )
 
 type Stream struct {
-	ctx        context.Context
-	w          http.ResponseWriter
-	done       bool
-	eventsSent int
-	limit      int
+	ctx         context.Context
+	w           http.ResponseWriter
+	done        bool
+	eventsSent  int
+	limit       int
+	initialized bool
 }
 
 // NewStream creates a new stream against the provided response writer.
@@ -37,12 +38,10 @@ func NewStream(ctx context.Context, w http.ResponseWriter) *Stream {
 // hello message. This should be called before any method that writes to the client to ensure that the preamble
 // has been sent first.
 func (s *Stream) Init() {
+	s.initialized = true
 	if s.eventsSent == 0 {
 		ok := WritePreamble(s.ctx, s.w)
-		if ok {
-			// The preamble includes sending a hello event
-			s.eventsSent++
-		} else {
+		if !ok {
 			s.done = true
 		}
 	}
@@ -65,9 +64,9 @@ func (s *Stream) Done() {
 }
 
 func (s *Stream) Err(err error) {
-	// If we haven't sent an event, we should simply return the normal HTTP
+	// We haven't initialized the stream, we should simply return the normal HTTP
 	// error because it means that we haven't sent the preamble.
-	if s.eventsSent == 0 {
+	if !s.initialized {
 		problem.Render(s.ctx, s.w, err)
 		return
 	}

--- a/services/horizon/internal/render/sse/stream.go
+++ b/services/horizon/internal/render/sse/stream.go
@@ -38,8 +38,8 @@ func NewStream(ctx context.Context, w http.ResponseWriter) *Stream {
 // hello message. This should be called before any method that writes to the client to ensure that the preamble
 // has been sent first.
 func (s *Stream) Init() {
-	s.initialized = true
-	if s.eventsSent == 0 {
+	if !s.initialized {
+		s.initialized = true
 		ok := WritePreamble(s.ctx, s.w)
 		if !ok {
 			s.done = true

--- a/services/horizon/internal/render/sse/stream_test.go
+++ b/services/horizon/internal/render/sse/stream_test.go
@@ -27,9 +27,7 @@ func (s *Stream) IsDone() bool {
 		return s.done
 	}
 
-	// The hello event shouldn't be counted for limit calculations
-	eventsSentExcludingHello := s.eventsSent - 1
-	return s.done || eventsSentExcludingHello >= s.limit
+	return s.done || s.eventsSent >= s.limit
 }
 
 type StreamTestSuite struct {
@@ -41,7 +39,7 @@ type StreamTestSuite struct {
 
 // Helper method to check that the preamble has been sent and all HTTP response headers are correctly set.
 func (suite *StreamTestSuite) checkHeadersAndPreamble() {
-	if suite.stream.SentCount() == 0 {
+	if !suite.stream.initialized {
 		assert.Equal(suite.T(), "application/problem+json; charset=utf-8", suite.w.Header().Get("Content-Type"))
 		assert.Equal(suite.T(), 500, suite.w.Code)
 		return
@@ -70,7 +68,7 @@ func (suite *StreamTestSuite) TestStream_Send() {
 	// Now check that the data got written
 	assert.Contains(suite.T(), suite.w.Body.String(), "data: \"test message\"\n\n")
 	suite.stream.Done()
-	assert.Equal(suite.T(), 2, suite.stream.SentCount())
+	assert.Equal(suite.T(), 1, suite.stream.SentCount())
 }
 
 // Tests that Stream can send error events.
@@ -84,8 +82,10 @@ func (suite *StreamTestSuite) TestStream_Err() {
 	// Reset the stream to test the scenario where an event has been sent.
 	suite.w = httptest.NewRecorder()
 	suite.stream = NewStream(suite.ctx, suite.w)
-	suite.stream.eventsSent++
+	suite.stream.initialized = false
+	suite.stream.Send(Event{})
 	suite.stream.Err(err)
+	suite.checkHeadersAndPreamble()
 	assert.Contains(suite.T(), suite.w.Body.String(), "event: error\ndata: Unexpected stream error\n\n")
 	assert.True(suite.T(), suite.stream.IsDone())
 }
@@ -97,8 +97,10 @@ func (suite *StreamTestSuite) TestStream_ErrRegisterError() {
 
 	suite.w = httptest.NewRecorder()
 	suite.stream = NewStream(suite.ctx, suite.w)
-	suite.stream.eventsSent++
+	suite.stream.initialized = false
+	suite.stream.Send(Event{})
 	suite.stream.Err(context.DeadlineExceeded)
+	suite.checkHeadersAndPreamble()
 	assert.Contains(suite.T(), suite.w.Body.String(), "event: error\ndata: problem: timeout\n\n")
 	assert.True(suite.T(), suite.stream.IsDone())
 }
@@ -110,8 +112,10 @@ func (suite *StreamTestSuite) TestStream_ErrNoRows() {
 
 	suite.w = httptest.NewRecorder()
 	suite.stream = NewStream(suite.ctx, suite.w)
-	suite.stream.eventsSent++
+	suite.stream.initialized = false
+	suite.stream.Send(Event{})
 	suite.stream.Err(sql.ErrNoRows)
+	suite.checkHeadersAndPreamble()
 	assert.Contains(suite.T(), suite.w.Body.String(), "event: error\ndata: problem: not_found\n\n")
 	assert.True(suite.T(), suite.stream.IsDone())
 }
@@ -133,10 +137,10 @@ func (suite *StreamTestSuite) TestStream_SentCount() {
 		message := "test message " + strconv.Itoa(i)
 		suite.stream.Send(Event{Data: message})
 	}
-	assert.Equal(suite.T(), 6, suite.stream.SentCount())
+	assert.Equal(suite.T(), 5, suite.stream.SentCount())
 	suite.stream.Err(errors.New("example error"))
 	// Make sure that errors don't contribute to the send count
-	assert.Equal(suite.T(), 6, suite.stream.SentCount())
+	assert.Equal(suite.T(), 5, suite.stream.SentCount())
 }
 
 // Runs the test suite.

--- a/services/horizon/internal/render/sse/stream_test.go
+++ b/services/horizon/internal/render/sse/stream_test.go
@@ -27,7 +27,9 @@ func (s *Stream) IsDone() bool {
 		return s.done
 	}
 
-	return s.done || s.eventsSent >= s.limit
+	// The hello event shouldn't be counted for limit calculations
+	eventsSentExcludingHello := s.eventsSent - 1
+	return s.done || eventsSentExcludingHello >= s.limit
 }
 
 type StreamTestSuite struct {


### PR DESCRIPTION
Leftover from https://github.com/stellar/go/pull/4151
