### PR TITLE
tools/horizon-cmp: Improve panic error message

### DIFF
--- a/tools/horizon-cmp/internal/response.go
+++ b/tools/horizon-cmp/internal/response.go
@@ -131,7 +131,7 @@ func NewResponse(domain, path string, stream bool) *Response {
 		resp.StatusCode != http.StatusGatewayTimeout &&
 		resp.StatusCode != http.StatusGone &&
 		resp.StatusCode != http.StatusServiceUnavailable {
-		panic(resp.StatusCode)
+		panic(fmt.Errorf("%d for GET %s", resp.StatusCode, domain+path))
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
### What
This adds the requested URL to a panic message.

### Why
If `horizon-cmp` encounters an unexpected HTTP status code (like a 500), it will just spit out `panic: 500`. This isn't useful for debugging or reproducing the error, since you have no idea what the requested URL was.