### PR TITLE
exp/lighthorizon: Modify trie tests to use `assert` over raw comparisons.

### DIFF
--- a/exp/lighthorizon/index/trie_test.go
+++ b/exp/lighthorizon/index/trie_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"math/rand"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,7 +96,7 @@ func TestTrieIndexSuffixes(t *testing.T) {
 
 func TestTrieIndexSerialization(t *testing.T) {
 	for i := 0; i < 10_000; i++ {
-		t.Run(fmt.Sprintf("attempt%d", i), func(t *testing.T) {
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) {
 			index, inserts := randomTrie(t, nil)
 
 			// Round-trip it to serialization and back

--- a/exp/lighthorizon/index/trie_test.go
+++ b/exp/lighthorizon/index/trie_test.go
@@ -41,10 +41,7 @@ func TestTrieIndex(t *testing.T) {
 
 		for key, expected := range inserts {
 			value, ok := index.Get([]byte(key))
-			if !assert.Truef(t, ok, "Key not found: %s", key) {
-				t.FailNow()
-				continue
-			}
+			require.Truef(t, ok, "Key not found: %s", key)
 			ledger := binary.BigEndian.Uint32(value)
 			assert.Equalf(t, expected, ledger,
 				"Key %s found: %v, expected: %v", key, ledger, expected)
@@ -115,9 +112,7 @@ func TestTrieIndexSerialization(t *testing.T) {
 
 			for key, expected := range inserts {
 				value, ok := read.Get([]byte(key))
-				if !assert.Truef(t, ok, "Key not found: %s", key) {
-					t.FailNow()
-				}
+				require.Truef(t, ok, "Key not found: %s", key)
 
 				ledger := binary.BigEndian.Uint32(value)
 				assert.Equal(t, expected, ledger, "for key %s", key)
@@ -286,27 +281,17 @@ func TestTrieIndexMerge(t *testing.T) {
 		// Should still have all the A keys
 		for key, expected := range aInserts {
 			value, ok := a.Get([]byte(key))
-			if !ok {
-				t.Errorf("Key not found: %s", key)
-			} else {
-				ledger := binary.BigEndian.Uint32(value)
-				if ledger != expected {
-					t.Errorf("Key %s found: %v, expected: %v", key, ledger, expected)
-				}
-			}
+			require.Truef(t, ok, "Key not found: %s", key)
+			ledger := binary.BigEndian.Uint32(value)
+			assert.Equalf(t, expected, ledger, "Key %s found", key)
 		}
 
 		// Should now also have all the B keys
 		for key, expected := range bInserts {
 			value, ok := a.Get([]byte(key))
-			if !ok {
-				t.Errorf("Key not found: %s", key)
-			} else {
-				ledger := binary.BigEndian.Uint32(value)
-				if ledger != expected {
-					t.Errorf("Key %s found: %v, expected: %v", key, ledger, expected)
-				}
-			}
+			require.Truef(t, ok, "Key not found: %s", key)
+			ledger := binary.BigEndian.Uint32(value)
+			assert.Equalf(t, expected, ledger, "Key %s found", key)
 		}
 	}
 }

--- a/exp/lighthorizon/index/trie_test.go
+++ b/exp/lighthorizon/index/trie_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +23,7 @@ func randomTrie(t *testing.T, index *TrieIndex) (*TrieIndex, map[string]uint32) 
 		ledger := uint32(rand.Int63())
 		hashBytes := make([]byte, 32)
 		if _, err := rand.Read(hashBytes); err != nil {
-			t.Error(err.Error())
+			assert.NoError(t, err)
 		}
 		hash := hex.EncodeToString(hashBytes)
 
@@ -39,14 +41,10 @@ func TestTrieIndex(t *testing.T) {
 
 		for key, expected := range inserts {
 			value, ok := index.Get([]byte(key))
-			if !ok {
-				t.Errorf("Key not found: %s", key)
-			} else {
-				ledger := binary.BigEndian.Uint32(value)
-				if ledger != expected {
-					t.Errorf("Key %s found: %v, expected: %v", key, ledger, expected)
-				}
-			}
+			assert.Truef(t, ok, "Key not found: %s", key)
+			ledger := binary.BigEndian.Uint32(value)
+			assert.Equalf(t, expected, ledger,
+				"Key %s found: %v, expected: %v", key, ledger, expected)
 		}
 	}
 }
@@ -56,19 +54,16 @@ func TestTrieIndexUpsertBasic(t *testing.T) {
 
 	key := "key"
 	prev, ok := index.Upsert([]byte(key), []byte("a"))
-	if ok || prev != nil {
-		t.Errorf("Unexpected previous value: %q, expected: nil", string(prev))
-	}
+	assert.Nil(t, prev)
+	assert.Falsef(t, ok, "expected nil, got prev: %q", string(prev))
 
 	prev, ok = index.Upsert([]byte(key), []byte("b"))
-	if !ok || string(prev) != "a" {
-		t.Errorf("Unexpected previous value: %q, expected: a", string(prev))
-	}
+	assert.Equal(t, "a", string(prev))
+	assert.Truef(t, ok, "expected 'a', got prev: %q", string(prev))
 
 	prev, ok = index.Upsert([]byte(key), []byte("c"))
-	if !ok || string(prev) != "b" {
-		t.Errorf("Unexpected previous value: %q, expected: b", string(prev))
-	}
+	assert.Equal(t, "b", string(prev))
+	assert.Truef(t, ok, "expected 'b', got prev: %q", string(prev))
 }
 
 func TestTrieIndexSuffixes(t *testing.T) {
@@ -101,36 +96,30 @@ func TestTrieIndexSuffixes(t *testing.T) {
 
 func TestTrieIndexSerialization(t *testing.T) {
 	for i := 0; i < 10_000; i++ {
-		index, inserts := randomTrie(t, nil)
+		t.Run(fmt.Sprintf("attempt%d", i), func(t *testing.T) {
+			index, inserts := randomTrie(t, nil)
 
-		// Round-trip it to serialization and back
-		buf := &bytes.Buffer{}
-		nWritten, err := index.WriteTo(buf)
-		if err != nil {
-			t.Error(err.Error())
-		}
+			// Round-trip it to serialization and back
+			buf := &bytes.Buffer{}
+			nWritten, err := index.WriteTo(buf)
+			assert.NoError(t, err)
 
-		read := &TrieIndex{}
-		nRead, err := read.ReadFrom(buf)
-		if err != nil {
-			t.Error(err.Error())
-		}
+			read := &TrieIndex{}
+			nRead, err := read.ReadFrom(buf)
+			assert.NoError(t, err)
 
-		if nWritten != nRead {
-			t.Errorf("Wrote %d bytes, but read %d bytes", nWritten, nRead)
-		}
+			assert.Equal(t, nWritten, nRead, "read more or less than we wrote")
 
-		for key, expected := range inserts {
-			value, ok := read.Get([]byte(key))
-			if !ok {
-				t.Errorf("Key not found: %s", key)
-			} else {
-				ledger := binary.BigEndian.Uint32(value)
-				if ledger != expected {
-					t.Errorf("Key %s found: %v, expected: %v", key, ledger, expected)
+			for key, expected := range inserts {
+				value, ok := read.Get([]byte(key))
+				if !assert.Truef(t, ok, "Key not found: %s", key) {
+					t.FailNow()
 				}
+
+				ledger := binary.BigEndian.Uint32(value)
+				assert.Equal(t, expected, ledger, "for key %s", key)
 			}
-		}
+		})
 	}
 }
 

--- a/exp/lighthorizon/index/trie_test.go
+++ b/exp/lighthorizon/index/trie_test.go
@@ -41,7 +41,10 @@ func TestTrieIndex(t *testing.T) {
 
 		for key, expected := range inserts {
 			value, ok := index.Get([]byte(key))
-			assert.Truef(t, ok, "Key not found: %s", key)
+			if !assert.Truef(t, ok, "Key not found: %s", key) {
+				t.FailNow()
+				continue
+			}
 			ledger := binary.BigEndian.Uint32(value)
 			assert.Equalf(t, expected, ledger,
 				"Key %s found: %v, expected: %v", key, ledger, expected)


### PR DESCRIPTION
### What
Use `testify/assert` library in `TrieIndex` tests. 

### Why 
This makes the test cases cleaner by having less reliance on custom conditionals & error messages. It's a preliminary step to moving the `TrieIndex` serialization to XDR so that it's clear that existing tests are unchanged (and pass).

Things still work:
```
exp/lighthorizon> go test -failfast ./index/...    
ok  	github.com/stellar/go/exp/lighthorizon/index	13.964s
```