### PR TITLE
services/horizon: Cap the minSeqAge precondition at MaxInt64

### DIFF
--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
@@ -241,7 +241,7 @@ func formatDuration(d *xdr.Duration) null.Int {
 	}
 
 	if *d > math.MaxInt64 {
-		*d = xdr.Duration(math.MaxInt64)
+		return null.IntFrom(math.MaxInt64)
 	}
 
 	return null.IntFrom(int64(*d))

--- a/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/transaction_batch_insert_builder.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -238,6 +239,11 @@ func formatDuration(d *xdr.Duration) null.Int {
 	if d == nil {
 		return null.Int{}
 	}
+
+	if *d > math.MaxInt64 {
+		*d = xdr.Duration(math.MaxInt64)
+	}
+
 	return null.IntFrom(int64(*d))
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
This caps the minSeqAge precondition field (of type `xdr.Duration = Uint64`) value to be an int64.

This is an alternative to #4339.

### Why
This ensures negative values don't make it into the database. We do the same thing with timebounds currently.

### Known limitations
You can't use the values in the interval `(MaxInt64, MaxUint64]`, but those are absurd anyway.