### PR TITLE
services/horizon: Improve transaction precondition `omitempty` behavior

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -552,7 +552,7 @@ type TransactionPreconditionsTimebounds struct {
 
 type TransactionPreconditionsLedgerbounds struct {
 	MinLedger uint32 `json:"min_ledger"`
-	MaxLedger uint32 `json:"max_ledger"`
+	MaxLedger uint32 `json:"max_ledger,omitempty"`
 }
 
 // FeeBumpTransaction contains information about a fee bump transaction

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -720,7 +720,8 @@ func (t *Transaction) HasPreconditions() bool {
 	return !t.TimeBounds.Null ||
 		!t.LedgerBounds.Null ||
 		t.MinAccountSequence.Valid ||
-		t.MinAccountSequenceAge.Valid ||
+		(t.MinAccountSequenceAge.Valid &&
+			t.MinAccountSequenceAge.String != "0") ||
 		t.MinAccountSequenceLedgerGap.Valid ||
 		len(t.ExtraSigners) > 0
 }

--- a/services/horizon/internal/db2/history/transaction_ledger_bounds.go
+++ b/services/horizon/internal/db2/history/transaction_ledger_bounds.go
@@ -79,6 +79,9 @@ func formatLedgerBounds(ledgerBounds *xdr.LedgerBounds) LedgerBounds {
 
 	return LedgerBounds{
 		MinLedger: null.IntFrom(int64(ledgerBounds.MinLedger)),
-		MaxLedger: null.IntFrom(int64(ledgerBounds.MaxLedger)),
+		// elide max_ledger if it's 0 since that means no upper bound
+		MaxLedger: null.NewInt(
+			int64(ledgerBounds.MaxLedger),
+			ledgerBounds.MaxLedger > 0),
 	}
 }

--- a/services/horizon/internal/resourceadapter/transaction.go
+++ b/services/horizon/internal/resourceadapter/transaction.go
@@ -84,7 +84,7 @@ func PopulateTransaction(
 		dest.Preconditions.MinAccountSequence = fmt.Sprint(row.MinAccountSequence.Int64)
 	}
 
-	if row.MinAccountSequenceAge.Valid {
+	if row.MinAccountSequenceAge.Valid && row.MinAccountSequenceAge.String != "0" {
 		dest.Preconditions.MinAccountSequenceAge = row.MinAccountSequenceAge.String
 	}
 


### PR DESCRIPTION
### What
Two new omissions:
 1. omit minimum account sequence age when it's `"0"`
 2. omit `max_ledger` when it's `0`

### Why
1. Because we use a string for the field (to work around languages that don't natively support uint64 values) in the JSON response, but the field is a non-pointer in the XDR, it will always be set and will be 0 by default. Since it's a duration, 0 is effectively "not set", and so it should be omitted from the resulting precondition.
2. Because `0` is "no upper bound," so it's effectively "not set."

### Known limitations
(1) feels a little hacky. Caveat: if someone explicitly sets it to 0 when building their tx, this is equivalent to not setting it, so they may be confused about its omission, but this is working as intended.