### PR TITLE
horizon: Fix integration tests

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.17, 1.18]
+        go: [1.18]
         pg: [9.6.5]
-        ingestion-backend: [db, captive-core, captive-core-remote-storage]
+        ingestion-backend: [captive-core]
         captive-core: [18.0.3-746.f3baea6.focal]
     runs-on: ${{ matrix.os }}
     services:
@@ -46,6 +46,13 @@ jobs:
         # We need to full history for git-restore-mtime to know what modification dates to use.
         # Otherwise, the Go test cache will fail (due to the modification time of fixtures changing).
         fetch-depth: '0'
+    - name: Setup upterm session
+      uses: lhotari/action-upterm@v1
+      with:
+        ## limits ssh access and adds the ssh public key for the user which triggered the workflow
+        limit-access-to-actor: true
+        ## limits ssh access and adds the ssh public keys of the listed GitHub users
+        limit-access-to-users: 2opremio
 
     - uses: ./.github/actions/setup-go
       with:

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.18]
+        go: [1.17, 1.18]
         pg: [9.6.5]
-        ingestion-backend: [captive-core]
+        ingestion-backend: [db, captive-core, captive-core-remote-storage]
         captive-core: [18.5.0-873.rc1.d387c6a71.focal]
     runs-on: ${{ matrix.os }}
     services:
@@ -46,13 +46,16 @@ jobs:
         # We need to full history for git-restore-mtime to know what modification dates to use.
         # Otherwise, the Go test cache will fail (due to the modification time of fixtures changing).
         fetch-depth: '0'
-    - name: Setup upterm session
-      uses: lhotari/action-upterm@v1
-      with:
-        ## limits ssh access and adds the ssh public key for the user which triggered the workflow
-        limit-access-to-actor: true
-        ## limits ssh access and adds the ssh public keys of the listed GitHub users
-        limit-access-to-users: 2opremio
+
+    # In order to debug the integration tests, run 'touch continue' once you connect to the ssh session
+    #
+    # - name: Setup upterm session
+    #  uses: lhotari/action-upterm@d23c2722bdab893785c9fbeae314cbf080645bd7
+    #  with:
+    #    ## limits ssh access and adds the ssh public key for the user which triggered the workflow
+    #    limit-access-to-actor: true
+    #    ## limits ssh access and adds the ssh public keys of the listed GitHub users
+    #    limit-access-to-users: <yourGithubUser>
 
     - uses: ./.github/actions/setup-go
       with:

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -15,7 +15,7 @@ jobs:
         go: [1.18]
         pg: [9.6.5]
         ingestion-backend: [captive-core]
-        captive-core: [18.0.3-746.f3baea6.focal]
+        captive-core: [18.5.0-873.rc1.d387c6a71.focal]
     runs-on: ${{ matrix.os }}
     services:
       postgres:

--- a/services/horizon/docker/docker-compose.integration-tests.yml
+++ b/services/horizon/docker/docker-compose.integration-tests.yml
@@ -11,8 +11,9 @@ services:
     command: ["-p", "5641"]
   core:
     platform: linux/amd64
-    # Note: keep image tag pinned an immutable tag to avoid unexpected upgrades
-    #       which break compatibility with the captive core version used.
+    # Note: keep image pinned to immutable tag matching captive core
+    #       to avoid implicit updates which break compatibility between
+    #       the core container and captive core.
     image: ${CORE_IMAGE:-stellar/stellar-core:18.5.0-873.rc1.d387c6a71.focal}
     depends_on:
       - core-postgres

--- a/services/horizon/docker/docker-compose.integration-tests.yml
+++ b/services/horizon/docker/docker-compose.integration-tests.yml
@@ -11,9 +11,9 @@ services:
     command: ["-p", "5641"]
   core:
     platform: linux/amd64
-    # Note: keep image pinned to immutable tag matching captive core
-    #       to avoid implicit updates which break compatibility between
-    #       the core container and captive core.
+    # Note: Please keep the image pinned to an immutable tag matching the Captive Core version.
+    #       This avoid implicit updates which break compatibility between
+    #       the Core container and captive core.
     image: ${CORE_IMAGE:-stellar/stellar-core:18.5.0-873.rc1.d387c6a71.focal}
     depends_on:
       - core-postgres

--- a/services/horizon/docker/docker-compose.integration-tests.yml
+++ b/services/horizon/docker/docker-compose.integration-tests.yml
@@ -11,12 +11,9 @@ services:
     command: ["-p", "5641"]
   core:
     platform: linux/amd64
-    # TODO replace with official SDF image when ready. Note that this:
-    # https://github.com/stellar/stellar-core/commit/31597b760f8e325fc84da0937adc373a78878ca9
-    # breaks the tests. I reverted it before building temp docker image.
-    # Command used to build custom image:
-    # docker build -t bartekno/stellar-core:17.4.0-p18 --build-arg STELLAR_CORE_VERSION=17.3.1-679.c5f6349.focal~protocol18~buildtests --build-arg DISTRO=focal .
-    image: ${CORE_IMAGE:-stellar/stellar-core:18}
+    # Note: keep image tag pinned an immutable tag to avoid unexpected upgrades
+    #       which break compatibility with the captive core version used.
+    image: ${CORE_IMAGE:-stellar/stellar-core:18.5.0-873.rc1.d387c6a71.focal}
     depends_on:
       - core-postgres
     restart: on-failure


### PR DESCRIPTION
Captive core `18.0.3-746.f3baea6.focal` seems to be incompatible with a Core container running version `18.5.0-873.rc1.d387c6a71.focal`

Upgrading captive core to `18.5.0-873.rc1.d387c6a71.focal` fixes the issue.