### PR TITLE
services/horizon: Use UNIX timestamps instead of RFC3339 strings for timebounds.

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -11,6 +11,8 @@ This is the final release after the [release candidate](v2.17.0-release-candidat
   * `min_account_sequence_age` when it's `"0"`, as this is the default value when the condition is not set
   * `preconditions.ledgerbounds.max_ledger` when it's set to 0 (this means that there is no upper bound)
 
+- Timebounds within the `preconditions` object are a string representing UNIX timestamps in seconds rather than formatted date-times (which was a bug) ([4361](https://github.com/stellar/go/pull/4361)).
+
 ## V2.17.0 Release Candidate
 
 **Upgrading to this version from <= v2.8.3 will trigger a state rebuild. During this process (which will take at least 10 minutes), Horizon will not ingest new ledgers.**

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -11,7 +11,7 @@ This is the final release after the [release candidate](v2.17.0-release-candidat
   * `min_account_sequence_age` when it's `"0"`, as this is the default value when the condition is not set
   * `preconditions.ledgerbounds.max_ledger` when it's set to 0 (this means that there is no upper bound)
 
-- Timebounds within the `preconditions` object are a string representing UNIX timestamps in seconds rather than formatted date-times (which was a bug) ([4361](https://github.com/stellar/go/pull/4361)).
+- Timebounds within the `preconditions` object are a string containing int64 UNIX timestamps in seconds rather than formatted date-times (which was a bug) ([4361](https://github.com/stellar/go/pull/4361)).
 
 ## V2.17.0 Release Candidate
 

--- a/services/horizon/internal/integration/transaction_preconditions_test.go
+++ b/services/horizon/internal/integration/transaction_preconditions_test.go
@@ -119,13 +119,23 @@ func TestTransactionPreconditionsTimeBounds(t *testing.T) {
 
 	txHistory, err := itest.Client().TransactionDetail(tx.Hash)
 	assert.NoError(t, err)
-	historyMaxTime, err := time.Parse(time.RFC3339, txHistory.Preconditions.TimeBounds.MaxTime)
+
+	// Check that the deprecated string datetime fields match the new UNIX
+	// timestamp fields.
+	deprecatedHistoryMinTime, err := time.Parse(time.RFC3339, txHistory.ValidAfter)
 	assert.NoError(t, err)
-	historyMinTime, err := time.Parse(time.RFC3339, txHistory.Preconditions.TimeBounds.MinTime)
+	deprecatedHistoryMaxTime, err := time.Parse(time.RFC3339, txHistory.ValidBefore)
 	assert.NoError(t, err)
 
-	assert.Equal(t, historyMaxTime.UTC().Unix(), txParams.Preconditions.TimeBounds.MaxTime)
-	assert.Equal(t, historyMinTime.UTC().Unix(), txParams.Preconditions.TimeBounds.MinTime)
+	historyMinTime, err := strconv.ParseInt(txHistory.Preconditions.TimeBounds.MinTime, 10, 64)
+	assert.NoError(t, err)
+	historyMaxTime, err := strconv.ParseInt(txHistory.Preconditions.TimeBounds.MaxTime, 10, 64)
+	assert.NoError(t, err)
+
+	assert.Equal(t, historyMinTime, deprecatedHistoryMinTime.UTC().Unix())
+	assert.Equal(t, historyMaxTime, deprecatedHistoryMaxTime.UTC().Unix())
+	assert.Equal(t, historyMinTime, txParams.Preconditions.TimeBounds.MinTime)
+	assert.Equal(t, historyMaxTime, txParams.Preconditions.TimeBounds.MaxTime)
 }
 
 func TestTransactionPreconditionsExtraSigners(t *testing.T) {

--- a/services/horizon/internal/resourceadapter/transaction.go
+++ b/services/horizon/internal/resourceadapter/transaction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/guregu/null"
@@ -65,8 +66,8 @@ func PopulateTransaction(
 		dest.ValidAfter = timeString(row.TimeBounds.Lower)
 
 		dest.Preconditions.TimeBounds = &protocol.TransactionPreconditionsTimebounds{
-			MaxTime: timeString(row.TimeBounds.Upper),
-			MinTime: timeString(row.TimeBounds.Lower),
+			MaxTime: timestampString(row.TimeBounds.Upper),
+			MinTime: timestampString(row.TimeBounds.Lower),
 		}
 	}
 
@@ -157,4 +158,12 @@ func timeString(in null.Int) string {
 	}
 
 	return time.Unix(in.Int64, 0).UTC().Format(time.RFC3339)
+}
+
+func timestampString(in null.Int) string {
+	if !in.Valid {
+		return ""
+	}
+
+	return strconv.FormatInt(in.Int64, 10)
 }

--- a/services/horizon/internal/resourceadapter/transaction_test.go
+++ b/services/horizon/internal/resourceadapter/transaction_test.go
@@ -195,8 +195,8 @@ func TestPopulateTransaction_Preconditions(t *testing.T) {
 	p := dest.Preconditions
 	assert.Equal(t, validAfter.Format(time.RFC3339), dest.ValidAfter)
 	assert.Equal(t, validBefore.Format(time.RFC3339), dest.ValidBefore)
-	assert.Equal(t, validAfter.Format(time.RFC3339), p.TimeBounds.MinTime)
-	assert.Equal(t, validBefore.Format(time.RFC3339), p.TimeBounds.MaxTime)
+	assert.Equal(t, fmt.Sprint(validAfter.Unix()), p.TimeBounds.MinTime)
+	assert.Equal(t, fmt.Sprint(validBefore.Unix()), p.TimeBounds.MaxTime)
 	assert.Equal(t, minLedger, p.LedgerBounds.MinLedger)
 	assert.Equal(t, maxLedger, p.LedgerBounds.MaxLedger)
 	assert.Equal(t, fmt.Sprint(minAccountSequence), p.MinAccountSequence)
@@ -289,8 +289,8 @@ func TestPopulateTransaction_PreconditionsV2(t *testing.T) {
 		assert.NoError(t, PopulateTransaction(ctx, row.TransactionHash, &dest, row))
 
 		gotTimebounds := dest.Preconditions.TimeBounds
-		assert.Equal(t, "1970-01-01T00:00:05Z", gotTimebounds.MinTime)
-		assert.Equal(t, "1970-01-01T00:00:10Z", gotTimebounds.MaxTime)
+		assert.Equal(t, "5", gotTimebounds.MinTime)
+		assert.Equal(t, "10", gotTimebounds.MaxTime)
 	}
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
The timebounds w/in the new preconditions field are now UNIX timestamps.

### Why
We all agreed that time-related fields going forward should be UNIX timestamps in seconds.

This one slipped through the cracks, because it comes from the existing ValidBefore/After timebound fields, but though they are the same _time_, they should not be the same _value_.

### Known limitations
This will break SDKs that are parsing strings, but the community SDK blast specifies that it's a UNIX timestamp. Furthermore, Horizon isn't released yet, so nobody should even know that they're strings right now.