### PR TITLE
services/horizon: Add LedgerHashStore to Captive-Core config

### DIFF
--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -232,6 +232,7 @@ func NewSystem(config Config) (System, error) {
 					NetworkPassphrase:   config.NetworkPassphrase,
 					HistoryArchiveURLs:  []string{config.HistoryArchiveURL},
 					CheckpointFrequency: config.CheckpointFrequency,
+					LedgerHashStore:     ledgerbackend.NewHorizonDBLedgerHashStore(config.HistorySession),
 					Log:                 logger,
 					Context:             ctx,
 				},


### PR DESCRIPTION
`LedgerHashStore` was removed from Horizon's `CaptiveCoreConfig` in: https://github.com/stellar/go/commit/b7fde588a61abdcb52b13b1b802b3e827202013b. This change makes it impossible to `PrepareRange` using Captive-Core if there is any other ingestion instance running because `CaptiveCoreBackend` tries to load the hash of the ledger from archives when `LedgerHashStore` is not set. But ledgers are published every 5 minutes so they contain the hash of the latest ledger only for a brief amount of time (the moment when checkpoint is published).