### PR TITLE
#4038: trying to fix issue with captive core integration tests hanging

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -138,8 +138,6 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	if parentCtx == nil {
 		parentCtx = context.Background()
 	}
-	var cancel context.CancelFunc
-	config.Context, cancel = context.WithCancel(parentCtx)
 
 	archivePool, err := historyarchive.NewArchivePool(
 		config.HistoryArchiveURLs,
@@ -151,17 +149,18 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	)
 
 	if err != nil {
+		_, cancel := context.WithCancel(parentCtx)
 		cancel()
 		return nil, errors.Wrap(err, "Error connecting to ALL history archives.")
 	}
 
 	c := &CaptiveStellarCore{
 		archive:           &archivePool,
-		cancel:            cancel,
 		checkpointManager: historyarchive.NewCheckpointManager(config.CheckpointFrequency),
 	}
 
 	c.stellarCoreRunnerFactory = func(mode stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
+		config.Context, c.cancel = context.WithCancel(parentCtx)
 		return newStellarCoreRunner(config, mode)
 	}
 	return c, nil
@@ -245,11 +244,8 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(ctx context.Context, fro
 	var runner stellarCoreRunnerInterface
 	if runner, err = c.stellarCoreRunnerFactory(stellarCoreRunnerModeOnline); err != nil {
 		return errors.Wrap(err, "error creating stellar-core runner")
-	} else {
-		// only assign c.stellarCoreRunner if runner is not nil to avoid nil interface check
-		// see https://golang.org/doc/faq#nil_error
-		c.stellarCoreRunner = runner
 	}
+	c.stellarCoreRunner = runner
 
 	runFrom, err := c.runFromParams(ctx, from)
 	if err != nil {
@@ -381,9 +377,12 @@ func (c *CaptiveStellarCore) isPrepared(ledgerRange Range) bool {
 	if c.stellarCoreRunner == nil {
 		return false
 	}
-	if c.closed {
+
+	exited, _ := c.stellarCoreRunner.getProcessExitError()
+	if exited {
 		return false
 	}
+
 	lastLedger := uint32(0)
 	if c.lastLedger != nil {
 		lastLedger = *c.lastLedger

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -139,6 +139,9 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 		parentCtx = context.Background()
 	}
 
+	var cancel context.CancelFunc
+	config.Context, cancel = context.WithCancel(parentCtx)
+
 	archivePool, err := historyarchive.NewArchivePool(
 		config.HistoryArchiveURLs,
 		historyarchive.ConnectOptions{
@@ -149,18 +152,17 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 	)
 
 	if err != nil {
-		_, cancel := context.WithCancel(parentCtx)
 		cancel()
 		return nil, errors.Wrap(err, "Error connecting to ALL history archives.")
 	}
 
 	c := &CaptiveStellarCore{
 		archive:           &archivePool,
+		cancel:            cancel,
 		checkpointManager: historyarchive.NewCheckpointManager(config.CheckpointFrequency),
 	}
 
 	c.stellarCoreRunnerFactory = func(mode stellarCoreRunnerMode) (stellarCoreRunnerInterface, error) {
-		config.Context, c.cancel = context.WithCancel(parentCtx)
 		return newStellarCoreRunner(config, mode)
 	}
 	return c, nil

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -358,8 +358,17 @@ func (i *Test) StartHorizon() error {
 		HorizonURL: fmt.Sprintf("http://%s:%s", hostname, horizonPort),
 	}
 
-	if err = i.app.Ingestion().BuildGenesisState(); err != nil {
-		return errors.Wrap(err, "cannot build genesis state")
+	if !RunWithCaptiveCore {
+		// captive core backend ledger is executed with sqlite on db, not memory, which results in
+		// different meta stream from 'steallar-core run' , it does not replay meta close stream from genesis during 'run' after 'new-db'
+		// rather at start of 'run' core will fast forward internally the ClosedMeta stream to start emitting ledgers from
+		// its current LCL(last committed ledger, not necessarily the latest from network side).
+		// Consequently, Don't want tests that are running captive core to initially set horizon ingest state to genesis here,
+		// the fsm would then get stuck in state loop since core is only emitting meta close ledger seqs that are > than genesis
+		// sequence of '2' which horizon's fsm keeps requesting as next ledger.
+		if err = i.app.Ingestion().BuildGenesisState(); err != nil {
+			return errors.Wrap(err, "cannot build genesis state")
+		}
 	}
 
 	done := make(chan struct{})


### PR DESCRIPTION
I noticed two things on captive core ingestion, `stellar-core new-db; stellar-core run` does not output meta replayed from genesis, rather it fast-forwards internally to whatever it has for current LCL, and starts emitting meta at that point, but some tests were defaulting horizon into ledger=2 genesis state, and the captive core runner tended to get stuck on that since it was expecting ledger 2 and getting greater than that from meta stream, then got stuck in a state retry loop with a cancelled ctx due to the first missed ledger retrieval and so subsequent new states that tried to get ledgers just kept failing early with ctx cancelled.