### PR TITLE
all: staticcheck fixes

### DIFF
--- a/historyarchive/http_archive.go
+++ b/historyarchive/http_archive.go
@@ -31,7 +31,7 @@ func checkResp(r *http.Response) error {
 }
 
 func (b *HttpArchiveBackend) GetFile(pth string) (io.ReadCloser, error) {
-	var derived url.URL = b.base
+	derived := b.base
 	derived.Path = path.Join(derived.Path, pth)
 	req, err := http.NewRequest("GET", derived.String(), nil)
 	if err != nil {
@@ -58,7 +58,7 @@ func (b *HttpArchiveBackend) GetFile(pth string) (io.ReadCloser, error) {
 }
 
 func (b *HttpArchiveBackend) Head(pth string) (*http.Response, error) {
-	var derived url.URL = b.base
+	var derived = b.base
 	derived.Path = path.Join(derived.Path, pth)
 	req, err := http.NewRequest("HEAD", derived.String(), nil)
 	if err != nil {

--- a/historyarchive/http_archive.go
+++ b/historyarchive/http_archive.go
@@ -58,7 +58,7 @@ func (b *HttpArchiveBackend) GetFile(pth string) (io.ReadCloser, error) {
 }
 
 func (b *HttpArchiveBackend) Head(pth string) (*http.Response, error) {
-	var derived = b.base
+	derived := b.base
 	derived.Path = path.Join(derived.Path, pth)
 	req, err := http.NewRequest("HEAD", derived.String(), nil)
 	if err != nil {

--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -374,7 +374,7 @@ func (r *stellarCoreRunner) handleExit() {
 
 	// Pattern recommended in:
 	// https://github.com/golang/go/blob/cacac8bdc5c93e7bc71df71981fdf32dded017bf/src/cmd/go/script_test.go#L1091-L1098
-	var interrupt os.Signal = os.Interrupt
+	interrupt := os.Interrupt
 	if runtime.GOOS == "windows" {
 		// Per https://golang.org/pkg/os/#Signal, “Interrupt is not implemented on
 		// Windows; using it with os.Process.Signal will return an error.”

--- a/services/horizon/internal/txsub/system.go
+++ b/services/horizon/internal/txsub/system.go
@@ -341,7 +341,7 @@ func (sys *System) Tick(ctx context.Context) {
 
 		// In Tick we only check txs in a queue so those which did not have results before Tick
 		// so we check for them in the last 5 mins of ledgers: 60.
-		var sinceLedgerSeq int32 = int32(latestLedger) - 60
+		sinceLedgerSeq := int32(latestLedger) - 60
 		if sinceLedgerSeq < 0 {
 			sinceLedgerSeq = 0
 		}

--- a/tools/archive-reader/archive_reader.go
+++ b/tools/archive-reader/archive_reader.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	ledgerPtr := flag.Uint64("ledger", 0, "`ledger to analyze` (tip: has to be of the form `ledger = 64*n - 1`, where n is > 0)")
 	flag.Parse()
-	var seqNum uint32 = uint32(*ledgerPtr)
+	seqNum := uint32(*ledgerPtr)
 
 	if seqNum == 0 {
 		flag.Usage()


### PR DESCRIPTION
### What
Make some small stylistic changes to satisfy the next version of static check that will be released with Go 1.18 support.

### Why
While seeing if our code runs with Go 1.18rc1 I discovered that newer versions of static check, that are required for checking code when using Go 1.18, are more particularly about duplicate type declarations. This is okay change to make regardless so I'm making it separately.

Related to #4143.