### PR TITLE
services/horizon/internal/integration: Clean up executing every integration test

### DIFF
--- a/services/horizon/internal/integration/claimable_balance_ops_test.go
+++ b/services/horizon/internal/integration/claimable_balance_ops_test.go
@@ -16,6 +16,7 @@ import (
 func TestClaimableBalanceCreationOperationsAndEffects(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	master := itest.Master()
 
 	t.Run("Successful", func(t *testing.T) {

--- a/services/horizon/internal/integration/claimable_balance_test.go
+++ b/services/horizon/internal/integration/claimable_balance_test.go
@@ -20,6 +20,7 @@ import (
 func TestClaimableBalanceBasics(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	master := itest.Master()
 
 	// Ensure predicting claimable balances works.
@@ -72,6 +73,7 @@ func TestClaimableBalanceBasics(t *testing.T) {
 
 func TestHappyClaimableBalances(t *testing.T) {
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	master, client := itest.Master(), itest.Client()
 
 	keys, accounts := itest.CreateAccounts(3, "1000")
@@ -295,6 +297,7 @@ func TestHappyClaimableBalances(t *testing.T) {
 // We want to ensure that users can't claim the same claimable balance twice.
 func TestDoubleClaim(t *testing.T) {
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	client := itest.Client()
 
 	// Create a couple of accounts to test the interactions.
@@ -355,6 +358,7 @@ func TestDoubleClaim(t *testing.T) {
 
 func TestClaimableBalancePredicates(t *testing.T) {
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	_, client := itest.Master(), itest.Client()
 
 	// Create a couple of accounts to test the interactions.

--- a/services/horizon/internal/integration/clawback_test.go
+++ b/services/horizon/internal/integration/clawback_test.go
@@ -19,6 +19,7 @@ import (
 func TestHappyClawbackAccount(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	master := itest.Master()
 
 	asset, fromKey, _ := setupClawbackAccountTest(tt, itest, master)

--- a/services/horizon/internal/integration/db_test.go
+++ b/services/horizon/internal/integration/db_test.go
@@ -442,6 +442,7 @@ func initializeDBIntegrationTest(t *testing.T) (itest *integration.Test, reached
 
 func TestReingestDB(t *testing.T) {
 	itest, reachedLedger := initializeDBIntegrationTest(t)
+	defer itest.Shutdown()
 	tt := assert.New(t)
 
 	// Create a fresh Horizon database
@@ -547,6 +548,7 @@ func command(horizonConfig horizon.Config, args ...string) []string {
 
 func TestFillGaps(t *testing.T) {
 	itest, reachedLedger := initializeDBIntegrationTest(t)
+	defer itest.Shutdown()
 	tt := assert.New(t)
 
 	// Create a fresh Horizon database
@@ -660,6 +662,7 @@ func TestFillGaps(t *testing.T) {
 
 func TestResumeFromInitializedDB(t *testing.T) {
 	itest, reachedLedger := initializeDBIntegrationTest(t)
+	defer itest.Shutdown()
 	tt := assert.New(t)
 
 	// Stop the integration test, and restart it with the same database

--- a/services/horizon/internal/integration/liquidity_pool_test.go
+++ b/services/horizon/internal/integration/liquidity_pool_test.go
@@ -19,6 +19,7 @@ import (
 func TestLiquidityPoolHappyPath(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	master := itest.Master()
 
 	keys, accounts := itest.CreateAccounts(2, "1000")
@@ -420,6 +421,7 @@ func TestLiquidityPoolHappyPath(t *testing.T) {
 func TestLiquidityPoolRevoke(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	master := itest.Master()
 
 	keys, accounts := itest.CreateAccounts(2, "1000")

--- a/services/horizon/internal/integration/muxed_account_details_test.go
+++ b/services/horizon/internal/integration/muxed_account_details_test.go
@@ -17,6 +17,7 @@ import (
 func TestMuxedAccountDetails(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	master := itest.Master()
 	masterStr := master.Address()
 	masterAcID := xdr.MustAddress(masterStr)

--- a/services/horizon/internal/integration/muxed_operations_test.go
+++ b/services/horizon/internal/integration/muxed_operations_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestMuxedOperations(t *testing.T) {
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 
 	sponsored := keypair.MustRandom()
 	// Is there an easier way?

--- a/services/horizon/internal/integration/negative_seq_txsub_test.go
+++ b/services/horizon/internal/integration/negative_seq_txsub_test.go
@@ -13,6 +13,7 @@ import (
 func TestNegativeSequenceTxSubmission(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	master := itest.Master()
 
 	// First, bump the sequence to the maximum value -1

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -2,14 +2,15 @@
 package integration
 
 import (
-	"github.com/stellar/go/services/horizon/internal/paths"
-	"github.com/stellar/go/services/horizon/internal/simplepath"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/stellar/go/services/horizon/internal/paths"
+	"github.com/stellar/go/services/horizon/internal/simplepath"
 
 	horizon "github.com/stellar/go/services/horizon/internal"
 	"github.com/stellar/go/services/horizon/internal/test/integration"
@@ -105,6 +106,7 @@ func (suite *FatalTestCase) TestEnvironmentPreserved() {
 	test := NewParameterTestWithEnv(t, map[string]string{}, map[string]string{
 		"CAPTIVE_CORE_CONFIG_PATH": confName,
 	})
+	defer test.Shutdown()
 
 	err = test.StartHorizon()
 	assert.NoError(t, err)
@@ -112,8 +114,6 @@ func (suite *FatalTestCase) TestEnvironmentPreserved() {
 
 	envValue := os.Getenv("CAPTIVE_CORE_CONFIG_PATH")
 	assert.Equal(t, confName, envValue)
-
-	test.Shutdown()
 
 	envValue = os.Getenv("CAPTIVE_CORE_CONFIG_PATH")
 	assert.Equal(t, "original value", envValue)
@@ -135,6 +135,7 @@ func TestCaptiveCoreConfigFilesystemState(t *testing.T) {
 	test := NewParameterTest(t, localParams)
 
 	err := test.StartHorizon()
+	defer test.StopHorizon()
 	assert.NoError(t, err)
 	test.WaitForHorizon()
 
@@ -150,35 +151,36 @@ func TestCaptiveCoreConfigFilesystemState(t *testing.T) {
 func TestMaxAssetsForPathRequests(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		test := NewParameterTest(t, map[string]string{})
+		defer test.Shutdown()
 		err := test.StartHorizon()
 		assert.NoError(t, err)
 		test.WaitForHorizon()
 		assert.Equal(t, test.Horizon().Config().MaxAssetsPerPathRequest, 15)
-		test.Shutdown()
 	})
 	t.Run("set to 2", func(t *testing.T) {
 		test := NewParameterTest(t, map[string]string{"max-assets-per-path-request": "2"})
+		defer test.Shutdown()
 		err := test.StartHorizon()
 		assert.NoError(t, err)
 		test.WaitForHorizon()
 		assert.Equal(t, test.Horizon().Config().MaxAssetsPerPathRequest, 2)
-		test.Shutdown()
 	})
 }
 
 func TestMaxPathFindingRequests(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		test := NewParameterTest(t, map[string]string{})
+		defer test.Shutdown()
 		err := test.StartHorizon()
 		assert.NoError(t, err)
 		test.WaitForHorizon()
 		assert.Equal(t, test.Horizon().Config().MaxPathFindingRequests, uint(0))
 		_, ok := test.Horizon().Paths().(simplepath.InMemoryFinder)
 		assert.True(t, ok)
-		test.Shutdown()
 	})
 	t.Run("set to 5", func(t *testing.T) {
 		test := NewParameterTest(t, map[string]string{"max-path-finding-requests": "5"})
+		defer test.Shutdown()
 		err := test.StartHorizon()
 		assert.NoError(t, err)
 		test.WaitForHorizon()
@@ -186,7 +188,6 @@ func TestMaxPathFindingRequests(t *testing.T) {
 		finder, ok := test.Horizon().Paths().(*paths.RateLimitedFinder)
 		assert.True(t, ok)
 		assert.Equal(t, finder.Limit(), 5)
-		test.Shutdown()
 	})
 }
 

--- a/services/horizon/internal/integration/protocol_19_upgrade_test.go
+++ b/services/horizon/internal/integration/protocol_19_upgrade_test.go
@@ -15,6 +15,7 @@ import (
 // correct behavior and no crashes.
 func TestProtocol19Upgrade(t *testing.T) {
 	itest := integration.NewTest(t, integration.Config{ProtocolVersion: 18})
+	defer itest.Shutdown()
 
 	master := itest.Master()
 	masterAccount := itest.MasterAccount()

--- a/services/horizon/internal/integration/sponsorship_test.go
+++ b/services/horizon/internal/integration/sponsorship_test.go
@@ -21,6 +21,7 @@ import (
 func TestSponsorships(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	client := itest.Client()
 
 	/* Query helpers that can/should? probably be added to IntegrationTest. */

--- a/services/horizon/internal/integration/state_verifier_test.go
+++ b/services/horizon/internal/integration/state_verifier_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestStateVerifier(t *testing.T) {
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 
 	sponsored := keypair.MustRandom()
 	sponsoredSource := &txnbuild.SimpleAccount{

--- a/services/horizon/internal/integration/trade_aggregations_test.go
+++ b/services/horizon/internal/integration/trade_aggregations_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestTradeAggregations(t *testing.T) {
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	ctx := context.Background()
 	historyQ := itest.Horizon().HistoryQ()
 

--- a/services/horizon/internal/integration/transaction_preconditions_test.go
+++ b/services/horizon/internal/integration/transaction_preconditions_test.go
@@ -22,6 +22,7 @@ import (
 func TestTransactionPreconditionsMinSeq(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	if itest.GetEffectiveProtocolVersion() < 19 {
 		t.Skip("Can't run with protocol < 19")
 	}
@@ -91,6 +92,7 @@ func TestTransactionPreconditionsMinSeq(t *testing.T) {
 func TestTransactionPreconditionsTimeBounds(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	if itest.GetEffectiveProtocolVersion() < 19 {
 		t.Skip("Can't run with protocol < 19")
 	}
@@ -141,6 +143,7 @@ func TestTransactionPreconditionsTimeBounds(t *testing.T) {
 func TestTransactionPreconditionsExtraSigners(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	if itest.GetEffectiveProtocolVersion() < 19 {
 		t.Skip("Can't run with protocol < 19")
 	}
@@ -176,6 +179,7 @@ func TestTransactionPreconditionsExtraSigners(t *testing.T) {
 func TestTransactionPreconditionsLedgerBounds(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	if itest.GetEffectiveProtocolVersion() < 19 {
 		t.Skip("Can't run with protocol < 19")
 	}
@@ -218,6 +222,7 @@ func TestTransactionPreconditionsLedgerBounds(t *testing.T) {
 func TestTransactionPreconditionsMinSequenceNumberAge(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	if itest.GetEffectiveProtocolVersion() < 19 {
 		t.Skip("Can't run with protocol < 19")
 	}
@@ -273,6 +278,7 @@ func TestTransactionPreconditionsMinSequenceNumberAge(t *testing.T) {
 func TestTransactionPreconditionsMinSequenceNumberLedgerGap(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	if itest.GetEffectiveProtocolVersion() < 19 {
 		t.Skip("Can't run with protocol < 19")
 	}
@@ -313,6 +319,7 @@ func TestTransactionPreconditionsMinSequenceNumberLedgerGap(t *testing.T) {
 func TestTransactionWithoutPreconditions(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	if itest.GetEffectiveProtocolVersion() < 19 {
 		t.Skip("Can't run with protocol < 19")
 	}
@@ -375,6 +382,7 @@ func TestTransactionWithoutPreconditions(t *testing.T) {
 func TestTransactionPreconditionsEdgeCases(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	if itest.GetEffectiveProtocolVersion() < 19 {
 		t.Skip("Can't run with protocol < 19")
 	}

--- a/services/horizon/internal/integration/txsub_test.go
+++ b/services/horizon/internal/integration/txsub_test.go
@@ -13,6 +13,7 @@ import (
 func TestTxsub(t *testing.T) {
 	tt := assert.New(t)
 	itest := integration.NewTest(t, integration.Config{})
+	defer itest.Shutdown()
 	master := itest.Master()
 
 	// Sanity check: create 20 accounts and submit 2 txs from each of them as


### PR DESCRIPTION
We were not calling `Shutdown()` appropriately calling shutdown after executing integration tests.

I think this is (at least partly) the cause of recent integration test problems like https://github.com/stellar/go/runs/6233228705