### PR TITLE
services/horizon: expose supported protocol version on root endpoint

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -343,16 +343,17 @@ type Root struct {
 		Transactions        hal.Link  `json:"transactions"`
 	} `json:"_links"`
 
-	HorizonVersion               string    `json:"horizon_version"`
-	StellarCoreVersion           string    `json:"core_version"`
-	IngestSequence               uint32    `json:"ingest_latest_ledger"`
-	HorizonSequence              int32     `json:"history_latest_ledger"`
-	HorizonLatestClosedAt        time.Time `json:"history_latest_ledger_closed_at"`
-	HistoryElderSequence         int32     `json:"history_elder_ledger"`
-	CoreSequence                 int32     `json:"core_latest_ledger"`
-	NetworkPassphrase            string    `json:"network_passphrase"`
-	CurrentProtocolVersion       int32     `json:"current_protocol_version"`
-	CoreSupportedProtocolVersion int32     `json:"core_supported_protocol_version"`
+	HorizonVersion                  string    `json:"horizon_version"`
+	StellarCoreVersion              string    `json:"core_version"`
+	IngestSequence                  uint32    `json:"ingest_latest_ledger"`
+	HorizonSequence                 int32     `json:"history_latest_ledger"`
+	HorizonLatestClosedAt           time.Time `json:"history_latest_ledger_closed_at"`
+	HistoryElderSequence            int32     `json:"history_elder_ledger"`
+	CoreSequence                    int32     `json:"core_latest_ledger"`
+	NetworkPassphrase               string    `json:"network_passphrase"`
+	CurrentProtocolVersion          int32     `json:"current_protocol_version"`
+	CoreSupportedProtocolVersion    int32     `json:"core_supported_protocol_version"`
+	HorizonSupportedProtocolVersion int32     `json:"horizon_supported_protocol_version"`
 }
 
 // Signer represents one of an account's signers.

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -343,17 +343,17 @@ type Root struct {
 		Transactions        hal.Link  `json:"transactions"`
 	} `json:"_links"`
 
