### PR TITLE
all: Fix Horizon integration tests

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -58,8 +58,8 @@ jobs:
       name: Install and enable Captive Core
       run: |
         # Workaround for https://github.com/actions/virtual-environments/issues/5245 , remove when fixed
-        sudo sed -i 's/azure.//' /etc/apt/sources.list
-        sudo apt-get update
+        wget http://archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-8/libc++1-8_8.0.1-9_amd64.deb
+        sudo dpkg -i libc++1-8_8.0.1-9_amd64.deb
         
         sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
         sudo bash -c 'echo "deb https://apt.stellar.org focal unstable" > /etc/apt/sources.list.d/SDF-unstable.list'

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -58,7 +58,7 @@ jobs:
       name: Install and enable Captive Core
       run: |
         # Workaround for https://github.com/actions/virtual-environments/issues/5245 , remove when fixed
-        sudo apt-get remove -y libc++1-10
+        sudo apt-get remove -y libc++1-10 libc++abi1-10
         wget -q http://archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-8/libc++1-8_8.0.1-9_amd64.deb
         wget -q http://archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-8/libc++abi1-8_8.0.1-9_amd64.deb
         sudo dpkg -i libc++abi1-8_8.0.1-9_amd64.deb libc++1-8_8.0.1-9_amd64.deb

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -64,6 +64,8 @@ jobs:
         curl -s http://azure.archive.ubuntu.com/ubuntu/dists/focal/universe/binary-amd64/Packages.gz | zgrep libc++1-8
         echo utah
         curl -s http://archive.ubuntu.com/ubuntu/dists/focal/universe/binary-amd64/Packages.gz | zgrep libc++1-8
+        # Workaround for https://github.com/actions/virtual-environments/issues/5245 , remove when fixed
+        sudo apt-get remove -y libc++1-10 libc++abi1-10 || true
         
         sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
         sudo bash -c 'echo "deb https://apt.stellar.org focal unstable" > /etc/apt/sources.list.d/SDF-unstable.list'

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -57,6 +57,10 @@ jobs:
     - if: ${{ startsWith(matrix.ingestion-backend, 'captive-core') }}
       name: Install and enable Captive Core
       run: |
+        # Workaround for https://github.com/actions/virtual-environments/issues/5245 , remove when fixed
+        sudo sed -i 's/azure.//' /etc/apt/sources.list
+        sudo apt-get update
+        
         sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
         sudo bash -c 'echo "deb https://apt.stellar.org focal unstable" > /etc/apt/sources.list.d/SDF-unstable.list'
         sudo apt-get update && sudo apt-get install -y stellar-core=${{ matrix.captive-core }}

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -57,14 +57,9 @@ jobs:
     - if: ${{ startsWith(matrix.ingestion-backend, 'captive-core') }}
       name: Install and enable Captive Core
       run: |
-        # see if the libc++1-8 package is there
-        echo normal archive
-        curl -s http://archive.ubuntu.com/ubuntu/dists/focal/universe/binary-amd64/Packages.gz | zgrep libc++1-8
-        echo azure
-        curl -s http://azure.archive.ubuntu.com/ubuntu/dists/focal/universe/binary-amd64/Packages.gz | zgrep libc++1-8
-        echo utah
-        curl -s http://archive.ubuntu.com/ubuntu/dists/focal/universe/binary-amd64/Packages.gz | zgrep libc++1-8
-        # Workaround for https://github.com/actions/virtual-environments/issues/5245 , remove when fixed
+        # Workaround for https://github.com/actions/virtual-environments/issues/5245,
+        # libc++1-8 won't be installed if another version is installed (but apt won't give you a helpul
+        # message about why the installation fails)
         sudo apt-get remove -y libc++1-10 libc++abi1-10 || true
         
         sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -57,6 +57,13 @@ jobs:
     - if: ${{ startsWith(matrix.ingestion-backend, 'captive-core') }}
       name: Install and enable Captive Core
       run: |
+        # see if the libc++1-8 package is there
+        echo normal archive
+        curl -s http://archive.ubuntu.com/ubuntu/dists/focal/universe/binary-amd64/Packages.gz | zgrep libc++1-8
+        echo azure
+        curl -s http://azure.archive.ubuntu.com/ubuntu/dists/focal/universe/binary-amd64/Packages.gz | zgrep libc++1-8
+        echo utah
+        curl -s http://archive.ubuntu.com/ubuntu/dists/focal/universe/binary-amd64/Packages.gz | zgrep libc++1-8
         # Workaround for https://github.com/actions/virtual-environments/issues/5245 , remove when fixed
         sudo apt-get remove -y libc++1-10 libc++abi1-10
         wget -q http://archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-8/libc++1-8_8.0.1-9_amd64.deb

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -59,8 +59,9 @@ jobs:
       run: |
         # Workaround for https://github.com/actions/virtual-environments/issues/5245 , remove when fixed
         sudo apt-get remove -y libc++1-10
-        wget http://archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-8/libc++1-8_8.0.1-9_amd64.deb
-        sudo dpkg -i libc++1-8_8.0.1-9_amd64.deb
+        wget -q http://archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-8/libc++1-8_8.0.1-9_amd64.deb
+        wget -q http://archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-8/libc++abi1-8_8.0.1-9_amd64.deb
+        sudo dpkg -i libc++abi1-8_8.0.1-9_amd64.deb libc++1-8_8.0.1-9_amd64.deb
         
         sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
         sudo bash -c 'echo "deb https://apt.stellar.org focal unstable" > /etc/apt/sources.list.d/SDF-unstable.list'

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -64,11 +64,6 @@ jobs:
         curl -s http://azure.archive.ubuntu.com/ubuntu/dists/focal/universe/binary-amd64/Packages.gz | zgrep libc++1-8
         echo utah
         curl -s http://archive.ubuntu.com/ubuntu/dists/focal/universe/binary-amd64/Packages.gz | zgrep libc++1-8
-        # Workaround for https://github.com/actions/virtual-environments/issues/5245 , remove when fixed
-        sudo apt-get remove -y libc++1-10 libc++abi1-10
-        wget -q http://archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-8/libc++1-8_8.0.1-9_amd64.deb
-        wget -q http://archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-8/libc++abi1-8_8.0.1-9_amd64.deb
-        sudo dpkg -i libc++abi1-8_8.0.1-9_amd64.deb libc++1-8_8.0.1-9_amd64.deb
         
         sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
         sudo bash -c 'echo "deb https://apt.stellar.org focal unstable" > /etc/apt/sources.list.d/SDF-unstable.list'

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -58,6 +58,7 @@ jobs:
       name: Install and enable Captive Core
       run: |
         # Workaround for https://github.com/actions/virtual-environments/issues/5245 , remove when fixed
+        sudo apt-get remove -y libc++1-10
         wget http://archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-8/libc++1-8_8.0.1-9_amd64.deb
         sudo dpkg -i libc++1-8_8.0.1-9_amd64.deb
         


### PR DESCRIPTION
They are failing with:

```
The following packages have unmet dependencies:
 stellar-core : Depends: libc++1-8 but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

Most likely due to a problem in the azure deb Ubuntu mirror used by GitHub

Workaround for https://github.com/actions/virtual-environments/issues/5245