### PR TITLE
#4038: fixed integration test to not use GenesisState

### DIFF
--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -314,12 +314,13 @@ func (r *stellarCoreRunner) runFrom(from uint32) error {
 	// Do a quick catch-up to set the LCL in core to be our expected starting
 	// point.
 	//
-	// TODO: If we're re-using the directory from a previous run, we need to do
-	// this differently, because the LCL in core might already be ahead of our
-	// `from` point.
 	if from > 2 {
 		// Can't catch up to the genesis ledger.
 		if err := r.createCmd("catchup", fmt.Sprintf("%d/0", from-1)).Run(); err != nil {
+			return errors.Wrap(err, "error runing stellar-core catchup")
+		}
+	} else {
+		if err := r.createCmd("catchup", "2/0").Run(); err != nil {
 			return errors.Wrap(err, "error runing stellar-core catchup")
 		}
 	}

--- a/ingest/ledgerbackend/toml.go
+++ b/ingest/ledgerbackend/toml.go
@@ -407,7 +407,6 @@ func (c *CaptiveCoreToml) CatchupToml() (*CaptiveCoreToml, error) {
 }
 
 func (c *CaptiveCoreToml) setDefaults(params CaptiveCoreTomlParams) {
-	// TODO: Do we need to skip this if we are in --in-memory mode?
 	if !c.tree.Has("DATABASE") {
 		c.Database = defaultDatabase
 	}
@@ -447,8 +446,6 @@ func (c *CaptiveCoreToml) setDefaults(params CaptiveCoreTomlParams) {
 }
 
 func (c *CaptiveCoreToml) validate(params CaptiveCoreTomlParams) error {
-	// TODO: Any way to validate database here?
-
 	if def := c.tree.Has("NETWORK_PASSPHRASE"); def && c.NetworkPassphrase != params.NetworkPassphrase {
 		return fmt.Errorf(
 			"NETWORK_PASSPHRASE in captive core config file: %s does not match Horizon network-passphrase flag: %s",

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -195,11 +195,6 @@ func (a *App) HistoryQ() *history.Q {
 	return a.historyQ
 }
 
-// Ingestion returns the ingestion system associated with this Horizon instance
-func (a *App) Ingestion() ingest.System {
-	return a.ingester
-}
-
 // HorizonSession returns a new session that loads data from the horizon
 // database.
 func (a *App) HorizonSession() db.SessionInterface {

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -358,19 +358,6 @@ func (i *Test) StartHorizon() error {
 		HorizonURL: fmt.Sprintf("http://%s:%s", hostname, horizonPort),
 	}
 
-	if !RunWithCaptiveCore {
-		// captive core backend ledger is executed with sqlite on db, not memory, which results in
-		// different meta stream from 'steallar-core run' , it does not replay meta close stream from genesis during 'run' after 'new-db'
-		// rather at start of 'run' core will fast forward internally the ClosedMeta stream to start emitting ledgers from
-		// its current LCL(last committed ledger, not necessarily the latest from network side).
-		// Consequently, Don't want tests that are running captive core to initially set horizon ingest state to genesis here,
-		// the fsm would then get stuck in state loop since core is only emitting meta close ledger seqs that are > than genesis
-		// sequence of '2' which horizon's fsm keeps requesting as next ledger.
-		if err = i.app.Ingestion().BuildGenesisState(); err != nil {
-			return errors.Wrap(err, "cannot build genesis state")
-		}
-	}
-
 	done := make(chan struct{})
 	go func() {
 		i.app.Serve()


### PR DESCRIPTION
cleaned up the integration test in terms of captive core, removed seeing with BuildGenesisState, it doesn't represent real life Horizon startup/installation scenarios and caused an issue with captive core meta replay not lining up.