### PR TITLE
Add ledgerexporter service which stores txmeta in GCS

### DIFF
--- a/exp/services/ledgerexporter/main.go
+++ b/exp/services/ledgerexporter/main.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"github.com/stellar/go/xdr"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"cloud.google.com/go/storage"
+
+	"github.com/stellar/go/ingest/ledgerbackend"
+	supportlog "github.com/stellar/go/support/log"
+)
+
+const (
+	bucket = "horizon-archive-poc"
+)
+var logger = supportlog.New()
+
+func main() {
+	logger.SetLevel(supportlog.InfoLevel)
+	binaryPath := os.Getenv("STELLAR_CORE_BINARY_PATH")
+
+	params := ledgerbackend.CaptiveCoreTomlParams{
+		NetworkPassphrase:  "Test SDF Network ; September 2015",
+		HistoryArchiveURLs: []string{"https://history.stellar.org/prd/core-testnet/core_testnet_001"},
+	}
+	captiveCoreToml, err := ledgerbackend.NewCaptiveCoreTomlFromFile(os.Getenv("CAPTIVE_CORE_TOML_PATH"),params)
+	if err != nil {
+		logger.WithError(err).Fatal("Invalid captive core toml")
+	}
+
+	captiveConfig := ledgerbackend.CaptiveCoreConfig{
+		BinaryPath:          binaryPath,
+		NetworkPassphrase:   params.NetworkPassphrase,
+		HistoryArchiveURLs:  params.HistoryArchiveURLs,
+		CheckpointFrequency: 64,
+		Log:                 logger.WithField("subservice", "stellar-core"),
+		Toml:                captiveCoreToml,
+	}
+	core, err := ledgerbackend.NewCaptive(captiveConfig)
+	if err != nil {
+		logger.WithError(err).Fatal("Could not create captive core instance")
+	}
+
+	client, err := storage.NewClient(context.Background())
+	if err != nil {
+		logger.WithError(err).Fatal("Could not create GCS client")
+	}
+	defer client.Close()
+
+	var latestLedger uint32
+	gcsBucket := client.Bucket(bucket)
+	latestLedger = readLatestLedger(gcsBucket)
+
+	nextLedger := latestLedger + 1
+	if err := core.PrepareRange(context.Background(), ledgerbackend.UnboundedRange(latestLedger)); err != nil {
+		logger.WithError(err).Fatalf("could not prepare unbounded range %v", nextLedger)
+	}
+
+	for {
+		leddger, err := core.GetLedger(context.Background(), nextLedger)
+		if err != nil {
+			logger.WithError(err).Warnf("could not fetch ledger %v, will retry", nextLedger)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		if err = writeLedger(gcsBucket, leddger); err != nil {
+			continue
+		}
+
+		if err = writeLatestLedger(gcsBucket, nextLedger); err != nil {
+			logger.WithError(err).Warnf("could not write latest ledger %v", nextLedger)
+		}
+
+		nextLedger++
+	}
+
+}
+
+func readLatestLedger(gcsBucket *storage.BucketHandle) uint32 {
+	r, err := gcsBucket.Object("latest").NewReader(context.Background())
+	if err == storage.ErrObjectNotExist {
+		return 2
+	} else if err != nil {
+		logger.WithError(err).Fatal("could not open latest ledger bucket")
+	} else {
+		defer r.Close()
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, r); err != nil {
+			logger.WithError(err).Fatal("could not read latest ledger")
+		}
+		if parsed, err := strconv.ParseUint(buf.String(), 10, 32); err != nil {
+			logger.WithError(err).Fatalf("could not parse latest ledger: %s", buf.String())
+		} else {
+			return uint32(parsed)
+		}
+	}
+	return 0
+}
+
+func writeLedger(gcsBucket *storage.BucketHandle, leddger xdr.LedgerCloseMeta) error {
+	writer := gcsBucket.Object("ledgers/" + strconv.FormatUint(uint64(leddger.LedgerSequence()), 10)).NewWriter(context.Background())
+	blob, err := leddger.MarshalBinary()
+	if err != nil {
+		logger.WithError(err).Fatalf("could not serialize ledger %v", uint64(leddger.LedgerSequence()))
+	}
+	if _, err = io.Copy(writer, bytes.NewReader(blob)); err != nil {
+		logger.WithError(err).Warnf("could not write ledger object %v, will retry", uint64(leddger.LedgerSequence()))
+		return err
+	}
+	if err = writer.Close(); err != nil {
+		logger.WithError(err).Warnf("could not close ledger object %v, will retry", uint64(leddger.LedgerSequence()))
+		return err
+	}
+	return nil
+}
+
+func writeLatestLedger(gcsBucket *storage.BucketHandle, ledger uint32) error {
+	w := gcsBucket.Object("latest").NewWriter(context.Background())
+	if _, err := io.Copy(w, bytes.NewBufferString(strconv.FormatUint(uint64(ledger), 10))); err != nil {
+		return nil
+	}
+	return w.Close()
+}

