### PR TITLE
exp/lighthorizon: Unify single-process and map-reduce index builders.

### DIFF
--- a/exp/lighthorizon/index/builder.go
+++ b/exp/lighthorizon/index/builder.go
@@ -89,7 +89,7 @@ func BuildIndices(
 		nextCheckpoint := (((startLedger / 64) * 64) + 63)
 
 		ledger := startLedger
-		nextLedger := ledger + (nextCheckpoint - startLedger)
+		nextLedger := min(endLedger, ledger+(nextCheckpoint-startLedger))
 		for ledger <= endLedger {
 			chunk := historyarchive.Range{Low: ledger, High: nextLedger}
 			log.Debugf("Submitted [%d, %d] for work", chunk.Low, chunk.High)

--- a/exp/lighthorizon/index/builder.go
+++ b/exp/lighthorizon/index/builder.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
+	"sync/atomic"
+	"time"
 
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest"
@@ -11,13 +14,151 @@ import (
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/toid"
 	"github.com/stellar/go/xdr"
+	"golang.org/x/sync/errgroup"
 )
 
-// Module is a way to process data and store it into an index.
+func BuildIndices(
+	ctx context.Context,
+	sourceUrl string, // where is raw txmeta coming from?
+	targetUrl string, // where should the resulting indices go?
+	networkPassphrase string,
+	startLedger, endLedger uint32,
+	modules []string,
+	workerCount int,
+) error {
+	indexStore, err := Connect(targetUrl)
+	if err != nil {
+		return err
+	}
+
+	// Simple file os access
+	source, err := historyarchive.ConnectBackend(
+		sourceUrl,
+		historyarchive.ConnectOptions{
+			Context:           ctx,
+			NetworkPassphrase: networkPassphrase,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	ledgerBackend := ledgerbackend.NewHistoryArchiveBackend(source)
+	defer ledgerBackend.Close()
+
+	if endLedger == 0 {
+		latest, err := ledgerBackend.GetLatestLedgerSequence(ctx)
+		if err != nil {
+			return err
+		}
+		endLedger = latest
+	}
+
+	ledgerCount := 1 + (endLedger - startLedger) // +1 because endLedger is inclusive
+	parallel := max(1, workerCount)
+
+	startTime := time.Now()
+	log.Infof("Creating indices for ledger range: %d through %d (%d ledgers)",
+		startLedger, endLedger, ledgerCount)
+	log.Infof("Using %d workers", parallel)
+
+	// Create a bunch of workers that process ledgers a checkpoint range at a
+	// time (better than a ledger at a time to minimize flushes).
+	wg, ctx := errgroup.WithContext(ctx)
+	ch := make(chan historyarchive.Range, parallel)
+
+	indexBuilder := NewIndexBuilder(indexStore, *ledgerBackend, networkPassphrase)
+	for _, part := range modules {
+		switch part {
+		case "transactions":
+			indexBuilder.RegisterModule(ProcessTransaction)
+		case "accounts":
+			indexBuilder.RegisterModule(ProcessAccounts)
+		case "accounts_unbacked":
+			indexBuilder.RegisterModule(ProcessAccountsWithoutBackend)
+		default:
+			return fmt.Errorf("Unknown module: %s", part)
+		}
+	}
+
+	// Submit the work to the channels, breaking up the range into individual
+	// checkpoint ranges.
+	go func() {
+		// Recall: A ledger X is a checkpoint ledger iff (X + 1) % 64 == 0
+		nextCheckpoint := (((startLedger / 64) * 64) + 63)
+
+		ledger := startLedger
+		nextLedger := ledger + (nextCheckpoint - startLedger)
+		for ledger <= endLedger {
+			chunk := historyarchive.Range{Low: ledger, High: nextLedger}
+			log.Debugf("Submitted [%d, %d] for work", chunk.Low, chunk.High)
+			ch <- chunk
+
+			ledger = nextLedger + 1
+			nextLedger = min(endLedger, ledger+63) // don't exceed upper bound
+		}
+
+		close(ch)
+	}()
+
+	processed := uint64(0)
+	for i := 0; i < parallel; i++ {
+		wg.Go(func() error {
+			for ledgerRange := range ch {
+				count := (ledgerRange.High - ledgerRange.Low) + 1
+				nprocessed := atomic.AddUint64(&processed, uint64(count))
+
+				log.Debugf("Working on checkpoint range [%d, %d]",
+					ledgerRange.Low, ledgerRange.High)
+
+				// Assertion for testing
+				if ledgerRange.High != endLedger &&
+					(ledgerRange.High+1)%64 != 0 {
+					log.Fatalf("Uh oh: bad range")
+				}
+
+				err = indexBuilder.Build(ctx, ledgerRange)
+				if err != nil {
+					return err
+				}
+
+				PostProgress("Reading ledgers",
+					nprocessed, uint64(ledgerCount), startTime)
+
+				// Upload indices once per checkpoint to save memory
+				if err := indexStore.Flush(); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	if err := wg.Wait(); err != nil {
+		return err
+	}
+
+	PostProgress("Reading ledgers",
+		uint64(ledgerCount), uint64(ledgerCount), startTime)
+
+	// Assertion for testing
+	if processed != uint64(ledgerCount) {
+		log.Fatalf("processed %d but expected %d", processed, ledgerCount)
+	}
+
+	log.Infof("Processed %d ledgers via %d workers", processed, parallel)
+	log.Infof("Uploading indices to %s", targetUrl)
+	if err := indexStore.FlushAccounts(); err != nil {
+		return err
+	}
+	return indexStore.Flush()
+}
+
+// Module is a way to process ingested data and shove it into an index store.
 type Module func(
 	idx Store,
 	ledger xdr.LedgerCloseMeta,
-	checkpoint uint32,
+	checkpoint uint32, // technically this is derivable from the meta?
 	transaction ingest.LedgerTransaction,
 ) error
 
@@ -63,6 +204,12 @@ func (builder *IndexBuilder) RunModules(
 	return nil
 }
 
+// Build sequentially creates indices for each ledger in the given range based
+// on the registered modules.
+//
+// TODO: We can probably optimize this by doing GetLedger in parallel with the
+//       ingestion & index building, since the network will be idle during the
+//       latter portion.
 func (builder *IndexBuilder) Build(ctx context.Context, ledgerRange historyarchive.Range) error {
 	for ledgerSeq := ledgerRange.Low; ledgerSeq <= ledgerRange.High; ledgerSeq++ {
 		ledger, err := builder.history.GetLedger(ctx, ledgerSeq)
@@ -291,4 +438,89 @@ func getLedgerKeyParticipants(ledgerKey xdr.LedgerKey) []string {
 		// nothing to do
 	}
 	return []string{}
+}
+
+func ProcessAccountsWithoutBackend(
+	indexStore Store,
+	_ xdr.LedgerCloseMeta,
+	checkpoint uint32,
+	tx ingest.LedgerTransaction,
+) error {
+	allParticipants, err := getParticipants(tx)
+	if err != nil {
+		return err
+	}
+
+	err = indexStore.AddParticipantsToIndexesNoBackend(checkpoint, "all_all", allParticipants)
+	if err != nil {
+		return err
+	}
+
+	paymentsParticipants, err := getPaymentParticipants(tx)
+	if err != nil {
+		return err
+	}
+
+	err = indexStore.AddParticipantsToIndexesNoBackend(checkpoint, "all_payments", paymentsParticipants)
+	if err != nil {
+		return err
+	}
+
+	if tx.Result.Successful() {
+		err = indexStore.AddParticipantsToIndexesNoBackend(checkpoint, "successful_all", allParticipants)
+		if err != nil {
+			return err
+		}
+
+		err = indexStore.AddParticipantsToIndexesNoBackend(checkpoint, "successful_payments", paymentsParticipants)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func PostProgress(prefix string, done, total uint64, startTime time.Time) {
+	// This should never happen, more of a runtime assertion for now.
+	// We can remove it when production-ready.
+	if done > total {
+		panic(fmt.Errorf("error for %s: done > total (%d > %d)",
+			prefix, done, total))
+	}
+
+	progress := float64(done) / float64(total)
+	elapsed := time.Since(startTime)
+
+	// Approximate based on how many ledgers are left and how long this much
+	// progress took, e.g. if 4/10 took 2s then 6/10 will "take" 3s (though this
+	// assumes consistent ledger load).
+	remaining := (float64(elapsed) / float64(done)) * float64(total-done)
+
+	var remainingStr string
+	if math.IsInf(remaining, 0) || math.IsNaN(remaining) {
+		remainingStr = "unknown"
+	} else {
+		remainingStr = time.Duration(remaining).Round(time.Millisecond).String()
+	}
+
+	log.Infof("%s - %.1f%% (%d/%d) - elapsed: %s, remaining: ~%s", prefix,
+		100*progress, done, total,
+		elapsed.Round(time.Millisecond),
+		remainingStr,
+	)
+}
+
+func min(a, b uint32) uint32 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/exp/lighthorizon/index/cmd/batch/doc.go
+++ b/exp/lighthorizon/index/cmd/batch/doc.go
@@ -27,8 +27,8 @@
 // account index was processed earlier it should be skipped instead of being
 // processed again. Each reduce job also runs multiple parallel workers. Finally
 // the method that is used to determine if the following (job, worker) should
-// process a given account is using a 64-bit hash of account ID. The hash is
-// split into two 32-bit parts: left and right. If the left part modulo
+// process a given account is using a 32-bit hash of account ID. The hash is
+// split into two 16-bit parts: left and right. If the left part modulo
 // REDUCE_JOBS is equal the job index and the right part modulo a number of
 // parallel workers is equal the worker index then the account is processed.
 // Otherwise it's skipped (and will be picked by another (job, worker) pair).
@@ -41,7 +41,7 @@
 //     |
 //     ㄴ job0/...       <- ...and partial indexes
 //
-//     hash(account_id) => XXXX YYYY <-  64 bit hash of account id is calculated
+//     hash(account_id) => XXXX YYYY <-  32 bit hash of account id is calculated
 //
 //     if XXXX % REDUCE_JOBS == JOB_ID and YYYY % WORKERS_COUNT = WORKER_ID
 //     then process a given account by merging all indexes of a given account

--- a/exp/lighthorizon/index/cmd/batch/doc.go
+++ b/exp/lighthorizon/index/cmd/batch/doc.go
@@ -46,7 +46,7 @@
 //     if XXXX % REDUCE_JOBS == JOB_ID and YYYY % WORKERS_COUNT = WORKER_ID
 //     then process a given account by merging all indexes of a given account
 //     in all map step results, then mark account as done so if the account
-//     is seen again it will be skiped,
+//     is seen again it will be skipped.
 //
 //     else: skip the account.
 //

--- a/exp/lighthorizon/index/cmd/batch/map/main.go
+++ b/exp/lighthorizon/index/cmd/batch/map/main.go
@@ -3,352 +3,78 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"strconv"
-	"sync/atomic"
-	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stellar/go/exp/lighthorizon/index"
 	"github.com/stellar/go/historyarchive"
-	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
-	"github.com/stellar/go/toid"
-	"github.com/stellar/go/xdr"
-	"golang.org/x/sync/errgroup"
 )
 
-var (
-	// Should we use runtime.NumCPU() for a reasonable default?
-	parallel = uint32(20)
-)
+type BatchConfig struct {
+	historyarchive.Range
+	TxMetaSourceUrl, TargetUrl string
+}
 
-func main() {
-	log.SetLevel(log.InfoLevel)
-	startTime := time.Now()
+func NewBatchConfigFromEnvironment() (*BatchConfig, error) {
+	const (
+		jobIndexEnv        = "AWS_BATCH_JOB_ARRAY_INDEX"
+		firstCheckpointEnv = "FIRST_CHECKPOINT"
+		batchSizeEnv       = "BATCH_SIZE"
+		txmetaSourceUrlEnv = "TXMETA_SOURCE"
+	)
 
-	jobIndexString := os.Getenv("AWS_BATCH_JOB_ARRAY_INDEX")
-	if jobIndexString == "" {
-		panic("AWS_BATCH_JOB_ARRAY_INDEX env required")
+	jobIndex, err := strconv.ParseUint(os.Getenv(jobIndexEnv), 10, 32)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid parameter "+jobIndexEnv)
 	}
 
-	jobIndex, err := strconv.ParseUint(jobIndexString, 10, 64)
+	firstCheckpoint, err := strconv.ParseUint(os.Getenv(firstCheckpointEnv), 10, 32)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrap(err, "invalid parameter "+firstCheckpointEnv)
 	}
 
-	firstCheckpointString := os.Getenv("FIRST_CHECKPOINT")
-	firstCheckpoint, err := strconv.ParseUint(firstCheckpointString, 10, 64)
+	batchSize, err := strconv.ParseUint(os.Getenv(batchSizeEnv), 10, 32)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrap(err, "invalid parameter "+batchSizeEnv)
 	}
 
-	batchSizeString := os.Getenv("BATCH_SIZE")
-	batchSize, err := strconv.ParseUint(batchSizeString, 10, 64)
-	if err != nil {
-		panic(err)
+	sourceUrl := os.Getenv(txmetaSourceUrlEnv)
+	if sourceUrl == "" {
+		return nil, errors.New("required parameter " + txmetaSourceUrlEnv)
 	}
 
 	startCheckpoint := uint32(firstCheckpoint + batchSize*jobIndex)
 	endCheckpoint := startCheckpoint + uint32(batchSize) - 1
+	return &BatchConfig{
+		Range:           historyarchive.Range{Low: startCheckpoint, High: endCheckpoint},
+		TargetUrl:       fmt.Sprintf("s3://some-url/job_%d?region=%s", jobIndex, "us-east-1"),
+		TxMetaSourceUrl: sourceUrl,
+	}, nil
+}
 
-	indexStore, err := index.NewS3Store(
-		&aws.Config{Region: aws.String("us-east-1")},
-		fmt.Sprintf("job_%d", jobIndex),
-		parallel,
-	)
+func main() {
+	log.SetLevel(log.InfoLevel)
+
+	batch, err := NewBatchConfigFromEnvironment()
 	if err != nil {
 		panic(err)
 	}
 
-	historyArchive, err := historyarchive.Connect(
-		"s3://history.stellar.org/prd/core-live/core_live_001",
-		historyarchive.ConnectOptions{
-			NetworkPassphrase: network.PublicNetworkPassphrase,
-			S3Region:          "eu-west-1",
-			UnsignedRequests:  true,
-		},
-	)
-	if err != nil {
+	log.Infof("Uploading ledger range [%d, %d] to %s",
+		batch.Range.Low, batch.Range.High, batch.TargetUrl)
+
+	if err := index.BuildIndices(
+		context.Background(),
+		batch.TxMetaSourceUrl,
+		batch.TargetUrl,
+		network.TestNetworkPassphrase,
+		batch.Low, batch.High,
+		[]string{"transactions", "accounts_unbacked"},
+		1,
+	); err != nil {
 		panic(err)
 	}
-
-	all := endCheckpoint - startCheckpoint
-
-	ctx := context.Background()
-	wg, _ := errgroup.WithContext(ctx)
-
-	ch := make(chan uint32, parallel)
-
-	go func() {
-		for i := startCheckpoint; i <= endCheckpoint; i++ {
-			ch <- i
-		}
-		close(ch)
-	}()
-
-	processed := uint64(0)
-	for i := uint32(0); i < parallel; i++ {
-		wg.Go(func() error {
-			for checkpoint := range ch {
-
-				startLedger := checkpoint * 64
-				if startLedger == 0 {
-					startLedger = 1
-				}
-				endLedger := checkpoint*64 + 64 - 1
-
-				log.Info("Processing checkpoint ", checkpoint, " ledgers ", startLedger, endLedger)
-
-				ledgers, err := historyArchive.GetLedgers(startLedger, endLedger)
-				if err != nil {
-					log.WithField("error", err).Error("error getting ledgers")
-					ch <- checkpoint
-					continue
-				}
-
-				for i := startLedger; i <= endLedger; i++ {
-					ledger, ok := ledgers[i]
-					if !ok {
-						return fmt.Errorf("no ledger %d", i)
-					}
-
-					resultMeta := make([]xdr.TransactionResultMeta, len(ledger.TransactionResult.TxResultSet.Results))
-					for i, result := range ledger.TransactionResult.TxResultSet.Results {
-						resultMeta[i].Result = result
-					}
-
-					closeMeta := xdr.LedgerCloseMeta{
-						V0: &xdr.LedgerCloseMetaV0{
-							LedgerHeader: ledger.Header,
-							TxSet:        ledger.Transaction.TxSet,
-							TxProcessing: resultMeta,
-						},
-					}
-
-					reader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(network.PublicNetworkPassphrase, closeMeta)
-					if err != nil {
-						return err
-					}
-
-					for {
-						tx, err := reader.Read()
-						if err != nil {
-							if err == io.EOF {
-								break
-							}
-							return err
-						}
-
-						indexStore.AddTransactionToIndexes(
-							toid.New(int32(closeMeta.LedgerSequence()), int32(tx.Index), 0).ToInt64(),
-							tx.Result.TransactionHash,
-						)
-
-						allParticipants, err := participantsForOperations(tx, false)
-						if err != nil {
-							return err
-						}
-
-						err = indexStore.AddParticipantsToIndexesNoBackend(checkpoint, "all_all", allParticipants)
-						if err != nil {
-							return err
-						}
-
-						paymentsParticipants, err := participantsForOperations(tx, true)
-						if err != nil {
-							return err
-						}
-
-						err = indexStore.AddParticipantsToIndexesNoBackend(checkpoint, "all_payments", paymentsParticipants)
-						if err != nil {
-							return err
-						}
-
-						if tx.Result.Successful() {
-							allParticipants, err := participantsForOperations(tx, false)
-							if err != nil {
-								return err
-							}
-
-							err = indexStore.AddParticipantsToIndexesNoBackend(checkpoint, "successful_all", allParticipants)
-							if err != nil {
-								return err
-							}
-
-							paymentsParticipants, err := participantsForOperations(tx, true)
-							if err != nil {
-								return err
-							}
-
-							err = indexStore.AddParticipantsToIndexesNoBackend(checkpoint, "successful_payments", paymentsParticipants)
-							if err != nil {
-								return err
-							}
-						}
-					}
-				}
-
-				nprocessed := atomic.AddUint64(&processed, 1)
-
-				if nprocessed%100 == 0 {
-					log.Infof(
-						"Reading checkpoints... - %.2f%% - elapsed: %s, remaining: %s",
-						(float64(nprocessed)/float64(all))*100,
-						time.Since(startTime).Round(1*time.Second),
-						(time.Duration(int64(time.Since(startTime))*int64(all)/int64(nprocessed)) - time.Since(startTime)).Round(1*time.Second),
-					)
-				}
-			}
-			return nil
-		})
-	}
-
-	if err := wg.Wait(); err != nil {
-		panic(err)
-	}
-	log.Infof("Uploading accounts")
-	if err := indexStore.FlushAccounts(); err != nil {
-		panic(err)
-	}
-	log.Infof("Uploading indexes")
-	if err := indexStore.Flush(); err != nil {
-		panic(err)
-	}
-}
-
-func participantsForOperations(transaction ingest.LedgerTransaction, onlyPayments bool) ([]string, error) {
-	var participants []string
-
-	for opindex, operation := range transaction.Envelope.Operations() {
-		opSource := operation.SourceAccount
-		if opSource == nil {
-			txSource := transaction.Envelope.SourceAccount()
-			opSource = &txSource
-		}
-
-		switch operation.Body.Type {
-		case xdr.OperationTypeCreateAccount,
-			xdr.OperationTypePayment,
-			xdr.OperationTypePathPaymentStrictReceive,
-			xdr.OperationTypePathPaymentStrictSend,
-			xdr.OperationTypeAccountMerge:
-			participants = append(participants, opSource.Address())
-		default:
-			if onlyPayments {
-				continue
-			}
-			participants = append(participants, opSource.Address())
-		}
-
-		switch operation.Body.Type {
-		case xdr.OperationTypeCreateAccount:
-			participants = append(participants, operation.Body.MustCreateAccountOp().Destination.Address())
-		case xdr.OperationTypePayment:
-			participants = append(participants, operation.Body.MustPaymentOp().Destination.ToAccountId().Address())
-		case xdr.OperationTypePathPaymentStrictReceive:
-			participants = append(participants, operation.Body.MustPathPaymentStrictReceiveOp().Destination.ToAccountId().Address())
-		case xdr.OperationTypePathPaymentStrictSend:
-			participants = append(participants, operation.Body.MustPathPaymentStrictSendOp().Destination.ToAccountId().Address())
-		case xdr.OperationTypeManageBuyOffer:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeManageSellOffer:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeCreatePassiveSellOffer:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeSetOptions:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeChangeTrust:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeAllowTrust:
-			participants = append(participants, operation.Body.MustAllowTrustOp().Trustor.Address())
-		case xdr.OperationTypeAccountMerge:
-			participants = append(participants, operation.Body.MustDestination().ToAccountId().Address())
-		case xdr.OperationTypeInflation:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeManageData:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeBumpSequence:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeCreateClaimableBalance:
-			for _, c := range operation.Body.MustCreateClaimableBalanceOp().Claimants {
-				participants = append(participants, c.MustV0().Destination.Address())
-			}
-		case xdr.OperationTypeClaimClaimableBalance:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeBeginSponsoringFutureReserves:
-			participants = append(participants, operation.Body.MustBeginSponsoringFutureReservesOp().SponsoredId.Address())
-		case xdr.OperationTypeEndSponsoringFutureReserves:
-			// Failed transactions may not have a compliant sandwich structure
-			// we can rely on (e.g. invalid nesting or a being operation with the wrong sponsoree ID)
-			// and thus we bail out since we could return incorrect information.
-			if transaction.Result.Successful() {
-				sponsoree := transaction.Envelope.SourceAccount().ToAccountId().Address()
-				if operation.SourceAccount != nil {
-					sponsoree = operation.SourceAccount.Address()
-				}
-				operations := transaction.Envelope.Operations()
-				for i := int(opindex) - 1; i >= 0; i-- {
-					if beginOp, ok := operations[i].Body.GetBeginSponsoringFutureReservesOp(); ok &&
-						beginOp.SponsoredId.Address() == sponsoree {
-						participants = append(participants, beginOp.SponsoredId.Address())
-					}
-				}
-			}
-		case xdr.OperationTypeRevokeSponsorship:
-			op := operation.Body.MustRevokeSponsorshipOp()
-			switch op.Type {
-			case xdr.RevokeSponsorshipTypeRevokeSponsorshipLedgerEntry:
-				participants = append(participants, getLedgerKeyParticipants(*op.LedgerKey)...)
-			case xdr.RevokeSponsorshipTypeRevokeSponsorshipSigner:
-				participants = append(participants, op.Signer.AccountId.Address())
-				// We don't add signer as a participant because a signer can be arbitrary account.
-				// This can spam successful operations history of any account.
-			}
-		case xdr.OperationTypeClawback:
-			op := operation.Body.MustClawbackOp()
-			participants = append(participants, op.From.ToAccountId().Address())
-		case xdr.OperationTypeClawbackClaimableBalance:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeSetTrustLineFlags:
-			op := operation.Body.MustSetTrustLineFlagsOp()
-			participants = append(participants, op.Trustor.Address())
-		case xdr.OperationTypeLiquidityPoolDeposit:
-			// the only direct participant is the source_account
-		case xdr.OperationTypeLiquidityPoolWithdraw:
-			// the only direct participant is the source_account
-		default:
-			return nil, fmt.Errorf("unknown operation type: %s", operation.Body.Type)
-		}
-
-		// Requires meta
-		// sponsor, err := operation.getSponsor()
-		// if err != nil {
-		// 	return nil, err
-		// }
-		// if sponsor != nil {
-		// 	otherParticipants = append(otherParticipants, *sponsor)
-		// }
-	}
-
-	return participants, nil
-}
-
-func getLedgerKeyParticipants(ledgerKey xdr.LedgerKey) []string {
-	var result []string
-	switch ledgerKey.Type {
-	case xdr.LedgerEntryTypeAccount:
-		result = append(result, ledgerKey.Account.AccountId.Address())
-	case xdr.LedgerEntryTypeClaimableBalance:
-		// nothing to do
-	case xdr.LedgerEntryTypeData:
-		result = append(result, ledgerKey.Data.AccountId.Address())
-	case xdr.LedgerEntryTypeOffer:
-		result = append(result, ledgerKey.Offer.SellerId.Address())
-	case xdr.LedgerEntryTypeTrustline:
-		result = append(result, ledgerKey.TrustLine.AccountId.Address())
-	}
-	return result
 }

--- a/exp/lighthorizon/index/cmd/batch/map/main.go
+++ b/exp/lighthorizon/index/cmd/batch/map/main.go
@@ -23,7 +23,7 @@ const (
 	jobIndexEnv        = "AWS_BATCH_JOB_ARRAY_INDEX"
 	firstCheckpointEnv = "FIRST_CHECKPOINT"
 	txmetaSourceUrlEnv = "TXMETA_SOURCE"
-	txmetaTargetUrlEnv = "TXMETA_TARGET"
+	indexTargetUrlEnv  = "INDEX_TARGET"
 
 	s3BucketName = "sdf-txmeta-pubnet"
 )
@@ -35,7 +35,7 @@ func NewS3BatchConfig() (*BatchConfig, error) {
 	}
 
 	url := fmt.Sprintf("s3://%s/job_%d?region=%s", s3BucketName, jobIndex, "us-east-1")
-	if err := os.Setenv(txmetaTargetUrlEnv, url); err != nil {
+	if err := os.Setenv(indexTargetUrlEnv, url); err != nil {
 		return nil, err
 	}
 
@@ -43,9 +43,9 @@ func NewS3BatchConfig() (*BatchConfig, error) {
 }
 
 func NewBatchConfig() (*BatchConfig, error) {
-	targetUrl := os.Getenv(txmetaTargetUrlEnv)
+	targetUrl := os.Getenv(indexTargetUrlEnv)
 	if targetUrl == "" {
-		return nil, errors.New("required parameter: " + txmetaTargetUrlEnv)
+		return nil, errors.New("required parameter: " + indexTargetUrlEnv)
 	}
 
 	jobIndex, err := strconv.ParseUint(os.Getenv(jobIndexEnv), 10, 32)

--- a/exp/lighthorizon/index/cmd/batch/reduce/main.go
+++ b/exp/lighthorizon/index/cmd/batch/reduce/main.go
@@ -131,7 +131,7 @@ func mergeAllIndices(finalIndexStore index.Store, config *ReduceConfig) error {
 			len(accounts), config.Workers)
 
 		workQueues := make([]chan string, config.Workers)
-		for i, _ := range workQueues {
+		for i := range workQueues {
 			workQueues[i] = make(chan string, 1)
 		}
 
@@ -144,7 +144,7 @@ func mergeAllIndices(finalIndexStore index.Store, config *ReduceConfig) error {
 					}
 
 					// Account doesn't belong in this work queue?
-					if config.shouldProcessAccount(account, index) {
+					if !config.shouldProcessAccount(account, index) {
 						continue
 					}
 
@@ -203,7 +203,7 @@ func mergeAllIndices(finalIndexStore index.Store, config *ReduceConfig) error {
 						innerJobStore, err := index.Connect(url)
 						if err != nil {
 							logger.WithError(err).
-								Errorf("Failed to open index at %s")
+								Errorf("Failed to open index at %s", url)
 							panic(err)
 						}
 
@@ -325,8 +325,8 @@ func (cfg *ReduceConfig) shouldProcessAccount(account string, routineIndex uint3
 }
 
 func (cfg *ReduceConfig) shouldProcessTx(txPrefix byte, routineIndex uint32) bool {
-	hashLeft := uint32(transactionPrefix >> 4)
-	hashRight := uint32(transactionPrefix & 0x0F)
+	hashLeft := uint32(txPrefix >> 4)
+	hashRight := uint32(txPrefix & 0x0F)
 
 	// Because the transaction hash (and thus the first byte or "prefix") is a
 	// random value, its remainders w.r.t. the indices will distribute the work

--- a/exp/lighthorizon/index/cmd/batch/reduce/main.go
+++ b/exp/lighthorizon/index/cmd/batch/reduce/main.go
@@ -19,11 +19,6 @@ var (
 	parallel = uint32(16)
 )
 
-type SafeStringSet struct {
-	lock sync.Mutex
-	set  map[string]struct{}
-}
-
 type ReduceConfig struct {
 	JobIndex       uint32
 	MapJobCount    uint32
@@ -245,26 +240,6 @@ func main() {
 
 		wg.Wait()
 	}
-}
-
-func NewSafeStringSet() *SafeStringSet {
-	return &SafeStringSet{
-		lock: sync.Mutex{},
-		set:  map[string]struct{}{},
-	}
-}
-
-func (set *SafeStringSet) Contains(key string) bool {
-	defer set.lock.Unlock()
-	set.lock.Lock()
-	_, ok := set.set[key]
-	return ok
-}
-
-func (set *SafeStringSet) Add(key string) {
-	defer set.lock.Unlock()
-	set.lock.Lock()
-	set.set[key] = struct{}{}
 }
 
 func shouldAccountBeProcessed(account string,

--- a/exp/lighthorizon/index/cmd/batch/reduce/main.go
+++ b/exp/lighthorizon/index/cmd/batch/reduce/main.go
@@ -302,7 +302,7 @@ func shouldTransactionBeProcessed(transactionPrefix byte,
 	jobIndex, jobCount uint32,
 	routineIndex, routineCount uint32,
 ) bool {
-	hashLeft := uint32(transactionPrefix & 0xF0)
+	hashLeft := uint32(transactionPrefix >> 4)
 	hashRight := uint32(0x0F & transactionPrefix)
 
 	// Because the transaction hash (and thus the first byte or "prefix") is a

--- a/exp/lighthorizon/index/cmd/batch/reduce/set.go
+++ b/exp/lighthorizon/index/cmd/batch/reduce/set.go
@@ -1,0 +1,29 @@
+package main
+
+import "sync"
+
+// SafeStringSet is a simple thread-safe set.
+type SafeStringSet struct {
+	lock sync.Mutex
+	set  map[string]struct{}
+}
+
+func NewSafeStringSet() *SafeStringSet {
+	return &SafeStringSet{
+		lock: sync.Mutex{},
+		set:  map[string]struct{}{},
+	}
+}
+
+func (set *SafeStringSet) Contains(key string) bool {
+	defer set.lock.Unlock()
+	set.lock.Lock()
+	_, ok := set.set[key]
+	return ok
+}
+
+func (set *SafeStringSet) Add(key string) {
+	defer set.lock.Unlock()
+	set.lock.Lock()
+	set.set[key] = struct{}{}
+}

--- a/exp/lighthorizon/index/cmd/single/main.go
+++ b/exp/lighthorizon/index/cmd/single/main.go
@@ -3,19 +3,12 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
-	"math"
 	"runtime"
 	"strings"
-	"sync/atomic"
-	"time"
 
 	"github.com/stellar/go/exp/lighthorizon/index"
-	"github.com/stellar/go/historyarchive"
-	"github.com/stellar/go/ingest/ledgerbackend"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/log"
-	"golang.org/x/sync/errgroup"
 )
 
 func main() {
@@ -33,170 +26,23 @@ func main() {
 	flag.Parse()
 	log.SetLevel(log.InfoLevel)
 
-	ctx := context.Background()
-
-	indexStore, err := index.Connect(*targetUrl)
-	if err != nil {
-		panic(err)
-	}
-
-	// Simple file os access
-	source, err := historyarchive.ConnectBackend(
+	err := index.BuildIndices(
+		context.Background(),
 		*sourceUrl,
-		historyarchive.ConnectOptions{
-			Context:           context.Background(),
-			NetworkPassphrase: *networkPassphrase,
-		},
+		*targetUrl,
+		*networkPassphrase,
+		uint32(max(*start, 2)),
+		uint32(*end),
+		strings.Split(*modules, ","),
+		*workerCount,
 	)
 	if err != nil {
 		panic(err)
 	}
-	ledgerBackend := ledgerbackend.NewHistoryArchiveBackend(source)
-	defer ledgerBackend.Close()
-
-	startTime := time.Now()
-
-	startLedger := uint32(max(*start, 2))
-	endLedger := uint32(*end)
-	if endLedger < 0 {
-		latest, err := ledgerBackend.GetLatestLedgerSequence(ctx)
-		if err != nil {
-			panic(err)
-		}
-		endLedger = latest
-	}
-	ledgerCount := 1 + (endLedger - startLedger) // +1 because endLedger is inclusive
-	parallel := max(1, *workerCount)
-
-	log.Infof("Creating indices for ledger range: %d through %d (%d ledgers)",
-		startLedger, endLedger, ledgerCount)
-	log.Infof("Using %d workers", parallel)
-
-	// Create a bunch of workers that process ledgers a checkpoint range at a
-	// time (better than a ledger at a time to minimize flushes).
-	wg, ctx := errgroup.WithContext(ctx)
-	ch := make(chan historyarchive.Range, parallel)
-
-	indexBuilder := index.NewIndexBuilder(indexStore, *ledgerBackend, *networkPassphrase)
-	for _, part := range strings.Split(*modules, ",") {
-		switch part {
-		case "transactions":
-			indexBuilder.RegisterModule(index.ProcessTransaction)
-		case "accounts":
-			indexBuilder.RegisterModule(index.ProcessAccounts)
-		default:
-			panic(fmt.Errorf("Unknown module: %s", part))
-		}
-	}
-
-	// Submit the work to the channels, breaking up the range into checkpoints.
-	go func() {
-		// Recall: A ledger X is a checkpoint ledger iff (X + 1) % 64 == 0
-		nextCheckpoint := (((startLedger / 64) * 64) + 63)
-
-		ledger := startLedger
-		nextLedger := ledger + (nextCheckpoint - startLedger)
-		for ledger <= endLedger {
-			ch <- historyarchive.Range{Low: ledger, High: nextLedger}
-
-			ledger = nextLedger + 1
-			// Ensure we don't exceed the upper ledger bound
-			nextLedger = uint32(min(int(endLedger), int(ledger+63)))
-		}
-
-		close(ch)
-	}()
-
-	processed := uint64(0)
-	for i := 0; i < parallel; i++ {
-		wg.Go(func() error {
-			for ledgerRange := range ch {
-				count := (ledgerRange.High - ledgerRange.Low) + 1
-				nprocessed := atomic.AddUint64(&processed, uint64(count))
-
-				log.Debugf("Working on checkpoint range %+v", ledgerRange)
-
-				// Assertion for testing
-				if ledgerRange.High != endLedger &&
-					(ledgerRange.High+1)%64 != 0 {
-					log.Fatalf("Uh oh: bad range")
-				}
-
-				err = indexBuilder.Build(ctx, ledgerRange)
-				if err != nil {
-					return err
-				}
-
-				printProgress("Reading ledgers",
-					nprocessed, uint64(ledgerCount), startTime)
-
-				// Upload indices once per checkpoint to save memory
-				if err := indexStore.Flush(); err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-	}
-
-	if err := wg.Wait(); err != nil {
-		panic(err)
-	}
-
-	printProgress("Reading ledgers",
-		uint64(ledgerCount), uint64(ledgerCount), startTime)
-
-	// Assertion for testing
-	if processed != uint64(ledgerCount) {
-		log.Fatalf("processed %d but expected %d", processed, ledgerCount)
-	}
-
-	log.Infof("Processed %d ledgers via %d workers", processed, parallel)
-	log.Infof("Uploading indices to %s", *targetUrl)
-	if err := indexStore.Flush(); err != nil {
-		panic(err)
-	}
-}
-
-func printProgress(prefix string, done, total uint64, startTime time.Time) {
-	// This should never happen, more of a runtime assertion for now.
-	// We can remove it when production-ready.
-	if done > total {
-		panic(fmt.Errorf("error for %s: done > total (%d > %d)",
-			prefix, done, total))
-	}
-
-	progress := float64(done) / float64(total)
-	elapsed := time.Since(startTime)
-
-	// Approximate based on how many ledgers are left and how long this much
-	// progress took, e.g. if 4/10 took 2s then 6/10 will "take" 3s (though this
-	// assumes consistent ledger load).
-	remaining := (float64(elapsed) / float64(done)) * float64(total-done)
-
-	var remainingStr string
-	if math.IsInf(remaining, 0) || math.IsNaN(remaining) {
-		remainingStr = "unknown"
-	} else {
-		remainingStr = time.Duration(remaining).Round(time.Millisecond).String()
-	}
-
-	log.Infof("%s - %.1f%% (%d/%d) - elapsed: %s, remaining: ~%s", prefix,
-		100*progress, done, total,
-		elapsed.Round(time.Millisecond),
-		remainingStr,
-	)
 }
 
 func max(a, b int) int {
 	if a > b {
-		return a
-	}
-	return b
-}
-
-func min(a, b int) int {
-	if a < b {
 		return a
 	}
 	return b

--- a/exp/lighthorizon/index/connect.go
+++ b/exp/lighthorizon/index/connect.go
@@ -2,8 +2,10 @@ package index
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"path/filepath"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 )
@@ -15,12 +17,27 @@ func Connect(backendUrl string) (Store, error) {
 	}
 	switch parsed.Scheme {
 	case "s3":
+		var parallel uint32 = 20
 		config := &aws.Config{}
 		query := parsed.Query()
 		if region := query.Get("region"); region != "" {
 			config.Region = aws.String(region)
 		}
-		return NewS3Store(config, parsed.Path, 20)
+
+		// Somewhat of a hack: allow control of parallelization via a special
+		// query parameter in the s3:// path.
+		if workers := query.Get("workers"); workers != "" {
+			workerCount, err := strconv.ParseUint(workers, 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse worker count (%s): %v", workers, err)
+			}
+			if workerCount > 0 {
+				parallel = uint32(workerCount)
+			}
+			query.Del("workers")
+		}
+
+		return NewS3Store(config, parsed.Path, parallel)
 
 	case "file":
 		return NewFileStore(filepath.Join(parsed.Host, parsed.Path), 20)

--- a/exp/lighthorizon/index/connect.go
+++ b/exp/lighthorizon/index/connect.go
@@ -1,13 +1,13 @@
 package index
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"path/filepath"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stellar/go/support/errors"
 )
 
 func Connect(backendUrl string) (Store, error) {
@@ -29,7 +29,7 @@ func Connect(backendUrl string) (Store, error) {
 		if workers := query.Get("workers"); workers != "" {
 			workerCount, err := strconv.ParseUint(workers, 10, 32)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse worker count (%s): %v", workers, err)
+				return nil, errors.Wrapf(err, "failed to parse worker count (%s)", workers)
 			}
 			if workerCount > 0 {
 				parallel = uint32(workerCount)
@@ -43,6 +43,7 @@ func Connect(backendUrl string) (Store, error) {
 		return NewFileStore(filepath.Join(parsed.Host, parsed.Path), 20)
 
 	default:
-		return nil, errors.New("unknown URL scheme: '" + parsed.Scheme + "'")
+		return nil, fmt.Errorf("unknown URL scheme: '%s' (from %s)",
+			parsed.Scheme, backendUrl)
 	}
 }

--- a/exp/lighthorizon/index/file.go
+++ b/exp/lighthorizon/index/file.go
@@ -1,15 +1,17 @@
 package index
 
 import (
+	"bytes"
 	"compress/gzip"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 
+	xdr3 "github.com/stellar/go-xdr/xdr3"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
+	"github.com/stellar/go/xdr"
 )
 
 type FileBackend struct {
@@ -50,9 +52,21 @@ func (s *FileBackend) FlushAccounts(accounts []string) error {
 
 	defer f.Close()
 
-	accountsString := strings.Join(accounts, "\n") + "\n" // trailing newline
-	if _, err := f.Write([]byte(accountsString)); err != nil {
-		return errors.Wrapf(err, "writing to %s failed", path)
+	for _, account := range accounts {
+		muxed := xdr.MuxedAccount{}
+		if err := muxed.SetAddress(account); err != nil {
+			return errors.Wrapf(err, "failed to encode %s", account)
+		}
+
+		raw, err := muxed.MarshalBinary()
+		if err != nil {
+			return errors.Wrapf(err, "failed to marshal %s", account)
+		}
+
+		_, err = f.Write(raw)
+		if err != nil {
+			return errors.Wrapf(err, "failed to write to %s", path)
+		}
 	}
 
 	return nil
@@ -142,23 +156,48 @@ func (s *FileBackend) ReadAccounts() ([]string, error) {
 	path := filepath.Join(s.dir, "accounts")
 	log.Debugf("Opening accounts list at %s", path)
 
-	// The entirety of pubnet accounts in a single file will consume ~750MB
+	// The entirety of pubnet accounts in a single file will consume ~400MB
 	// (according to Hubble + napkin math). That should never be done on a
 	// single machine anyway. Thus, if this file is insurmountably large to fit
 	// into memory, you should be splitting the work better. That means we can
 	// safely read it all in one go.
-	//
-	// TODO: This can be optimized by ~43% by reading/writing raw public keys.
 	buffer, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return nil, err
 	} else if err != nil {
 		return nil, errors.Wrapf(err, "failed to read %s", path)
 	} else if len(buffer) == 0 {
+		// This is probably an error... We could also return os.ErrNotExist?
 		return nil, fmt.Errorf("account list at %s is empty", path)
 	}
 
-	return strings.Split(string(buffer), "\n"), nil
+	// The capacity here is ballparked based on all of the values being
+	// G-addresses (32 public key bytes) plus the key type (4 bytes). Note that
+	// this means it's never too large, but might be too small.
+	accounts := make([]string, 0, len(buffer)/36)
+
+	// We don't use UnmarshalBinary here because we need to know how much of
+	// the file was read for each account.
+	reader := bytes.NewReader(buffer)
+	d := xdr3.NewDecoder(reader)
+
+	for i := 0; i < len(buffer); {
+		muxed := xdr.MuxedAccount{}
+		readBytes, err := muxed.DecodeFrom(d)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to decode account")
+		}
+
+		account, err := muxed.GetAddress()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get strkey")
+		}
+
+		accounts = append(accounts, account)
+		i += readBytes
+	}
+
+	return accounts, nil
 }
 
 func (s *FileBackend) ReadTransactions(prefix string) (*TrieIndex, error) {

--- a/exp/lighthorizon/index/file.go
+++ b/exp/lighthorizon/index/file.go
@@ -142,8 +142,13 @@ func (s *FileBackend) ReadAccounts() ([]string, error) {
 	path := filepath.Join(s.dir, "accounts")
 	log.Debugf("Opening accounts list at %s", path)
 
-	// This file probably isn't insurmountably large (TODO: Confirm that), so we
-	// can probably read it all in one go.
+	// The entirety of pubnet accounts in a single file will consume ~750MB
+	// (according to Hubble + napkin math). That should never be done on a
+	// single machine anyway. Thus, if this file is insurmountably large to fit
+	// into memory, you should be splitting the work better. That means we can
+	// safely read it all in one go.
+	//
+	// TODO: This can be optimized by ~43% by reading/writing raw public keys.
 	buffer, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return nil, err

--- a/exp/lighthorizon/index/s3.go
+++ b/exp/lighthorizon/index/s3.go
@@ -193,9 +193,9 @@ func (s *S3Backend) Read(account string) (map[string]*CheckpointIndex, error) {
 
 func (s *S3Backend) ReadTransactions(prefix string) (*TrieIndex, error) {
 	// Check if index exists in S3
-	log.Debugf("Downloading index: %s", prefix)
 	b := &aws.WriteAtBuffer{}
 	path := filepath.Join(s.prefix, "tx", prefix)
+	log.Debugf("Downloading index: %s (path=%s)", prefix, path)
 	n, err := s.downloader.Download(b, &s3.GetObjectInput{
 		Bucket: aws.String(BUCKET),
 		Key:    aws.String(path),

--- a/exp/lighthorizon/index/store.go
+++ b/exp/lighthorizon/index/store.go
@@ -83,6 +83,9 @@ func (s *store) MergeTransactions(prefix string, other *TrieIndex) error {
 	if err := index.Merge(other); err != nil {
 		return err
 	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	s.txIndexes[prefix] = index
 	return nil
 }

--- a/exp/lighthorizon/index/store.go
+++ b/exp/lighthorizon/index/store.go
@@ -60,12 +60,7 @@ func (s *store) accounts() []string {
 func (s *store) FlushAccounts() error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-
-	if err := s.backend.FlushAccounts(s.accounts()); err != nil {
-		return err
-	}
-
-	return nil
+	return s.backend.FlushAccounts(s.accounts())
 }
 
 func (s *store) Read(account string) (map[string]*CheckpointIndex, error) {
@@ -97,6 +92,10 @@ func (s *store) Flush() error {
 	defer s.mutex.Unlock()
 
 	if err := s.backend.Flush(s.indexes); err != nil {
+		return err
+	}
+
+	if err := s.backend.FlushAccounts(s.accounts()); err != nil {
 		return err
 	}
 
@@ -159,6 +158,7 @@ func (s *store) AddParticipantsToIndexesNoBackend(checkpoint uint32, index strin
 			return err
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
### What
This unifies the index building across the map-reduce and single-process versions: 
 - `builder.go:BuildIndices` does the work (so we get txmeta indexing "for free")
 - the redundant `participantsForOperations` and `getLedgerKeyParticipants` are gone
 - the new `ProcessAccountsWithoutBackend` module does the backend-less index building
 - the `shouldAccountBeProcessed` and `shouldTransactionBeProcessed` helpers are pulled out versions of the batching code

It also cleans up and abstracts away the environmental variables for AWS Batch, which should make it simpler to support other platforms or even local runs.

### Why
Less code, more sharing. Related to #4403.

### Known limitations
I haven't tested this on AWS Batch yet.