### PR TITLE
txnbuild: add NewGenericTransaction* functions

### DIFF
--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -612,6 +612,18 @@ type GenericTransaction struct {
 	feeBump *FeeBumpTransaction
 }
 
+// NewGenericTransactionWithTransaction creates a GenericTransaction containing
+// a Transaction.
+func NewGenericTransactionWithTransaction(tx *Transaction) *GenericTransaction {
+	return &GenericTransaction{simple: tx}
+}
+
+// NewGenericTransactionWithFeeBumpTransaction creates a GenericTransaction
+// containing a FeeBumpTransaction.
+func NewGenericTransactionWithFeeBumpTransaction(feeBumpTx *FeeBumpTransaction) *GenericTransaction {
+	return &GenericTransaction{feeBump: feeBumpTx}
+}
+
 // Transaction unpacks the GenericTransaction instance into a Transaction.
 // The function also returns a boolean which is true if the GenericTransaction can be
 // unpacked into a Transaction.


### PR DESCRIPTION
### What
Add NewGenericTransaction* functions for creating a GenericTransaction with either a Transaction of a FeeBumpTransaction.

### Why
GenericTransaction was created as a temporary type that houses a Transaction or FeeBumpTransaction after being parsed, and so the SDK exposes no way to build a GenericTransaction with the other types. 

When an application starts using GenericTransaction it inevitably ends up needing to build them which is what I've run into.