### PR TITLE
exp/lighthorizon: Refactor single-process index builder.

### DIFF
--- a/exp/lighthorizon/index/builder.go
+++ b/exp/lighthorizon/index/builder.go
@@ -1,0 +1,294 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/stellar/go/historyarchive"
+	"github.com/stellar/go/ingest"
+	"github.com/stellar/go/ingest/ledgerbackend"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/go/toid"
+	"github.com/stellar/go/xdr"
+)
+
+// Module is a way to process data and store it into an index.
+type Module func(
+	idx Store,
+	ledger xdr.LedgerCloseMeta,
+	checkpoint uint32,
+	transaction ingest.LedgerTransaction,
+) error
+
+// IndexBuilder contains everything needed to build indices from ledger ranges.
+type IndexBuilder struct {
+	store             Store
+	history           ledgerbackend.HistoryArchiveBackend
+	networkPassphrase string
+
+	modules []Module
+}
+
+func NewIndexBuilder(
+	indexStore Store,
+	backend ledgerbackend.HistoryArchiveBackend,
+	networkPassphrase string,
+) *IndexBuilder {
+	return &IndexBuilder{
+		store:             indexStore,
+		history:           backend,
+		networkPassphrase: networkPassphrase,
+	}
+}
+
+// RegisterModule adds a module to process every given ledger. It is not
+// threadsafe and all calls should be made *before* any calls to `Build`.
+func (builder *IndexBuilder) RegisterModule(module Module) {
+	builder.modules = append(builder.modules, module)
+}
+
+// RunModules executes all of the registered modules on the given ledger.
+func (builder *IndexBuilder) RunModules(
+	ledger xdr.LedgerCloseMeta,
+	checkpoint uint32,
+	tx ingest.LedgerTransaction,
+) error {
+	for _, module := range builder.modules {
+		if err := module(builder.store, ledger, checkpoint, tx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (builder *IndexBuilder) Build(ctx context.Context, ledgerRange historyarchive.Range) error {
+	for ledgerSeq := ledgerRange.Low; ledgerSeq <= ledgerRange.High; ledgerSeq++ {
+		ledger, err := builder.history.GetLedger(ctx, ledgerSeq)
+		if err != nil {
+			log.WithField("error", err).Errorf("error getting ledger %d", ledgerSeq)
+			return err
+		}
+
+		checkpoint := ledgerSeq / 64
+
+		reader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(
+			builder.networkPassphrase, ledger)
+		if err != nil {
+			return err
+		}
+
+		for {
+			tx, err := reader.Read()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return err
+			}
+
+			if err := builder.RunModules(ledger, checkpoint, tx); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func ProcessTransaction(
+	indexStore Store,
+	ledger xdr.LedgerCloseMeta,
+	_ uint32,
+	tx ingest.LedgerTransaction,
+) error {
+	return indexStore.AddTransactionToIndexes(
+		toid.New(int32(ledger.LedgerSequence()), int32(tx.Index), 0).ToInt64(),
+		tx.Result.TransactionHash,
+	)
+}
+
+func ProcessAccounts(
+	indexStore Store,
+	_ xdr.LedgerCloseMeta,
+	checkpoint uint32,
+	tx ingest.LedgerTransaction,
+) error {
+	allParticipants, err := getParticipants(tx)
+	if err != nil {
+		return err
+	}
+
+	err = indexStore.AddParticipantsToIndexes(checkpoint, "all_all", allParticipants)
+	if err != nil {
+		return err
+	}
+
+	paymentsParticipants, err := getPaymentParticipants(tx)
+	if err != nil {
+		return err
+	}
+
+	err = indexStore.AddParticipantsToIndexes(checkpoint, "all_payments", paymentsParticipants)
+	if err != nil {
+		return err
+	}
+
+	if tx.Result.Successful() {
+		err = indexStore.AddParticipantsToIndexes(checkpoint, "successful_all", allParticipants)
+		if err != nil {
+			return err
+		}
+
+		err = indexStore.AddParticipantsToIndexes(checkpoint, "successful_payments", paymentsParticipants)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+func getPaymentParticipants(transaction ingest.LedgerTransaction) ([]string, error) {
+	return participantsForOperations(transaction, true)
+}
+
+func getParticipants(transaction ingest.LedgerTransaction) ([]string, error) {
+	return participantsForOperations(transaction, false)
+}
+
+func participantsForOperations(transaction ingest.LedgerTransaction, onlyPayments bool) ([]string, error) {
+	var participants []string
+
+	for opindex, operation := range transaction.Envelope.Operations() {
+		opSource := operation.SourceAccount
+		if opSource == nil {
+			txSource := transaction.Envelope.SourceAccount()
+			opSource = &txSource
+		}
+
+		switch operation.Body.Type {
+		case xdr.OperationTypeCreateAccount,
+			xdr.OperationTypePayment,
+			xdr.OperationTypePathPaymentStrictReceive,
+			xdr.OperationTypePathPaymentStrictSend,
+			xdr.OperationTypeAccountMerge:
+			participants = append(participants, opSource.Address())
+		default:
+			if onlyPayments {
+				continue
+			}
+			participants = append(participants, opSource.Address())
+		}
+
+		switch operation.Body.Type {
+		case xdr.OperationTypeCreateAccount:
+			participants = append(participants, operation.Body.MustCreateAccountOp().Destination.Address())
+		case xdr.OperationTypePayment:
+			participants = append(participants, operation.Body.MustPaymentOp().Destination.ToAccountId().Address())
+		case xdr.OperationTypePathPaymentStrictReceive:
+			participants = append(participants, operation.Body.MustPathPaymentStrictReceiveOp().Destination.ToAccountId().Address())
+		case xdr.OperationTypePathPaymentStrictSend:
+			participants = append(participants, operation.Body.MustPathPaymentStrictSendOp().Destination.ToAccountId().Address())
+		case xdr.OperationTypeManageBuyOffer:
+			// the only direct participant is the source_account
+		case xdr.OperationTypeManageSellOffer:
+			// the only direct participant is the source_account
+		case xdr.OperationTypeCreatePassiveSellOffer:
+			// the only direct participant is the source_account
+		case xdr.OperationTypeSetOptions:
+			// the only direct participant is the source_account
+		case xdr.OperationTypeChangeTrust:
+			// the only direct participant is the source_account
+		case xdr.OperationTypeAllowTrust:
+			participants = append(participants, operation.Body.MustAllowTrustOp().Trustor.Address())
+		case xdr.OperationTypeAccountMerge:
+			participants = append(participants, operation.Body.MustDestination().ToAccountId().Address())
+		case xdr.OperationTypeInflation:
+			// the only direct participant is the source_account
+		case xdr.OperationTypeManageData:
+			// the only direct participant is the source_account
+		case xdr.OperationTypeBumpSequence:
+			// the only direct participant is the source_account
+		case xdr.OperationTypeCreateClaimableBalance:
+			for _, c := range operation.Body.MustCreateClaimableBalanceOp().Claimants {
+				participants = append(participants, c.MustV0().Destination.Address())
+			}
+		case xdr.OperationTypeClaimClaimableBalance:
+			// the only direct participant is the source_account
+		case xdr.OperationTypeBeginSponsoringFutureReserves:
+			participants = append(participants, operation.Body.MustBeginSponsoringFutureReservesOp().SponsoredId.Address())
+		case xdr.OperationTypeEndSponsoringFutureReserves:
+			// Failed transactions may not have a compliant sandwich structure
+			// we can rely on (e.g. invalid nesting or a being operation with the wrong sponsoree ID)
+			// and thus we bail out since we could return incorrect information.
+			if transaction.Result.Successful() {
+				sponsoree := transaction.Envelope.SourceAccount().ToAccountId().Address()
+				if operation.SourceAccount != nil {
+					sponsoree = operation.SourceAccount.Address()
+				}
+				operations := transaction.Envelope.Operations()
+				for i := int(opindex) - 1; i >= 0; i-- {
+					if beginOp, ok := operations[i].Body.GetBeginSponsoringFutureReservesOp(); ok &&
+						beginOp.SponsoredId.Address() == sponsoree {
+						participants = append(participants, beginOp.SponsoredId.Address())
+					}
+				}
+			}
+		case xdr.OperationTypeRevokeSponsorship:
+			op := operation.Body.MustRevokeSponsorshipOp()
+			switch op.Type {
+			case xdr.RevokeSponsorshipTypeRevokeSponsorshipLedgerEntry:
+				participants = append(participants, getLedgerKeyParticipants(*op.LedgerKey)...)
+			case xdr.RevokeSponsorshipTypeRevokeSponsorshipSigner:
+				participants = append(participants, op.Signer.AccountId.Address())
+				// We don't add signer as a participant because a signer can be arbitrary account.
+				// This can spam successful operations history of any account.
+			}
+		case xdr.OperationTypeClawback:
+			op := operation.Body.MustClawbackOp()
+			participants = append(participants, op.From.ToAccountId().Address())
+		case xdr.OperationTypeClawbackClaimableBalance:
+			// the only direct participant is the source_account
+		case xdr.OperationTypeSetTrustLineFlags:
+			op := operation.Body.MustSetTrustLineFlagsOp()
+			participants = append(participants, op.Trustor.Address())
+		case xdr.OperationTypeLiquidityPoolDeposit:
+			// the only direct participant is the source_account
+		case xdr.OperationTypeLiquidityPoolWithdraw:
+			// the only direct participant is the source_account
+		default:
+			return nil, fmt.Errorf("unknown operation type: %s", operation.Body.Type)
+		}
+
+		// Requires meta
+		// sponsor, err := operation.getSponsor()
+		// if err != nil {
+		// 	return nil, err
+		// }
+		// if sponsor != nil {
+		// 	otherParticipants = append(otherParticipants, *sponsor)
+		// }
+	}
+
+	return participants, nil
+}
+
+// getLedgerKeyParticipants returns a list of accounts that are considered
+// "participants" in a particular ledger entry.
+//
+// This list will have zero or one element, making it easy to expand via `...`.
+func getLedgerKeyParticipants(ledgerKey xdr.LedgerKey) []string {
+	switch ledgerKey.Type {
+	case xdr.LedgerEntryTypeAccount:
+		return []string{ledgerKey.Account.AccountId.Address()}
+	case xdr.LedgerEntryTypeData:
+		return []string{ledgerKey.Data.AccountId.Address()}
+	case xdr.LedgerEntryTypeOffer:
+		return []string{ledgerKey.Offer.SellerId.Address()}
+	case xdr.LedgerEntryTypeTrustline:
+		return []string{ledgerKey.TrustLine.AccountId.Address()}
+	case xdr.LedgerEntryTypeClaimableBalance:
+		// nothing to do
+	}
+	return []string{}
+}

--- a/exp/lighthorizon/index/builder.go
+++ b/exp/lighthorizon/index/builder.go
@@ -71,7 +71,7 @@ func (builder *IndexBuilder) Build(ctx context.Context, ledgerRange historyarchi
 			return err
 		}
 
-		checkpoint := ledgerSeq / 64
+		checkpoint := (ledgerSeq / 64) + 1
 
 		reader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(
 			builder.networkPassphrase, ledger)

--- a/exp/lighthorizon/index/cmd/single/main.go
+++ b/exp/lighthorizon/index/cmd/single/main.go
@@ -22,14 +22,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// Module is a way to process data and store it into an index.
-type Module func(
-	idx index.Store,
-	ledger xdr.LedgerCloseMeta,
-	checkpoint uint32,
-	transaction ingest.LedgerTransaction,
-) error
-
 func main() {
 	sourceUrl := flag.String("source", "gcs://horizon-archive-poc", "history archive url to read txmeta files")
 	targetUrl := flag.String("target", "file://indexes", "where to write indexes")
@@ -50,18 +42,6 @@ func main() {
 	indexStore, err := index.Connect(*targetUrl)
 	if err != nil {
 		panic(err)
-	}
-
-	moduleFuncs := []Module{}
-	for _, part := range strings.Split(*modules, ",") {
-		switch part {
-		case "transactions":
-			moduleFuncs = append(moduleFuncs, processTransaction)
-		case "accounts":
-			moduleFuncs = append(moduleFuncs, processAccounts)
-		default:
-			panic(fmt.Errorf("Unknown module: %s", part))
-		}
 	}
 
 	// Simple file os access
@@ -101,6 +81,18 @@ func main() {
 	wg, ctx := errgroup.WithContext(ctx)
 	ch := make(chan historyarchive.Range, parallel)
 
+	indexBuilder := NewIndexBuilder(indexStore, *ledgerBackend, *networkPassphrase)
+	for _, part := range strings.Split(*modules, ",") {
+		switch part {
+		case "transactions":
+			indexBuilder.RegisterModule(processTransaction)
+		case "accounts":
+			indexBuilder.RegisterModule(processAccounts)
+		default:
+			panic(fmt.Errorf("Unknown module: %s", part))
+		}
+	}
+
 	// Submit the work to the channels, breaking up the range into checkpoints.
 	go func() {
 		// Recall: A ledger X is a checkpoint ledger iff (X + 1) % 64 == 0
@@ -134,10 +126,7 @@ func main() {
 					log.Fatalf("Uh oh: bad range")
 				}
 
-				err = buildIndices(ctx, indexStore, ledgerBackend,
-					*networkPassphrase,
-					moduleFuncs,
-					ledgerRange)
+				err = indexBuilder.Build(ctx, ledgerRange)
 				if err != nil {
 					return err
 				}
@@ -173,16 +162,59 @@ func main() {
 	}
 }
 
-func buildIndices(
-	ctx context.Context,
+// Module is a way to process data and store it into an index.
+type Module func(
+	idx index.Store,
+	ledger xdr.LedgerCloseMeta,
+	checkpoint uint32,
+	transaction ingest.LedgerTransaction,
+) error
+
+// IndexBuilder contains everything needed to build indices from ledger ranges.
+type IndexBuilder struct {
+	store             index.Store
+	history           ledgerbackend.HistoryArchiveBackend
+	networkPassphrase string
+
+	modules []Module
+}
+
+func NewIndexBuilder(
 	indexStore index.Store,
-	ledgerBackend *ledgerbackend.HistoryArchiveBackend,
+	backend ledgerbackend.HistoryArchiveBackend,
 	networkPassphrase string,
-	modules []Module,
-	ledgerRange historyarchive.Range,
+) *IndexBuilder {
+	return &IndexBuilder{
+		store:             indexStore,
+		history:           backend,
+		networkPassphrase: networkPassphrase,
+	}
+}
+
+// RegisterModule adds a module to process every given ledger. It is not
+// threadsafe and all calls should be made *before* any calls to `Build`.
+func (builder *IndexBuilder) RegisterModule(module Module) {
+	builder.modules = append(builder.modules, module)
+}
+
+// RunModules executes all of the registered modules on the given ledger.
+func (builder *IndexBuilder) RunModules(
+	ledger xdr.LedgerCloseMeta,
+	checkpoint uint32,
+	tx ingest.LedgerTransaction,
 ) error {
+	for _, module := range builder.modules {
+		if err := module(builder.store, ledger, checkpoint, tx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (builder *IndexBuilder) Build(ctx context.Context, ledgerRange historyarchive.Range) error {
 	for ledgerSeq := ledgerRange.Low; ledgerSeq <= ledgerRange.High; ledgerSeq++ {
-		ledger, err := ledgerBackend.GetLedger(ctx, ledgerSeq)
+		ledger, err := builder.history.GetLedger(ctx, ledgerSeq)
 		if err != nil {
 			log.WithField("error", err).Errorf("error getting ledger %d", ledgerSeq)
 			return err
@@ -190,7 +222,8 @@ func buildIndices(
 
 		checkpoint := ledgerSeq / 64
 
-		reader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(networkPassphrase, ledger)
+		reader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(
+			builder.networkPassphrase, ledger)
 		if err != nil {
 			return err
 		}
@@ -203,10 +236,8 @@ func buildIndices(
 				return err
 			}
 
-			for _, module := range modules {
-				if err := module(indexStore, ledger, checkpoint, tx); err != nil {
-					return err
-				}
+			if err := builder.RunModules(ledger, checkpoint, tx); err != nil {
+				return err
 			}
 		}
 	}

--- a/exp/lighthorizon/index/cmd/single/main.go
+++ b/exp/lighthorizon/index/cmd/single/main.go
@@ -98,11 +98,8 @@ func main() {
 
 	// Create a bunch of workers that process ledgers a checkpoint range at a
 	// time (better than a ledger at a time to minimize flushes).
-	type work struct {
-		startLedger, endLedger uint32
-	}
 	wg, ctx := errgroup.WithContext(ctx)
-	ch := make(chan work, parallel)
+	ch := make(chan historyarchive.Range, parallel)
 
 	// Submit the work to the channels, breaking up the range into checkpoints.
 	go func() {
@@ -112,7 +109,7 @@ func main() {
 		ledger := startLedger
 		nextLedger := ledger + (nextCheckpoint - startLedger)
 		for ledger <= endLedger {
-			ch <- work{ledger, nextLedger}
+			ch <- historyarchive.Range{Low: ledger, High: nextLedger}
 
 			ledger = nextLedger + 1
 			// Ensure we don't exceed the upper ledger bound
@@ -126,22 +123,21 @@ func main() {
 	for i := 0; i < parallel; i++ {
 		wg.Go(func() error {
 			for ledgerRange := range ch {
-				count := (ledgerRange.endLedger - ledgerRange.startLedger) + 1
+				count := (ledgerRange.High - ledgerRange.Low) + 1
 				nprocessed := atomic.AddUint64(&processed, uint64(count))
 
-				log.Debugf("Working on checkpoint range [%d, %d]",
-					ledgerRange.startLedger, ledgerRange.endLedger)
+				log.Debugf("Working on checkpoint range %+v", ledgerRange)
 
 				// Assertion for testing
-				if ledgerRange.endLedger != endLedger &&
-					(ledgerRange.endLedger+1)%64 != 0 {
+				if ledgerRange.High != endLedger &&
+					(ledgerRange.High+1)%64 != 0 {
 					log.Fatalf("Uh oh: bad range")
 				}
 
 				err = buildIndices(ctx, indexStore, ledgerBackend,
 					*networkPassphrase,
 					moduleFuncs,
-					ledgerRange.startLedger, ledgerRange.endLedger)
+					ledgerRange)
 				if err != nil {
 					return err
 				}
@@ -167,7 +163,7 @@ func main() {
 
 	// Assertion for testing
 	if processed != uint64(ledgerCount) {
-		log.Fatalf("wtf? processed %d but expected %d", processed, ledgerCount)
+		log.Fatalf("processed %d but expected %d", processed, ledgerCount)
 	}
 
 	log.Infof("Processed %d ledgers via %d workers", processed, parallel)
@@ -183,9 +179,9 @@ func buildIndices(
 	ledgerBackend *ledgerbackend.HistoryArchiveBackend,
 	networkPassphrase string,
 	modules []Module,
-	startLedger, endLedger uint32,
+	ledgerRange historyarchive.Range,
 ) error {
-	for ledgerSeq := startLedger; ledgerSeq <= endLedger; ledgerSeq++ {
+	for ledgerSeq := ledgerRange.Low; ledgerSeq <= ledgerRange.High; ledgerSeq++ {
 		ledger, err := ledgerBackend.GetLedger(ctx, ledgerSeq)
 		if err != nil {
 			log.WithField("error", err).Errorf("error getting ledger %d", ledgerSeq)

--- a/exp/lighthorizon/index/cmd/single/main.go
+++ b/exp/lighthorizon/index/cmd/single/main.go
@@ -127,7 +127,7 @@ func main() {
 					return err
 				}
 
-				postProgress("Reading checkpoints",
+				postProgress("Reading ledgers",
 					nprocessed, uint64(ledgerCount), startTime)
 
 				// Upload indices once per checkpoint to save memory
@@ -143,7 +143,7 @@ func main() {
 		panic(err)
 	}
 
-	postProgress("Reading checkpoints",
+	postProgress("Reading ledgers",
 		uint64(ledgerCount), uint64(ledgerCount), startTime)
 
 	// Assertion for testing

--- a/exp/lighthorizon/index/cmd/single/main.go
+++ b/exp/lighthorizon/index/cmd/single/main.go
@@ -22,6 +22,14 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// Module is a way to process data and store it into an index.
+type Module func(
+	idx index.Store,
+	ledger xdr.LedgerCloseMeta,
+	checkpoint uint32,
+	transaction ingest.LedgerTransaction,
+) error
+
 func main() {
 	sourceUrl := flag.String("source", "gcs://horizon-archive-poc", "history archive url to read txmeta files")
 	targetUrl := flag.String("target", "file://indexes", "where to write indexes")
@@ -42,6 +50,18 @@ func main() {
 	indexStore, err := index.Connect(*targetUrl)
 	if err != nil {
 		panic(err)
+	}
+
+	moduleFuncs := []Module{}
+	for _, part := range strings.Split(*modules, ",") {
+		switch part {
+		case "transactions":
+			moduleFuncs = append(moduleFuncs, processTransaction)
+		case "accounts":
+			moduleFuncs = append(moduleFuncs, processAccounts)
+		default:
+			panic(fmt.Errorf("Unknown module: %s", part))
+		}
 	}
 
 	// Simple file os access
@@ -120,7 +140,7 @@ func main() {
 
 				err = buildIndices(ctx, indexStore, ledgerBackend,
 					*networkPassphrase,
-					strings.Split(*modules, ","),
+					moduleFuncs,
 					ledgerRange.startLedger, ledgerRange.endLedger)
 				if err != nil {
 					return err
@@ -162,7 +182,7 @@ func buildIndices(
 	indexStore index.Store,
 	ledgerBackend *ledgerbackend.HistoryArchiveBackend,
 	networkPassphrase string,
-	modules []string,
+	modules []Module,
 	startLedger, endLedger uint32,
 ) error {
 	for ledgerSeq := startLedger; ledgerSeq <= endLedger; ledgerSeq++ {
@@ -187,18 +207,8 @@ func buildIndices(
 				return err
 			}
 
-			for _, part := range modules {
-				var err error
-				switch part {
-				case "transactions":
-					err = processTransactionModule(indexStore, ledger, tx)
-				case "accounts":
-					err = processAccountsModule(indexStore, checkpoint, tx)
-				default:
-					err = fmt.Errorf("unknown module: %s", part)
-				}
-
-				if err != nil {
+			for _, module := range modules {
+				if err := module(indexStore, ledger, checkpoint, tx); err != nil {
 					return err
 				}
 			}
@@ -238,9 +248,10 @@ func postProgress(prefix string, done, total uint64, startTime time.Time) {
 	)
 }
 
-func processTransactionModule(
+func processTransaction(
 	indexStore index.Store,
 	ledger xdr.LedgerCloseMeta,
+	_ uint32,
 	tx ingest.LedgerTransaction,
 ) error {
 	return indexStore.AddTransactionToIndexes(
@@ -249,8 +260,9 @@ func processTransactionModule(
 	)
 }
 
-func processAccountsModule(
+func processAccounts(
 	indexStore index.Store,
+	_ xdr.LedgerCloseMeta,
 	checkpoint uint32,
 	tx ingest.LedgerTransaction,
 ) error {

--- a/exp/lighthorizon/index/cmd/single/main.go
+++ b/exp/lighthorizon/index/cmd/single/main.go
@@ -36,6 +36,7 @@ func main() {
 
 	flag.Parse()
 	log.SetLevel(log.InfoLevel)
+
 	ctx := context.Background()
 
 	indexStore, err := index.Connect(*targetUrl)
@@ -105,71 +106,34 @@ func main() {
 	for i := 0; i < parallel; i++ {
 		wg.Go(func() error {
 			for ledgerRange := range ch {
-				log.Infof("Working on checkpoint range [%d, %d]",
+				count := (ledgerRange.endLedger - ledgerRange.startLedger) + 1
+				nprocessed := atomic.AddUint64(&processed, uint64(count))
+
+				log.Debugf("Working on checkpoint range [%d, %d]",
 					ledgerRange.startLedger, ledgerRange.endLedger)
 
 				// Assertion for testing
 				if ledgerRange.endLedger != endLedger &&
 					(ledgerRange.endLedger+1)%64 != 0 {
-					log.Warnf("Uh oh: bad range")
+					log.Fatalf("Uh oh: bad range")
 				}
 
-				for ledgerSeq := ledgerRange.startLedger; ledgerSeq <= ledgerRange.endLedger; ledgerSeq++ {
-					ledger, err := ledgerBackend.GetLedger(ctx, ledgerSeq)
-					if err != nil {
-						log.WithField("error", err).Errorf("error getting ledger %d", ledgerSeq)
-						return err
-					}
-
-					checkpoint := ledgerSeq / 64
-
-					reader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(*networkPassphrase, ledger)
-					if err != nil {
-						return err
-					}
-
-					for {
-						tx, err := reader.Read()
-						if err == io.EOF {
-							break
-						} else if err != nil {
-							return err
-						}
-
-						for _, part := range strings.Split(*modules, ",") {
-							var err error
-
-							switch part {
-							case "transactions":
-								err = processTransactionModule(indexStore, ledger, tx)
-							case "accounts":
-								err = processAccountsModule(indexStore, checkpoint, tx)
-							default:
-								err = fmt.Errorf("unknown module: %s", part)
-							}
-
-							if err != nil {
-								return err
-							}
-						}
-					}
-
-					nprocessed := atomic.AddUint64(&processed, 1)
-
-					// 42 is an arbitrary number so we don't get boring
-					// multiples of 10 as % updates.
-					if nprocessed%42 == 0 {
-						postProgress("Reading checkpoints",
-							nprocessed, uint64(ledgerCount), startTime)
-					}
+				err = buildIndices(ctx, indexStore, ledgerBackend,
+					*networkPassphrase,
+					strings.Split(*modules, ","),
+					ledgerRange.startLedger, ledgerRange.endLedger)
+				if err != nil {
+					return err
 				}
+
+				postProgress("Reading checkpoints",
+					nprocessed, uint64(ledgerCount), startTime)
 
 				// Upload indices once per checkpoint to save memory
 				if err := indexStore.Flush(); err != nil {
 					return err
 				}
 			}
-
 			return nil
 		})
 	}
@@ -181,8 +145,9 @@ func main() {
 	postProgress("Reading checkpoints",
 		uint64(ledgerCount), uint64(ledgerCount), startTime)
 
+	// Assertion for testing
 	if processed != uint64(ledgerCount) {
-		panic(fmt.Errorf("wtf? processed %d but expected %d", processed, ledgerCount))
+		log.Fatalf("wtf? processed %d but expected %d", processed, ledgerCount)
 	}
 
 	log.Infof("Processed %d ledgers via %d workers", processed, parallel)
@@ -190,6 +155,57 @@ func main() {
 	if err := indexStore.Flush(); err != nil {
 		panic(err)
 	}
+}
+
+func buildIndices(
+	ctx context.Context,
+	indexStore index.Store,
+	ledgerBackend *ledgerbackend.HistoryArchiveBackend,
+	networkPassphrase string,
+	modules []string,
+	startLedger, endLedger uint32,
+) error {
+	for ledgerSeq := startLedger; ledgerSeq <= endLedger; ledgerSeq++ {
+		ledger, err := ledgerBackend.GetLedger(ctx, ledgerSeq)
+		if err != nil {
+			log.WithField("error", err).Errorf("error getting ledger %d", ledgerSeq)
+			return err
+		}
+
+		checkpoint := ledgerSeq / 64
+
+		reader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(networkPassphrase, ledger)
+		if err != nil {
+			return err
+		}
+
+		for {
+			tx, err := reader.Read()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return err
+			}
+
+			for _, part := range modules {
+				var err error
+				switch part {
+				case "transactions":
+					err = processTransactionModule(indexStore, ledger, tx)
+				case "accounts":
+					err = processAccountsModule(indexStore, checkpoint, tx)
+				default:
+					err = fmt.Errorf("unknown module: %s", part)
+				}
+
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func postProgress(prefix string, done, total uint64, startTime time.Time) {

--- a/exp/lighthorizon/index/cmd/single/main.go
+++ b/exp/lighthorizon/index/cmd/single/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io"
 	"math"
 	"runtime"
 	"strings"
@@ -13,12 +12,9 @@ import (
 
 	"github.com/stellar/go/exp/lighthorizon/index"
 	"github.com/stellar/go/historyarchive"
-	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/ingest/ledgerbackend"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/log"
-	"github.com/stellar/go/toid"
-	"github.com/stellar/go/xdr"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -81,13 +77,13 @@ func main() {
 	wg, ctx := errgroup.WithContext(ctx)
 	ch := make(chan historyarchive.Range, parallel)
 
-	indexBuilder := NewIndexBuilder(indexStore, *ledgerBackend, *networkPassphrase)
+	indexBuilder := index.NewIndexBuilder(indexStore, *ledgerBackend, *networkPassphrase)
 	for _, part := range strings.Split(*modules, ",") {
 		switch part {
 		case "transactions":
-			indexBuilder.RegisterModule(processTransaction)
+			indexBuilder.RegisterModule(index.ProcessTransaction)
 		case "accounts":
-			indexBuilder.RegisterModule(processAccounts)
+			indexBuilder.RegisterModule(index.ProcessAccounts)
 		default:
 			panic(fmt.Errorf("Unknown module: %s", part))
 		}
@@ -162,89 +158,6 @@ func main() {
 	}
 }
 
-// Module is a way to process data and store it into an index.
-type Module func(
-	idx index.Store,
-	ledger xdr.LedgerCloseMeta,
-	checkpoint uint32,
-	transaction ingest.LedgerTransaction,
-) error
-
-// IndexBuilder contains everything needed to build indices from ledger ranges.
-type IndexBuilder struct {
-	store             index.Store
-	history           ledgerbackend.HistoryArchiveBackend
-	networkPassphrase string
-
-	modules []Module
-}
-
-func NewIndexBuilder(
-	indexStore index.Store,
-	backend ledgerbackend.HistoryArchiveBackend,
-	networkPassphrase string,
-) *IndexBuilder {
-	return &IndexBuilder{
-		store:             indexStore,
-		history:           backend,
-		networkPassphrase: networkPassphrase,
-	}
-}
-
-// RegisterModule adds a module to process every given ledger. It is not
-// threadsafe and all calls should be made *before* any calls to `Build`.
-func (builder *IndexBuilder) RegisterModule(module Module) {
-	builder.modules = append(builder.modules, module)
-}
-
-// RunModules executes all of the registered modules on the given ledger.
-func (builder *IndexBuilder) RunModules(
-	ledger xdr.LedgerCloseMeta,
-	checkpoint uint32,
-	tx ingest.LedgerTransaction,
-) error {
-	for _, module := range builder.modules {
-		if err := module(builder.store, ledger, checkpoint, tx); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (builder *IndexBuilder) Build(ctx context.Context, ledgerRange historyarchive.Range) error {
-	for ledgerSeq := ledgerRange.Low; ledgerSeq <= ledgerRange.High; ledgerSeq++ {
-		ledger, err := builder.history.GetLedger(ctx, ledgerSeq)
-		if err != nil {
-			log.WithField("error", err).Errorf("error getting ledger %d", ledgerSeq)
-			return err
-		}
-
-		checkpoint := ledgerSeq / 64
-
-		reader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(
-			builder.networkPassphrase, ledger)
-		if err != nil {
-			return err
-		}
-
-		for {
-			tx, err := reader.Read()
-			if err == io.EOF {
-				break
-			} else if err != nil {
-				return err
-			}
-
-			if err := builder.RunModules(ledger, checkpoint, tx); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
 func postProgress(prefix string, done, total uint64, startTime time.Time) {
 	// This should never happen, more of a runtime assertion for now.
 	// We can remove it when production-ready.
@@ -273,204 +186,6 @@ func postProgress(prefix string, done, total uint64, startTime time.Time) {
 		elapsed.Round(time.Millisecond),
 		remainingStr,
 	)
-}
-
-func processTransaction(
-	indexStore index.Store,
-	ledger xdr.LedgerCloseMeta,
-	_ uint32,
-	tx ingest.LedgerTransaction,
-) error {
-	return indexStore.AddTransactionToIndexes(
-		toid.New(int32(ledger.LedgerSequence()), int32(tx.Index), 0).ToInt64(),
-		tx.Result.TransactionHash,
-	)
-}
-
-func processAccounts(
-	indexStore index.Store,
-	_ xdr.LedgerCloseMeta,
-	checkpoint uint32,
-	tx ingest.LedgerTransaction,
-) error {
-	allParticipants, err := getParticipants(tx)
-	if err != nil {
-		return err
-	}
-
-	err = indexStore.AddParticipantsToIndexes(checkpoint, "all_all", allParticipants)
-	if err != nil {
-		return err
-	}
-
-	paymentsParticipants, err := getPaymentParticipants(tx)
-	if err != nil {
-		return err
-	}
-
-	err = indexStore.AddParticipantsToIndexes(checkpoint, "all_payments", paymentsParticipants)
-	if err != nil {
-		return err
-	}
-
-	if tx.Result.Successful() {
-		err = indexStore.AddParticipantsToIndexes(checkpoint, "successful_all", allParticipants)
-		if err != nil {
-			return err
-		}
-
-		err = indexStore.AddParticipantsToIndexes(checkpoint, "successful_payments", paymentsParticipants)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func getPaymentParticipants(transaction ingest.LedgerTransaction) ([]string, error) {
-	return participantsForOperations(transaction, true)
-}
-
-func getParticipants(transaction ingest.LedgerTransaction) ([]string, error) {
-	return participantsForOperations(transaction, false)
-}
-
-func participantsForOperations(transaction ingest.LedgerTransaction, onlyPayments bool) ([]string, error) {
-	var participants []string
-
-	for opindex, operation := range transaction.Envelope.Operations() {
-		opSource := operation.SourceAccount
-		if opSource == nil {
-			txSource := transaction.Envelope.SourceAccount()
-			opSource = &txSource
-		}
-
-		switch operation.Body.Type {
-		case xdr.OperationTypeCreateAccount,
-			xdr.OperationTypePayment,
-			xdr.OperationTypePathPaymentStrictReceive,
-			xdr.OperationTypePathPaymentStrictSend,
-			xdr.OperationTypeAccountMerge:
-			participants = append(participants, opSource.Address())
-		default:
-			if onlyPayments {
-				continue
-			}
-			participants = append(participants, opSource.Address())
-		}
-
-		switch operation.Body.Type {
-		case xdr.OperationTypeCreateAccount:
-			participants = append(participants, operation.Body.MustCreateAccountOp().Destination.Address())
-		case xdr.OperationTypePayment:
-			participants = append(participants, operation.Body.MustPaymentOp().Destination.ToAccountId().Address())
-		case xdr.OperationTypePathPaymentStrictReceive:
-			participants = append(participants, operation.Body.MustPathPaymentStrictReceiveOp().Destination.ToAccountId().Address())
-		case xdr.OperationTypePathPaymentStrictSend:
-			participants = append(participants, operation.Body.MustPathPaymentStrictSendOp().Destination.ToAccountId().Address())
-		case xdr.OperationTypeManageBuyOffer:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeManageSellOffer:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeCreatePassiveSellOffer:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeSetOptions:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeChangeTrust:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeAllowTrust:
-			participants = append(participants, operation.Body.MustAllowTrustOp().Trustor.Address())
-		case xdr.OperationTypeAccountMerge:
-			participants = append(participants, operation.Body.MustDestination().ToAccountId().Address())
-		case xdr.OperationTypeInflation:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeManageData:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeBumpSequence:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeCreateClaimableBalance:
-			for _, c := range operation.Body.MustCreateClaimableBalanceOp().Claimants {
-				participants = append(participants, c.MustV0().Destination.Address())
-			}
-		case xdr.OperationTypeClaimClaimableBalance:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeBeginSponsoringFutureReserves:
-			participants = append(participants, operation.Body.MustBeginSponsoringFutureReservesOp().SponsoredId.Address())
-		case xdr.OperationTypeEndSponsoringFutureReserves:
-			// Failed transactions may not have a compliant sandwich structure
-			// we can rely on (e.g. invalid nesting or a being operation with the wrong sponsoree ID)
-			// and thus we bail out since we could return incorrect information.
-			if transaction.Result.Successful() {
-				sponsoree := transaction.Envelope.SourceAccount().ToAccountId().Address()
-				if operation.SourceAccount != nil {
-					sponsoree = operation.SourceAccount.Address()
-				}
-				operations := transaction.Envelope.Operations()
-				for i := int(opindex) - 1; i >= 0; i-- {
-					if beginOp, ok := operations[i].Body.GetBeginSponsoringFutureReservesOp(); ok &&
-						beginOp.SponsoredId.Address() == sponsoree {
-						participants = append(participants, beginOp.SponsoredId.Address())
-					}
-				}
-			}
-		case xdr.OperationTypeRevokeSponsorship:
-			op := operation.Body.MustRevokeSponsorshipOp()
-			switch op.Type {
-			case xdr.RevokeSponsorshipTypeRevokeSponsorshipLedgerEntry:
-				participants = append(participants, getLedgerKeyParticipants(*op.LedgerKey)...)
-			case xdr.RevokeSponsorshipTypeRevokeSponsorshipSigner:
-				participants = append(participants, op.Signer.AccountId.Address())
-				// We don't add signer as a participant because a signer can be arbitrary account.
-				// This can spam successful operations history of any account.
-			}
-		case xdr.OperationTypeClawback:
-			op := operation.Body.MustClawbackOp()
-			participants = append(participants, op.From.ToAccountId().Address())
-		case xdr.OperationTypeClawbackClaimableBalance:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeSetTrustLineFlags:
-			op := operation.Body.MustSetTrustLineFlagsOp()
-			participants = append(participants, op.Trustor.Address())
-		case xdr.OperationTypeLiquidityPoolDeposit:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeLiquidityPoolWithdraw:
-			// the only direct participant is the source_account
-		default:
-			return nil, fmt.Errorf("unknown operation type: %s", operation.Body.Type)
-		}
-
-		// Requires meta
-		// sponsor, err := operation.getSponsor()
-		// if err != nil {
-		// 	return nil, err
-		// }
-		// if sponsor != nil {
-		// 	otherParticipants = append(otherParticipants, *sponsor)
-		// }
-	}
-
-	return participants, nil
-}
-
-// getLedgerKeyParticipants returns a list of accounts that are considered
-// "participants" in a particular ledger entry.
-//
-// This list will have zero or one element, making it easy to expand via `...`.
-func getLedgerKeyParticipants(ledgerKey xdr.LedgerKey) []string {
-	switch ledgerKey.Type {
-	case xdr.LedgerEntryTypeAccount:
-		return []string{ledgerKey.Account.AccountId.Address()}
-	case xdr.LedgerEntryTypeData:
-		return []string{ledgerKey.Data.AccountId.Address()}
-	case xdr.LedgerEntryTypeOffer:
-		return []string{ledgerKey.Offer.SellerId.Address()}
-	case xdr.LedgerEntryTypeTrustline:
-		return []string{ledgerKey.TrustLine.AccountId.Address()}
-	case xdr.LedgerEntryTypeClaimableBalance:
-		// nothing to do
-	}
-	return []string{}
 }
 
 func max(a, b int) int {

--- a/exp/lighthorizon/index/cmd/single/main.go
+++ b/exp/lighthorizon/index/cmd/single/main.go
@@ -127,7 +127,7 @@ func main() {
 					return err
 				}
 
-				postProgress("Reading ledgers",
+				printProgress("Reading ledgers",
 					nprocessed, uint64(ledgerCount), startTime)
 
 				// Upload indices once per checkpoint to save memory
@@ -143,7 +143,7 @@ func main() {
 		panic(err)
 	}
 
-	postProgress("Reading ledgers",
+	printProgress("Reading ledgers",
 		uint64(ledgerCount), uint64(ledgerCount), startTime)
 
 	// Assertion for testing
@@ -158,7 +158,7 @@ func main() {
 	}
 }
 
-func postProgress(prefix string, done, total uint64, startTime time.Time) {
+func printProgress(prefix string, done, total uint64, startTime time.Time) {
 	// This should never happen, more of a runtime assertion for now.
 	// We can remove it when production-ready.
 	if done > total {

--- a/exp/lighthorizon/index/cmd/single/main.go
+++ b/exp/lighthorizon/index/cmd/single/main.go
@@ -77,38 +77,48 @@ func main() {
 
 	// Create a bunch of workers that process ledgers a checkpoint range at a
 	// time (better than a ledger at a time to minimize flushes).
+	type work struct {
+		startLedger, endLedger uint32
+	}
 	wg, ctx := errgroup.WithContext(ctx)
-	ch := make(chan uint32, parallel)
+	ch := make(chan work, parallel)
 
 	// Submit the work to the channels, breaking up the range into checkpoints.
 	go func() {
-		for i := startLedger; i <= endLedger; i += 64 {
-			ch <- i
+		// Recall: A ledger X is a checkpoint ledger iff (X + 1) % 64 == 0
+		nextCheckpoint := (((startLedger / 64) * 64) + 63)
+
+		ledger := startLedger
+		nextLedger := ledger + (nextCheckpoint - startLedger)
+		for ledger <= endLedger {
+			ch <- work{ledger, nextLedger}
+
+			ledger = nextLedger + 1
+			// Ensure we don't exceed the upper ledger bound
+			nextLedger = uint32(min(int(endLedger), int(ledger+63)))
 		}
+
 		close(ch)
 	}()
 
 	processed := uint64(0)
 	for i := 0; i < parallel; i++ {
 		wg.Go(func() error {
-			for ledgerStartSeq := range ch {
-				top := min(
-					64,
-					// If this is the last checkpoint range, we might not have
-					// requested a full 64 ledgers, so make sure we cap the
-					// worker appropriately. We also do +1 here because the
-					// `endLedger` in the range is inclusive.
-					int(1+endLedger-ledgerStartSeq),
-				)
+			for ledgerRange := range ch {
+				log.Infof("Working on checkpoint range [%d, %d]",
+					ledgerRange.startLedger, ledgerRange.endLedger)
 
-				for i := 0; i < top; i++ {
-					ledgerSeq := ledgerStartSeq + uint32(i)
+				// Assertion for testing
+				if ledgerRange.endLedger != endLedger &&
+					(ledgerRange.endLedger+1)%64 != 0 {
+					log.Warnf("Uh oh: bad range")
+				}
 
+				for ledgerSeq := ledgerRange.startLedger; ledgerSeq <= ledgerRange.endLedger; ledgerSeq++ {
 					ledger, err := ledgerBackend.GetLedger(ctx, ledgerSeq)
 					if err != nil {
 						log.WithField("error", err).Errorf("error getting ledger %d", ledgerSeq)
-						ch <- ledgerSeq
-						continue
+						return err
 					}
 
 					checkpoint := ledgerSeq / 64

--- a/exp/lighthorizon/index/cmd/single/main.go
+++ b/exp/lighthorizon/index/cmd/single/main.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -20,22 +22,20 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var (
-	// Should we use runtime.NumCPU() for a reasonable default?
-	parallel = uint32(20)
-)
-
 func main() {
 	sourceUrl := flag.String("source", "gcs://horizon-archive-poc", "history archive url to read txmeta files")
 	targetUrl := flag.String("target", "file://indexes", "where to write indexes")
 	networkPassphrase := flag.String("network-passphrase", network.TestNetworkPassphrase, "network passphrase")
-	start := flag.Int("start", -1, "ledger to start at (default: earliest)")
-	end := flag.Int("end", -1, "ledger to end at (default: latest)")
+	start := flag.Int("start", -1, "ledger to start at (inclusive, default: earliest)")
+	end := flag.Int("end", -1, "ledger to end at (inclusive, default: latest)")
 	modules := flag.String("modules", "accounts,transactions", "comma-separated list of modules to index (default: all)")
+
+	// Should we use runtime.NumCPU() for a reasonable default?
+	// Yes, but leave a CPU open so I can actually use my PC while this runs.
+	workerCount := flag.Int("workers", runtime.NumCPU()-1, "number of workers (default: # of CPUs - 1)")
+
 	flag.Parse()
-
 	log.SetLevel(log.InfoLevel)
-
 	ctx := context.Background()
 
 	indexStore, err := index.Connect(*targetUrl)
@@ -59,127 +59,107 @@ func main() {
 
 	startTime := time.Now()
 
-	if *start < 2 {
-		*start = 2
-	}
-	if *end == -1 {
+	startLedger := uint32(max(*start, 2))
+	endLedger := uint32(*end)
+	if endLedger < 0 {
 		latest, err := ledgerBackend.GetLatestLedgerSequence(ctx)
 		if err != nil {
 			panic(err)
 		}
-		*end = int(latest)
+		endLedger = latest
 	}
-	startLedger := uint32(*start) //uint32((39680056) / 64)
-	endLedger := uint32(*end)
-	all := endLedger - startLedger
+	ledgerCount := 1 + (endLedger - startLedger) // +1 because endLedger is inclusive
+	parallel := max(1, *workerCount)
 
+	log.Infof("Creating indices for ledger range: %d through %d (%d ledgers)",
+		startLedger, endLedger, ledgerCount)
+	log.Infof("Using %d workers", parallel)
+
+	// Create a bunch of workers that process ledgers a checkpoint range at a
+	// time (better than a ledger at a time to minimize flushes).
 	wg, ctx := errgroup.WithContext(ctx)
-
 	ch := make(chan uint32, parallel)
 
+	// Submit the work to the channels, breaking up the range into checkpoints.
 	go func() {
-		for i := startLedger; i <= endLedger; i++ {
+		for i := startLedger; i <= endLedger; i += 64 {
 			ch <- i
 		}
 		close(ch)
 	}()
 
 	processed := uint64(0)
-	for i := uint32(0); i < parallel; i++ {
+	for i := 0; i < parallel; i++ {
 		wg.Go(func() error {
-			for ledgerSeq := range ch {
-				fmt.Println("Processing ledger", ledgerSeq)
-				ledger, err := ledgerBackend.GetLedger(ctx, ledgerSeq)
-				if err != nil {
-					log.WithField("error", err).Error("error getting ledgers")
-					ch <- ledgerSeq
-					continue
-				}
+			for ledgerStartSeq := range ch {
+				top := min(
+					64,
+					// If this is the last checkpoint range, we might not have
+					// requested a full 64 ledgers, so make sure we cap the
+					// worker appropriately. We also do +1 here because the
+					// `endLedger` in the range is inclusive.
+					int(1+endLedger-ledgerStartSeq),
+				)
 
-				checkpoint := ledgerSeq / 64
+				for i := 0; i < top; i++ {
+					ledgerSeq := ledgerStartSeq + uint32(i)
 
-				reader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(*networkPassphrase, ledger)
-				if err != nil {
-					return err
-				}
-
-				for {
-					tx, err := reader.Read()
+					ledger, err := ledgerBackend.GetLedger(ctx, ledgerSeq)
 					if err != nil {
-						if err == io.EOF {
-							break
-						}
+						log.WithField("error", err).Errorf("error getting ledger %d", ledgerSeq)
+						ch <- ledgerSeq
+						continue
+					}
+
+					checkpoint := ledgerSeq / 64
+
+					reader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(*networkPassphrase, ledger)
+					if err != nil {
 						return err
 					}
 
-					if strings.Contains(*modules, "transactions") {
-						indexStore.AddTransactionToIndexes(
-							toid.New(int32(ledger.LedgerSequence()), int32(tx.Index), 0).ToInt64(),
-							tx.Result.TransactionHash,
-						)
+					for {
+						tx, err := reader.Read()
+						if err == io.EOF {
+							break
+						} else if err != nil {
+							return err
+						}
+
+						for _, part := range strings.Split(*modules, ",") {
+							var err error
+
+							switch part {
+							case "transactions":
+								err = processTransactionModule(indexStore, ledger, tx)
+							case "accounts":
+								err = processAccountsModule(indexStore, checkpoint, tx)
+							default:
+								err = fmt.Errorf("unknown module: %s", part)
+							}
+
+							if err != nil {
+								return err
+							}
+						}
 					}
 
-					if strings.Contains(*modules, "accounts") {
-						allParticipants, err := participantsForOperations(tx, false)
-						if err != nil {
-							return err
-						}
+					nprocessed := atomic.AddUint64(&processed, 1)
 
-						err = indexStore.AddParticipantsToIndexes(checkpoint, "all_all", allParticipants)
-						if err != nil {
-							return err
-						}
-
-						paymentsParticipants, err := participantsForOperations(tx, true)
-						if err != nil {
-							return err
-						}
-
-						err = indexStore.AddParticipantsToIndexes(checkpoint, "all_payments", paymentsParticipants)
-						if err != nil {
-							return err
-						}
-
-						if tx.Result.Successful() {
-							allParticipants, err := participantsForOperations(tx, false)
-							if err != nil {
-								return err
-							}
-
-							err = indexStore.AddParticipantsToIndexes(checkpoint, "successful_all", allParticipants)
-							if err != nil {
-								return err
-							}
-
-							paymentsParticipants, err := participantsForOperations(tx, true)
-							if err != nil {
-								return err
-							}
-
-							err = indexStore.AddParticipantsToIndexes(checkpoint, "successful_payments", paymentsParticipants)
-							if err != nil {
-								return err
-							}
-						}
+					// 42 is an arbitrary number so we don't get boring
+					// multiples of 10 as % updates.
+					if nprocessed%42 == 0 {
+						postProgress("Reading checkpoints",
+							nprocessed, uint64(ledgerCount), startTime)
 					}
 				}
-			}
 
-			nprocessed := atomic.AddUint64(&processed, 1)
-
-			if nprocessed%100 == 0 {
-				log.Infof(
-					"Reading checkpoints... - %.2f%% - elapsed: %s, remaining: %s",
-					(float64(nprocessed)/float64(all))*100,
-					time.Since(startTime).Round(1*time.Second),
-					(time.Duration(int64(time.Since(startTime))*int64(all)/int64(nprocessed)) - time.Since(startTime)).Round(1*time.Second),
-				)
-
-				// Clear indexes to save memory
+				// Upload indices once per checkpoint to save memory
 				if err := indexStore.Flush(); err != nil {
 					return err
 				}
 			}
+
 			return nil
 		})
 	}
@@ -187,10 +167,108 @@ func main() {
 	if err := wg.Wait(); err != nil {
 		panic(err)
 	}
-	log.Infof("Uploading indexes")
+
+	postProgress("Reading checkpoints",
+		uint64(ledgerCount), uint64(ledgerCount), startTime)
+
+	if processed != uint64(ledgerCount) {
+		panic(fmt.Errorf("wtf? processed %d but expected %d", processed, ledgerCount))
+	}
+
+	log.Infof("Processed %d ledgers via %d workers", processed, parallel)
+	log.Infof("Uploading indices to %s", *targetUrl)
 	if err := indexStore.Flush(); err != nil {
 		panic(err)
 	}
+}
+
+func postProgress(prefix string, done, total uint64, startTime time.Time) {
+	// This should never happen, more of a runtime assertion for now.
+	// We can remove it when production-ready.
+	if done > total {
+		panic(fmt.Errorf("error for %s: done > total (%d > %d)",
+			prefix, done, total))
+	}
+
+	progress := float64(done) / float64(total)
+	elapsed := time.Since(startTime)
+
+	// Approximate based on how many ledgers are left and how long this much
+	// progress took, e.g. if 4/10 took 2s then 6/10 will "take" 3s (though this
+	// assumes consistent ledger load).
+	remaining := (float64(elapsed) / float64(done)) * float64(total-done)
+
+	var remainingStr string
+	if math.IsInf(remaining, 0) || math.IsNaN(remaining) {
+		remainingStr = "unknown"
+	} else {
+		remainingStr = time.Duration(remaining).Round(time.Millisecond).String()
+	}
+
+	log.Infof("%s - %.1f%% (%d/%d) - elapsed: %s, remaining: ~%s", prefix,
+		100*progress, done, total,
+		elapsed.Round(time.Millisecond),
+		remainingStr,
+	)
+}
+
+func processTransactionModule(
+	indexStore index.Store,
+	ledger xdr.LedgerCloseMeta,
+	tx ingest.LedgerTransaction,
+) error {
+	return indexStore.AddTransactionToIndexes(
+		toid.New(int32(ledger.LedgerSequence()), int32(tx.Index), 0).ToInt64(),
+		tx.Result.TransactionHash,
+	)
+}
+
+func processAccountsModule(
+	indexStore index.Store,
+	checkpoint uint32,
+	tx ingest.LedgerTransaction,
+) error {
+	allParticipants, err := getParticipants(tx)
+	if err != nil {
+		return err
+	}
+
+	err = indexStore.AddParticipantsToIndexes(checkpoint, "all_all", allParticipants)
+	if err != nil {
+		return err
+	}
+
+	paymentsParticipants, err := getPaymentParticipants(tx)
+	if err != nil {
+		return err
+	}
+
+	err = indexStore.AddParticipantsToIndexes(checkpoint, "all_payments", paymentsParticipants)
+	if err != nil {
+		return err
+	}
+
+	if tx.Result.Successful() {
+		err = indexStore.AddParticipantsToIndexes(checkpoint, "successful_all", allParticipants)
+		if err != nil {
+			return err
+		}
+
+		err = indexStore.AddParticipantsToIndexes(checkpoint, "successful_payments", paymentsParticipants)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getPaymentParticipants(transaction ingest.LedgerTransaction) ([]string, error) {
+	return participantsForOperations(transaction, true)
+}
+
+func getParticipants(transaction ingest.LedgerTransaction) ([]string, error) {
+	return participantsForOperations(transaction, false)
 }
 
 func participantsForOperations(transaction ingest.LedgerTransaction, onlyPayments bool) ([]string, error) {
@@ -310,19 +388,36 @@ func participantsForOperations(transaction ingest.LedgerTransaction, onlyPayment
 	return participants, nil
 }
 
+// getLedgerKeyParticipants returns a list of accounts that are considered
+// "participants" in a particular ledger entry.
+//
+// This list will have zero or one element, making it easy to expand via `...`.
 func getLedgerKeyParticipants(ledgerKey xdr.LedgerKey) []string {
-	var result []string
 	switch ledgerKey.Type {
 	case xdr.LedgerEntryTypeAccount:
-		result = append(result, ledgerKey.Account.AccountId.Address())
+		return []string{ledgerKey.Account.AccountId.Address()}
+	case xdr.LedgerEntryTypeData:
+		return []string{ledgerKey.Data.AccountId.Address()}
+	case xdr.LedgerEntryTypeOffer:
+		return []string{ledgerKey.Offer.SellerId.Address()}
+	case xdr.LedgerEntryTypeTrustline:
+		return []string{ledgerKey.TrustLine.AccountId.Address()}
 	case xdr.LedgerEntryTypeClaimableBalance:
 		// nothing to do
-	case xdr.LedgerEntryTypeData:
-		result = append(result, ledgerKey.Data.AccountId.Address())
-	case xdr.LedgerEntryTypeOffer:
-		result = append(result, ledgerKey.Offer.SellerId.Address())
-	case xdr.LedgerEntryTypeTrustline:
-		result = append(result, ledgerKey.TrustLine.AccountId.Address())
 	}
-	return result
+	return []string{}
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/toid/main.go
+++ b/toid/main.go
@@ -127,6 +127,9 @@ func (id *ID) IncOperationOrder() {
 }
 
 // New creates a new total order ID
+//
+// FIXME: I feel like since ledger sequences are uint32s, TOIDs should
+// take that into account for the ledger parameter...
 func New(ledger int32, tx int32, op int32) *ID {
 	return &ID{
 		LedgerSequence:   ledger,


### PR DESCRIPTION
### What
This refactors the single-process index builder: (see 90d8ffa1c5512e467e5368acdf71485b878702c0):
 - allow worker count to be a command line parameter
 - split work by checkpoints rather than ledgers
 - move actual index insertion work to helpers
 - move progress bar into helpers
 - simplify participants code, payments vs. all
 - move index building into its own object (`IndexBuilder`)

This also chunks out work to the workers using ledger ranges that correspond to checkpoints.

### Why
Code cleanup and optimization: this minimizes flushes to the filesystem/network by isolating it to checkpoint ranges, which makes flushes more meaningful and is a better discretization.

The refactor into `IndexBuilder` is prep work for #4403, where an important part of that is using a unified codebase for both builders.

### Known limitations
tests are lacking but this is still in poc stages