-	HorizonVersion                  string    `json:"horizon_version"`
-	StellarCoreVersion              string    `json:"core_version"`
-	IngestSequence                  uint32    `json:"ingest_latest_ledger"`
-	HorizonSequence                 int32     `json:"history_latest_ledger"`
-	HorizonLatestClosedAt           time.Time `json:"history_latest_ledger_closed_at"`
-	HistoryElderSequence            int32     `json:"history_elder_ledger"`
-	CoreSequence                    int32     `json:"core_latest_ledger"`
-	NetworkPassphrase               string    `json:"network_passphrase"`
-	CurrentProtocolVersion          int32     `json:"current_protocol_version"`
-	CoreSupportedProtocolVersion    int32     `json:"core_supported_protocol_version"`
-	HorizonSupportedProtocolVersion uint32    `json:"horizon_supported_protocol_version"`
+	HorizonVersion               string    `json:"horizon_version"`
+	StellarCoreVersion           string    `json:"core_version"`
+	IngestSequence               uint32    `json:"ingest_latest_ledger"`
+	HorizonSequence              int32     `json:"history_latest_ledger"`
+	HorizonLatestClosedAt        time.Time `json:"history_latest_ledger_closed_at"`
+	HistoryElderSequence         int32     `json:"history_elder_ledger"`
+	CoreSequence                 int32     `json:"core_latest_ledger"`
+	NetworkPassphrase            string    `json:"network_passphrase"`
+	CurrentProtocolVersion       int32     `json:"current_protocol_version"`
+	CoreSupportedProtocolVersion int32     `json:"core_supported_protocol_version"`
+	SupportedProtocolVersion     uint32    `json:"supported_protocol_version"`
 }
 
 // Signer represents one of an account's signers.

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -353,7 +353,7 @@ type Root struct {
 	NetworkPassphrase               string    `json:"network_passphrase"`
 	CurrentProtocolVersion          int32     `json:"current_protocol_version"`
 	CoreSupportedProtocolVersion    int32     `json:"core_supported_protocol_version"`
-	HorizonSupportedProtocolVersion uint32     `json:"horizon_supported_protocol_version"`
+	HorizonSupportedProtocolVersion uint32    `json:"horizon_supported_protocol_version"`
 }
 
 // Signer represents one of an account's signers.

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -353,7 +353,7 @@ type Root struct {
 	NetworkPassphrase               string    `json:"network_passphrase"`
 	CurrentProtocolVersion          int32     `json:"current_protocol_version"`
 	CoreSupportedProtocolVersion    int32     `json:"core_supported_protocol_version"`
-	HorizonSupportedProtocolVersion int32     `json:"horizon_supported_protocol_version"`
+	HorizonSupportedProtocolVersion uint32     `json:"horizon_supported_protocol_version"`
 }
 
 // Signer represents one of an account's signers.

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -352,8 +352,8 @@ type Root struct {
 	CoreSequence                 int32     `json:"core_latest_ledger"`
 	NetworkPassphrase            string    `json:"network_passphrase"`
 	CurrentProtocolVersion       int32     `json:"current_protocol_version"`
-	CoreSupportedProtocolVersion int32     `json:"core_supported_protocol_version"`
 	SupportedProtocolVersion     uint32    `json:"supported_protocol_version"`
+	CoreSupportedProtocolVersion int32     `json:"core_supported_protocol_version"`
 }
 
 // Signer represents one of an account's signers.

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -25,7 +25,7 @@ import (
 const (
 	// MaxSupportedProtocolVersion defines the maximum supported version of
 	// the Stellar protocol.
-	MaxSupportedProtocolVersion uint32 = 19
+	MaxSupportedProtocolVersion = 19
 
 	// CurrentVersion reflects the latest version of the ingestion
 	// algorithm. This value is stored in KV store and is used to decide

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -25,7 +25,7 @@ import (
 const (
 	// MaxSupportedProtocolVersion defines the maximum supported version of
 	// the Stellar protocol.
-	MaxSupportedProtocolVersion = 19
+	MaxSupportedProtocolVersion uint32 = 19
 
 	// CurrentVersion reflects the latest version of the ingestion
 	// algorithm. This value is stored in KV store and is used to decide

--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stellar/go/protocols/horizon"
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
+	"github.com/stellar/go/services/horizon/internal/ingest"
 	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/support/render/hal"
 )
@@ -32,6 +33,7 @@ func PopulateRoot(
 	dest.NetworkPassphrase = passphrase
 	dest.CurrentProtocolVersion = currentProtocolVersion
 	dest.CoreSupportedProtocolVersion = coreSupportedProtocolVersion
+	dest.HorizonSupportedProtocolVersion = ingest.MaxSupportedProtocolVersion
 
 	lb := hal.LinkBuilder{Base: horizonContext.BaseURL(ctx)}
 	if friendBotURL != nil {

--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -32,8 +32,8 @@ func PopulateRoot(
 	dest.StellarCoreVersion = cVersion
 	dest.NetworkPassphrase = passphrase
 	dest.CurrentProtocolVersion = currentProtocolVersion
-	dest.CoreSupportedProtocolVersion = coreSupportedProtocolVersion
 	dest.SupportedProtocolVersion = ingest.MaxSupportedProtocolVersion
+	dest.CoreSupportedProtocolVersion = coreSupportedProtocolVersion
 
 	lb := hal.LinkBuilder{Base: horizonContext.BaseURL(ctx)}
 	if friendBotURL != nil {

--- a/services/horizon/internal/resourceadapter/root.go
+++ b/services/horizon/internal/resourceadapter/root.go
@@ -33,7 +33,7 @@ func PopulateRoot(
 	dest.NetworkPassphrase = passphrase
 	dest.CurrentProtocolVersion = currentProtocolVersion
 	dest.CoreSupportedProtocolVersion = coreSupportedProtocolVersion
-	dest.HorizonSupportedProtocolVersion = ingest.MaxSupportedProtocolVersion
+	dest.SupportedProtocolVersion = ingest.MaxSupportedProtocolVersion
 
 	lb := hal.LinkBuilder{Base: horizonContext.BaseURL(ctx)}
 	if friendBotURL != nil {

--- a/services/horizon/internal/resourceadapter/root_test.go
+++ b/services/horizon/internal/resourceadapter/root_test.go
@@ -47,7 +47,7 @@ func TestPopulateRoot(t *testing.T) {
 	assert.Equal(t, "cVersion", res.StellarCoreVersion)
 	assert.Equal(t, "passphrase", res.NetworkPassphrase)
 	assert.Equal(t, "https://friendbot.example.com/{?addr}", res.Links.Friendbot.Href)
-	assert.Equal(t, int32(ingest.MaxSupportedProtocolVersion), res.HorizonSupportedProtocolVersion)
+	assert.Equal(t, uint32(ingest.MaxSupportedProtocolVersion), res.HorizonSupportedProtocolVersion)
 
 	// Without testbot
 	res = &horizon.Root{}

--- a/services/horizon/internal/resourceadapter/root_test.go
+++ b/services/horizon/internal/resourceadapter/root_test.go
@@ -47,7 +47,7 @@ func TestPopulateRoot(t *testing.T) {
 	assert.Equal(t, "cVersion", res.StellarCoreVersion)
 	assert.Equal(t, "passphrase", res.NetworkPassphrase)
 	assert.Equal(t, "https://friendbot.example.com/{?addr}", res.Links.Friendbot.Href)
-	assert.Equal(t, uint32(ingest.MaxSupportedProtocolVersion), res.HorizonSupportedProtocolVersion)
+	assert.Equal(t, uint32(ingest.MaxSupportedProtocolVersion), res.SupportedProtocolVersion)
 
 	// Without testbot
 	res = &horizon.Root{}

--- a/services/horizon/internal/resourceadapter/root_test.go
+++ b/services/horizon/internal/resourceadapter/root_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/services/horizon/internal/ingest"
 	"github.com/stellar/go/services/horizon/internal/ledger"
 )
 
@@ -46,6 +47,7 @@ func TestPopulateRoot(t *testing.T) {
 	assert.Equal(t, "cVersion", res.StellarCoreVersion)
 	assert.Equal(t, "passphrase", res.NetworkPassphrase)
 	assert.Equal(t, "https://friendbot.example.com/{?addr}", res.Links.Friendbot.Href)
+	assert.Equal(t, int32(ingest.MaxSupportedProtocolVersion), res.HorizonSupportedProtocolVersion)
 
 	// Without testbot
 	res = &horizon.Root{}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Expose the supported protocol version of Horizon on the root endpoint.

### Why

Improved visibility for debugging, etc. Also useful in contexts like the quickstart tests that want to upgrade core to the latest version supported by all components.

### Known limitations

N/A