### PR TITLE
services/friendbot: include txhash in logs

### DIFF
--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -44,7 +44,7 @@ func (minion *Minion) Run(destAddress string, resultChan chan SubmitResult) {
 		}
 		return
 	}
-	txStr, err := minion.makeTx(destAddress)
+	txHash, txStr, err := minion.makeTx(destAddress)
 	if err != nil {
 		resultChan <- SubmitResult{
 			maybeTransactionSuccess: nil,
@@ -55,7 +55,7 @@ func (minion *Minion) Run(destAddress string, resultChan chan SubmitResult) {
 	succ, err := minion.SubmitTransaction(minion, minion.Horizon, txStr)
 	resultChan <- SubmitResult{
 		maybeTransactionSuccess: succ,
-		maybeErr:                errors.Wrap(err, "submitting tx to minion"),
+		maybeErr:                errors.Wrapf(err, "submitting tx to minion %x", txHash),
 	}
 }
 
@@ -105,7 +105,7 @@ func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
 	minion.forceRefreshSequence = true
 }
 
-func (minion *Minion) makeTx(destAddress string) (string, error) {
+func (minion *Minion) makeTx(destAddress string) ([32]byte, string, error) {
 	createAccountOp := txnbuild.CreateAccount{
 		Destination:   destAddress,
 		SourceAccount: minion.BotAccount.GetAccountID(),
@@ -121,23 +121,28 @@ func (minion *Minion) makeTx(destAddress string) (string, error) {
 		},
 	)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to build tx")
+		return [32]byte{}, "", errors.Wrap(err, "unable to build tx")
 	}
 
 	tx, err = tx.Sign(minion.Network, minion.Keypair, minion.BotKeypair)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to sign tx")
+		return [32]byte{}, "", errors.Wrap(err, "unable to sign tx")
 	}
 
 	txe, err := tx.Base64()
 	if err != nil {
-		return "", errors.Wrap(err, "unable to serialize")
+		return [32]byte{}, "", errors.Wrap(err, "unable to serialize")
+	}
+
+	txh, err := tx.HashHex(minion.Network)
+	if err != nil {
+		return [32]byte{}, "", errors.Wrap(err, "unable to hash")
 	}
 
 	// Increment the in-memory sequence number, since the tx will be submitted.
 	_, err = minion.Account.IncrementSequenceNumber()
 	if err != nil {
-		return "", errors.Wrap(err, "incrementing minion seq")
+		return [32]byte{}, "", errors.Wrap(err, "incrementing minion seq")
 	}
-	return txe, err
+	return txh, txe, err
 }

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -134,7 +134,7 @@ func (minion *Minion) makeTx(destAddress string) ([32]byte, string, error) {
 		return [32]byte{}, "", errors.Wrap(err, "unable to serialize")
 	}
 
-	txh, err := tx.HashHex(minion.Network)
+	txh, err := tx.Hash(minion.Network)
 	if err != nil {
 		return [32]byte{}, "", errors.Wrap(err, "unable to hash")
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Include the transaction hash in friendbot logs when transactions are being submitted to the network.

### Why

To help with debugging in cases where transactions fail to submit since we can lookup what happened in Horizon for the transaction.

### Known limitations

N/A