### PR TITLE
services/horizon: Improve logging the LP verification mismatch

### DIFF
--- a/services/horizon/internal/ingest/orderbook.go
+++ b/services/horizon/internal/ingest/orderbook.go
@@ -271,6 +271,7 @@ func (o *OrderBookStream) verifyAllLiquidityPools(ctx context.Context, liquidity
 
 	mismatch := len(liquidityPools) != len(ingestionLiquidityPools)
 
+	var liquidityPoolEntryBase64, liquidityPoolRowBase64 string
 	if !mismatch {
 		sort.Slice(liquidityPools, func(i, j int) bool {
 			return processors.PoolIDToString(liquidityPools[i].LiquidityPoolId) <
@@ -281,16 +282,18 @@ func (o *OrderBookStream) verifyAllLiquidityPools(ctx context.Context, liquidity
 		})
 
 		for i, liquidityPoolRow := range ingestionLiquidityPools {
+			var liquidityPoolRowXDR xdr.LiquidityPoolEntry
+			var err error
 			liquidityPoolEntry := liquidityPools[i]
-			liquidityPoolRowXDR, err := liquidityPoolToXDR(liquidityPoolRow)
+			liquidityPoolRowXDR, err = liquidityPoolToXDR(liquidityPoolRow)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from converting liquidity pool row to xdr")
 			}
-			liquidityPoolEntryBase64, err := o.encodingBuffer.MarshalBase64(&liquidityPoolEntry)
+			liquidityPoolEntryBase64, err = o.encodingBuffer.MarshalBase64(&liquidityPoolEntry)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from marshalling liquidityPoolEntry")
 			}
-			liquidityPoolRowBase64, err := o.encodingBuffer.MarshalBase64(&liquidityPoolRowXDR)
+			liquidityPoolRowBase64, err = o.encodingBuffer.MarshalBase64(&liquidityPoolRowXDR)
 			if err != nil {
 				return false, errors.Wrap(err, "Error from marshalling liquidityPoolRowXDR")
 			}
@@ -302,9 +305,9 @@ func (o *OrderBookStream) verifyAllLiquidityPools(ctx context.Context, liquidity
 	}
 
 	if mismatch {
-		log.WithField("stream_liquidity_pools", liquidityPools).
-			WithField("ingestion_liquidity_pools", ingestionLiquidityPools).
-			Error("liquidity pools derived from order book stream does not match liquidity pool from ingestion")
+		log.WithField("stream_liquidity_pool", liquidityPoolEntryBase64).
+			WithField("ingestion_liquidity_pools", liquidityPoolRowBase64).
+			Error("one or more liquidity pools derived from order book stream does not match liquidity pool from ingestion")
 		return false, nil
 	}
 	log.Info("liquidity pool stream verification succeeded")

--- a/services/horizon/internal/ingest/orderbook.go
+++ b/services/horizon/internal/ingest/orderbook.go
@@ -306,7 +306,7 @@ func (o *OrderBookStream) verifyAllLiquidityPools(ctx context.Context, liquidity
 
 	if mismatch {
 		log.WithField("stream_liquidity_pool", liquidityPoolEntryBase64).
-			WithField("ingestion_liquidity_pools", liquidityPoolRowBase64).
+			WithField("ingestion_liquidity_pool", liquidityPoolRowBase64).
 			Error("one or more liquidity pools derived from order book stream does not match liquidity pool from ingestion")
 		return false, nil
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

While debugging https://github.com/stellar/go/issues/4197 I realized that logging the two sets of LPs is broken. One set contains a pointer field which is logged as a memory address (ex. 0xc004ceb0e0). Also, the sets are two long to read and compare manually. To fix this, Horizon is now printing the first found difference.