### PR TITLE
all: update staticcheck to 2022.1

### DIFF
--- a/staticcheck.sh
+++ b/staticcheck.sh
@@ -1,11 +1,7 @@
 #! /bin/bash
 set -e
 
-gover=$(go version | { read _ _ gover _; printf $gover; })
-
-# This unreleased version of staticcheck has support for Go 1.18.
-# TODO: Update this to v3.0.0 when released.
-version='d5c28addcbbbafca0b9a0f9ad8957912e9371015'
+version='2022.1'
 
 staticcheck='go run honnef.co/go/tools/cmd/staticcheck@'"$version"
 


### PR DESCRIPTION
### What

Update staticcheck to 2022.1.

### Why

Version 2022.1 is the first released version supporting Go 1.18. We've been using a non-released version to get Go 1.18 support.

### Known limitations

N/A