### PR TITLE
all: fix ci ref_protected check for caching

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -42,7 +42,7 @@ runs:
   # rebuilds and cause test runs to skip tests that have no reason to rerun.
   # Don't run this for protected branches like master/main.
   - uses: actions/cache@v2
-    if: (!github.ref_protected) || github.ref != 'refs/heads/master' || github.ref != 'refs/heads/main'
+    if: (!github.ref_protected) && github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main'
     with:
       path: ~/.cache/go-build
       key: ${{ env.PREFIX }}-go-build-${{ github.ref }}-${{ hashFiles('**', '!.git') }}

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -42,7 +42,7 @@ runs:
   # rebuilds and cause test runs to skip tests that have no reason to rerun.
   # Don't run this for protected branches like master/main.
   - uses: actions/cache@v2
-    if: github.ref_protected || github.ref != 'refs/heads/master'
+    if: (!github.ref_protected) || github.ref != 'refs/heads/master' || github.ref != 'refs/heads/main'
     with:
       path: ~/.cache/go-build
       key: ${{ env.PREFIX }}-go-build-${{ github.ref }}-${{ hashFiles('**', '!.git') }}


### PR DESCRIPTION
### What
Invert the ref_protected checked used to control whether test caching occurs.

### Why
Caching of tests should be disabled for protected branches, not enabled.