### PR TITLE
support/db: Pass context to db transactions

### DIFF
--- a/services/horizon/internal/actions/orderbook_test.go
+++ b/services/horizon/internal/actions/orderbook_test.go
@@ -577,7 +577,7 @@ func TestOrderbookGetResource(t *testing.T) {
 	assert.NoError(t, q.TruncateTables(tt.Ctx, []string{"offers"}))
 	assert.NoError(t, q.UpsertOffers(tt.Ctx, offers))
 
-	assert.NoError(t, q.BeginTx(&sql.TxOptions{
+	assert.NoError(t, q.BeginTx(tt.Ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	}))

--- a/services/horizon/internal/actions/path_test.go
+++ b/services/horizon/internal/actions/path_test.go
@@ -27,7 +27,7 @@ func TestAssetsForAddressRequiresTransaction(t *testing.T) {
 	_, _, err := assetsForAddress(r.WithContext(ctx), "GCATOZ7YJV2FANQQLX47TIV6P7VMPJCEEJGQGR6X7TONPKBN3UCLKEIS")
 	assert.EqualError(t, err, "cannot be called outside of a transaction")
 
-	assert.NoError(t, q.Begin())
+	assert.NoError(t, q.Begin(ctx))
 	defer q.Rollback()
 
 	_, _, err = assetsForAddress(r.WithContext(ctx), "GCATOZ7YJV2FANQQLX47TIV6P7VMPJCEEJGQGR6X7TONPKBN3UCLKEIS")

--- a/services/horizon/internal/actions_path_test.go
+++ b/services/horizon/internal/actions_path_test.go
@@ -52,7 +52,7 @@ func mockPathFindingClient(
 	router.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			s := session.Clone()
-			s.BeginTx(&sql.TxOptions{
+			s.BeginTx(r.Context(), &sql.TxOptions{
 				Isolation: sql.LevelRepeatableRead,
 				ReadOnly:  true,
 			})

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -266,8 +266,8 @@ type IngestionQ interface {
 	QTrustLines
 	QTxSubmissionResult
 
-	Begin() error
-	BeginTx(*sql.TxOptions) error
+	Begin(context.Context) error
+	BeginTx(context.Context, *sql.TxOptions) error
 	Commit() error
 	CloneIngestionQ() IngestionQ
 	Close() error

--- a/services/horizon/internal/db2/history/orderbook_test.go
+++ b/services/horizon/internal/db2/history/orderbook_test.go
@@ -18,7 +18,7 @@ func TestGetOrderBookSummaryRequiresTransaction(t *testing.T) {
 	_, err := q.GetOrderBookSummary(tt.Ctx, nativeAsset, eurAsset, 10)
 	assert.EqualError(t, err, "cannot be called outside of a transaction")
 
-	assert.NoError(t, q.Begin())
+	assert.NoError(t, q.Begin(tt.Ctx))
 	defer q.Rollback()
 
 	_, err = q.GetOrderBookSummary(tt.Ctx, nativeAsset, eurAsset, 10)
@@ -215,7 +215,7 @@ func TestGetOrderBookSummary(t *testing.T) {
 			assert.NoError(t, q.TruncateTables(tt.Ctx, []string{"offers"}))
 			assert.NoError(t, q.UpsertOffers(tt.Ctx, testCase.offers))
 
-			assert.NoError(t, q.BeginTx(&sql.TxOptions{
+			assert.NoError(t, q.BeginTx(tt.Ctx, &sql.TxOptions{
 				Isolation: sql.LevelRepeatableRead,
 				ReadOnly:  true,
 			}))
@@ -257,7 +257,7 @@ func TestGetOrderBookSummaryExcludesRemovedOffers(t *testing.T) {
 
 	assert.NoError(t, q.UpsertOffers(tt.Ctx, offers))
 
-	assert.NoError(t, q.BeginTx(&sql.TxOptions{
+	assert.NoError(t, q.BeginTx(tt.Ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	}))
@@ -278,7 +278,7 @@ func TestGetOrderBookSummaryExcludesRemovedOffers(t *testing.T) {
 	}
 	assert.NoError(t, q.UpsertOffers(tt.Ctx, offersToDelete))
 
-	assert.NoError(t, q.BeginTx(&sql.TxOptions{
+	assert.NoError(t, q.BeginTx(tt.Ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	}))
@@ -294,7 +294,7 @@ func TestGetOrderBookSummaryExcludesRemovedOffers(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(len(offers)), count)
 
-	assert.NoError(t, q.BeginTx(&sql.TxOptions{
+	assert.NoError(t, q.BeginTx(tt.Ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	}))

--- a/services/horizon/internal/httpx/handler.go
+++ b/services/horizon/internal/httpx/handler.go
@@ -104,7 +104,7 @@ func repeatableReadStream(
 
 	return func() ([]sse.Event, error) {
 		if session != nil {
-			err := session.BeginTx(&sql.TxOptions{
+			err := session.BeginTx(r.Context(), &sql.TxOptions{
 				Isolation: sql.LevelRepeatableRead,
 				ReadOnly:  true,
 			})

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -322,7 +322,7 @@ func (m *StateMiddleware) WrapFunc(h http.HandlerFunc) http.HandlerFunc {
 		// Otherwise, because the ingestion system is running concurrently with this request,
 		// it is possible to have one read fetch data from ledger N and another read
 		// fetch data from ledger N+1 .
-		err := session.BeginTx(&sql.TxOptions{
+		err := session.BeginTx(r.Context(), &sql.TxOptions{
 			Isolation: sql.LevelRepeatableRead,
 			ReadOnly:  true,
 		})

--- a/services/horizon/internal/httpx/stream_handler_test.go
+++ b/services/horizon/internal/httpx/stream_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/stellar/go/services/horizon/internal/actions"
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
@@ -477,13 +478,13 @@ func TestRepeatableReadStream(t *testing.T) {
 		}
 
 		session := &db.MockSession{}
-		session.On("BeginTx", &sql.TxOptions{
+		session.On("BeginTx", mock.Anything, &sql.TxOptions{
 			Isolation: sql.LevelRepeatableRead,
 			ReadOnly:  true,
 		}).Return(nil).Once()
 		session.On("Rollback").Return(nil).Once()
 
-		session.On("BeginTx", &sql.TxOptions{
+		session.On("BeginTx", mock.Anything, &sql.TxOptions{
 			Isolation: sql.LevelRepeatableRead,
 			ReadOnly:  true,
 		}).Return(nil).Once()
@@ -516,13 +517,13 @@ func TestRepeatableReadStream(t *testing.T) {
 		}
 
 		session := &db.MockSession{}
-		session.On("BeginTx", &sql.TxOptions{
+		session.On("BeginTx", mock.Anything, &sql.TxOptions{
 			Isolation: sql.LevelRepeatableRead,
 			ReadOnly:  true,
 		}).Return(nil).Once()
 		session.On("Rollback").Return(nil).Once()
 
-		session.On("BeginTx", &sql.TxOptions{
+		session.On("BeginTx", mock.Anything, &sql.TxOptions{
 			Isolation: sql.LevelRepeatableRead,
 			ReadOnly:  true,
 		}).Return(nil).Once()

--- a/services/horizon/internal/ingest/build_state_test.go
+++ b/services/horizon/internal/ingest/build_state_test.go
@@ -50,7 +50,7 @@ func (s *BuildStateTestSuite) SetupTest() {
 	}
 	s.system.initMetrics()
 
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("Rollback").Return(nil).Once()
 
 	s.ledgerBackend.On("IsPrepared", s.ctx, ledgerbackend.UnboundedRange(63)).Return(false, nil).Once()
@@ -136,7 +136,7 @@ func (s *BuildStateTestSuite) TestRangeNotPreparedSuccessPrepareGetLedgerFail() 
 func (s *BuildStateTestSuite) TestBeginReturnsError() {
 	// Recreate mock in this single test to remove assertions.
 	*s.historyQ = mockDBQ{}
-	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(errors.New("my error")).Once()
 
 	next, err := buildState{checkpointLedger: s.checkpointLedger}.run(s.system)
 	s.Assert().Error(err)

--- a/services/horizon/internal/ingest/fsm.go
+++ b/services/horizon/internal/ingest/fsm.go
@@ -118,7 +118,7 @@ func (startState) String() string {
 }
 
 func (state startState) run(s *system) (transition, error) {
-	if err := s.historyQ.Begin(); err != nil {
+	if err := s.historyQ.Begin(s.ctx); err != nil {
 		return start(), errors.Wrap(err, "Error starting a transaction")
 	}
 	defer s.historyQ.Rollback()
@@ -267,7 +267,7 @@ func (b buildState) run(s *system) (transition, error) {
 		}).Info("Ledger returned from the backend")
 	}
 
-	if err := s.historyQ.Begin(); err != nil {
+	if err := s.historyQ.Begin(s.ctx); err != nil {
 		return nextFailState, errors.Wrap(err, "Error starting a transaction")
 	}
 	defer s.historyQ.Rollback()
@@ -397,7 +397,7 @@ func (r resumeState) run(s *system) (transition, error) {
 
 	s.Metrics().LedgerFetchDurationSummary.Observe(float64(duration))
 
-	if err = s.historyQ.Begin(); err != nil {
+	if err = s.historyQ.Begin(s.ctx); err != nil {
 		return retryResume(r),
 			errors.Wrap(err, "Error starting a transaction")
 	}
@@ -571,7 +571,7 @@ func (h historyRangeState) run(s *system) (transition, error) {
 		return start(), err
 	}
 
-	if err = s.historyQ.Begin(); err != nil {
+	if err = s.historyQ.Begin(s.ctx); err != nil {
 		return start(), errors.Wrap(err, "Error starting a transaction")
 	}
 	defer s.historyQ.Rollback()
@@ -747,7 +747,7 @@ func (h reingestHistoryRangeState) run(s *system) (transition, error) {
 		}
 		startTime = time.Now()
 
-		if err := s.historyQ.Begin(); err != nil {
+		if err := s.historyQ.Begin(s.ctx); err != nil {
 			return stop(), errors.Wrap(err, "Error starting a transaction")
 		}
 		defer s.historyQ.Rollback()
@@ -783,7 +783,7 @@ func (h reingestHistoryRangeState) run(s *system) (transition, error) {
 
 		for cur := h.fromLedger; cur <= h.toLedger; cur++ {
 			err = func(ledger uint32) error {
-				if e := s.historyQ.Begin(); e != nil {
+				if e := s.historyQ.Begin(s.ctx); e != nil {
 					return errors.Wrap(e, "Error starting a transaction")
 				}
 				defer s.historyQ.Rollback()
@@ -853,7 +853,7 @@ func (v verifyRangeState) run(s *system) (transition, error) {
 		return stop(), errors.Errorf("invalid range: [%d, %d]", v.fromLedger, v.toLedger)
 	}
 
-	if err := s.historyQ.Begin(); err != nil {
+	if err := s.historyQ.Begin(s.ctx); err != nil {
 		err = errors.Wrap(err, "Error starting a transaction")
 		return stop(), err
 	}
@@ -923,7 +923,7 @@ func (v verifyRangeState) run(s *system) (transition, error) {
 		}).Info("Processing ledger")
 		startTime := time.Now()
 
-		if err = s.historyQ.Begin(); err != nil {
+		if err = s.historyQ.Begin(s.ctx); err != nil {
 			err = errors.Wrap(err, "Error starting a transaction")
 			return stop(), err
 		}
@@ -978,7 +978,7 @@ func (stressTestState) String() string {
 }
 
 func (stressTestState) run(s *system) (transition, error) {
-	if err := s.historyQ.Begin(); err != nil {
+	if err := s.historyQ.Begin(s.ctx); err != nil {
 		err = errors.Wrap(err, "Error starting a transaction")
 		return stop(), err
 	}

--- a/services/horizon/internal/ingest/ingest_history_range_state_test.go
+++ b/services/horizon/internal/ingest/ingest_history_range_state_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/stellar/go/ingest/ledgerbackend"
@@ -104,7 +105,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestBeginReturnsError() {
 	// Recreate mock in this single test to remove Rollback assertion.
 	*s.historyQ = mockDBQ{}
 
-	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(errors.New("my error")).Once()
 
 	next, err := historyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
 	s.Assert().Error(err)
@@ -113,7 +114,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestBeginReturnsError() {
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestGetLastLedgerIngestReturnsError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), errors.New("my error")).Once()
 
 	next, err := historyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
@@ -123,7 +124,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestGetLastLedgerIngestReturnsError()
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestGetLatestLedgerReturnsError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(0), errors.New("my error")).Once()
 
@@ -136,7 +137,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestGetLatestLedgerReturnsError() {
 // TestAnotherNodeIngested tests the case when another node has ingested the range.
 // In such case we go back to `init` state without processing.
 func (s *IngestHistoryRangeStateTestSuite) TestAnotherNodeIngested() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(200), nil).Once()
 
@@ -146,7 +147,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestAnotherNodeIngested() {
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedgerReturnsError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(99), nil).Once()
 
@@ -175,7 +176,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedgerR
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestSuccess() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(99), nil).Once()
 
@@ -207,7 +208,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestSuccess() {
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(99), nil).Once()
 
@@ -237,7 +238,7 @@ func (s *IngestHistoryRangeStateTestSuite) TestSuccessOneLedger() {
 }
 
 func (s *IngestHistoryRangeStateTestSuite) TestCommitsWorkOnLedgerBackendFailure() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(99), nil).Once()
 
@@ -299,7 +300,7 @@ func (s *ReingestHistoryRangeStateTestSuite) SetupTest() {
 
 	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("Rollback").Return(nil).Once()
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 
 	s.ledgerBackend.On("PrepareRange", s.ctx, ledgerbackend.BoundedRange(100, 200)).Return(nil).Once()
 }
@@ -334,7 +335,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestBeginReturnsError() {
 	s.historyQ.On("GetTx").Return(nil)
 	s.historyQ.On("GetLastLedgerIngestNonBlocking", s.ctx).Return(uint32(0), nil).Once()
 
-	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(errors.New("my error")).Once()
 
 	err := s.system.ReingestRange([]history.LedgerRange{{100, 200}}, false)
 	s.Assert().EqualError(err, "Error starting a transaction: my error")
@@ -375,7 +376,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestClearHistoryFails() {
 	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngestNonBlocking", s.ctx).Return(uint32(0), nil).Once()
 
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 	toidFrom := toid.New(100, 0, 0)
 	toidTo := toid.New(101, 0, 0)
@@ -394,7 +395,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestRunTransactionProcessorsOnLedge
 	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngestNonBlocking", s.ctx).Return(uint32(0), nil).Once()
 
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 	toidFrom := toid.New(100, 0, 0)
 	toidTo := toid.New(101, 0, 0)
@@ -431,7 +432,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestCommitFails() {
 	s.historyQ.On("GetTx").Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngestNonBlocking", s.ctx).Return(uint32(0), nil).Once()
 
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 	toidFrom := toid.New(100, 0, 0)
 	toidTo := toid.New(101, 0, 0)
@@ -470,7 +471,7 @@ func (s *ReingestHistoryRangeStateTestSuite) TestSuccess() {
 	s.historyQ.On("GetLastLedgerIngestNonBlocking", s.ctx).Return(uint32(0), nil).Once()
 
 	for i := uint32(100); i <= uint32(200); i++ {
-		s.historyQ.On("Begin").Return(nil).Once()
+		s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 		s.historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 
 		toidFrom := toid.New(int32(i), 0, 0)

--- a/services/horizon/internal/ingest/init_state_test.go
+++ b/services/horizon/internal/ingest/init_state_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stellar/go/support/errors"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -45,7 +46,7 @@ func (s *InitStateTestSuite) TearDownTest() {
 func (s *InitStateTestSuite) TestBeginReturnsError() {
 	// Recreate mock in this single test to remove Rollback assertion.
 	*s.historyQ = mockDBQ{}
-	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(errors.New("my error")).Once()
 
 	next, err := startState{}.run(s.system)
 	s.Assert().Error(err)
@@ -54,7 +55,7 @@ func (s *InitStateTestSuite) TestBeginReturnsError() {
 }
 
 func (s *InitStateTestSuite) TestGetLastLedgerIngestReturnsError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), errors.New("my error")).Once()
 
 	next, err := startState{}.run(s.system)
@@ -64,7 +65,7 @@ func (s *InitStateTestSuite) TestGetLastLedgerIngestReturnsError() {
 }
 
 func (s *InitStateTestSuite) TestGetIngestVersionReturnsError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(0, errors.New("my error")).Once()
 
@@ -75,7 +76,7 @@ func (s *InitStateTestSuite) TestGetIngestVersionReturnsError() {
 }
 
 func (s *InitStateTestSuite) TestCurrentVersionIsOutdated() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(1), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(CurrentVersion+1, nil).Once()
 
@@ -85,7 +86,7 @@ func (s *InitStateTestSuite) TestCurrentVersionIsOutdated() {
 }
 
 func (s *InitStateTestSuite) TestGetLatestLedgerReturnsError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(0, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(0), errors.New("my error")).Once()
@@ -97,7 +98,7 @@ func (s *InitStateTestSuite) TestGetLatestLedgerReturnsError() {
 }
 
 func (s *InitStateTestSuite) TestBuildStateEmptyDatabase() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(0, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(0), nil).Once()
@@ -113,7 +114,7 @@ func (s *InitStateTestSuite) TestBuildStateEmptyDatabase() {
 }
 
 func (s *InitStateTestSuite) TestBuildStateEmptyDatabaseFromSuggestedCheckpoint() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(0, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(0), nil).Once()
@@ -130,7 +131,7 @@ func (s *InitStateTestSuite) TestBuildStateEmptyDatabaseFromSuggestedCheckpoint(
 // * the ingest system version has been incremented or no ingest ledger,
 // * the old system is in front of the latest checkpoint.
 func (s *InitStateTestSuite) TestBuildStateWait() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(100), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(0, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(100), nil).Once()
@@ -149,7 +150,7 @@ func (s *InitStateTestSuite) TestBuildStateWait() {
 // * the ingest system version has been incremented or no ingest ledger,
 // * the old system is behind the latest checkpoint.
 func (s *InitStateTestSuite) TestBuildStateCatchup() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(100), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(0, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(100), nil).Once()
@@ -171,7 +172,7 @@ func (s *InitStateTestSuite) TestBuildStateCatchup() {
 // * the ingest system version has been incremented or no ingest ledger,
 // * the old system latest ledger is equal to the latest checkpoint.
 func (s *InitStateTestSuite) TestBuildStateOldHistory() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(127), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(0, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(127), nil).Once()
@@ -193,7 +194,7 @@ func (s *InitStateTestSuite) TestBuildStateOldHistory() {
 // * state doesn't need to be rebuilt,
 // * history is in front of ingest.
 func (s *InitStateTestSuite) TestResumeStateInFront() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(100), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(130), nil).Once()
@@ -210,7 +211,7 @@ func (s *InitStateTestSuite) TestResumeStateInFront() {
 // * state doesn't need to be rebuilt,
 // * history is behind of ingest.
 func (s *InitStateTestSuite) TestResumeStateBehind() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(130), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(100), nil).Once()
@@ -231,7 +232,7 @@ func (s *InitStateTestSuite) TestResumeStateBehind() {
 // * there are no ledgers in history tables.
 // In such case we load offers and continue ingesting the next ledger.
 func (s *InitStateTestSuite) TestResumeStateBehindHistory0() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(130), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(0), nil).Once()
@@ -251,7 +252,7 @@ func (s *InitStateTestSuite) TestResumeStateBehindHistory0() {
 // * state doesn't need to be rebuilt,
 // * history is in sync with ingest.
 func (s *InitStateTestSuite) TestResumeStateSync() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(130), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(130), nil).Once()

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -121,7 +121,7 @@ func TestStateMachineTransition(t *testing.T) {
 	}
 
 	historyQ.On("GetTx").Return(nil).Once()
-	historyQ.On("Begin").Return(errors.New("my error")).Once()
+	historyQ.On("Begin", mock.Anything).Return(errors.New("my error")).Once()
 	historyQ.On("GetTx").Return(&sqlx.Tx{}).Once()
 
 	assert.PanicsWithValue(t, "unexpected transaction", func() {
@@ -138,7 +138,7 @@ func TestContextCancel(t *testing.T) {
 	}
 
 	historyQ.On("GetTx").Return(nil).Once()
-	historyQ.On("Begin").Return(errors.New("my error")).Once()
+	historyQ.On("Begin", mock.Anything).Return(errors.New("my error")).Once()
 
 	cancel()
 	assert.NoError(t, system.runStateMachine(startState{}))
@@ -210,11 +210,11 @@ func TestMaybeVerifyInternalDBErrCancelOrContextCanceled(t *testing.T) {
 	historyQ.On("Rollback").Return(nil).Twice()
 	historyQ.On("CloneIngestionQ").Return(historyQ).Twice()
 
-	historyQ.On("BeginTx", mock.Anything).Return(db.ErrCancelled).Once()
+	historyQ.On("BeginTx", system.ctx, mock.Anything).Return(db.ErrCancelled).Once()
 	system.maybeVerifyState(63)
 	system.wg.Wait()
 
-	historyQ.On("BeginTx", mock.Anything).Return(context.Canceled).Once()
+	historyQ.On("BeginTx", system.ctx, mock.Anything).Return(context.Canceled).Once()
 	system.maybeVerifyState(63)
 	system.wg.Wait()
 
@@ -247,13 +247,13 @@ type mockDBQ struct {
 	history.MockQTxSubmissionResult
 }
 
-func (m *mockDBQ) Begin() error {
-	args := m.Called()
+func (m *mockDBQ) Begin(ctx context.Context) error {
+	args := m.Called(ctx)
 	return args.Error(0)
 }
 
-func (m *mockDBQ) BeginTx(txOpts *sql.TxOptions) error {
-	args := m.Called(txOpts)
+func (m *mockDBQ) BeginTx(ctx context.Context, txOpts *sql.TxOptions) error {
+	args := m.Called(ctx, txOpts)
 	return args.Error(0)
 }
 

--- a/services/horizon/internal/ingest/orderbook.go
+++ b/services/horizon/internal/ingest/orderbook.go
@@ -319,7 +319,7 @@ func (o *OrderBookStream) verifyAllLiquidityPools(ctx context.Context, liquidity
 // After calling this function, the the in memory order book graph should be consistent with the
 // Horizon DB (assuming no error is returned).
 func (o *OrderBookStream) Update(ctx context.Context) error {
-	if err := o.historyQ.BeginTx(&sql.TxOptions{ReadOnly: true, Isolation: sql.LevelRepeatableRead}); err != nil {
+	if err := o.historyQ.BeginTx(ctx, &sql.TxOptions{ReadOnly: true, Isolation: sql.LevelRepeatableRead}); err != nil {
 		return errors.Wrap(err, "Error starting repeatable read transaction")
 	}
 	defer o.historyQ.Rollback()

--- a/services/horizon/internal/ingest/resume_state_test.go
+++ b/services/horizon/internal/ingest/resume_state_test.go
@@ -124,7 +124,7 @@ func (s *ResumeTestTestSuite) TestBeginReturnsError() {
 	// Recreate mock in this single test to remove Rollback assertion.
 	*s.historyQ = mockDBQ{}
 
-	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(errors.New("my error")).Once()
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
 	s.Assert().Error(err)
@@ -139,7 +139,7 @@ func (s *ResumeTestTestSuite) TestBeginReturnsError() {
 }
 
 func (s *ResumeTestTestSuite) TestGetLastLedgerIngestReturnsError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), errors.New("my error")).Once()
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
@@ -155,7 +155,7 @@ func (s *ResumeTestTestSuite) TestGetLastLedgerIngestReturnsError() {
 }
 
 func (s *ResumeTestTestSuite) TestGetLatestLedgerLessThanCurrent() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(99), nil).Once()
 
 	next, err := resumeState{latestSuccessfullyProcessedLedger: 100}.run(s.system)
@@ -168,7 +168,7 @@ func (s *ResumeTestTestSuite) TestGetLatestLedgerLessThanCurrent() {
 }
 
 func (s *ResumeTestTestSuite) TestGetIngestionVersionError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(100), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(0, errors.New("my error")).Once()
 
@@ -185,7 +185,7 @@ func (s *ResumeTestTestSuite) TestGetIngestionVersionError() {
 }
 
 func (s *ResumeTestTestSuite) TestIngestionVersionLessThanCurrentVersion() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(100), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(CurrentVersion-1, nil).Once()
 
@@ -198,7 +198,7 @@ func (s *ResumeTestTestSuite) TestIngestionVersionLessThanCurrentVersion() {
 }
 
 func (s *ResumeTestTestSuite) TestIngestionVersionGreaterThanCurrentVersion() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(100), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(CurrentVersion+1, nil).Once()
 
@@ -211,7 +211,7 @@ func (s *ResumeTestTestSuite) TestIngestionVersionGreaterThanCurrentVersion() {
 }
 
 func (s *ResumeTestTestSuite) TestGetLatestLedgerError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(100), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(0), errors.New("my error"))
@@ -229,7 +229,7 @@ func (s *ResumeTestTestSuite) TestGetLatestLedgerError() {
 }
 
 func (s *ResumeTestTestSuite) TestLatestHistoryLedgerLessThanIngestLedger() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(100), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(99), nil)
@@ -243,7 +243,7 @@ func (s *ResumeTestTestSuite) TestLatestHistoryLedgerLessThanIngestLedger() {
 }
 
 func (s *ResumeTestTestSuite) TestLatestHistoryLedgerGreaterThanIngestLedger() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(100), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(101), nil)
@@ -257,7 +257,7 @@ func (s *ResumeTestTestSuite) TestLatestHistoryLedgerGreaterThanIngestLedger() {
 }
 
 func (s *ResumeTestTestSuite) mockSuccessfulIngestion() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(100), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(100), nil)
@@ -301,7 +301,7 @@ func (s *ResumeTestTestSuite) TestBumpIngestLedger() {
 		},
 	}, nil).Once()
 
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(101), nil).Once()
 
 	s.stellarCoreClient.On(
@@ -340,7 +340,7 @@ func (s *ResumeTestTestSuite) TestIngestAllMasterNode() {
 }
 
 func (s *ResumeTestTestSuite) TestErrorSettingCursorIgnored() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(100), nil).Once()
 	s.historyQ.On("GetIngestVersion", s.ctx).Return(CurrentVersion, nil).Once()
 	s.historyQ.On("GetLatestHistoryLedger", s.ctx).Return(uint32(100), nil)

--- a/services/horizon/internal/ingest/stress_test.go
+++ b/services/horizon/internal/ingest/stress_test.go
@@ -67,14 +67,14 @@ func (s *StressTestStateTestSuite) TestBounds() {
 func (s *StressTestStateTestSuite) TestBeginReturnsError() {
 	*s.historyQ = mockDBQ{}
 	s.historyQ.On("GetTx").Return(nil).Once()
-	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(errors.New("my error")).Once()
 
 	err := s.system.StressTest(10, 4)
 	s.Assert().EqualError(err, "Error starting a transaction: my error")
 }
 
 func (s *StressTestStateTestSuite) TestGetLastLedgerIngestReturnsError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), errors.New("my error")).Once()
 
 	err := s.system.StressTest(10, 4)
@@ -82,7 +82,7 @@ func (s *StressTestStateTestSuite) TestGetLastLedgerIngestReturnsError() {
 }
 
 func (s *StressTestStateTestSuite) TestGetLastLedgerIngestNonEmpty() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(100), nil).Once()
 
 	err := s.system.StressTest(10, 4)
@@ -90,7 +90,7 @@ func (s *StressTestStateTestSuite) TestGetLastLedgerIngestNonEmpty() {
 }
 
 func (s *StressTestStateTestSuite) TestRunAllProcessorsOnLedgerReturnsError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 
 	s.runner.On("RunAllProcessorsOnLedger", mock.AnythingOfType("xdr.LedgerCloseMeta")).Return(
@@ -103,7 +103,7 @@ func (s *StressTestStateTestSuite) TestRunAllProcessorsOnLedgerReturnsError() {
 }
 
 func (s *StressTestStateTestSuite) TestUpdateLastLedgerIngestReturnsError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.runner.On("RunAllProcessorsOnLedger", mock.AnythingOfType("xdr.LedgerCloseMeta")).Return(
 		ledgerStats{},
@@ -116,7 +116,7 @@ func (s *StressTestStateTestSuite) TestUpdateLastLedgerIngestReturnsError() {
 }
 
 func (s *StressTestStateTestSuite) TestCommitReturnsError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.runner.On("RunAllProcessorsOnLedger", mock.AnythingOfType("xdr.LedgerCloseMeta")).Return(
 		ledgerStats{},
@@ -130,7 +130,7 @@ func (s *StressTestStateTestSuite) TestCommitReturnsError() {
 }
 
 func (s *StressTestStateTestSuite) TestSucceeds() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.runner.On("RunAllProcessorsOnLedger", mock.AnythingOfType("xdr.LedgerCloseMeta")).Return(
 		ledgerStats{},

--- a/services/horizon/internal/ingest/verify.go
+++ b/services/horizon/internal/ingest/verify.go
@@ -62,7 +62,7 @@ func (s *system) verifyState(verifyAgainstLatestCheckpoint bool) error {
 
 	historyQ := s.historyQ.CloneIngestionQ()
 	defer historyQ.Rollback()
-	err := historyQ.BeginTx(&sql.TxOptions{
+	err := historyQ.BeginTx(s.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	})

--- a/services/horizon/internal/ingest/verify_range_state_test.go
+++ b/services/horizon/internal/ingest/verify_range_state_test.go
@@ -106,7 +106,7 @@ func (s *VerifyRangeStateTestSuite) TestInvalidRange() {
 func (s *VerifyRangeStateTestSuite) TestBeginReturnsError() {
 	// Recreate mock in this single test to remove Rollback assertion.
 	*s.historyQ = mockDBQ{}
-	s.historyQ.On("Begin").Return(errors.New("my error")).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(errors.New("my error")).Once()
 
 	next, err := verifyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
 	s.Assert().Error(err)
@@ -118,7 +118,7 @@ func (s *VerifyRangeStateTestSuite) TestBeginReturnsError() {
 }
 
 func (s *VerifyRangeStateTestSuite) TestGetLastLedgerIngestReturnsError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), errors.New("my error")).Once()
 
 	next, err := verifyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
@@ -131,7 +131,7 @@ func (s *VerifyRangeStateTestSuite) TestGetLastLedgerIngestReturnsError() {
 }
 
 func (s *VerifyRangeStateTestSuite) TestGetLastLedgerIngestNonEmpty() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(100), nil).Once()
 
 	next, err := verifyRangeState{fromLedger: 100, toLedger: 200}.run(s.system)
@@ -144,7 +144,7 @@ func (s *VerifyRangeStateTestSuite) TestGetLastLedgerIngestNonEmpty() {
 }
 
 func (s *VerifyRangeStateTestSuite) TestRunHistoryArchiveIngestionReturnsError() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.ledgerBackend.On("PrepareRange", s.ctx, ledgerbackend.BoundedRange(100, 200)).Return(nil).Once()
 
@@ -172,7 +172,7 @@ func (s *VerifyRangeStateTestSuite) TestRunHistoryArchiveIngestionReturnsError()
 }
 
 func (s *VerifyRangeStateTestSuite) TestSuccess() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.ledgerBackend.On("PrepareRange", s.ctx, ledgerbackend.BoundedRange(100, 200)).Return(nil).Once()
 
@@ -194,7 +194,7 @@ func (s *VerifyRangeStateTestSuite) TestSuccess() {
 	s.historyQ.On("Commit").Return(nil).Once()
 
 	for i := uint32(101); i <= 200; i++ {
-		s.historyQ.On("Begin").Return(nil).Once()
+		s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 
 		meta := xdr.LedgerCloseMeta{
 			V0: &xdr.LedgerCloseMetaV0{
@@ -228,7 +228,7 @@ func (s *VerifyRangeStateTestSuite) TestSuccess() {
 // Bartek: looks like this test really tests the state verifier. Instead, I think we should just ensure
 // data is passed so a single account would be enough to test if the FSM state works correctly.
 func (s *VerifyRangeStateTestSuite) TestSuccessWithVerify() {
-	s.historyQ.On("Begin").Return(nil).Once()
+	s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(0), nil).Once()
 	s.ledgerBackend.On("PrepareRange", s.ctx, ledgerbackend.BoundedRange(100, 110)).Return(nil).Once()
 
@@ -250,7 +250,7 @@ func (s *VerifyRangeStateTestSuite) TestSuccessWithVerify() {
 	s.historyQ.On("Commit").Return(nil).Once()
 
 	for i := uint32(101); i <= 110; i++ {
-		s.historyQ.On("Begin").Return(nil).Once()
+		s.historyQ.On("Begin", mock.Anything).Return(nil).Once()
 
 		meta := xdr.LedgerCloseMeta{
 			V0: &xdr.LedgerCloseMetaV0{
@@ -276,8 +276,8 @@ func (s *VerifyRangeStateTestSuite) TestSuccessWithVerify() {
 	clonedQ := &mockDBQ{}
 	s.historyQ.On("CloneIngestionQ").Return(clonedQ).Once()
 
-	clonedQ.On("BeginTx", mock.AnythingOfType("*sql.TxOptions")).Run(func(args mock.Arguments) {
-		arg := args.Get(0).(*sql.TxOptions)
+	clonedQ.On("BeginTx", mock.Anything, mock.AnythingOfType("*sql.TxOptions")).Run(func(args mock.Arguments) {
+		arg := args.Get(1).(*sql.TxOptions)
 		s.Assert().Equal(sql.LevelRepeatableRead, arg.Isolation)
 		s.Assert().True(arg.ReadOnly)
 	}).Return(nil).Once()

--- a/services/horizon/internal/integration/state_verifier_test.go
+++ b/services/horizon/internal/integration/state_verifier_test.go
@@ -122,7 +122,7 @@ func TestStateVerifier(t *testing.T) {
 	// Trigger state rebuild to check if ingesting from history archive works
 	session := itest.Horizon().HistoryQ().Clone()
 	q := &history.Q{session}
-	err = q.Begin()
+	err = q.Begin(context.Background())
 	assert.NoError(t, err)
 	_, err = q.GetLastLedgerIngest(context.Background())
 	assert.NoError(t, err)

--- a/services/horizon/internal/integration/trade_aggregations_test.go
+++ b/services/horizon/internal/integration/trade_aggregations_test.go
@@ -272,7 +272,7 @@ func TestTradeAggregations(t *testing.T) {
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
 			// Run each in a txn so the ids don't conflict.
-			assert.NoError(t, historyQ.Begin())
+			assert.NoError(t, historyQ.Begin(ctx))
 			defer func() {
 				assert.NoError(t, historyQ.Rollback())
 			}()

--- a/services/horizon/internal/reap/system.go
+++ b/services/horizon/internal/reap/system.go
@@ -95,7 +95,7 @@ func (r *System) clearBefore(ctx context.Context, startSeq, endSeq int32) error 
 			return err
 		}
 
-		err = r.HistoryQ.Begin()
+		err = r.HistoryQ.Begin(ctx)
 		if err != nil {
 			return errors.Wrap(err, "Error in begin")
 		}

--- a/services/horizon/internal/txsub/helpers_test.go
+++ b/services/horizon/internal/txsub/helpers_test.go
@@ -31,8 +31,8 @@ type mockDBQ struct {
 	history.MockQTxSubmissionResult
 }
 
-func (m *mockDBQ) BeginTx(txOpts *sql.TxOptions) error {
-	args := m.Called(txOpts)
+func (m *mockDBQ) BeginTx(ctx context.Context, txOpts *sql.TxOptions) error {
+	args := m.Called(ctx, txOpts)
 	return args.Error(0)
 }
 

--- a/services/horizon/internal/txsub/results.go
+++ b/services/horizon/internal/txsub/results.go
@@ -43,7 +43,7 @@ func txResultFromHistory(tx history.Transaction) (history.Transaction, error) {
 // because the first query occurs when the tx is not yet ingested and the second query occurs when the tx
 // is ingested.
 func checkTxAlreadyExists(ctx context.Context, db HorizonDB, hash, sourceAddress string) (history.Transaction, uint64, error) {
-	err := db.BeginTx(&sql.TxOptions{
+	err := db.BeginTx(ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	})

--- a/services/horizon/internal/txsub/system.go
+++ b/services/horizon/internal/txsub/system.go
@@ -17,7 +17,7 @@ import (
 type HorizonDB interface {
 	history.QTxSubmissionResult
 	GetSequenceNumbers(ctx context.Context, addresses []string) (map[string]uint64, error)
-	BeginTx(*sql.TxOptions) error
+	BeginTx(context.Context, *sql.TxOptions) error
 	Commit() error
 	Rollback() error
 	NoRows(error) bool
@@ -350,7 +350,7 @@ func (sys *System) Tick(ctx context.Context) {
 		// we need to delete old transaction submission entries
 		ReadOnly: false,
 	}
-	if err := db.BeginTx(options); err != nil {
+	if err := db.BeginTx(ctx, options); err != nil {
 		logger.WithError(err).Error("could not start repeatable read transaction for txsub tick")
 		return
 	}

--- a/services/horizon/internal/txsub/system_test.go
+++ b/services/horizon/internal/txsub/system_test.go
@@ -124,7 +124,7 @@ func (suite *SystemTestSuite) TearDownTest() {
 
 // Returns the result provided by the ResultProvider.
 func (suite *SystemTestSuite) TestSubmit_Basic() {
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	}).Return(nil).Once()
@@ -144,7 +144,7 @@ func (suite *SystemTestSuite) TestTimeoutDuringSequenceLoop() {
 	defer cancel()
 
 	suite.submitter.R = suite.badSeq
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	}).Return(nil).Once()
@@ -167,7 +167,7 @@ func (suite *SystemTestSuite) TestClientDisconnectedDuringSequenceLoop() {
 	suite.ctx, cancel = context.WithCancel(suite.ctx)
 
 	suite.submitter.R = suite.badSeq
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	}).Return(nil).Once()
@@ -204,7 +204,7 @@ func getMetricValue(metric prometheus.Metric) *dto.Metric {
 
 // Returns the error from submission if no result is found by hash and the suite.submitter returns an error.
 func (suite *SystemTestSuite) TestSubmit_NotFoundError() {
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	}).Return(nil).Once()
@@ -231,7 +231,7 @@ func (suite *SystemTestSuite) TestSubmit_NotFoundError() {
 // If the error is bad_seq and the result at the transaction's sequence number is for the same hash, return result.
 func (suite *SystemTestSuite) TestSubmit_BadSeq() {
 	suite.submitter.R = suite.badSeq
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	}).Return(nil).Once()
@@ -260,7 +260,7 @@ func (suite *SystemTestSuite) TestSubmit_BadSeq() {
 // If error is bad_seq and no result is found, return error.
 func (suite *SystemTestSuite) TestSubmit_BadSeqNotFound() {
 	suite.submitter.R = suite.badSeq
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	}).Return(nil).Once()
@@ -289,7 +289,7 @@ func (suite *SystemTestSuite) TestSubmit_BadSeqNotFound() {
 
 // If no result found and no error submitting, add to open transaction list.
 func (suite *SystemTestSuite) TestSubmit_OpenTransactionList() {
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	}).Return(nil).Once()
@@ -314,7 +314,7 @@ func (suite *SystemTestSuite) TestSubmit_OpenTransactionList() {
 
 // Tick should be a no-op if there are no open submissions.
 func (suite *SystemTestSuite) TestTick_Noop() {
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  false,
 	}).Return(nil).Once()
@@ -327,7 +327,7 @@ func (suite *SystemTestSuite) TestTick_Noop() {
 
 // Delete should only be called every TTL
 func (suite *SystemTestSuite) TestTick_DeleteEveryTTL() {
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  false,
 	}).Return(nil).Once()
@@ -339,7 +339,7 @@ func (suite *SystemTestSuite) TestTick_DeleteEveryTTL() {
 
 	// Delete shouldn't be called the second time since it should wait 300 seconds
 
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  false,
 	}).Return(nil).Once()
@@ -350,7 +350,7 @@ func (suite *SystemTestSuite) TestTick_DeleteEveryTTL() {
 	// But it should be called a third time if we ensure the TTL has passed
 	suite.system.SubmissionResultTTL = time.Second
 	time.Sleep(2 * time.Second)
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  false,
 	}).Return(nil).Once()
@@ -368,7 +368,7 @@ func (suite *SystemTestSuite) TestTick_DeleteEveryTTL() {
 // `sys.Sequences.Get(addys)` is delayed by 1 second. It allows to simulate two
 // calls to `Tick()` executed at the same time.
 func (suite *SystemTestSuite) TestTick_Deadlock() {
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  false,
 	}).Return(nil).Once()
@@ -394,7 +394,7 @@ func (suite *SystemTestSuite) TestTick_FinishesResultTransactions() {
 	l := make(chan Result, 1)
 	suite.system.Pending.Add(suite.ctx, suite.successTx.Transaction.TransactionHash, l)
 
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  false,
 	}).Return(nil).Once()
@@ -411,7 +411,7 @@ func (suite *SystemTestSuite) TestTick_FinishesResultTransactions() {
 	assert.Equal(suite.T(), 0, len(l))
 	assert.Equal(suite.T(), 1, len(suite.system.Pending.Pending(suite.ctx)))
 
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  false,
 	}).Return(nil).Once()
@@ -433,7 +433,7 @@ func (suite *SystemTestSuite) TestTick_FinishesHistoryTransactions() {
 	l := make(chan Result, 1)
 	suite.system.Pending.Add(suite.ctx, suite.successTx.Transaction.TransactionHash, l)
 
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  false,
 	}).Return(nil).Once()
@@ -471,7 +471,7 @@ func (suite *SystemTestSuite) TestTickFinishFeeBumpTransaction() {
 		},
 	}
 
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	}).Return(nil).Once()
@@ -489,7 +489,7 @@ func (suite *SystemTestSuite) TestTickFinishFeeBumpTransaction() {
 	assert.Equal(suite.T(), 0, len(l))
 	assert.Equal(suite.T(), 1, len(suite.system.Pending.Pending(suite.ctx)))
 
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  false,
 	}).Return(nil).Once()
@@ -517,7 +517,7 @@ func (suite *SystemTestSuite) TestTick_RemovesStaleSubmissions() {
 	suite.system.Pending.Add(suite.ctx, suite.successTx.Transaction.TransactionHash, l)
 	<-time.After(101 * time.Millisecond)
 
-	suite.db.On("BeginTx", &sql.TxOptions{
+	suite.db.On("BeginTx", suite.ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  false,
 	}).Return(nil).Once()

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -114,8 +114,8 @@ type Session struct {
 }
 
 type SessionInterface interface {
-	BeginTx(opts *sql.TxOptions) error
-	Begin() error
+	BeginTx(ctx context.Context, opts *sql.TxOptions) error
+	Begin(ctx context.Context) error
 	Rollback() error
 	Commit() error
 	GetTx() *sqlx.Tx

--- a/support/db/mock_session.go
+++ b/support/db/mock_session.go
@@ -17,13 +17,13 @@ type MockSession struct {
 	mock.Mock
 }
 
-func (m *MockSession) Begin() error {
-	args := m.Called()
+func (m *MockSession) Begin(ctx context.Context) error {
+	args := m.Called(ctx)
 	return args.Error(0)
 }
 
-func (m *MockSession) BeginTx(opts *sql.TxOptions) error {
-	args := m.Called(opts)
+func (m *MockSession) BeginTx(ctx context.Context, opts *sql.TxOptions) error {
+	args := m.Called(ctx, opts)
 	return args.Error(0)
 }
 

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -16,12 +16,12 @@ import (
 )
 
 // Begin binds this session to a new transaction.
-func (s *Session) Begin() error {
+func (s *Session) Begin(ctx context.Context) error {
 	if s.tx != nil {
 		return errors.New("already in transaction")
 	}
 
-	tx, err := s.DB.BeginTxx(context.Background(), nil)
+	tx, err := s.DB.BeginTxx(ctx, nil)
 	if err != nil {
 		if knownErr := s.replaceWithKnownError(err, context.Background()); knownErr != nil {
 			return knownErr
@@ -37,12 +37,12 @@ func (s *Session) Begin() error {
 
 // BeginTx binds this session to a new transaction which is configured with the
 // given transaction options
-func (s *Session) BeginTx(opts *sql.TxOptions) error {
+func (s *Session) BeginTx(ctx context.Context, opts *sql.TxOptions) error {
 	if s.tx != nil {
 		return errors.New("already in transaction")
 	}
 
-	tx, err := s.DB.BeginTxx(context.Background(), opts)
+	tx, err := s.DB.BeginTxx(ctx, opts)
 	if err != nil {
 		if knownErr := s.replaceWithKnownError(err, context.Background()); knownErr != nil {
 			return knownErr
@@ -179,7 +179,7 @@ func (s *Session) Exec(ctx context.Context, query sq.Sqlizer) (sql.Result, error
 // ExecAll runs all sql commands in `script` against `r` within a single
 // transaction.
 func (s *Session) ExecAll(ctx context.Context, script string) error {
-	err := s.Begin()
+	err := s.Begin(ctx)
 	if err != nil {
 		return err
 	}

--- a/support/db/session_test.go
+++ b/support/db/session_test.go
@@ -97,7 +97,7 @@ func TestSession(t *testing.T) {
 
 	// Test transactions
 	db.Load(testSchema)
-	require.NoError(sess.Begin(), "begin failed")
+	require.NoError(sess.Begin(ctx), "begin failed")
 	err = sess.GetRaw(ctx, &count, "SELECT COUNT(*) FROM people")
 	assert.NoError(err)
 	assert.Equal(3, count)
@@ -109,7 +109,7 @@ func TestSession(t *testing.T) {
 	assert.NoError(sess.Rollback(), "rollback failed")
 
 	// Ensure commit works
-	require.NoError(sess.Begin(), "begin failed")
+	require.NoError(sess.Begin(ctx), "begin failed")
 	sess.ExecRaw(ctx, "DELETE FROM people")
 	assert.NoError(sess.Commit(), "commit failed")
 	err = sess.GetRaw(ctx, &count, "SELECT COUNT(*) FROM people")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Pass a specific context to db transactions, instead of using `context.Background()`

### Why

Ensures we don't have hanging txns if the outer context is cancelled.

### Known limitations

Not sure this is right for ingestion. We use txns in a specific way there, so we might need to pass `context.Background()`
