### PR TITLE
protocols/horizon: add missing strkey type names.

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -21,10 +21,12 @@ import (
 // KeyTypeNames maps from strkey version bytes into json string values to use in
 // horizon responses.
 var KeyTypeNames = map[strkey.VersionByte]string{
-	strkey.VersionByteAccountID: "ed25519_public_key",
-	strkey.VersionByteSeed:      "ed25519_secret_seed",
-	strkey.VersionByteHashX:     "sha256_hash",
-	strkey.VersionByteHashTx:    "preauth_tx",
+	strkey.VersionByteAccountID:     "ed25519_public_key",
+	strkey.VersionByteSeed:          "ed25519_secret_seed",
+	strkey.VersionByteMuxedAccount:  "muxed_account",
+	strkey.VersionByteHashTx:        "preauth_tx",
+	strkey.VersionByteHashX:         "sha256_hash",
+	strkey.VersionByteSignedPayload: "ed25519_signed_payload",
 }
 
 // Account is the summary of an account

--- a/protocols/horizon/main_test.go
+++ b/protocols/horizon/main_test.go
@@ -238,3 +238,21 @@ func TestTradeAggregation_PagingToken(t *testing.T) {
 	ta := TradeAggregation{Timestamp: 64}
 	assert.Equal(t, "64", ta.PagingToken())
 }
+
+func TestMustKeyTypeFromAddress(t *testing.T) {
+	tests := []struct {
+		address string
+		keyType string
+	}{
+		{"GBUYDJH3AOPFFND3L54DUDWIHOMYKUONDV4RAHOHDBNN2D5N4BPPWDQ3", "ed25519_public_key"},
+		{"SBUYDJH3AOPFFND3L54DUDWIHOMYKUONDV4RAHOHDBNN2D5N4BPPXHDE", "ed25519_secret_seed"},
+		{"MBUYDJH3AOPFFND3L54DUDWIHOMYKUONDV4RAHOHDBNN2D5N4BPPWAAAAAAAAAPCIBYBE", "muxed_account"},
+		{"TBUYDJH3AOPFFND3L54DUDWIHOMYKUONDV4RAHOHDBNN2D5N4BPPX6CK", "preauth_tx"},
+		{"XBUYDJH3AOPFFND3L54DUDWIHOMYKUONDV4RAHOHDBNN2D5N4BPPW2HT", "sha256_hash"},
+		{"PBUYDJH3AOPFFND3L54DUDWIHOMYKUONDV4RAHOHDBNN2D5N4BPPWAAAAACWQZLMNRXQAAAA22YA", "ed25519_signed_payload"},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, MustKeyTypeFromAddress(test.address), test.keyType)
+	}
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

fix #4428 

### Why

see #4428 

### Known limitations

N/A
