### PR TITLE
all: [GitHub actions] Reset the module and build cache in master/protected

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -50,6 +50,6 @@ runs:
 
   # Reset the cache for master/protected branches, to ensure they build and run the tests from zero
   # and that the module cache is cleaned (otherwise it accumulates orphan dependencies over time).
-  - if: "github.ref_protected || github.ref == 'refs/heads/master'"
+  - if: github.ref_protected
     shell: bash
     run: rm -r ~/.cache/go-build ~/go/pkg/mod

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -36,7 +36,7 @@ runs:
     with:
       path: ~/go/pkg/mod
       key: ${{ env.PREFIX }}-go-mod-${{ hashFiles('**/go.sum') }}
-      restore-keys: ${{ env.PREFIX }}-go-mod
+      restore-keys: ${{ env.PREFIX }}-go-mod-
 
   # Cache any build and test artifacts during the job, which will speed up
   # rebuilds and cause test runs to skip tests that have no reason to rerun.
@@ -45,8 +45,9 @@ runs:
       path: ~/.cache/go-build
       key: ${{ env.PREFIX }}-go-build-${{ github.ref }}-${{ hashFiles('**', '!.git') }}
       restore-keys: |
-        ${{ env.PREFIX }}-go-build-${{ github.ref }}
-        ${{ env.PREFIX }}-go-build
+        ${{ env.PREFIX }}-go-build-${{ github.ref }}-
+        ${{ env.PREFIX }}-go-build-master-
+        ${{ env.PREFIX }}-go-build-
 
   # Reset the cache for master/protected branches, to ensure they build and run the tests from zero
   # and that the module cache is cleaned (otherwise it accumulates orphan dependencies over time).

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -40,12 +40,16 @@ runs:
 
   # Cache any build and test artifacts during the job, which will speed up
   # rebuilds and cause test runs to skip tests that have no reason to rerun.
-  # Don't run this for protected branches like master/main.
   - uses: actions/cache@v2
-    if: (!github.ref_protected) && github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main'
     with:
       path: ~/.cache/go-build
       key: ${{ env.PREFIX }}-go-build-${{ github.ref }}-${{ hashFiles('**', '!.git') }}
       restore-keys: |
         ${{ env.PREFIX }}-go-build-${{ github.ref }}
         ${{ env.PREFIX }}-go-build
+
+  # Reset the cache for master/protected branches, to ensure they build and run the tests from zero
+  # and that the module cache is cleaned (otherwise it accumulates orphan dependencies over time).
+  - if: "github.ref_protected || github.ref == 'refs/heads/master'"
+    shell: bash
+    run: rm -r ~/.cache/go-build ~/go/pkg/mod


### PR DESCRIPTION
Before, we:

1. Didn't use the build cache in the master branch. This caused the cache
   to not be updated. This caused PRs to rerun all the tests.

2. Didn't reset the go module cache. This would eventually cause the cache
   to accumulate orphan dependencies when we remove them.

