### PR TITLE
internal/integrations: db_test should drop test db instances when finished

### DIFF
--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -374,17 +374,14 @@ var dbFillGapsCmd = &cobra.Command{
 }
 
 func runDBReingestRange(ledgerRanges []history.LedgerRange, reingestForce bool, parallelWorkers uint, config horizon.Config) error {
+	var err error
+
 	if reingestForce && parallelWorkers > 1 {
 		return errors.New("--force is incompatible with --parallel-workers > 1")
-	}
-	horizonSession, err := db.Open("postgres", config.DatabaseURL)
-	if err != nil {
-		return fmt.Errorf("cannot open Horizon DB: %v", err)
 	}
 
 	ingestConfig := ingest.Config{
 		NetworkPassphrase:           config.NetworkPassphrase,
-		HistorySession:              horizonSession,
 		HistoryArchiveURL:           config.HistoryArchiveURLs[0],
 		CheckpointFrequency:         config.CheckpointFrequency,
 		MaxReingestRetries:          int(retries),
@@ -398,15 +395,18 @@ func runDBReingestRange(ledgerRanges []history.LedgerRange, reingestForce bool, 
 		StellarCoreURL:              config.StellarCoreURL,
 	}
 
-	if !ingestConfig.EnableCaptiveCore {
+	if ingestConfig.HistorySession, err = db.Open("postgres", config.DatabaseURL); err != nil {
+		return fmt.Errorf("cannot open Horizon DB: %v", err)
+	}
+
+	if !config.EnableCaptiveCoreIngestion {
 		if config.StellarCoreDatabaseURL == "" {
 			return fmt.Errorf("flag --%s cannot be empty", horizon.StellarCoreDBURLFlagName)
 		}
-		coreSession, dbErr := db.Open("postgres", config.StellarCoreDatabaseURL)
-		if dbErr != nil {
-			return fmt.Errorf("cannot open Core DB: %v", dbErr)
+		if ingestConfig.CoreSession, err = db.Open("postgres", config.StellarCoreDatabaseURL); err != nil {
+			ingestConfig.HistorySession.Close()
+			return fmt.Errorf("cannot open Core DB: %v", err)
 		}
-		ingestConfig.CoreSession = coreSession
 	}
 
 	if parallelWorkers > 1 {
@@ -425,6 +425,7 @@ func runDBReingestRange(ledgerRanges []history.LedgerRange, reingestForce bool, 
 	if systemErr != nil {
 		return systemErr
 	}
+	defer system.Shutdown()
 
 	err = system.ReingestRange(ledgerRanges, reingestForce)
 	if err != nil {
@@ -477,6 +478,7 @@ func runDBDetectGaps(config horizon.Config) ([]history.LedgerRange, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer horizonSession.Close()
 	q := &history.Q{horizonSession}
 	return q.GetLedgerGaps(context.Background())
 }
@@ -486,6 +488,7 @@ func runDBDetectGapsInRange(config horizon.Config, start, end uint32) ([]history
 	if err != nil {
 		return nil, err
 	}
+	defer horizonSession.Close()
 	q := &history.Q{horizonSession}
 	return q.GetLedgerGapsInRange(context.Background(), start, end)
 }

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -265,6 +265,7 @@ type IngestionQ interface {
 	BeginTx(*sql.TxOptions) error
 	Commit() error
 	CloneIngestionQ() IngestionQ
+	Close() error
 	Rollback() error
 	GetTx() *sqlx.Tx
 	GetIngestVersion(context.Context) (int, error)

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -693,6 +693,7 @@ func (s *system) Shutdown() {
 	s.cancel()
 	// wait for ingestion state machine to terminate
 	s.wg.Wait()
+	s.historyQ.Close()
 	if err := s.ledgerBackend.Close(); err != nil {
 		log.WithError(err).Info("could not close ledger backend")
 	}

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -265,6 +265,11 @@ func (m *mockDBQ) Commit() error {
 	return args.Error(0)
 }
 
+func (m *mockDBQ) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func (m *mockDBQ) Rollback() error {
 	args := m.Called()
 	return args.Error(0)

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -262,10 +262,8 @@ func (i *Test) StartHorizon() error {
 	if horizonPostgresURL == "" {
 		postgres := dbtest.Postgres(i.t)
 		i.shutdownCalls = append(i.shutdownCalls, func() {
-			// FIXME: Unfortunately, Horizon leaves open sessions behind,
-			//        leading to a "database is being accessed by other users"
-			//        error when trying to drop it.
-			// postgres.Close()
+			i.StopHorizon()
+			postgres.Close()
 		})
 		horizonPostgresURL = postgres.DSN
 	}
@@ -471,6 +469,11 @@ func (i *Test) Horizon() *horizon.App {
 
 // StopHorizon shuts down the running Horizon process
 func (i *Test) StopHorizon() {
+	if i.app == nil {
+		// horizon has already been stopped
+		return
+	}
+
 	i.app.CloseDB()
 	i.app.Close()
 

--- a/support/db/dbtest/db.go
+++ b/support/db/dbtest/db.go
@@ -132,6 +132,9 @@ func Postgres(t testing.TB) *DB {
 	result.DSN = fmt.Sprintf("postgres://%s@localhost/%s?sslmode=disable&timezone=UTC", pgUser, result.dbName)
 
 	result.closer = func() {
+		// pg_terminate_backend is a best effort, it does not gaurantee that it can close any lingering connections
+		// it sends a quit signal to each remaining connection in the db
+		execStatement(t, pgUser, "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '"+pq.QuoteIdentifier(result.dbName)+"';")
 		execStatement(t, pgUser, "DROP DATABASE "+pq.QuoteIdentifier(result.dbName))
 	}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
After integration test was ran, the postgres DB instances it created were not getting dropped/deleted at end of test run.


### Why

It's best to clean up test db instances, especially for local development, as the db server can start to have hundreds of abandoned test db instances that are left over.

Closes: #3268 

### Known limitations

This effort focused on getting the test db instances purged after integrations/test_db.go, other integration tests and unit tests that create test db instances are still leaving instances behind after runtime, likely requires revisiting each tests and look for similar db conn patterns, as those tend to block being able to drop the db at end of test.
