### PR TITLE
services/horizon: Set docker platform flag so core works on ARM Macs

### DIFF
--- a/integration.sh
+++ b/integration.sh
@@ -12,7 +12,12 @@ export TRACY_NO_INVARIANT_CHECK=1 # This fails on my dev vm. - Paul
 # launch postgres if it's not already.
 if [[ "$(docker inspect integration_postgres -f '{{.State.Running}}')" != "true" ]]; then
   docker rm -f integration_postgres || true;
-  docker run -d --name integration_postgres --env POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 circleci/postgres:9.6.5-alpine
+  docker run -d \
+    --name integration_postgres \
+    --platform linux/amd64 \
+    --env POSTGRES_HOST_AUTH_METHOD=trust \
+    -p 5432:5432 \
+    circleci/postgres:9.6.5-alpine
 fi
 
 exec go test -timeout 25m github.com/stellar/go/services/horizon/internal/integration/... "$@"

--- a/services/horizon/docker/docker-compose.integration-tests.yml
+++ b/services/horizon/docker/docker-compose.integration-tests.yml
@@ -10,6 +10,7 @@ services:
       - "5641:5641"
     command: ["-p", "5641"]
   core:
+    platform: linux/amd64
     # TODO replace with official SDF image when ready. Note that this:
     # https://github.com/stellar/stellar-core/commit/31597b760f8e325fc84da0937adc373a78878ca9
     # breaks the tests. I reverted it before building temp docker image.

--- a/services/horizon/docker/docker-compose.pubnet.yml
+++ b/services/horizon/docker/docker-compose.pubnet.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   horizon:
+    platform: linux/amd64
     environment:
       - HISTORY_ARCHIVE_URLS=https://history.stellar.org/prd/core-live/core_live_001
       - NETWORK_PASSPHRASE=Public Global Stellar Network ; September 2015

--- a/services/horizon/docker/docker-compose.standalone.yml
+++ b/services/horizon/docker/docker-compose.standalone.yml
@@ -13,6 +13,7 @@ services:
       - "core-db-data:/var/lib/postgresql/data"
 
   core:
+    platform: linux/amd64
     image: ${CORE_IMAGE:-stellar/stellar-core:18}
     depends_on:
       - core-postgres

--- a/services/horizon/docker/docker-compose.yml
+++ b/services/horizon/docker/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - "horizon-db-data:/var/lib/postgresql/data"
 
   horizon:
+    platform: linux/amd64
     depends_on:
       - horizon-postgres
     build:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Set `platform: linux/amd64` for docker commands.

### Why

Core isn't currently compiled for arm, so the integration tests etc wouldn't work on new ARM macs. Previously there were bugs in docker/hypervisor which would crash core when running with the `platform: linux/amd64` flag set. But those seem fixed, as it works with the newest version of docker.
