### PR TITLE
services/ticker: cache tomls during scraping

### DIFF
--- a/services/ticker/internal/scraper/asset_scraper.go
+++ b/services/ticker/internal/scraper/asset_scraper.go
@@ -60,10 +60,8 @@ func decodeTOMLIssuer(tomlData string) (issuer TOMLIssuer, err error) {
 	return
 }
 
-// fetchTOMLData fetches the TOML data for a given hProtocol.AssetStat
-func fetchTOMLData(asset hProtocol.AssetStat) (data string, err error) {
-	tomlURL := asset.Links.Toml.Href
-
+// fetchTOMLData fetches the TOML data from the URL.
+func fetchTOMLData(tomlURL string) (data string, err error) {
 	if tomlURL == "" {
 		err = errors.New("Asset does not have a TOML URL")
 		return
@@ -214,19 +212,27 @@ func makeFinalAsset(
 }
 
 // processAsset merges data from an AssetStat with data retrieved from its corresponding TOML file
-func processAsset(asset hProtocol.AssetStat, shouldValidateTOML bool) (FinalAsset, error) {
+func processAsset(asset hProtocol.AssetStat, tomlCache map[string]TOMLIssuer, shouldValidateTOML bool) (FinalAsset, error) {
 	var errors []error
 	var issuer TOMLIssuer
 
 	if shouldValidateTOML {
-		tomlData, err := fetchTOMLData(asset)
-		if err != nil {
-			errors = append(errors, err)
-		}
+		tomlURL := asset.Links.Toml.Href
 
-		issuer, err = decodeTOMLIssuer(tomlData)
-		if err != nil {
-			errors = append(errors, err)
+		var ok bool
+		issuer, ok = tomlCache[tomlURL]
+		if !ok {
+			tomlData, err := fetchTOMLData(tomlURL)
+			if err != nil {
+				errors = append(errors, err)
+			}
+
+			issuer, err = decodeTOMLIssuer(tomlData)
+			if err != nil {
+				errors = append(errors, err)
+			}
+
+			tomlCache[tomlURL] = issuer
 		}
 	}
 
@@ -255,9 +261,15 @@ func (c *ScraperConfig) parallelProcessAssets(assets []hProtocol.AssetStat, para
 				end = numAssets
 			}
 
+			// Each routine running concurrently has a separate cache of TOMLs
+			// loaded. A single shared cache would be better, but this is a
+			// tradeoff for simplicity because a shared map mutated with HTTP
+			// lookups would have a significant amount of contention.
+			tomlCache := map[string]TOMLIssuer{}
+
 			for j := start; j < end; j++ {
 				if !shouldDiscardAsset(assets[j], shouldValidateTOML) {
-					finalAsset, err := processAsset(assets[j], shouldValidateTOML)
+					finalAsset, err := processAsset(assets[j], tomlCache, shouldValidateTOML)
 					if err != nil {
 						mutex.Lock()
 						numTrash++

--- a/services/ticker/internal/scraper/asset_scraper.go
+++ b/services/ticker/internal/scraper/asset_scraper.go
@@ -212,7 +212,7 @@ func makeFinalAsset(
 }
 
 // processAsset merges data from an AssetStat with data retrieved from its corresponding TOML file
-func processAsset(asset hProtocol.AssetStat, tomlCache map[string]TOMLIssuer, shouldValidateTOML bool) (FinalAsset, error) {
+func (c *ScraperConfig) processAsset(asset hProtocol.AssetStat, tomlCache map[string]TOMLIssuer, shouldValidateTOML bool) (FinalAsset, error) {
 	var errors []error
 	var issuer TOMLIssuer
 
@@ -221,7 +221,10 @@ func processAsset(asset hProtocol.AssetStat, tomlCache map[string]TOMLIssuer, sh
 
 		var ok bool
 		issuer, ok = tomlCache[tomlURL]
-		if !ok {
+		if ok {
+			c.Logger.Infof("Using cached TOML for asset %s:%s", asset.Asset.Code, asset.Asset.Issuer)
+		} else {
+			c.Logger.Infof("Fetching TOML for asset %s:%s", asset.Asset.Code, asset.Asset.Issuer)
 			tomlData, err := fetchTOMLData(tomlURL)
 			if err != nil {
 				errors = append(errors, err)
@@ -269,7 +272,8 @@ func (c *ScraperConfig) parallelProcessAssets(assets []hProtocol.AssetStat, para
 
 			for j := start; j < end; j++ {
 				if !shouldDiscardAsset(assets[j], shouldValidateTOML) {
-					finalAsset, err := processAsset(assets[j], tomlCache, shouldValidateTOML)
+					c.Logger.Infof("Processing asset %s:%s", assets[j].Asset.Code, assets[j].Asset.Issuer)
+					finalAsset, err := c.processAsset(assets[j], tomlCache, shouldValidateTOML)
 					if err != nil {
 						mutex.Lock()
 						numTrash++
@@ -278,6 +282,7 @@ func (c *ScraperConfig) parallelProcessAssets(assets []hProtocol.AssetStat, para
 					}
 					assetQueue <- finalAsset
 				} else {
+					c.Logger.Infof("Discarding asset %s:%s", assets[j].Asset.Code, assets[j].Asset.Issuer)
 					mutex.Lock()
 					numTrash++
 					mutex.Unlock()

--- a/services/ticker/internal/scraper/asset_scraper_test.go
+++ b/services/ticker/internal/scraper/asset_scraper_test.go
@@ -150,7 +150,7 @@ func TestIgnoreInvalidTOMLUrls(t *testing.T) {
 }
 
 func TestProcessAsset_notCached(t *testing.T) {
-	scraper := &ScraperConfig{Logger:log.DefaultLogger}
+	scraper := &ScraperConfig{Logger: log.DefaultLogger}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `SIGNING_KEY="not cached signing key"`)
 	}))
@@ -168,7 +168,7 @@ func TestProcessAsset_notCached(t *testing.T) {
 }
 
 func TestProcessAsset_cached(t *testing.T) {
-	scraper := &ScraperConfig{Logger:log.DefaultLogger}
+	scraper := &ScraperConfig{Logger: log.DefaultLogger}
 	asset := hProtocol.AssetStat{
 		Amount:      "123901.0129310",
 		NumAccounts: 100,

--- a/services/ticker/internal/scraper/asset_scraper_test.go
+++ b/services/ticker/internal/scraper/asset_scraper_test.go
@@ -9,6 +9,7 @@ import (
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -149,6 +150,7 @@ func TestIgnoreInvalidTOMLUrls(t *testing.T) {
 }
 
 func TestProcessAsset_notCached(t *testing.T) {
+	scraper := &ScraperConfig{Logger:log.DefaultLogger}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `SIGNING_KEY="not cached signing key"`)
 	}))
@@ -159,13 +161,14 @@ func TestProcessAsset_notCached(t *testing.T) {
 	asset.Code = "SOMETHINGVALID"
 	asset.Links.Toml.Href = server.URL
 	tomlCache := map[string]TOMLIssuer{}
-	finalAsset, err := processAsset(asset, tomlCache, true)
+	finalAsset, err := scraper.processAsset(asset, tomlCache, true)
 	require.NoError(t, err)
 	assert.NotZero(t, finalAsset)
 	assert.Equal(t, "not cached signing key", finalAsset.IssuerDetails.SigningKey)
 }
 
 func TestProcessAsset_cached(t *testing.T) {
+	scraper := &ScraperConfig{Logger:log.DefaultLogger}
 	asset := hProtocol.AssetStat{
 		Amount:      "123901.0129310",
 		NumAccounts: 100,
@@ -177,7 +180,7 @@ func TestProcessAsset_cached(t *testing.T) {
 			SigningKey: "signing key",
 		},
 	}
-	finalAsset, err := processAsset(asset, tomlCache, true)
+	finalAsset, err := scraper.processAsset(asset, tomlCache, true)
 	require.NoError(t, err)
 	assert.NotZero(t, finalAsset)
 	assert.Equal(t, "signing key", finalAsset.IssuerDetails.SigningKey)

--- a/services/ticker/internal/scraper/asset_scraper_test.go
+++ b/services/ticker/internal/scraper/asset_scraper_test.go
@@ -1,13 +1,16 @@
 package scraper
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/support/render/hal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShouldDiscardAsset(t *testing.T) {
@@ -134,10 +137,7 @@ func TestIsDomainVerified(t *testing.T) {
 
 func TestIgnoreInvalidTOMLUrls(t *testing.T) {
 	invalidURL := "https:// there is something wrong here.com/stellar.toml"
-	assetStat := hProtocol.AssetStat{}
-	assetStat.Links.Toml = hal.Link{Href: invalidURL}
-
-	_, err := fetchTOMLData(assetStat)
+	_, err := fetchTOMLData(invalidURL)
 
 	urlErr, ok := errors.Cause(err).(*url.Error)
 	if !ok {
@@ -146,4 +146,39 @@ func TestIgnoreInvalidTOMLUrls(t *testing.T) {
 	assert.Equal(t, "parse", urlErr.Op)
 	assert.Equal(t, "https:// there is something wrong here.com/stellar.toml", urlErr.URL)
 	assert.EqualError(t, urlErr.Err, `invalid character " " in host name`)
+}
+
+func TestProcessAsset_notCached(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `SIGNING_KEY="not cached signing key"`)
+	}))
+	asset := hProtocol.AssetStat{
+		Amount:      "123901.0129310",
+		NumAccounts: 100,
+	}
+	asset.Code = "SOMETHINGVALID"
+	asset.Links.Toml.Href = server.URL
+	tomlCache := map[string]TOMLIssuer{}
+	finalAsset, err := processAsset(asset, tomlCache, true)
+	require.NoError(t, err)
+	assert.NotZero(t, finalAsset)
+	assert.Equal(t, "not cached signing key", finalAsset.IssuerDetails.SigningKey)
+}
+
+func TestProcessAsset_cached(t *testing.T) {
+	asset := hProtocol.AssetStat{
+		Amount:      "123901.0129310",
+		NumAccounts: 100,
+	}
+	asset.Code = "SOMETHINGVALID"
+	asset.Links.Toml.Href = "url"
+	tomlCache := map[string]TOMLIssuer{
+		"url": {
+			SigningKey: "signing key",
+		},
+	}
+	finalAsset, err := processAsset(asset, tomlCache, true)
+	require.NoError(t, err)
+	assert.NotZero(t, finalAsset)
+	assert.Equal(t, "signing key", finalAsset.IssuerDetails.SigningKey)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Cache TOMLs to during scraping to some degree. Caching is local to each routine that is scraping and not shared across those routines, so it is possible to still get duplicate requests. Cache usage is logged.

### Why

The asset scraper may end up repeatedly scraping the same issuer's TOML many times if the issuer has issued many assets. This is not great since any scraper should attempt to respect the resources of hosts as much as possible.

The cache is in-memory and per routine because the cache is only required temporarily, and to introduce an external cache, such as redis, would be overkill.

Cache usage is logged so that it can be inspected and understood.

### Known limitations

It's unclear to me if this will unwind the efforts that @stfung77 did recently to reduce memory usage.