### PR TITLE
services/horizon: Rename methods and functions in submission system

### DIFF
--- a/services/horizon/internal/txsub/sequence/account_tx_submission_queue_test.go
+++ b/services/horizon/internal/txsub/sequence/account_tx_submission_queue_test.go
@@ -15,12 +15,12 @@ import (
 type QueueTestSuite struct {
 	suite.Suite
 	ctx   context.Context
-	queue *Queue
+	queue *AccountTxSubmissionQueue
 }
 
 func (suite *QueueTestSuite) SetupTest() {
 	suite.ctx = test.Context()
-	suite.queue = NewQueue()
+	suite.queue = NewAccountTxSubmissionQueue()
 }
 
 //Push adds the provided channel on to the priority queue
@@ -43,7 +43,7 @@ func (suite *QueueTestSuite) TestQueue_Push() {
 
 // Tests the update method
 func (suite *QueueTestSuite) TestQueue_Update() {
-	// Update removes sequences that are submittable or in the past
+	// NotifyLastAccountSequence removes sequences that are submittable or in the past
 	results := []<-chan error{
 		suite.queue.Push(1),
 		suite.queue.Push(2),
@@ -51,7 +51,7 @@ func (suite *QueueTestSuite) TestQueue_Update() {
 		suite.queue.Push(4),
 	}
 
-	suite.queue.Update(2)
+	suite.queue.NotifyLastAccountSequence(2)
 
 	// the update above signifies that 2 is the accounts current sequence,
 	// meaning that 3 is submittable, and so only 4 should still be queued
@@ -59,7 +59,7 @@ func (suite *QueueTestSuite) TestQueue_Update() {
 	_, s := suite.queue.head()
 	assert.Equal(suite.T(), uint64(4), s)
 
-	suite.queue.Update(4)
+	suite.queue.NotifyLastAccountSequence(4)
 	assert.Equal(suite.T(), 0, suite.queue.Size())
 
 	assert.Equal(suite.T(), ErrBadSequence, <-results[0])
@@ -67,11 +67,11 @@ func (suite *QueueTestSuite) TestQueue_Update() {
 	assert.Equal(suite.T(), nil, <-results[2])
 	assert.Equal(suite.T(), ErrBadSequence, <-results[3])
 
-	// Update clears the queue if the head has not been released within the time limit
+	// NotifyLastAccountSequence clears the queue if the head has not been released within the time limit
 	suite.queue.timeout = 1 * time.Millisecond
 	result := suite.queue.Push(2)
 	<-time.After(10 * time.Millisecond)
-	suite.queue.Update(0)
+	suite.queue.NotifyLastAccountSequence(0)
 
 	assert.Equal(suite.T(), 0, suite.queue.Size())
 	assert.Equal(suite.T(), ErrBadSequence, <-result)

--- a/services/horizon/internal/txsub/sequence/manager_test.go
+++ b/services/horizon/internal/txsub/sequence/manager_test.go
@@ -20,7 +20,7 @@ func TestManager_Push(t *testing.T) {
 	assert.Equal(t, 1, mgr.queues["2"].Size())
 }
 
-// Test the Update method
+// Test the NotifyLastAccountSequence method
 func TestManager_Update(t *testing.T) {
 	mgr := NewManager()
 	results := []<-chan error{

--- a/services/horizon/internal/txsub/submitter.go
+++ b/services/horizon/internal/txsub/submitter.go
@@ -50,7 +50,7 @@ func (sub *submitter) Submit(ctx context.Context, env string) (result Submission
 		return
 	}
 
-	// interpet response
+	// interpret response
 	if cresp.IsException() {
 		result.Err = errors.Errorf("stellar-core exception: %s", cresp.Exception)
 		return


### PR DESCRIPTION
It's the first time I get into this code (as part of https://github.com/stellar/go/issues/4283 ) and the naming has made it hard to understand. So, I decided to make the naming more understandable.
