### PR TITLE
Add integration test for extra signers using tx preconditions

### DIFF
--- a/services/horizon/internal/integration/transaction_preconditions_test.go
+++ b/services/horizon/internal/integration/transaction_preconditions_test.go
@@ -90,7 +90,6 @@ func TestTransactionPreconditionsExtraSigners(t *testing.T) {
 
 	// Now the transaction should be submitted without problems, the extra signer specified
 	// has also signed this transaction.
-	// TODO - doesn't work yet, need to figure out how
 	txParams.Preconditions.ExtraSigners = []string{addtlAccounts[0].GetAccountID()}
 	_, err = itest.SubmitMultiSigTransaction([]*keypair.Full{master, addtlSigners[0]}, txParams)
 	tt.NoError(err)

--- a/services/horizon/internal/integration/transaction_preconditions_test.go
+++ b/services/horizon/internal/integration/transaction_preconditions_test.go
@@ -1,14 +1,14 @@
 package integration
 
 import (
-	"strconv"
-	"testing"
-	"time"
 	sdk "github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/services/horizon/internal/test/integration"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stretchr/testify/assert"
+	"strconv"
+	"testing"
+	"time"
 )
 
 func TestTransactionPreconditionsMinSeq(t *testing.T) {


### PR DESCRIPTION
new integration test case for using the `Precondtions.ExtraSigners` parameter with a standard AccountID as the additional signer.