### PR TITLE
xdr: add instructions for generating xdr

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ namespace :xdr do
 
     HAYASHI_XDR.each do |src|
       local_path = "xdr/" + File.basename(src)
-      encoded    = client.contents("stellar/stellar-core", query: {ref: 'master'}, path: src).content
+      encoded    = client.contents("stellar/stellar-core", query: {ref: "master"}, path: src).content
       decoded    = Base64.decode64 encoded
 
       IO.write(local_path, decoded)

--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ namespace :xdr do
 
     HAYASHI_XDR.each do |src|
       local_path = "xdr/" + File.basename(src)
-      encoded    = client.contents("stellar/stellar-core", path: src).content
+      encoded    = client.contents("stellar/stellar-core", query: {ref: 'master'}, path: src).content
       decoded    = Base64.decode64 encoded
 
       IO.write(local_path, decoded)

--- a/xdr/README.md
+++ b/xdr/README.md
@@ -1,0 +1,21 @@
+# xdr
+
+The xdr package contains encoding/decoding of Stellar XDR types.
+
+## Code Generate
+
+Most of the code this package is generated.
+
+To download new XDR for code generation:
+
+```
+docker run --platform linux/amd64 -it --rm -v $PWD:/wd -w /wd ruby /bin/bash -c 'bundle install && bundle exec rake xdr:download'
+```
+
+To regenerate the code from the local XDR:
+
+```
+docker run --platform linux/amd64 -it --rm -v $PWD:/wd -w /wd ruby /bin/bash -c 'bundle install && bundle exec rake xdr:generate' && go fmt ./xdr
+```
+
+To download XDR for a different branch of stellar-core, modify `Rakefile` in the root.


### PR DESCRIPTION
### What

Add a readme for the xdr package describing how to generate xdr.

### Why

I frequently forget and have to figure it out each time. This might help someone else too.

The examples use docker so that it is a quick copy/paste for most people. We use docker frequently so most of us have docker. There's a good chance that less of us have ruby setup in a good state locally.

I also added the ref to the Rakefile because I also forget how to specify a different source location for downloading XDR and if the ref was always specified it would be easier to just edit it.

### Known limitations

N/A
