### PR TITLE
services/horizon: Attempt state verification when bumping ledger sequence

### DIFF
--- a/services/horizon/internal/ingest/fsm.go
+++ b/services/horizon/internal/ingest/fsm.go
@@ -424,6 +424,8 @@ func (r resumeState) run(s *system) (transition, error) {
 			log.WithError(err).Warn("error updating stellar-core cursor")
 		}
 
+		s.maybeVerifyState(ingestLedger)
+
 		// resume immediately so Captive-Core catchup is not slowed down
 		return resumeImmediately(lastIngestedLedger), nil
 	}

--- a/services/horizon/internal/ingest/resume_state_test.go
+++ b/services/horizon/internal/ingest/resume_state_test.go
@@ -311,6 +311,9 @@ func (s *ResumeTestTestSuite) TestBumpIngestLedger() {
 		int32(101),
 	).Return(errors.New("my error")).Once()
 
+	// Skips state verification but ensures maybeVerifyState called
+	s.historyQ.On("GetExpStateInvalid", s.ctx).Return(true, nil).Once()
+
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 99}.run(s.system)
 	s.Assert().NoError(err)
 	s.Assert().Equal(


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Try to verify state even when not ingesting current ledger.

### Why

In distributed ingestion, it's possible that a single node will keep ingesting for a longer period of time. If state verification is stuck for whatever reason on the ingesting instance the entire cluster will stop verifying state.

### Known limitations

[TODO or N/A]
