### PR TITLE
friendbot: create new problem on each handler call

### DIFF
--- a/services/friendbot/internal/friendbot_handler.go
+++ b/services/friendbot/internal/friendbot_handler.go
@@ -17,13 +17,15 @@ type FriendbotHandler struct {
 
 // Handle is a method that implements http.HandlerFunc
 func (handler *FriendbotHandler) Handle(w http.ResponseWriter, r *http.Request) {
+	// Register account doesn't exist error.
 	accountExistsProblem := problem.BadRequest
 	accountExistsProblem.Detail = ErrAccountExists.Error()
-	problem.RegisterError(ErrAccountExists, accountExistsProblem)
+	ps := problem.New(problem.DefaultServiceHost, problem.DefaultLogger, problem.LogAllErrors)
+	ps.RegisterError(ErrAccountExists, accountExistsProblem)
 
 	result, err := handler.doHandle(r)
 	if err != nil {
-		problem.Render(r.Context(), w, err)
+		ps.Render(r.Context(), w, err)
 		return
 	}
 

--- a/services/friendbot/internal/friendbot_handler.go
+++ b/services/friendbot/internal/friendbot_handler.go
@@ -17,15 +17,9 @@ type FriendbotHandler struct {
 
 // Handle is a method that implements http.HandlerFunc
 func (handler *FriendbotHandler) Handle(w http.ResponseWriter, r *http.Request) {
-	// Register account doesn't exist error.
-	accountExistsProblem := problem.BadRequest
-	accountExistsProblem.Detail = ErrAccountExists.Error()
-	ps := problem.New(problem.DefaultServiceHost, problem.DefaultLogger, problem.LogAllErrors)
-	ps.RegisterError(ErrAccountExists, accountExistsProblem)
-
 	result, err := handler.doHandle(r)
 	if err != nil {
-		ps.Render(r.Context(), w, err)
+		problem.Render(r.Context(), w, err)
 		return
 	}
 

--- a/services/friendbot/main.go
+++ b/services/friendbot/main.go
@@ -99,4 +99,8 @@ func initRouter(fb *internal.Bot) *chi.Mux {
 
 func registerProblems() {
 	problem.RegisterError(sql.ErrNoRows, problem.NotFound)
+
+	accountExistsProblem := problem.BadRequest
+	accountExistsProblem.Detail = internal.ErrAccountExists.Error()
+	problem.RegisterError(internal.ErrAccountExists, accountExistsProblem)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ]x This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

fixes friendbot handler to register the account exists error on app start

### Why

Right now each request is registering the same error, which created an error when two requests try to access at the exact same time. See `fatal error: concurrent map writes` error at bottom of [kibana logs](https://kibana.stellar-ops.com/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:'2022-01-23T13:25:27.059Z',mode:absolute,to:'2022-01-23T13:25:41.722Z'))&_a=(columns:!(message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:application,negate:!f,params:(query:kube,type:phrase),type:phrase,value:kube),query:(match:(application:(query:kube,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:k8s_cluster,negate:!f,params:(query:kube001-prd,type:phrase),type:phrase,value:kube001-prd),query:(match:(k8s_cluster:(query:kube001-prd,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.namespace,negate:!f,params:(query:friendbot-prd,type:phrase),type:phrase,value:friendbot-prd),query:(match:(kubernetes.namespace:(query:friendbot-prd,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.deployment.name,negate:!f,params:(query:friendbot,type:phrase),type:phrase,value:friendbot),query:(match:(kubernetes.deployment.name:(query:friendbot,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.pod.name,negate:!f,params:(query:friendbot-6d669566f6-c644h,type:phrase),type:phrase,value:friendbot-6d669566f6-c644h),query:(match:(kubernetes.pod.name:(query:friendbot-6d669566f6-c644h,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'NOT%20%22finished%20request%22%20AND%20NOT%20%22starting%20request%22%20AND%20NOT%20%22Selecting%20minion%22'),sort:!('@timestamp',desc)))

This now registers once to avoid that problem.

### Known limitations

n/a
