### PR TITLE
exp/lighthorizon: Add XDR marshalling for the `TrieNode` structure.

### DIFF
--- a/exp/lighthorizon/index/trie.go
+++ b/exp/lighthorizon/index/trie.go
@@ -2,10 +2,10 @@ package index
 
 import (
 	"bufio"
-	"encoding/binary"
-	"fmt"
 	"io"
 	"sync"
+
+	"github.com/stellar/go/exp/lighthorizon/index/xdr"
 )
 
 const (
@@ -224,224 +224,95 @@ func (i *TrieIndex) Merge(other *TrieIndex) error {
 	return nil
 }
 
-// TODO: Use XDR for this, to be more consistent with rest of the codebase, and
-// do less custom shenanigans.
 func (i *TrieIndex) ReadFrom(r io.Reader) (int64, error) {
 	i.Lock()
 	defer i.Unlock()
 
-	var nRead int64
 	br := bufio.NewReader(r)
-
-	// Read the index version
-	version, err := binary.ReadUvarint(br)
-	nRead += int64(uvarintSize(version))
+	bytes, err := io.ReadAll(br)
 	if err != nil {
-		return nRead, err
-	} else if version != TrieIndexVersion {
-		return nRead, fmt.Errorf("unsupported trie version: %d", version)
+		return int64(len(bytes)), err
 	}
 
-	i.Root = &trieNode{}
-	n, err := i.Root.readFrom(br)
-	return nRead + n, err
-}
-
-func (i *trieNode) readFrom(r *bufio.Reader) (int64, error) {
-	var nRead int64
-
-	// Read the header flags byte
-	header, err := r.ReadByte()
-	nRead += 1
+	xdrIndex := xdr.TrieIndex{}
+	err = xdrIndex.UnmarshalBinary(bytes)
 	if err != nil {
-		return nRead, err
+		return int64(len(bytes)), err
 	}
 
-	// Read this node's prefix
-	if header&HeaderHasPrefix > 0 {
-		prefix, n64, err := readBytes(r)
-		nRead += n64
-		if err != nil {
-			return nRead, err
-		}
-		i.Prefix = prefix
+	i.Root = &trieNode{
+		Prefix:   xdrIndex.Root.Prefix,
+		Value:    xdrIndex.Root.Value,
+		Children: make(map[byte]*trieNode, len(xdrIndex.Root.Children)),
 	}
 
-	// Read this node's value
-	if header&HeaderHasValue > 0 {
-		value, n64, err := readBytes(r)
-		nRead += n64
-		if err != nil {
-			return nRead, err
-		}
-		i.Value = value
+	for _, node := range xdrIndex.Root.Children {
+		buildTrie(&node, i.Root)
 	}
 
-	// Read this node's children count
-	if header&HeaderHasChildren > 0 {
-		childLen, err := binary.ReadUvarint(r)
-		nRead += int64(uvarintSize(childLen))
-		if err != nil {
-			return nRead, err
-		}
-
-		if childLen > 0 {
-			i.Children = map[byte]*trieNode{}
-			// Read this node's children
-			for j := uint64(0); j < childLen; j++ {
-				// Read the child's key
-				key, err := r.ReadByte()
-				nRead += 1
-				if err != nil {
-					return nRead, err
-				}
-
-				// Read the rest of the child
-				var node trieNode
-				n64, err := node.readFrom(r)
-				nRead += n64
-				if err != nil {
-					return nRead, err
-				}
-				i.Children[key] = &node
-			}
-		}
-	}
-
-	return nRead, nil
+	return int64(len(bytes)), nil
 }
 
-// TODO: Do this better, without allocating a new byte buffer each time, etc..
-func uvarintSize(value uint64) int {
-	return binary.PutUvarint(make([]byte, binary.MaxVarintLen64), value)
+func buildTrie(xdrNode *xdr.TrieNodeChild, parent *trieNode) {
+	node := &trieNode{
+		Prefix:   xdrNode.Node.Prefix,
+		Value:    xdrNode.Node.Value,
+		Children: make(map[byte]*trieNode, len(xdrNode.Node.Children)),
+	}
+	parent.Children[xdrNode.Key[0]] = node
+
+	for _, child := range xdrNode.Node.Children {
+		buildTrie(&child, node)
+	}
 }
 
-// TODO: Use XDR for this, to be more consistent with rest of the codebase, and
-// do less custom shenanigans.
 func (i *TrieIndex) WriteTo(w io.Writer) (int64, error) {
 	i.RLock()
 	defer i.RUnlock()
-	buf := make([]byte, binary.MaxVarintLen64)
 
-	var nWritten, n64 int64
+	xdrRoot := xdr.TrieNode{}
 
-	// Write the index version
-	n := binary.PutUvarint(buf, uint64(TrieIndexVersion))
-	n, err := w.Write(buf[:n])
-	nWritten += int64(n)
+	// Apparently this is possible?
+	if i.Root != nil {
+		xdrRoot.Prefix = i.Root.Prefix
+		xdrRoot.Value = i.Root.Value
+		xdrRoot.Children = make([]xdr.TrieNodeChild, 0, len(i.Root.Children))
+
+		for key, node := range i.Root.Children {
+			buildXdrTrie(key, node, &xdrRoot)
+		}
+	}
+
+	xdrIndex := xdr.TrieIndex{Version: TrieIndexVersion, Root: xdrRoot}
+	bytes, err := xdrIndex.MarshalBinary()
 	if err != nil {
-		return nWritten, err
+		return int64(len(bytes)), err
 	}
 
-	if i.Root == nil {
-		n64, err = (&trieNode{}).writeTo(w, buf)
-	} else {
-		n64, err = i.Root.writeTo(w, buf)
-	}
-	return nWritten + n64, err
+	count, err := w.Write(bytes)
+	return int64(count), err
 }
 
-func (i *trieNode) writeTo(w io.Writer, buf []byte) (int64, error) {
-	var nWritten, n64 int64
-
-	// Write the header flags byte
-	var header byte
-	if len(i.Prefix) > 0 {
-		header |= HeaderHasPrefix
-	}
-	if len(i.Value) > 0 {
-		header |= HeaderHasValue
-	}
-	if i.Children != nil && len(i.Children) > 0 {
-		header |= HeaderHasChildren
-	}
-	n, err := w.Write([]byte{header})
-	nWritten += int64(n)
-	if err != nil {
-		return nWritten, err
+// Recursively builds the XDR-equivalent Trie structure, where `i` is the node
+// we're converting and `parent` is the already-converted parent. That is, the
+// non-XDR version of `parent` should have had (`key`, `i`) as a child.
+func buildXdrTrie(key byte, node *trieNode, parent *xdr.TrieNode) {
+	self := xdr.TrieNode{
+		Prefix:   node.Prefix,
+		Value:    node.Value,
+		Children: make([]xdr.TrieNodeChild, 0, len(node.Children)),
 	}
 
-	// Write this node's prefix
-	if header&HeaderHasPrefix > 0 {
-		n64, err := writeBytes(w, i.Prefix, buf)
-		nWritten += n64
-		if err != nil {
-			return nWritten, err
-		}
+	for key, node := range node.Children {
+		buildXdrTrie(key, node, &self)
 	}
 
-	// Write this node's value
-	if header&HeaderHasValue > 0 {
-		n64, err = writeBytes(w, i.Value, buf)
-		nWritten += n64
-		if err != nil {
-			return nWritten, err
-		}
-	}
-
-	// TODO: Can we write an "index" of sorts, here that has the byte-offsets, so
-	// that we do just-in-time parsing? Might be more verbose than as is, tho
-
-	// Write how many children we have
-	if header&HeaderHasChildren > 0 {
-		n = binary.PutUvarint(buf, uint64(len(i.Children)))
-		n, err = w.Write(buf[:n])
-		nWritten += int64(n)
-		if err != nil {
-			return nWritten, err
-		}
-
-		// Write all the children
-		for key, child := range i.Children {
-			// Write the child's key
-			n, err = w.Write([]byte{key})
-			nWritten += int64(n)
-			if err != nil {
-				return nWritten, err
-			}
-
-			// Write the rest of the child
-			n64, err := child.writeTo(w, buf)
-			nWritten += n64
-			if err != nil {
-				return nWritten, err
-			}
-		}
-	}
-
-	return nWritten, nil
+	parent.Children = append(parent.Children, xdr.TrieNodeChild{
+		Key:  [1]byte{key},
+		Node: self,
+	})
 }
 
-// Read a length-prefixed chunk of bytes
-func readBytes(r *bufio.Reader) ([]byte, int64, error) {
-	var nRead int64
-	// Read this node's value's length
-	valueLen, err := binary.ReadUvarint(r)
-	nRead += int64(uvarintSize(valueLen))
-	if err != nil || valueLen == 0 {
-		return nil, nRead, err
-	}
-
-	// Read this node's value
-	data := make([]byte, valueLen)
-	n, err := io.ReadFull(r, data)
-	nRead += int64(n)
-	if err != nil {
-		return nil, nRead, err
-	}
-	return data, nRead, nil
-}
-
-// Write a length-prefixed chunk of bytes
-func writeBytes(w io.Writer, data, scratch []byte) (int64, error) {
-	var nWritten int64
-	n := binary.PutUvarint(scratch, uint64(len(data)))
-	n, err := w.Write(scratch[:n])
-	nWritten += int64(n)
-	if err != nil || len(data) == 0 {
-		return nWritten, err
-	}
-
-	n, err = w.Write(data)
-	return nWritten + int64(n), err
-}
+// Ensure we're compatible with stdlib interfaces.
+var _ io.WriterTo = &TrieIndex{}
+var _ io.ReaderFrom = &TrieIndex{}

--- a/exp/lighthorizon/index/trie.go
+++ b/exp/lighthorizon/index/trie.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"bufio"
+	"encoding"
 	"io"
 	"sync"
 
@@ -224,49 +225,7 @@ func (i *TrieIndex) Merge(other *TrieIndex) error {
 	return nil
 }
 
-func (i *TrieIndex) ReadFrom(r io.Reader) (int64, error) {
-	i.Lock()
-	defer i.Unlock()
-
-	br := bufio.NewReader(r)
-	bytes, err := io.ReadAll(br)
-	if err != nil {
-		return int64(len(bytes)), err
-	}
-
-	xdrIndex := xdr.TrieIndex{}
-	err = xdrIndex.UnmarshalBinary(bytes)
-	if err != nil {
-		return int64(len(bytes)), err
-	}
-
-	i.Root = &trieNode{
-		Prefix:   xdrIndex.Root.Prefix,
-		Value:    xdrIndex.Root.Value,
-		Children: make(map[byte]*trieNode, len(xdrIndex.Root.Children)),
-	}
-
-	for _, node := range xdrIndex.Root.Children {
-		buildTrie(&node, i.Root)
-	}
-
-	return int64(len(bytes)), nil
-}
-
-func buildTrie(xdrNode *xdr.TrieNodeChild, parent *trieNode) {
-	node := &trieNode{
-		Prefix:   xdrNode.Node.Prefix,
-		Value:    xdrNode.Node.Value,
-		Children: make(map[byte]*trieNode, len(xdrNode.Node.Children)),
-	}
-	parent.Children[xdrNode.Key[0]] = node
-
-	for _, child := range xdrNode.Node.Children {
-		buildTrie(&child, node)
-	}
-}
-
-func (i *TrieIndex) WriteTo(w io.Writer) (int64, error) {
+func (i *TrieIndex) MarshalBinary() ([]byte, error) {
 	i.RLock()
 	defer i.RUnlock()
 
@@ -284,7 +243,14 @@ func (i *TrieIndex) WriteTo(w io.Writer) (int64, error) {
 	}
 
 	xdrIndex := xdr.TrieIndex{Version: TrieIndexVersion, Root: xdrRoot}
-	bytes, err := xdrIndex.MarshalBinary()
+	return xdrIndex.MarshalBinary()
+}
+
+func (i *TrieIndex) WriteTo(w io.Writer) (int64, error) {
+	i.RLock()
+	defer i.RUnlock()
+
+	bytes, err := i.MarshalBinary()
 	if err != nil {
 		return int64(len(bytes)), err
 	}
@@ -293,9 +259,67 @@ func (i *TrieIndex) WriteTo(w io.Writer) (int64, error) {
 	return int64(count), err
 }
 
-// Recursively builds the XDR-equivalent Trie structure, where `i` is the node
-// we're converting and `parent` is the already-converted parent. That is, the
-// non-XDR version of `parent` should have had (`key`, `i`) as a child.
+func (i *TrieIndex) UnmarshalBinary(bytes []byte) error {
+	i.RLock()
+	defer i.RUnlock()
+
+	xdrIndex := xdr.TrieIndex{}
+	err := xdrIndex.UnmarshalBinary(bytes)
+	if err != nil {
+		return err
+	}
+
+	i.Root = &trieNode{
+		Prefix:   xdrIndex.Root.Prefix,
+		Value:    xdrIndex.Root.Value,
+		Children: make(map[byte]*trieNode, len(xdrIndex.Root.Children)),
+	}
+
+	for _, node := range xdrIndex.Root.Children {
+		buildTrie(&node, i.Root)
+	}
+
+	return nil
+}
+
+func (i *TrieIndex) ReadFrom(r io.Reader) (int64, error) {
+	i.RLock()
+	defer i.RUnlock()
+
+	br := bufio.NewReader(r)
+	bytes, err := io.ReadAll(br)
+	if err != nil {
+		return int64(len(bytes)), err
+	}
+
+	return int64(len(bytes)), i.UnmarshalBinary(bytes)
+}
+
+// buildTrie recursively builds the equivalent `TrieNode` structure from raw
+// XDR, creating the key->value child mapping from the flat list of children.
+// Here, `xdrNode` is the node we're processing and `parent` is its non-XDR
+// parent (i.e. the parent was already converted from XDR).
+//
+// This is the opposite of buildXdrTrie.
+func buildTrie(xdrNode *xdr.TrieNodeChild, parent *trieNode) {
+	node := &trieNode{
+		Prefix:   xdrNode.Node.Prefix,
+		Value:    xdrNode.Node.Value,
+		Children: make(map[byte]*trieNode, len(xdrNode.Node.Children)),
+	}
+	parent.Children[xdrNode.Key[0]] = node
+
+	for _, child := range xdrNode.Node.Children {
+		buildTrie(&child, node)
+	}
+}
+
+// buildXdrTrie recursively builds the XDR-equivalent TrieNode structure, where
+// `i` is the node we're converting and `parent` is the already-converted
+// parent. That is, the non-XDR version of `parent` should have had (`key`, `i`)
+// as a child.
+//
+// This is the opposite of buildTrie.
 func buildXdrTrie(key byte, node *trieNode, parent *xdr.TrieNode) {
 	self := xdr.TrieNode{
 		Prefix:   node.Prefix,
@@ -316,3 +340,6 @@ func buildXdrTrie(key byte, node *trieNode, parent *xdr.TrieNode) {
 // Ensure we're compatible with stdlib interfaces.
 var _ io.WriterTo = &TrieIndex{}
 var _ io.ReaderFrom = &TrieIndex{}
+
+var _ encoding.BinaryMarshaler = &TrieIndex{}
+var _ encoding.BinaryUnmarshaler = &TrieIndex{}

--- a/exp/lighthorizon/index/xdr/LightHorizon-types.x
+++ b/exp/lighthorizon/index/xdr/LightHorizon-types.x
@@ -14,4 +14,20 @@ struct CheckpointIndex {
     Value bitmap;
 };
 
+struct TrieIndex {
+    uint32 version;
+    TrieNode root;
+};
+
+struct TrieNodeChild {
+    opaque key[1];
+    TrieNode node;
+};
+
+struct TrieNode {
+    Value prefix;
+    Value value;
+    TrieNodeChild children<>;
+};
+
 }

--- a/exp/lighthorizon/index/xdr/xdr_generated.go
+++ b/exp/lighthorizon/index/xdr/xdr_generated.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/stellar/go-xdr/xdr3"
+	xdr "github.com/stellar/go-xdr/xdr3"
 )
 
 type xdrType interface {

--- a/exp/lighthorizon/index/xdr/xdr_generated.go
+++ b/exp/lighthorizon/index/xdr/xdr_generated.go
@@ -244,4 +244,241 @@ func (s CheckpointIndex) xdrType() {}
 
 var _ xdrType = (*CheckpointIndex)(nil)
 
+// TrieIndex is an XDR Struct defines as:
+//
+//   struct TrieIndex {
+//        uint32 version;
+//        TrieNode root;
+//    };
+//
+type TrieIndex struct {
+	Version Uint32
+	Root    TrieNode
+}
+
+// EncodeTo encodes this value using the Encoder.
+func (s *TrieIndex) EncodeTo(e *xdr.Encoder) error {
+	var err error
+	if err = s.Version.EncodeTo(e); err != nil {
+		return err
+	}
+	if err = s.Root.EncodeTo(e); err != nil {
+		return err
+	}
+	return nil
+}
+
+var _ decoderFrom = (*TrieIndex)(nil)
+
+// DecodeFrom decodes this value using the Decoder.
+func (s *TrieIndex) DecodeFrom(d *xdr.Decoder) (int, error) {
+	var err error
+	var n, nTmp int
+	nTmp, err = s.Version.DecodeFrom(d)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Uint32: %s", err)
+	}
+	nTmp, err = s.Root.DecodeFrom(d)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding TrieNode: %s", err)
+	}
+	return n, nil
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s TrieIndex) MarshalBinary() ([]byte, error) {
+	b := bytes.Buffer{}
+	e := xdr.NewEncoder(&b)
+	err := s.EncodeTo(e)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *TrieIndex) UnmarshalBinary(inp []byte) error {
+	r := bytes.NewReader(inp)
+	d := xdr.NewDecoder(r)
+	_, err := s.DecodeFrom(d)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*TrieIndex)(nil)
+	_ encoding.BinaryUnmarshaler = (*TrieIndex)(nil)
+)
+
+// xdrType signals that this type is an type representing
+// representing XDR values defined by this package.
+func (s TrieIndex) xdrType() {}
+
+var _ xdrType = (*TrieIndex)(nil)
+
+// TrieNodeChild is an XDR Struct defines as:
+//
+//   struct TrieNodeChild {
+//        opaque key[1];
+//        TrieNode node;
+//    };
+//
+type TrieNodeChild struct {
+	Key  [1]byte `xdrmaxsize:"1"`
+	Node TrieNode
+}
+
+// EncodeTo encodes this value using the Encoder.
+func (s *TrieNodeChild) EncodeTo(e *xdr.Encoder) error {
+	var err error
+	if _, err = e.EncodeFixedOpaque(s.Key[:]); err != nil {
+		return err
+	}
+	if err = s.Node.EncodeTo(e); err != nil {
+		return err
+	}
+	return nil
+}
+
+var _ decoderFrom = (*TrieNodeChild)(nil)
+
+// DecodeFrom decodes this value using the Decoder.
+func (s *TrieNodeChild) DecodeFrom(d *xdr.Decoder) (int, error) {
+	var err error
+	var n, nTmp int
+	nTmp, err = d.DecodeFixedOpaqueInplace(s.Key[:])
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Key: %s", err)
+	}
+	nTmp, err = s.Node.DecodeFrom(d)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding TrieNode: %s", err)
+	}
+	return n, nil
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s TrieNodeChild) MarshalBinary() ([]byte, error) {
+	b := bytes.Buffer{}
+	e := xdr.NewEncoder(&b)
+	err := s.EncodeTo(e)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *TrieNodeChild) UnmarshalBinary(inp []byte) error {
+	r := bytes.NewReader(inp)
+	d := xdr.NewDecoder(r)
+	_, err := s.DecodeFrom(d)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*TrieNodeChild)(nil)
+	_ encoding.BinaryUnmarshaler = (*TrieNodeChild)(nil)
+)
+
+// xdrType signals that this type is an type representing
+// representing XDR values defined by this package.
+func (s TrieNodeChild) xdrType() {}
+
+var _ xdrType = (*TrieNodeChild)(nil)
+
+// TrieNode is an XDR Struct defines as:
+//
+//   struct TrieNode {
+//        Value prefix;
+//        Value value;
+//        TrieNodeChild children<>;
+//    };
+//
+type TrieNode struct {
+	Prefix   Value
+	Value    Value
+	Children []TrieNodeChild
+}
+
+// EncodeTo encodes this value using the Encoder.
+func (s *TrieNode) EncodeTo(e *xdr.Encoder) error {
+	var err error
+	if err = s.Prefix.EncodeTo(e); err != nil {
+		return err
+	}
+	if err = s.Value.EncodeTo(e); err != nil {
+		return err
+	}
+	if _, err = e.EncodeUint(uint32(len(s.Children))); err != nil {
+		return err
+	}
+	for i := 0; i < len(s.Children); i++ {
+		if err = s.Children[i].EncodeTo(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var _ decoderFrom = (*TrieNode)(nil)
+
+// DecodeFrom decodes this value using the Decoder.
+func (s *TrieNode) DecodeFrom(d *xdr.Decoder) (int, error) {
+	var err error
+	var n, nTmp int
+	nTmp, err = s.Prefix.DecodeFrom(d)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Value: %s", err)
+	}
+	nTmp, err = s.Value.DecodeFrom(d)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Value: %s", err)
+	}
+	var l uint32
+	l, nTmp, err = d.DecodeUint()
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding TrieNodeChild: %s", err)
+	}
+	s.Children = nil
+	if l > 0 {
+		s.Children = make([]TrieNodeChild, l)
+		for i := uint32(0); i < l; i++ {
+			nTmp, err = s.Children[i].DecodeFrom(d)
+			n += nTmp
+			if err != nil {
+				return n, fmt.Errorf("decoding TrieNodeChild: %s", err)
+			}
+		}
+	}
+	return n, nil
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s TrieNode) MarshalBinary() ([]byte, error) {
+	b := bytes.Buffer{}
+	e := xdr.NewEncoder(&b)
+	err := s.EncodeTo(e)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *TrieNode) UnmarshalBinary(inp []byte) error {
+	r := bytes.NewReader(inp)
+	d := xdr.NewDecoder(r)
+	_, err := s.DecodeFrom(d)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*TrieNode)(nil)
+	_ encoding.BinaryUnmarshaler = (*TrieNode)(nil)
+)
+
+// xdrType signals that this type is an type representing
+// representing XDR values defined by this package.
+func (s TrieNode) xdrType() {}
+
+var _ xdrType = (*TrieNode)(nil)
+
 var fmtTest = fmt.Sprint("this is a dummy usage of fmt")


### PR DESCRIPTION
This is a continuation of #4369.

### What
Generate XDR for the trie and extend it to support the `encoding.Binary(Un)marshaler` interface.

### Why
XDR is better than custom stuff.

### Known limitations
I'm not sure if there's a better way to do this than the current full conversion to/from `TrieNode`, since the in-memory structure needs a key-value mapping for the children but XDR doesn't support maps.