### PR TITLE
Horizon: merge db performance optimizations to 2.17.1

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -7,6 +7,8 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Querying claimable balances has been optimized ([4385](https://github.com/stellar/go/pull/4385)).
 - Querying trade aggregations has been optimized ([4389](https://github.com/stellar/go/pull/4389)).
+- Postgres connections for non ingesting Horizon instances are now configured to timeout on long running queries / transactions ([4390](https://github.com/stellar/go/pull/4390)).
+- Added `disable-path-finding` Horizon flag to disable the path finding endpoints. This flag should be enabled on ingesting Horizon instances which do not serve HTTP traffic ([4399](https://github.com/stellar/go/pull/4399)).
 
 ## V2.17.0
 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this
 file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- Querying claimable balances has been optimized ([4385](https://github.com/stellar/go/pull/4385)).
+
 ## V2.17.0
 
 This is the final release after the [release candidate](v2.17.0-release-candidate), including some small additional changes:

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 - Querying claimable balances has been optimized ([4385](https://github.com/stellar/go/pull/4385)).
+- Querying trade aggregations has been optimized ([4389](https://github.com/stellar/go/pull/4389)).
 
 ## V2.17.0
 

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -90,7 +90,9 @@ func (a *App) Serve() error {
 	}
 
 	go a.run()
-	go a.orderBookStream.Run(a.ctx)
+	if !a.config.DisablePathFinding {
+		go a.orderBookStream.Run(a.ctx)
+	}
 
 	// WaitGroup for all go routines. Makes sure that DB is closed when
 	// all services gracefully shutdown.

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -52,6 +52,8 @@ type Config struct {
 	// DisablePoolPathFinding configures horizon to run path finding without including liquidity pools
 	// in the path finding search.
 	DisablePoolPathFinding bool
+	// DisablePathFinding configures horizon without the path finding endpoint.
+	DisablePathFinding bool
 	// MaxPathFindingRequests is the maximum number of path finding requests horizon will allow
 	// in a 1-second period. A value of 0 disables the limit.
 	MaxPathFindingRequests uint

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -220,7 +220,7 @@ func (q *Q) GetClaimableBalances(ctx context.Context, query ClaimableBalancesQue
 	sql = sql.
 		Prefix("WITH cb AS (").
 		Suffix(
-			") select "+claimableBalancesSelectStatement+" from cb LIMIT ?",
+			"LIMIT ?) select "+claimableBalancesSelectStatement+" from cb",
 			query.PageQuery.Limit,
 		)
 

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -58,20 +58,25 @@ func (cbq ClaimableBalancesQuery) Cursor() (int64, string, error) {
 // indexes.
 func (cbq ClaimableBalancesQuery) ApplyCursor(sql sq.SelectBuilder) (sq.SelectBuilder, error) {
 	p := cbq.PageQuery
+	hasPagedLimit := false
 	l, r, err := cbq.Cursor()
 	if err != nil {
 		return sql, err
 	}
+	if l > 0 && r != "" {
+		hasPagedLimit = true
+	}
 
 	switch p.Order {
 	case db2.OrderAscending:
-		if l > 0 && r != "" {
+		if hasPagedLimit {
 			sql = sql.
 				Where(sq.Expr("(cb.last_modified_ledger, cb.id) > (?, ?)", l, r))
+
 		}
 		sql = sql.OrderBy("cb.last_modified_ledger asc, cb.id asc")
 	case db2.OrderDescending:
-		if l > 0 && r != "" {
+		if hasPagedLimit {
 			sql = sql.
 				Where(sq.Expr("(cb.last_modified_ledger, cb.id) < (?, ?)", l, r))
 		}
@@ -197,11 +202,17 @@ func (q *Q) FindClaimableBalanceByID(ctx context.Context, balanceID string) (Cla
 // GetClaimableBalances finds all claimable balances where accountID is one of the claimants
 func (q *Q) GetClaimableBalances(ctx context.Context, query ClaimableBalancesQuery) ([]ClaimableBalance, error) {
 	sql, err := query.ApplyCursor(selectClaimableBalances)
+	// we need to use WITH syntax and correct LIMIT placement to force the query planner to use the right
+	// indexes, otherwise when the limit is small, it will use an index scan
+	// which will be very slow once we have millions of records
+	limitClausePlacement := "LIMIT ?) select " + claimableBalancesSelectStatement + " from cb"
+
 	if err != nil {
 		return nil, errors.Wrap(err, "could not apply query to page")
 	}
 
 	if query.Asset != nil {
+		// when search by asset, profiling has shown best performance to have the LIMIT on inner query
 		sql = sql.Where("cb.asset = ?", query.Asset)
 	}
 
@@ -212,15 +223,15 @@ func (q *Q) GetClaimableBalances(ctx context.Context, query ClaimableBalancesQue
 	if query.Claimant != nil {
 		sql = sql.
 			Where(`cb.claimants @> '[{"destination": "` + query.Claimant.Address() + `"}]'`)
+		// when search by claimant, profiling has shown the LIMIT should be on the outer query to
+		// hint appropriate indexes for best performance
+		limitClausePlacement = ") select " + claimableBalancesSelectStatement + " from cb LIMIT ?"
 	}
 
-	// we need to use WITH syntax to force the query planner to use the right
-	// indexes, otherwise when the limit is small, it will use an index scan
-	// which will be very slow once we have millions of records
 	sql = sql.
 		Prefix("WITH cb AS (").
 		Suffix(
-			"LIMIT ?) select "+claimableBalancesSelectStatement+" from cb",
+			limitClausePlacement,
 			query.PageQuery.Limit,
 		)
 

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/guregu/null"
@@ -114,7 +115,7 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 			},
 		},
 		Asset:              asset,
-		LastModifiedLedger: 123,
+		LastModifiedLedger: 300,
 		Amount:             10,
 	}
 
@@ -126,6 +127,7 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 		Claimant:  xdr.MustAddressPtr(dest1),
 	}
 
+	// this validates the cb query with claimant parameter
 	cbs, err := q.GetClaimableBalances(tt.Ctx, query)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(cbs, 2)
@@ -134,11 +136,28 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 		tt.Assert.Equal(dest1, cb.Claimants[0].Destination)
 	}
 
+	// this validates the cb query with different claimant parameter
 	query.Claimant = xdr.MustAddressPtr(dest2)
 	cbs, err = q.GetClaimableBalances(tt.Ctx, query)
 	tt.Assert.NoError(err)
 	tt.Assert.Len(cbs, 1)
 	tt.Assert.Equal(dest2, cbs[0].Claimants[1].Destination)
+
+	// this validates the cb query with claimant and cb.id/ledger cursor parameters
+	query.PageQuery = db2.MustPageQuery(fmt.Sprintf("%v-%s", 150, cbs[0].BalanceID), false, "", 10)
+	query.Claimant = xdr.MustAddressPtr(dest1)
+	cbs, err = q.GetClaimableBalances(tt.Ctx, query)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(cbs, 1)
+	tt.Assert.Equal(dest2, cbs[0].Claimants[1].Destination)
+
+	// this validates the cb query with no claimant parameter,
+	// should still produce working sql, as it triggers different LIMIT position in sql.
+	query.PageQuery = db2.MustPageQuery("", false, "", 1)
+	query.Claimant = nil
+	cbs, err = q.GetClaimableBalances(tt.Ctx, query)
+	tt.Assert.NoError(err)
+	tt.Assert.Len(cbs, 1)
 }
 
 func TestUpdateClaimableBalance(t *testing.T) {

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -393,6 +393,14 @@ func Flags() (*Config, support.ConfigOptions) {
 			Usage:       "excludes liquidity pools from consideration in the `/paths` endpoint",
 		},
 		&support.ConfigOption{
+			Name:        "disable-path-finding",
+			ConfigKey:   &config.DisablePathFinding,
+			OptType:     types.Bool,
+			FlagDefault: false,
+			Required:    false,
+			Usage:       "disables the path finding endpoints",
+		},
+		&support.ConfigOption{
 			Name:        "max-path-finding-requests",
 			ConfigKey:   &config.MaxPathFindingRequests,
 			OptType:     types.Uint,

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -196,22 +196,24 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 
 		r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/assets", restPageHandler(ledgerState, actions.AssetStatsHandler{LedgerState: ledgerState}))
 
-		findPaths := ObjectActionHandler{actions.FindPathsHandler{
-			StaleThreshold:       config.StaleThreshold,
-			SetLastLedgerHeader:  true,
-			MaxPathLength:        config.MaxPathLength,
-			MaxAssetsParamLength: config.MaxAssetsPerPathRequest,
-			PathFinder:           config.PathFinder,
-		}}
-		findFixedPaths := ObjectActionHandler{actions.FindFixedPathsHandler{
-			MaxPathLength:        config.MaxPathLength,
-			SetLastLedgerHeader:  true,
-			MaxAssetsParamLength: config.MaxAssetsPerPathRequest,
-			PathFinder:           config.PathFinder,
-		}}
-		r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths", findPaths)
-		r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths/strict-receive", findPaths)
-		r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths/strict-send", findFixedPaths)
+		if config.PathFinder != nil {
+			findPaths := ObjectActionHandler{actions.FindPathsHandler{
+				StaleThreshold:       config.StaleThreshold,
+				SetLastLedgerHeader:  true,
+				MaxPathLength:        config.MaxPathLength,
+				MaxAssetsParamLength: config.MaxAssetsPerPathRequest,
+				PathFinder:           config.PathFinder,
+			}}
+			findFixedPaths := ObjectActionHandler{actions.FindFixedPathsHandler{
+				MaxPathLength:        config.MaxPathLength,
+				SetLastLedgerHeader:  true,
+				MaxAssetsParamLength: config.MaxAssetsPerPathRequest,
+				PathFinder:           config.PathFinder,
+			}}
+			r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths", findPaths)
+			r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths/strict-receive", findPaths)
+			r.With(stateMiddleware.Wrap).Method(http.MethodGet, "/paths/strict-send", findFixedPaths)
+		}
 		r.With(stateMiddleware.Wrap).Method(
 			http.MethodGet,
 			"/order_book",

--- a/services/horizon/internal/httpx/server.go
+++ b/services/horizon/internal/httpx/server.go
@@ -58,6 +58,7 @@ func init() {
 	problem.RegisterError(context.Canceled, hProblem.ClientDisconnected)
 	problem.RegisterError(db.ErrCancelled, hProblem.ClientDisconnected)
 	problem.RegisterError(db.ErrTimeout, hProblem.ServiceUnavailable)
+	problem.RegisterError(db.ErrStatementTimeout, hProblem.ServiceUnavailable)
 	problem.RegisterError(db.ErrConflictWithRecovery, hProblem.ServiceUnavailable)
 	problem.RegisterError(db.ErrBadConnection, hProblem.ServiceUnavailable)
 }

--- a/services/horizon/internal/ingest/orderbook.go
+++ b/services/horizon/internal/ingest/orderbook.go
@@ -136,7 +136,6 @@ func (o *OrderBookStream) update(ctx context.Context, status ingestionStatus) (b
 			o.graph.AddOffers(offerToXDR(offer))
 			return nil
 		})
-
 		if err != nil {
 			return true, errors.Wrap(err, "Error loading offers into orderbook")
 		}

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -126,6 +126,9 @@ func initIngester(app *App) {
 }
 
 func initPathFinder(app *App) {
+	if app.config.DisablePathFinding {
+		return
+	}
 	orderBookGraph := orderbook.NewOrderBookGraph()
 	app.orderBookStream = ingest.NewOrderBookStream(
 		&history.Q{app.HorizonSession()},
@@ -192,7 +195,9 @@ func initDbMetrics(app *App) {
 
 	app.coreState.RegisterMetrics(app.prometheusRegistry)
 
-	app.prometheusRegistry.MustRegister(app.orderBookStream.LatestLedgerGauge)
+	if !app.config.DisablePathFinding {
+		app.prometheusRegistry.MustRegister(app.orderBookStream.LatestLedgerGauge)
+	}
 }
 
 // initGoMetrics registers the Go collector provided by prometheus package which

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -190,6 +190,27 @@ func TestMaxPathFindingRequests(t *testing.T) {
 	})
 }
 
+func TestDisablePathFinding(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		test := NewParameterTest(t, map[string]string{})
+		err := test.StartHorizon()
+		assert.NoError(t, err)
+		test.WaitForHorizon()
+		assert.Equal(t, test.Horizon().Config().MaxPathFindingRequests, uint(0))
+		_, ok := test.Horizon().Paths().(simplepath.InMemoryFinder)
+		assert.True(t, ok)
+		test.Shutdown()
+	})
+	t.Run("set to true", func(t *testing.T) {
+		test := NewParameterTest(t, map[string]string{"disable-path-finding": "true"})
+		err := test.StartHorizon()
+		assert.NoError(t, err)
+		test.WaitForHorizon()
+		assert.Nil(t, test.Horizon().Paths())
+		test.Shutdown()
+	})
+}
+
 // Pattern taken from testify issue:
 // https://github.com/stretchr/testify/issues/858#issuecomment-600491003
 //

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -14,6 +14,9 @@ package db
 import (
 	"context"
 	"database/sql"
+	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/squirrel"
@@ -44,6 +47,9 @@ var (
 	// ErrBadConnection is an error returned when driver returns `bad connection`
 	// error.
 	ErrBadConnection = errors.New("bad connection")
+	// ErrStatementTimeout is an error returned by Session methods when request has
+	// been cancelled due to a statement timeout.
+	ErrStatementTimeout = errors.New("canceling statement due to statement timeout")
 )
 
 // Conn represents a connection to a single database.
@@ -163,8 +169,59 @@ func pingDB(db *sqlx.DB) error {
 	return errors.Wrapf(err, "failed to connect to DB after %v attempts", maxDBPingAttempts)
 }
 
+type ClientConfig struct {
+	Key   string
+	Value string
+}
+
+func StatementTimeout(timeout time.Duration) ClientConfig {
+	return ClientConfig{
+		Key:   "statement_timeout",
+		Value: strconv.FormatInt(timeout.Milliseconds(), 10),
+	}
+}
+
+func IdleTransactionTimeout(timeout time.Duration) ClientConfig {
+	return ClientConfig{
+		Key:   "idle_in_transaction_session_timeout",
+		Value: strconv.FormatInt(timeout.Milliseconds(), 10),
+	}
+}
+
+func augmentDSN(dsn string, clientConfigs []ClientConfig) string {
+	parsed, err := url.Parse(dsn)
+	// dsn can either be a postgres url like "postgres://postgres:123456@127.0.0.1:5432"
+	// or, it can be a white space separated string of key value pairs like
+	// "host=localhost port=5432 user=bob password=secret"
+	if err != nil || parsed.Scheme == "" {
+		// if dsn does not parse as a postgres url, we assume it must be take
+		// the form of a white space separated string
+		parts := []string{dsn}
+		for _, config := range clientConfigs {
+			// do not override if the key is already present in dsn
+			if strings.Contains(dsn, config.Key+"=") {
+				continue
+			}
+			parts = append(parts, config.Key+"="+config.Value)
+		}
+		return strings.Join(parts, " ")
+	}
+
+	q := parsed.Query()
+	for _, config := range clientConfigs {
+		// do not override if the key is already present in dsn
+		if len(q.Get(config.Key)) > 0 {
+			continue
+		}
+		q.Set(config.Key, config.Value)
+	}
+	parsed.RawQuery = q.Encode()
+	return parsed.String()
+}
+
 // Open the database at `dsn` and returns a new *Session using it.
-func Open(dialect, dsn string) (*Session, error) {
+func Open(dialect, dsn string, clientConfigs ...ClientConfig) (*Session, error) {
+	dsn = augmentDSN(dsn, clientConfigs)
 	db, err := sqlx.Open(dialect, dsn)
 	if err != nil {
 		return nil, errors.Wrap(err, "open failed")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

porting the db performance optimizations into a 2.17.1 release 

### Why

want to get these changes out soon to avoid further repeat of some known performance issues

### Known limitations