--- a/exp/services/ledgerexporter/main.go
+++ b/exp/services/ledgerexporter/main.go
@@ -3,40 +3,48 @@ package main
 import (
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
-	"github.com/stellar/go/xdr"
 	"io"
+	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/stellar/go/xdr"
+
+	"github.com/stellar/go/historyarchive"
+	"github.com/stellar/go/xdr"
 
 	"github.com/stellar/go/ingest/ledgerbackend"
 	supportlog "github.com/stellar/go/support/log"
 )
 
-const (
-	bucket = "horizon-archive-poc"
-)
 var logger = supportlog.New()
 
 func main() {
+	targetUrl := flag.String("target", "gcs://horizon-archive-poc", "history archive url to write txmeta files")
+	stellarCoreBinaryPath := flag.String("stellar-core-binary-path", os.Getenv("STELLAR_CORE_BINARY_PATH"), "path to the stellar core binary")
+	networkPassphrase := flag.String("network-passphrase", "Test SDF Network ; September 2015", "network passphrase")
+	historyArchiveUrls := flag.String("history-archive-urls", "https://history.stellar.org/prd/core-testnet/core_testnet_001", "comma-separated list of history archive urls to read from")
+	flag.Parse()
+
 	logger.SetLevel(supportlog.InfoLevel)
-	binaryPath := os.Getenv("STELLAR_CORE_BINARY_PATH")
 
 	params := ledgerbackend.CaptiveCoreTomlParams{
-		NetworkPassphrase:  "Test SDF Network ; September 2015",
-		HistoryArchiveURLs: []string{"https://history.stellar.org/prd/core-testnet/core_testnet_001"},
+		NetworkPassphrase:  *networkPassphrase,
+		HistoryArchiveURLs: strings.Split(*historyArchiveUrls, ","),
 	}
-	captiveCoreToml, err := ledgerbackend.NewCaptiveCoreTomlFromFile(os.Getenv("CAPTIVE_CORE_TOML_PATH"),params)
+	captiveCoreToml, err := ledgerbackend.NewCaptiveCoreTomlFromFile(os.Getenv("CAPTIVE_CORE_TOML_PATH"), params)
 	if err != nil {
 		logger.WithError(err).Fatal("Invalid captive core toml")
 	}
 
 	captiveConfig := ledgerbackend.CaptiveCoreConfig{
-		BinaryPath:          binaryPath,
+		BinaryPath:          *stellarCoreBinaryPath,
 		NetworkPassphrase:   params.NetworkPassphrase,
 		HistoryArchiveURLs:  params.HistoryArchiveURLs,
 		CheckpointFrequency: 64,
@@ -48,15 +56,17 @@ func main() {
 		logger.WithError(err).Fatal("Could not create captive core instance")
 	}
 
-	client, err := storage.NewClient(context.Background())
-	if err != nil {
-		logger.WithError(err).Fatal("Could not create GCS client")
-	}
-	defer client.Close()
+	target, err := historyarchive.ConnectBackend(
+		*targetUrl,
+		historyarchive.ConnectOptions{
+			Context:           context.Background(),
+			NetworkPassphrase: params.NetworkPassphrase,
+		},
+	)
+	defer target.Close()
 
 	var latestLedger uint32
-	gcsBucket := client.Bucket(bucket)
-	latestLedger, err = readLatestLedger(gcsBucket)
+	latestLedger, err = readLatestLedger(target)
 	if err != nil {
 		logger.WithError(err).Fatal("could not read latest ledger")
 	}
@@ -83,11 +93,11 @@ func main() {
 			continue
 		}
 
-		if err = writeLedger(gcsBucket, leddger); err != nil {
+		if err = writeLedger(target, leddger); err != nil {
 			continue
 		}
 
-		if err = writeLatestLedger(gcsBucket, nextLedger); err != nil {
+		if err = writeLatestLedger(target, nextLedger); err != nil {
 			logger.WithError(err).Warnf("could not write latest ledger %v", nextLedger)
 		}
 
@@ -96,9 +106,9 @@ func main() {
 
 }
 
-func readLatestLedger(gcsBucket *storage.BucketHandle) (uint32, error) {
-	r, err := gcsBucket.Object("latest").NewReader(context.Background())
-	if err == storage.ErrObjectNotExist {
+func readLatestLedger(backend historyarchive.ArchiveBackend) (uint32, error) {
+	r, err := backend.GetFile("latest")
+	if err == os.ErrNotExist {
 		return 2, nil
 	} else if err != nil {
 		return 0, err
@@ -124,7 +134,7 @@ func timeToLedger(gcsBucket *storage.BucketHandle, timestamp time.Time) (uint32,
 	if latest < 3 {
 		return 0, fmt.Errorf("not enough ledgers")
 	}
-	upper := int(latest-2)
+	upper := int(latest - 2)
 	backend := ledgerbackend.GCSBackend{Bucket: gcsBucket}
 	var lcm xdr.LedgerCloseMeta
 	count := 0
@@ -160,30 +170,31 @@ func timeToLedger(gcsBucket *storage.BucketHandle, timestamp time.Time) (uint32,
 	}
 
 	fmt.Printf("number of get leger calls %v\n", count)
-	return uint32(result+3), err
+	return uint32(result + 3), err
 }
 
-func writeLedger(gcsBucket *storage.BucketHandle, leddger xdr.LedgerCloseMeta) error {
-	writer := gcsBucket.Object("ledgers/" + strconv.FormatUint(uint64(leddger.LedgerSequence()), 10)).NewWriter(context.Background())
+func writeLedger(backend historyarchive.ArchiveBackend, leddger xdr.LedgerCloseMeta) error {
 	blob, err := leddger.MarshalBinary()
 	if err != nil {
 		logger.WithError(err).Fatalf("could not serialize ledger %v", uint64(leddger.LedgerSequence()))
 	}
-	if _, err = io.Copy(writer, bytes.NewReader(blob)); err != nil {
+	err = backend.PutFile(
+		"ledgers/"+strconv.FormatUint(uint64(leddger.LedgerSequence()), 10),
+		ioutil.NopCloser(bytes.NewReader(blob)),
+	)
+	if err != nil {
 		logger.WithError(err).Warnf("could not write ledger object %v, will retry", uint64(leddger.LedgerSequence()))
-		return err
 	}
-	if err = writer.Close(); err != nil {
-		logger.WithError(err).Warnf("could not close ledger object %v, will retry", uint64(leddger.LedgerSequence()))
-		return err
-	}
-	return nil
+	return err
 }
 
-func writeLatestLedger(gcsBucket *storage.BucketHandle, ledger uint32) error {
-	w := gcsBucket.Object("latest").NewWriter(context.Background())
-	if _, err := io.Copy(w, bytes.NewBufferString(strconv.FormatUint(uint64(ledger), 10))); err != nil {
-		return nil
-	}
-	return w.Close()
+func writeLatestLedger(backend historyarchive.ArchiveBackend, ledger uint32) error {
+	return backend.PutFile(
+		"latest",
+		ioutil.NopCloser(
+			bytes.NewBufferString(
+				strconv.FormatUint(uint64(ledger), 10),
+			),
+		),
+	)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	cloud.google.com/go/firestore v1.5.0 // indirect
+	cloud.google.com/go/storage v1.10.0 // indirect
 	firebase.google.com/go v3.12.0+incompatible
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Masterminds/squirrel v1.5.0

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -64,6 +64,7 @@ type ArchiveBackend interface {
 	PutFile(path string, in io.ReadCloser) error
 	ListFiles(path string) (chan string, chan error)
 	CanListFiles() bool
+	Close() error
 }
 
 type ArchiveInterface interface {

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -45,6 +45,7 @@ type ConnectOptions struct {
 	S3Region          string
 	S3Endpoint        string
 	UnsignedRequests  bool
+	GCSEndpoint       string
 	// CheckpointFrequency is the number of ledgers between checkpoints
 	// if unset, DefaultCheckpointFrequency will be used
 	CheckpointFrequency uint32
@@ -407,20 +408,28 @@ func Connect(u string, opts ConnectOptions) (*Archive, error) {
 	}
 
 	pth := parsed.Path
-	if parsed.Scheme == "s3" {
+	switch parsed.Scheme {
+	case "s3":
 		// Inside s3, all paths start _without_ the leading /
-		if len(pth) > 0 && pth[0] == '/' {
-			pth = pth[1:]
-		}
+		pth = strings.TrimPrefix(pth, "/")
 		arch.backend, err = makeS3Backend(parsed.Host, pth, opts)
-	} else if parsed.Scheme == "file" {
+
+	case "gcs":
+		// Inside gcs, all paths start _without_ the leading /
+		pth = strings.TrimPrefix(pth, "/")
+		arch.backend, err = makeGCSBackend(parsed.Host, pth, opts)
+
+	case "file":
 		pth = path.Join(parsed.Host, pth)
 		arch.backend = makeFsBackend(pth, opts)
-	} else if parsed.Scheme == "http" || parsed.Scheme == "https" {
+
+	case "http", "https":
 		arch.backend = makeHttpBackend(parsed, opts)
-	} else if parsed.Scheme == "mock" {
+
+	case "mock":
 		arch.backend = makeMockBackend(opts)
-	} else {
+
+	default:
 		err = errors.New("unknown URL scheme: '" + parsed.Scheme + "'")
 	}
 	return &arch, err

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -395,13 +395,23 @@ func Connect(u string, opts ConnectOptions) (*Archive, error) {
 		arch.checkpointFiles[cat] = make(map[uint32]bool)
 	}
 
+	if opts.Context == nil {
+		opts.Context = context.Background()
+	}
+
+	var err error
+	arch.backend, err = ConnectBackend(u, opts)
+	return &arch, err
+}
+
+func ConnectBackend(u string, opts ConnectOptions) (ArchiveBackend, error) {
 	if u == "" {
-		return &arch, errors.New("URL is empty")
+		return nil, errors.New("URL is empty")
 	}
 
 	parsed, err := url.Parse(u)
 	if err != nil {
-		return &arch, err
+		return nil, err
 	}
 
 	if opts.Context == nil {
@@ -409,31 +419,32 @@ func Connect(u string, opts ConnectOptions) (*Archive, error) {
 	}
 
 	pth := parsed.Path
+	var backend ArchiveBackend
 	switch parsed.Scheme {
 	case "s3":
 		// Inside s3, all paths start _without_ the leading /
 		pth = strings.TrimPrefix(pth, "/")
-		arch.backend, err = makeS3Backend(parsed.Host, pth, opts)
+		backend, err = makeS3Backend(parsed.Host, pth, opts)
 
 	case "gcs":
 		// Inside gcs, all paths start _without_ the leading /
 		pth = strings.TrimPrefix(pth, "/")
-		arch.backend, err = makeGCSBackend(parsed.Host, pth, opts)
+		backend, err = makeGCSBackend(parsed.Host, pth, opts)
 
 	case "file":
 		pth = path.Join(parsed.Host, pth)
-		arch.backend = makeFsBackend(pth, opts)
+		backend = makeFsBackend(pth, opts)
 
 	case "http", "https":
-		arch.backend = makeHttpBackend(parsed, opts)
+		backend = makeHttpBackend(parsed, opts)
 
 	case "mock":
-		arch.backend = makeMockBackend(opts)
+		backend = makeMockBackend(opts)
 
 	default:
 		err = errors.New("unknown URL scheme: '" + parsed.Scheme + "'")
 	}
-	return &arch, err
+	return backend, err
 }
 
 func MustConnect(u string, opts ConnectOptions) *Archive {

--- a/historyarchive/fs_archive.go
+++ b/historyarchive/fs_archive.go
@@ -121,6 +121,10 @@ func (b *FsArchiveBackend) CanListFiles() bool {
 	return true
 }
 
+func (b *FsArchiveBackend) Close() error {
+	return nil
+}
+
 func makeFsBackend(pth string, opts ConnectOptions) ArchiveBackend {
 	return &FsArchiveBackend{
 		prefix: pth,

--- a/historyarchive/gcs_archive.go
+++ b/historyarchive/gcs_archive.go
@@ -1,0 +1,135 @@
+// Copyright 2016 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+package historyarchive
+
+import (
+	"context"
+	"io"
+	"os"
+	"path"
+
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+
+	"cloud.google.com/go/storage"
+)
+
+type GCSArchiveBackend struct {
+	ctx    context.Context
+	client *storage.Client
+	bucket *storage.BucketHandle
+	prefix string
+}
+
+func (b *GCSArchiveBackend) Exists(pth string) (bool, error) {
+	log.WithField("path", path.Join(b.prefix, pth)).Trace("gcs: check exists")
+	_, err := b.Size(pth)
+	return err == nil, err
+}
+
+func (b *GCSArchiveBackend) Size(pth string) (int64, error) {
+	pth = path.Join(b.prefix, pth)
+	log.WithField("path", pth).Trace("gcs: get size")
+	attrs, err := b.bucket.Object(pth).Attrs(context.Background())
+	if err == storage.ErrObjectNotExist {
+		err = os.ErrNotExist
+	}
+	if err != nil {
+		return 0, err
+	}
+	return attrs.Size, nil
+}
+
+func (b *GCSArchiveBackend) GetFile(pth string) (io.ReadCloser, error) {
+	pth = path.Join(b.prefix, pth)
+	log.WithField("path", pth).Trace("gcs: get file")
+	r, err := b.bucket.Object(pth).NewReader(context.Background())
+	if err == storage.ErrObjectNotExist {
+		// TODO: Check this is right
+		err = os.ErrNotExist
+	}
+	return r, nil
+}
+
+func (b *GCSArchiveBackend) PutFile(pth string, in io.ReadCloser) error {
+	pth = path.Join(b.prefix, pth)
+	log.WithField("path", pth).Trace("gcs: get file")
+	w := b.bucket.Object(pth).NewWriter(context.Background())
+	if _, err := io.Copy(w, in); err != nil {
+		return err
+	}
+	in.Close()
+	return w.Close()
+}
+
+func (b *GCSArchiveBackend) ListFiles(pth string) (chan string, chan error) {
+	prefix := path.Join(b.prefix, pth)
+	ch := make(chan string)
+	errs := make(chan error)
+
+	go func() {
+		log.WithField("path", pth).Trace("gcs: list files")
+		defer close(ch)
+		defer close(errs)
+
+		iter := b.bucket.Objects(context.Background(), &storage.Query{Prefix: prefix})
+		for {
+			object, err := iter.Next()
+			if err == iterator.Done {
+				return
+			} else if err != nil {
+				errs <- err
+			} else {
+				// TODO: Check Name is right
+				ch <- object.Name
+			}
+		}
+	}()
+
+	return ch, errs
+}
+
+func (b *GCSArchiveBackend) CanListFiles() bool {
+	log.Trace("gcs: can list files")
+	return true
+}
+
+func (b *GCSArchiveBackend) Close() error {
+	log.Trace("gcs: close")
+	return b.client.Close()
+}
+
+func makeGCSBackend(bucketName string, prefix string, opts ConnectOptions) (ArchiveBackend, error) {
+	log.WithFields(log.Fields{
+		"bucket":   bucketName,
+		"prefix":   prefix,
+		"endpoint": opts.GCSEndpoint,
+	}).Debug("gcs: making backend")
+
+	var options []option.ClientOption
+	if opts.GCSEndpoint != "" {
+		options = append(options, option.WithEndpoint(opts.GCSEndpoint))
+	}
+
+	client, err := storage.NewClient(opts.Context, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check the bucket exists
+	bucket := client.Bucket(bucketName)
+	if _, err := bucket.Attrs(opts.Context); err != nil {
+		return nil, err
+	}
+
+	backend := GCSArchiveBackend{
+		ctx:    opts.Context,
+		client: client,
+		bucket: bucket,
+		prefix: prefix,
+	}
+	return &backend, nil
+}

--- a/historyarchive/http_archive.go
+++ b/historyarchive/http_archive.go
@@ -125,6 +125,10 @@ func (b *HttpArchiveBackend) CanListFiles() bool {
 	return false
 }
 
+func (b *HttpArchiveBackend) Close() error {
+	return nil
+}
+
 func makeHttpBackend(base *url.URL, opts ConnectOptions) ArchiveBackend {
 	return &HttpArchiveBackend{
 		ctx:  opts.Context,

--- a/historyarchive/mock_archive.go
+++ b/historyarchive/mock_archive.go
@@ -83,6 +83,10 @@ func (b *MockArchiveBackend) CanListFiles() bool {
 	return true
 }
 
+func (b *MockArchiveBackend) Close() error {
+	return nil
+}
+
 func makeMockBackend(opts ConnectOptions) ArchiveBackend {
 	b := new(MockArchiveBackend)
 	b.files = make(map[string][]byte)

--- a/historyarchive/s3_archive.go
+++ b/historyarchive/s3_archive.go
@@ -7,10 +7,11 @@ package historyarchive
 import (
 	"bytes"
 	"context"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"net/http"
 	"path"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -191,6 +192,10 @@ func (b *S3ArchiveBackend) ListFiles(pth string) (chan string, chan error) {
 
 func (b *S3ArchiveBackend) CanListFiles() bool {
 	return true
+}
+
+func (b *S3ArchiveBackend) Close() error {
+	return nil
 }
 
 func makeS3Backend(bucket string, prefix string, opts ConnectOptions) (ArchiveBackend, error) {

--- a/ingest/ledgerbackend/gcs.go
+++ b/ingest/ledgerbackend/gcs.go
@@ -1,0 +1,68 @@
+package ledgerbackend
+
+import (
+	"bytes"
+	"cloud.google.com/go/storage"
+	"context"
+	"fmt"
+	"github.com/stellar/go/xdr"
+	"io"
+	"strconv"
+	"time"
+)
+
+type GCSBackend struct {
+	Bucket *storage.BucketHandle
+}
+
+func (b GCSBackend) GetLatestLedgerSequence(ctx context.Context) (uint32, error) {
+	r, err := b.Bucket.Object("latest").NewReader(context.Background())
+	if err != nil {
+		return 0, err
+	}
+	defer r.Close()
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		return 0, err
+	}
+	if parsed, err := strconv.ParseUint(buf.String(), 10, 32); err != nil {
+		return 0, err
+	} else {
+		return uint32(parsed), nil
+	}
+}
+
+func (b GCSBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error) {
+	var ledger xdr.LedgerCloseMeta
+	startTime := time.Now()
+	r, err := b.Bucket.Object("ledgers/" + strconv.FormatUint(uint64(sequence), 10)).NewReader(context.Background())
+	if err != nil {
+		return ledger, err
+	}
+	defer r.Close()
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		return ledger, err
+	}
+	if err = ledger.UnmarshalBinary(buf.Bytes()); err != nil {
+		return ledger, err
+	}
+
+	duration := time.Now().Sub(startTime)
+	fmt.Printf("duration is %v\n", duration)
+	return ledger, nil
+}
+
+func (b GCSBackend) PrepareRange(ctx context.Context, ledgerRange Range) error {
+	return nil
+}
+
+func (b GCSBackend) IsPrepared(ctx context.Context, ledgerRange Range) (bool, error) {
+	return true, nil
+}
+
+func (b GCSBackend) Close() error {
+	return b.Close()
+}

--- a/services/horizon/internal/ingest/processors/transactions_processor.go
+++ b/services/horizon/internal/ingest/processors/transactions_processor.go
@@ -36,3 +36,7 @@ func (p *TransactionProcessor) Commit(ctx context.Context) error {
 
 	return nil
 }
+
+func (p *TransactionProcessor) Rows() []history.TransactionWithoutLedger {
+	return p.batch.Rows()
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This is a prototype of a service which consumes tx meta from captive core and uploads individual ledgers as objects in a GCS bucket. Whenever a new ledger object is upload the service also updates the "latest"  object with the sequence number of the most recent ledger object in the GCS object.

Note we can have multiple instances of this service for redundancy in case one of the instances crashes. There is no coordination required by the multiple instances (GCS writes are atomic so it is safe if multiple instances write the same object at the same time).

### Why

Having tx meta is useful because it can save time when performing ingestion. It also provides an ingestion source which is easier to use than captive core. The problem with captive core is that you need to bundle the stellar-core binary and provide configuration for captive core. But reading tx meta from GCS we no longer need captive core as a dependency.

### Known limitations

* the service assumes there are no gaps (e.g. no ledger objects are missing and we have a contiguous range of ledger objects from genesis until the sequence recorded in the "latest" object)
* when starting from scratch it can will take a long time to populate all the ledger objects to span full history. we should support parallel exporters (similar to parallel ingestion).
* this is just a proof of concept so all the hardcoded configuration should be extracted out into parameters 