### PR TITLE
txnbuild: add MarshalBinary to GenericTransaction

### DIFF
--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -663,6 +663,18 @@ func (t GenericTransaction) HashHex(network string) (string, error) {
 	return "", fmt.Errorf("unable to get hash of empty GenericTransaction")
 }
 
+// MarshalBinary returns the binary XDR representation of the transaction
+// envelope.
+func (t *GenericTransaction) MarshalBinary() ([]byte, error) {
+	if tx, ok := t.Transaction(); ok {
+		return tx.MarshalBinary()
+	}
+	if fbtx, ok := t.FeeBump(); ok {
+		return fbtx.MarshalBinary()
+	}
+	return nil, errors.New("unable to marshal empty GenericTransaction")
+}
+
 // MarshalText returns the base64 XDR representation of the transaction
 // envelope.
 func (t *GenericTransaction) MarshalText() ([]byte, error) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add MarshalBinary to GenericTransaction.

### Why

GenericTransaction can be marshaled to text in base64, but not to binary. Transaction and FeeBumpTransaction can be marshaled to binary and there's no reason I can see to disallow same on GenericTransaction. For users who need to marshal a GenericTransaction to binary this is more convenient without having to unwrap the transaction manually.

### Known limitations

N/A