### PR TITLE
services/horizon: Add (unstable) Stellar Core build to run integration tests against.

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -15,7 +15,7 @@ jobs:
         go: [1.17, 1.18]
         pg: [9.6.5]
         ingestion-backend: [db, captive-core, captive-core-remote-storage]
-        captive-core: [18.0.3-746.f3baea6.focal]
+        captive-core: [18.4.1-875.95d896a49.focal~v19unsafe]
     runs-on: ${{ matrix.os }}
     services:
       postgres:

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -2,6 +2,7 @@ package ingest
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"reflect"
 	"testing"
@@ -157,7 +158,9 @@ func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t 
 	}
 
 	_, err := runner.RunHistoryArchiveIngestion(100, 200, xdr.Hash{})
-	assert.EqualError(t, err, "Error while checking for supported protocol version: This Horizon version does not support protocol version 200. The latest supported protocol version is 18. Please upgrade to the latest Horizon version.")
+	assert.EqualError(t, err, fmt.Sprintf(
+		"Error while checking for supported protocol version: This Horizon version does not support protocol version 200. The latest supported protocol version is %d. Please upgrade to the latest Horizon version.",
+		MaxSupportedProtocolVersion))
 }
 
 func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
@@ -342,5 +345,7 @@ func TestProcessorRunnerRunAllProcessorsOnLedgerProtocolVersionNotSupported(t *t
 	}
 
 	_, err := runner.RunAllProcessorsOnLedger(ledger)
-	assert.EqualError(t, err, "Error while checking for supported protocol version: This Horizon version does not support protocol version 200. The latest supported protocol version is 18. Please upgrade to the latest Horizon version.")
+	assert.EqualError(t, err, fmt.Sprintf(
+		"Error while checking for supported protocol version: This Horizon version does not support protocol version 200. The latest supported protocol version is %d. Please upgrade to the latest Horizon version.",
+		MaxSupportedProtocolVersion))
 }


### PR DESCRIPTION
This is the first step to #4305.

However, note that the new Core build here is **untested** and **incomplete**. It will still be useful for testing things like backwards compatibility and also creating scaffolding for integration tests, but **do not test functionality** yet.