### PR TITLE
services/horizon: Bump Stellar Core to official v19.0.0rc1 for Horizon tests

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -34,8 +34,8 @@ jobs:
     env:
       HORIZON_INTEGRATION_TESTS_ENABLED: true
       HORIZON_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL: ${{ matrix.protocol-version }}
-      PROTOCOL_19_CORE_DEBIAN_PKG_VERSION: 18.4.1-875.95d896a49.focal~v19unsafe
-      PROTOCOL_19_CORE_DOCKER_IMG: stellar/stellar-core:18.4.1-875.95d896a49.focal-v19unsafe
+      PROTOCOL_19_CORE_DEBIAN_PKG_VERSION: 19.0.0-891.rc1.9d0704eb4.focal
+      PROTOCOL_19_CORE_DOCKER_IMG: stellar/stellar-core:19.0.0-891.rc1.9d0704eb4.focal
       PROTOCOL_18_CORE_DEBIAN_PKG_VERSION: 18.5.0-873.rc1.d387c6a71.focal
       PROTOCOL_18_CORE_DOCKER_IMG: stellar/stellar-core:18.5.0-873.rc1.d387c6a71.focal
       PGHOST: localhost

--- a/services/horizon/docker/docker-compose.integration-tests.yml
+++ b/services/horizon/docker/docker-compose.integration-tests.yml
@@ -14,7 +14,7 @@ services:
     # Note: Please keep the image pinned to an immutable tag matching the Captive Core version.
     #       This avoid implicit updates which break compatibility between
     #       the Core container and captive core.
-    image: ${CORE_IMAGE:-stellar/stellar-core:18.5.0-873.rc1.d387c6a71.focal}
+    image: ${CORE_IMAGE:-stellar/stellar-core:19.0.0-891.rc1.9d0704eb4.focal}
     depends_on:
       - core-postgres
     restart: on-failure


### PR DESCRIPTION
[v19.0.0rc1](https://github.com/stellar/stellar-core/releases/tag/v19.0.0rc1) of Stellar Core is released, and we should use it in our tests as early as possible.