### PR TITLE
ingest/ledgerbackend: Check if there are newer ledger when requested ledger does not exist

### DIFF
--- a/ingest/ledgerbackend/database_backend.go
+++ b/ingest/ledgerbackend/database_backend.go
@@ -132,22 +132,22 @@ func (dbb *DatabaseBackend) GetLedger(ctx context.Context, sequence uint32) (xdr
 			// Check if there are ledgers after `sequence`. If so, it's likely
 			// the requested sequence was removed during maintenance so return
 			// error.
-			ledgerAfterExist, err := dbb.getLedgerAfterExist(ctx, sequence)
+			ledgerAfterExist, oldestSequenceAfter, err := dbb.getLedgerAfterExist(ctx, sequence)
 			if err != nil {
 				return xdr.LedgerCloseMeta{}, err
 			}
 
 			if ledgerAfterExist {
-				return xdr.LedgerCloseMeta{}, errors.Errorf("ledgers after %d exist, requested ledger already removed", sequence)
+				return xdr.LedgerCloseMeta{}, errors.Errorf("requested ledger already removed (oldest sequence after %d is %d)", sequence, oldestSequenceAfter)
 			}
 			time.Sleep(time.Second)
 		}
 	}
 }
 
-// getLedgerAfterExist returns true if there's a ledger in the Stellar-Core DB
-// with the sequence number higher than sequence.
-func (dbb *DatabaseBackend) getLedgerAfterExist(ctx context.Context, sequence uint32) (bool, error) {
+// getLedgerAfterExist returns true (and sequence number) if there's a ledger in
+// the Stellar-Core DB with the sequence number higher than sequence.
+func (dbb *DatabaseBackend) getLedgerAfterExist(ctx context.Context, sequence uint32) (bool, uint32, error) {
 	var fetchedSequence uint32
 	err := dbb.session.GetRaw(ctx, &fetchedSequence, ledgerSequenceAfterQuery, sequence)
 	// Return errors...
@@ -155,13 +155,13 @@ func (dbb *DatabaseBackend) getLedgerAfterExist(ctx context.Context, sequence ui
 		switch err {
 		case sql.ErrNoRows:
 			// Ledger was not found
-			return false, nil
+			return false, fetchedSequence, nil
 		default:
-			return false, errors.Wrapf(err, "Error getting ledger after %d", sequence)
+			return false, fetchedSequence, errors.Wrapf(err, "Error getting ledger after %d", sequence)
 		}
 	}
 
-	return true, nil
+	return true, fetchedSequence, nil
 }
 
 // getLedgerQuery returns the LedgerCloseMeta for the given ledger sequence number.

--- a/ingest/ledgerbackend/database_backend.go
+++ b/ingest/ledgerbackend/database_backend.go
@@ -13,13 +13,14 @@ import (
 )
 
 const (
-	latestLedgerSeqQuery = "select ledgerseq, closetime from ledgerheaders order by ledgerseq desc limit 1"
-	txHistoryQuery       = "select txbody, txresult, txmeta, txindex from txhistory where ledgerseq = ? "
-	ledgerHeaderQuery    = "select ledgerhash, data from ledgerheaders where ledgerseq = ? "
-	txFeeHistoryQuery    = "select txchanges, txindex from txfeehistory where ledgerseq = ? "
-	upgradeHistoryQuery  = "select ledgerseq, upgradeindex, upgrade, changes from upgradehistory where ledgerseq = ? order by upgradeindex asc"
-	orderBy              = "order by txindex asc"
-	dbDriver             = "postgres"
+	latestLedgerSeqQuery     = "select ledgerseq, closetime from ledgerheaders order by ledgerseq desc limit 1"
+	txHistoryQuery           = "select txbody, txresult, txmeta, txindex from txhistory where ledgerseq = ? "
+	ledgerHeaderQuery        = "select ledgerhash, data from ledgerheaders where ledgerseq = ? "
+	ledgerSequenceAfterQuery = "select ledgerseq from ledgerheaders where ledgerseq > ? "
+	txFeeHistoryQuery        = "select txchanges, txindex from txfeehistory where ledgerseq = ? "
+	upgradeHistoryQuery      = "select ledgerseq, upgradeindex, upgrade, changes from upgradehistory where ledgerseq = ? order by upgradeindex asc"
+	orderBy                  = "order by txindex asc"
+	dbDriver                 = "postgres"
 )
 
 // Ensure DatabaseBackend implements LedgerBackend
@@ -128,9 +129,39 @@ func (dbb *DatabaseBackend) GetLedger(ctx context.Context, sequence uint32) (xdr
 		if exists {
 			return meta, nil
 		} else {
+			// Check if there are ledgers after `sequence`. If so, it's likely
+			// the requested sequence was removed during maintenance so return
+			// error.
+			ledgerAfterExist, err := dbb.getLedgerAfterExist(ctx, sequence)
+			if err != nil {
+				return xdr.LedgerCloseMeta{}, err
+			}
+
+			if ledgerAfterExist {
+				return xdr.LedgerCloseMeta{}, errors.Errorf("ledgers after %d exist, requested ledger already removed", sequence)
+			}
 			time.Sleep(time.Second)
 		}
 	}
+}
+
+// getLedgerAfterExist returns true if there's a ledger in the Stellar-Core DB
+// with the sequence number higher than sequence.
+func (dbb *DatabaseBackend) getLedgerAfterExist(ctx context.Context, sequence uint32) (bool, error) {
+	var fetchedSequence uint32
+	err := dbb.session.GetRaw(ctx, &fetchedSequence, ledgerSequenceAfterQuery, sequence)
+	// Return errors...
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			// Ledger was not found
+			return false, nil
+		default:
+			return false, errors.Wrapf(err, "Error getting ledger after %d", sequence)
+		}
+	}
+
+	return true, nil
 }
 
 // getLedgerQuery returns the LedgerCloseMeta for the given ledger sequence number.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

In `DatabaseBackend.GetLedger(ctx, sequence)` check if there are newer ledgers than `sequence` if ledger not found. If there are newer ledgers return an error.

### Why

If Stellar-Core cursors were manually removed or updated, it's possible it run a maintenance removing older ledgers. In such situation `DatabaseBackend.GetLedger` would loop indefinitely waiting for a ledger to appear in the DB but it never will.

### Known limitations

No tests because there is no test suite for `DatabaseBackend`.