### PR TITLE
services/horizon: Fix captive core tests to write to /tmp, instead of polluting the repo

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/network"
@@ -131,6 +133,9 @@ type testLedgerHeader struct {
 }
 
 func TestCaptiveNew(t *testing.T) {
+	storagePath, err := os.MkdirTemp(os.TempDir(), "captive-core-*")
+	require.NoError(t, err)
+
 	executablePath := "/etc/stellar-core"
 	networkPassphrase := network.PublicNetworkPassphrase
 	historyURLs := []string{"http://history.stellar.org/prd/core-live/core_live_001"}
@@ -140,6 +145,7 @@ func TestCaptiveNew(t *testing.T) {
 			BinaryPath:         executablePath,
 			NetworkPassphrase:  networkPassphrase,
 			HistoryArchiveURLs: historyURLs,
+			StoragePath:        storagePath,
 		},
 	)
 
@@ -821,6 +827,9 @@ func TestCaptiveGetLedger_NextLedger0RangeFromIsSmallerThanLedgerFromBuffer(t *t
 }
 
 func TestCaptiveStellarCore_PrepareRangeAfterClose(t *testing.T) {
+	storagePath, err := os.MkdirTemp(os.TempDir(), "captive-core-*")
+	require.NoError(t, err)
+
 	ctx := context.Background()
 	executablePath := "/etc/stellar-core"
 	networkPassphrase := network.PublicNetworkPassphrase
@@ -835,6 +844,7 @@ func TestCaptiveStellarCore_PrepareRangeAfterClose(t *testing.T) {
 			NetworkPassphrase:  networkPassphrase,
 			HistoryArchiveURLs: historyURLs,
 			Toml:               captiveCoreToml,
+			StoragePath:        storagePath,
 		},
 	)
 	assert.NoError(t, err)

--- a/ingest/ledgerbackend/file_watcher_test.go
+++ b/ingest/ledgerbackend/file_watcher_test.go
@@ -3,6 +3,7 @@ package ledgerbackend
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/stellar/go/support/log"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockHash struct {
@@ -43,6 +45,9 @@ func (m *mockHash) hashFile(fp string) (hash, error) {
 }
 
 func createFWFixtures(t *testing.T) (*mockHash, *stellarCoreRunner, *fileWatcher) {
+	storagePath, err := os.MkdirTemp(os.TempDir(), "captive-core-*")
+	require.NoError(t, err)
+
 	ms := &mockHash{
 		hashResult:   hash{},
 		expectedPath: "/some/path",
@@ -58,6 +63,7 @@ func createFWFixtures(t *testing.T) (*mockHash, *stellarCoreRunner, *fileWatcher
 		Log:                log.New(),
 		Context:            context.Background(),
 		Toml:               captiveCoreToml,
+		StoragePath:        storagePath,
 	}, stellarCoreRunnerModeOffline)
 	assert.NoError(t, err)
 
@@ -69,6 +75,9 @@ func createFWFixtures(t *testing.T) (*mockHash, *stellarCoreRunner, *fileWatcher
 }
 
 func TestNewFileWatcherError(t *testing.T) {
+	storagePath, err := os.MkdirTemp(os.TempDir(), "captive-core-*")
+	require.NoError(t, err)
+
 	ms := &mockHash{
 		hashResult:   hash{},
 		expectedPath: "/some/path",
@@ -85,6 +94,7 @@ func TestNewFileWatcherError(t *testing.T) {
 		Log:                log.New(),
 		Context:            context.Background(),
 		Toml:               captiveCoreToml,
+		StoragePath:        storagePath,
 	}, stellarCoreRunnerModeOffline)
 	assert.NoError(t, err)
 

--- a/ingest/ledgerbackend/stellar_core_runner_test.go
+++ b/ingest/ledgerbackend/stellar_core_runner_test.go
@@ -7,11 +7,15 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/go/support/log"
 )
 
 func TestCloseBeforeStartOffline(t *testing.T) {
+	storagePath, err := os.MkdirTemp(os.TempDir(), "captive-core-*")
+	require.NoError(t, err)
+
 	captiveCoreToml, err := NewCaptiveCoreToml(CaptiveCoreTomlParams{})
 	assert.NoError(t, err)
 
@@ -20,6 +24,7 @@ func TestCloseBeforeStartOffline(t *testing.T) {
 		Log:                log.New(),
 		Context:            context.Background(),
 		Toml:               captiveCoreToml,
+		StoragePath:        storagePath,
 	}, stellarCoreRunnerModeOffline)
 	assert.NoError(t, err)
 
@@ -37,6 +42,9 @@ func TestCloseBeforeStartOffline(t *testing.T) {
 }
 
 func TestCloseBeforeStartOnline(t *testing.T) {
+	storagePath, err := os.MkdirTemp(os.TempDir(), "captive-core-*")
+	require.NoError(t, err)
+
 	captiveCoreToml, err := NewCaptiveCoreToml(CaptiveCoreTomlParams{})
 	assert.NoError(t, err)
 
@@ -47,6 +55,7 @@ func TestCloseBeforeStartOnline(t *testing.T) {
 		Log:                log.New(),
 		Context:            context.Background(),
 		Toml:               captiveCoreToml,
+		StoragePath:        storagePath,
 	}, stellarCoreRunnerModeOnline)
 	assert.NoError(t, err)
 
@@ -63,6 +72,9 @@ func TestCloseBeforeStartOnline(t *testing.T) {
 }
 
 func TestCloseBeforeStartOnlineWithError(t *testing.T) {
+	storagePath, err := os.MkdirTemp(os.TempDir(), "captive-core-*")
+	require.NoError(t, err)
+
 	captiveCoreToml, err := NewCaptiveCoreToml(CaptiveCoreTomlParams{})
 	assert.NoError(t, err)
 
@@ -73,6 +85,7 @@ func TestCloseBeforeStartOnlineWithError(t *testing.T) {
 		Log:                log.New(),
 		Context:            context.Background(),
 		Toml:               captiveCoreToml,
+		StoragePath:        storagePath,
 	}, stellarCoreRunnerModeOnline)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Write captive core test files to `/tmp`. So they don't pollute local workspace.

### Why

Fixes #4290
