### PR TITLE
services/horizon/internal: Add flag to disable path finding endpoints

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -90,7 +90,9 @@ func (a *App) Serve() error {
 	}
 
 	go a.run()
-	go a.orderBookStream.Run(a.ctx)
+	if !a.config.DisablePathFinding {
+		go a.orderBookStream.Run(a.ctx)
+	}
 
 	// WaitGroup for all go routines. Makes sure that DB is closed when
 	// all services gracefully shutdown.

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -52,6 +52,8 @@ type Config struct {
 	// DisablePoolPathFinding configures horizon to run path finding without including liquidity pools
 	// in the path finding search.
 	DisablePoolPathFinding bool
+	// DisablePathFinding configures horizon without the path finding endpoint.
+	DisablePathFinding bool
 	// MaxPathFindingRequests is the maximum number of path finding requests horizon will allow
 	// in a 1-second period. A value of 0 disables the limit.
 	MaxPathFindingRequests uint

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -393,6 +393,14 @@ func Flags() (*Config, support.ConfigOptions) {
 			Usage:       "excludes liquidity pools from consideration in the `/paths` endpoint",
 		},
 		&support.ConfigOption{
+			Name:        "disable-path-finding",
+			ConfigKey:   &config.DisablePathFinding,
+			OptType:     types.Bool,
+			FlagDefault: false,
+			Required:    false,
+			Usage:       "disables the path finding endpoints",
+		},
+		&support.ConfigOption{
 			Name:        "max-path-finding-requests",
 			ConfigKey:   &config.MaxPathFindingRequests,
 			OptType:     types.Uint,

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -196,22 +196,24 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 
 		r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/assets", restPageHandler(ledgerState, actions.AssetStatsHandler{LedgerState: ledgerState}))
 
-		findPaths := ObjectActionHandler{actions.FindPathsHandler{
-			StaleThreshold:       config.StaleThreshold,
-			SetLastLedgerHeader:  true,
-			MaxPathLength:        config.MaxPathLength,
-			MaxAssetsParamLength: config.MaxAssetsPerPathRequest,
-			PathFinder:           config.PathFinder,
-		}}
-		findFixedPaths := ObjectActionHandler{actions.FindFixedPathsHandler{
-			MaxPathLength:        config.MaxPathLength,
-			SetLastLedgerHeader:  true,
-			MaxAssetsParamLength: config.MaxAssetsPerPathRequest,
-			PathFinder:           config.PathFinder,
-		}}
-		r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths", findPaths)
-		r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths/strict-receive", findPaths)
-		r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths/strict-send", findFixedPaths)
+		if config.PathFinder != nil {
+			findPaths := ObjectActionHandler{actions.FindPathsHandler{
+				StaleThreshold:       config.StaleThreshold,
+				SetLastLedgerHeader:  true,
+				MaxPathLength:        config.MaxPathLength,
+				MaxAssetsParamLength: config.MaxAssetsPerPathRequest,
+				PathFinder:           config.PathFinder,
+			}}
+			findFixedPaths := ObjectActionHandler{actions.FindFixedPathsHandler{
+				MaxPathLength:        config.MaxPathLength,
+				SetLastLedgerHeader:  true,
+				MaxAssetsParamLength: config.MaxAssetsPerPathRequest,
+				PathFinder:           config.PathFinder,
+			}}
+			r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths", findPaths)
+			r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths/strict-receive", findPaths)
+			r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths/strict-send", findFixedPaths)
+		}
 		r.With(stateMiddleware.Wrap).Method(
 			http.MethodGet,
 			"/order_book",

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -126,6 +126,9 @@ func initIngester(app *App) {
 }
 
 func initPathFinder(app *App) {
+	if app.config.DisablePathFinding {
+		return
+	}
 	orderBookGraph := orderbook.NewOrderBookGraph()
 	app.orderBookStream = ingest.NewOrderBookStream(
 		&history.Q{app.HorizonSession()},
@@ -192,7 +195,9 @@ func initDbMetrics(app *App) {
 
 	app.coreState.RegisterMetrics(app.prometheusRegistry)
 
-	app.prometheusRegistry.MustRegister(app.orderBookStream.LatestLedgerGauge)
+	if !app.config.DisablePathFinding {
+		app.prometheusRegistry.MustRegister(app.orderBookStream.LatestLedgerGauge)
+	}
 }
 
 // initGoMetrics registers the Go collector provided by prometheus package which

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -190,6 +190,27 @@ func TestMaxPathFindingRequests(t *testing.T) {
 	})
 }
 
+func TestDisablePathFinding(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		test := NewParameterTest(t, map[string]string{})
+		err := test.StartHorizon()
+		assert.NoError(t, err)
+		test.WaitForHorizon()
+		assert.Equal(t, test.Horizon().Config().MaxPathFindingRequests, uint(0))
+		_, ok := test.Horizon().Paths().(simplepath.InMemoryFinder)
+		assert.True(t, ok)
+		test.Shutdown()
+	})
+	t.Run("set to true", func(t *testing.T) {
+		test := NewParameterTest(t, map[string]string{"disable-path-finding": "true"})
+		err := test.StartHorizon()
+		assert.NoError(t, err)
+		test.WaitForHorizon()
+		assert.Nil(t, test.Horizon().Paths())
+		test.Shutdown()
+	})
+}
+
 // Pattern taken from testify issue:
 // https://github.com/stretchr/testify/issues/858#issuecomment-600491003
 //


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add a flag to disable path finding endpoints.

### Why

For ingesting horizon nodes that do not serve HTTP traffic it makes sense to disable the path finding endpoints because the path finding endpoints require storing all offers and liquidity pools in an in-memory graph data structure. This data structure is updated periodically to ensure it is consistent with the latest ledger. However, all of that work is unnecessary if the horizon node will not be serving any HTTP traffic.

### Known limitations

[N/A]
