### PR TITLE
all: remove go1.16 add go1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.17, 1.18.0-rc1]
+        go: [1.18]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.17, 1.16.7, 1.18.0-rc1]
+        go: [1.17, 1.18]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.17, 1.16.7, 1.18.0-rc1]
+        go: [1.17, 1.18]
         pg: [9.6.5, 10]
     runs-on: ${{ matrix.os }}
     services:

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.17]
+        go: [1.17, 1.18]
         pg: [9.6.5]
         ingestion-backend: [db, captive-core, captive-core-remote-storage]
         captive-core: [18.0.3-746.f3baea6.focal]

--- a/exp/services/recoverysigner/docker/Dockerfile
+++ b/exp/services/recoverysigner/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 
 ADD . /src/recoverysigner
 WORKDIR /src/recoverysigner

--- a/exp/services/webauth/docker/Dockerfile
+++ b/exp/services/webauth/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 
 ADD . /src/webauth
 WORKDIR /src/webauth

--- a/go.mod
+++ b/go.mod
@@ -3,44 +3,29 @@ module github.com/stellar/go
 go 1.17
 
 require (
-	cloud.google.com/go/firestore v1.5.0 // indirect
 	firebase.google.com/go v3.12.0+incompatible
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Masterminds/squirrel v1.5.0
 	github.com/Microsoft/go-winio v0.4.14
 	github.com/adjust/goautoneg v0.0.0-20150426214442-d788f35a0315
-	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/aws/aws-sdk-go v1.39.5
 	github.com/elazarl/go-bindata-assetfs v1.0.0
-	github.com/fatih/structs v1.0.0 // indirect
-	github.com/gavv/monotime v0.0.0-20161010190848-47d58efa6955 // indirect
 	github.com/getsentry/raven-go v0.0.0-20160805001729-c9d3cc542ad1
 	github.com/go-chi/chi v4.0.3+incompatible
 	github.com/go-errors/errors v0.0.0-20150906023321-a41850380601
-	github.com/gobuffalo/packr v1.12.1 // indirect
 	github.com/golang-jwt/jwt v3.2.1+incompatible
-	github.com/google/go-querystring v0.0.0-20160401233042-9235644dd9e5 // indirect
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/schema v1.1.0
 	github.com/graph-gophers/graphql-go v1.3.0
 	github.com/guregu/null v2.1.3-0.20151024101046-79c5bd36b615+incompatible
 	github.com/holiman/uint256 v1.2.0
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c
-	github.com/imkira/go-interpol v1.1.0 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jarcoal/httpmock v0.0.0-20161210151336-4442edb3db31
 	github.com/jmoiron/sqlx v1.2.0
-	github.com/klauspost/compress v0.0.0-20161106143436-e3b7981a12dd // indirect
-	github.com/klauspost/cpuid v0.0.0-20160302075316-09cded8978dc // indirect
-	github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6 // indirect
 	github.com/lib/pq v1.2.0
-	github.com/magiconair/properties v1.5.4 // indirect
 	github.com/manucorporat/sse v0.0.0-20160126180136-ee05b128a739
-	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/mapstructure v0.0.0-20150613213606-2caf8efc9366 // indirect
-	github.com/moul/http2curl v0.0.0-20161031194548-4e24498b31db // indirect
 	github.com/onsi/ginkgo v1.7.0
 	github.com/onsi/gomega v1.4.3
 	github.com/pelletier/go-toml v1.9.0
@@ -48,26 +33,70 @@ require (
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
 	github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00
-	github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 // indirect
 	github.com/rubenv/sql-migrate v0.0.0-20190717103323-87ce952f7079
 	github.com/segmentio/go-loggly v0.5.1-0.20171222203950-eb91657e62b2
-	github.com/sergi/go-diff v0.0.0-20161205080420-83532ca1c1ca // indirect
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
 	github.com/sirupsen/logrus v1.4.1
-	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
-	github.com/spf13/cast v0.0.0-20150508191742-4d07383ffe94 // indirect
 	github.com/spf13/cobra v0.0.0-20160830174925-9c28e4bbd74e
-	github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431 // indirect
 	github.com/spf13/pflag v0.0.0-20161005214240-4bd69631f475
 	github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189
 	github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee
 	github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible
-	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/tyler-smith/go-bip39 v0.0.0-20180618194314-52158e4697b8
+	github.com/xdrpp/goxdr v0.1.1
+	google.golang.org/api v0.50.0
+	gopkg.in/gavv/httpexpect.v1 v1.0.0-20170111145843-40724cf1e4a0
+	gopkg.in/square/go-jose.v2 v2.4.1
+	gopkg.in/tylerb/graceful.v1 v1.2.13
+)
+
+require (
+	cloud.google.com/go v0.84.0 // indirect
+	cloud.google.com/go/firestore v1.5.0 // indirect
+	cloud.google.com/go/storage v1.10.0 // indirect
+	github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f // indirect
+	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/structs v1.0.0 // indirect
+	github.com/gavv/monotime v0.0.0-20161010190848-47d58efa6955 // indirect
+	github.com/gobuffalo/packr v1.12.1 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/go-querystring v0.0.0-20160401233042-9235644dd9e5 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
+	github.com/hpcloud/tail v1.0.0 // indirect
+	github.com/imkira/go-interpol v1.1.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/klauspost/compress v0.0.0-20161106143436-e3b7981a12dd // indirect
+	github.com/klauspost/cpuid v0.0.0-20160302075316-09cded8978dc // indirect
+	github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/kr/text v0.1.0 // indirect
+	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
+	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
+	github.com/magiconair/properties v1.5.4 // indirect
+	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/mitchellh/mapstructure v0.0.0-20150613213606-2caf8efc9366 // indirect
+	github.com/moul/http2curl v0.0.0-20161031194548-4e24498b31db // indirect
+	github.com/opentracing/opentracing-go v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/common v0.2.0 // indirect
+	github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1 // indirect
+	github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521 // indirect
+	github.com/sergi/go-diff v0.0.0-20161205080420-83532ca1c1ca // indirect
+	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
+	github.com/spf13/cast v0.0.0-20150508191742-4d07383ffe94 // indirect
+	github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431 // indirect
+	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v0.0.0-20170109085056-0a7f0a797cd6 // indirect
-	github.com/xdrpp/goxdr v0.1.1
 	github.com/xeipuuv/gojsonpointer v0.0.0-20151027082146-e0fe6f683076 // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20150808065054-e02fc20de94c // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20161231055540-f06f290571ce // indirect
@@ -76,11 +105,24 @@ require (
 	github.com/yudai/golcs v0.0.0-20150405163532-d1c525dea8ce // indirect
 	github.com/yudai/pp v2.0.1+incompatible // indirect
 	github.com/ziutek/mymysql v1.5.4 // indirect
+	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20211202192323-5770296d904e // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
+	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
-	google.golang.org/api v0.50.0
-	gopkg.in/gavv/httpexpect.v1 v1.0.0-20170111145843-40724cf1e4a0
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/tools v0.1.4 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210624195500-8bfb893ecb84 // indirect
+	google.golang.org/grpc v1.38.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/gorp.v1 v1.7.1 // indirect
-	gopkg.in/square/go-jose.v2 v2.4.1
-	gopkg.in/tylerb/graceful.v1 v1.2.13
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stellar/go
 
-go 1.16
+go 1.17
 
 require (
 	cloud.google.com/go/firestore v1.5.0 // indirect

--- a/services/friendbot/docker/Dockerfile
+++ b/services/friendbot/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 
 ADD . /src/friendbot
 WORKDIR /src/friendbot

--- a/services/keystore/docker/Dockerfile
+++ b/services/keystore/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 
 ADD . /src/keystore
 WORKDIR /src/keystore

--- a/services/regulated-assets-approval-server/docker/Dockerfile
+++ b/services/regulated-assets-approval-server/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 
 ADD . /src/regulated-assets-approval-server
 WORKDIR /src/regulated-assets-approval-server

--- a/services/ticker/docker/Dockerfile
+++ b/services/ticker/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 
 ADD . /src/ticker
 WORKDIR /src/ticker

--- a/services/ticker/docker/Dockerfile-dev
+++ b/services/ticker/docker/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM golang:1.17-stretch as build
+FROM golang:1.18 as build
 
 LABEL maintainer="Alex Cordeiro <alexc@stellar.org>"
 

--- a/staticcheck.sh
+++ b/staticcheck.sh
@@ -3,10 +3,9 @@ set -e
 
 gover=$(go version | { read _ _ gover _; printf $gover; })
 
-version='2020.1.4'
-if [[ "$gover" = "go1.18"* ]]; then
-  version='d5c28addcbbbafca0b9a0f9ad8957912e9371015'
-fi
+# This unreleased version of staticcheck has support for Go 1.18.
+# TODO: Update this to v3.0.0 when released.
+version='d5c28addcbbbafca0b9a0f9ad8957912e9371015'
 
 staticcheck='go run honnef.co/go/tools/cmd/staticcheck@'"$version"
 
@@ -15,11 +14,3 @@ printf "Running staticcheck $version...\n"
 ls -d */ \
   | egrep -v '^vendor|^docs' \
   | xargs -I {} $staticcheck -tests=false -checks="all,-ST1003,-SA1019,-ST1005,-ST1000,-ST1016,-S1039,-ST1021,-ST1020,-ST1019,-SA4022" ./{}...
-
-# Whole program unused checks were removed from staticcheck in newer versions,
-# so this check is being sunset and will be removed once Go 1.18 is released and
-# a proper release of staticcheck is released that supports it.
-if [ "$version" = "2020.1.4" ]; then
-  # Check horizon for unused exported symbols (relying on the fact that it should be self-contained)
-  $staticcheck -unused.whole-program -checks='U*' ./services/horizon/...
-fi


### PR DESCRIPTION
### What

Remove testing and official support for Go 1.16, and add support for Go 1.18. Update all docker images to use Go 1.18, except Horizon.

### Why

Go 1.18 was released today and Go 1.16 is now no longer supported for security fixes.

### Known limitations

I have not updated the Horizon docker images as that should be coordinated by @stellar/horizon-committers.

Please note that this commit will cease to run Horizon whole program checks. See this for more details:
https://github.com/stellar/go/blob/3d935af3d9e78bec5a729473cac3434689cd4186/staticcheck.sh#L19-L25

Depends on: https://github.com/docker-library/official-images/pull/12045