### PR TITLE
protocols/horizon: Change Account.Sequence to int64

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -5,8 +5,6 @@ package horizon
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
-	"math"
 	"math/big"
 	"strconv"
 	"time"
@@ -44,7 +42,7 @@ type Account struct {
 
 	ID                   string            `json:"id"`
 	AccountID            string            `json:"account_id"`
-	Sequence             string            `json:"sequence"`
+	Sequence             int64             `json:"sequence,string"`
 	SequenceLedger       uint32            `json:"sequence_ledger,omitempty"`
 	SequenceTime         string            `json:"sequence_time,omitempty"`
 	SubentryCount        int32             `json:"subentry_count"`
@@ -98,29 +96,18 @@ func (a Account) GetCreditBalance(code string, issuer string) string {
 
 // GetSequenceNumber returns the sequence number of the account,
 // and returns it as a 64-bit integer.
+// TODO: since Account.Sequence was changed to int64, error is no longer needed.
 func (a Account) GetSequenceNumber() (int64, error) {
-	seqNum, err := strconv.ParseInt(a.Sequence, 10, 64)
-	if err != nil {
-		return 0, errors.Wrap(err, "Failed to parse account sequence number")
-	}
-
-	return seqNum, nil
+	return a.Sequence, nil
 }
 
 // IncrementSequenceNumber increments the internal record of the account's sequence
 // number by 1. This is typically used after a transaction build so that the next
 // transaction to be built will be valid.
+// TODO: since Account.Sequence was changed to int64, error is no longer needed.
 func (a *Account) IncrementSequenceNumber() (int64, error) {
-	seqNum, err := a.GetSequenceNumber()
-	if err != nil {
-		return 0, err
-	}
-	if seqNum == math.MaxInt64 {
-		return 0, fmt.Errorf("sequence cannot be increased, it already reached MaxInt64 (%d)", int64(math.MaxInt64))
-	}
-	seqNum++
-	a.Sequence = strconv.FormatInt(seqNum, 10)
-	return seqNum, nil
+	a.Sequence++
+	return a.Sequence, nil
 }
 
 // MustGetData returns decoded value for a given key. If the key does

--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -5,6 +5,8 @@ package horizon
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"math"
 	"math/big"
 	"strconv"
 	"time"
@@ -104,8 +106,10 @@ func (a Account) GetSequenceNumber() (int64, error) {
 // IncrementSequenceNumber increments the internal record of the account's sequence
 // number by 1. This is typically used after a transaction build so that the next
 // transaction to be built will be valid.
-// TODO: since Account.Sequence was changed to int64, error is no longer needed.
 func (a *Account) IncrementSequenceNumber() (int64, error) {
+	if a.Sequence == math.MaxInt64 {
+		return 0, fmt.Errorf("sequence cannot be increased, it already reached MaxInt64 (%d)", int64(math.MaxInt64))
+	}
 	a.Sequence++
 	return a.Sequence, nil
 }

--- a/protocols/horizon/main_test.go
+++ b/protocols/horizon/main_test.go
@@ -14,14 +14,14 @@ var exampleAccount = Account{
 		"test":    "aGVsbG8=",
 		"invalid": "a_*&^*",
 	},
-	Sequence: "3002985298788353",
+	Sequence: 3002985298788353,
 }
 
 func TestAccount_IncrementSequenceNumber(t *testing.T) {
 	seqNum, err := exampleAccount.IncrementSequenceNumber()
 
 	assert.Nil(t, err)
-	assert.Equal(t, "3002985298788354", exampleAccount.Sequence, "sequence number string was incremented")
+	assert.Equal(t, int64(3002985298788354), exampleAccount.Sequence, "sequence number was incremented")
 	assert.Equal(t, int64(3002985298788354), seqNum, "incremented sequence number is correct value/type")
 }
 

--- a/services/friendbot/init_friendbot_test.go
+++ b/services/friendbot/init_friendbot_test.go
@@ -23,7 +23,7 @@ func TestInitFriendbot_createMinionAccounts_success(t *testing.T) {
 	botAccountID := botKeypair.Address()
 	botAccountMock := horizon.Account{
 		AccountID: botAccountID,
-		Sequence:  "1",
+		Sequence:  1,
 	}
 	botAccount := internal.Account{AccountID: botAccountID, Sequence: 1}
 

--- a/services/friendbot/init_friendbot_test.go
+++ b/services/friendbot/init_friendbot_test.go
@@ -55,7 +55,7 @@ func TestInitFriendbot_createMinionAccounts_timeoutError(t *testing.T) {
 	botAccountID := botKeypair.Address()
 	botAccountMock := horizon.Account{
 		AccountID: botAccountID,
-		Sequence:  "1",
+		Sequence:  1,
 	}
 	botAccount := internal.Account{AccountID: botAccountID, Sequence: 1}
 

--- a/services/friendbot/internal/account.go
+++ b/services/friendbot/internal/account.go
@@ -1,8 +1,6 @@
 package internal
 
 import (
-	"strconv"
-
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/support/errors"
 )
@@ -36,10 +34,6 @@ func (a *Account) RefreshSequenceNumber(hclient horizonclient.ClientInterface) e
 	if err != nil {
 		return errors.Wrap(err, "getting account detail")
 	}
-	seq, err := strconv.ParseInt(accountDetail.Sequence, 10, 64)
-	if err != nil {
-		return errors.Wrap(err, "parsing account seqnum")
-	}
-	a.Sequence = seq
+	a.Sequence = accountDetail.Sequence
 	return nil
 }

--- a/services/horizon/internal/actions/account_test.go
+++ b/services/horizon/internal/actions/account_test.go
@@ -241,7 +241,7 @@ func TestAccountInfo(t *testing.T) {
 	account, err := AccountInfo(tt.Ctx, &history.Q{tt.HorizonSession()}, accountID)
 	tt.Assert.NoError(err)
 
-	tt.Assert.Equal("8589934593", account.Sequence)
+	tt.Assert.Equal(int64(8589934593), account.Sequence)
 	tt.Assert.Equal(uint32(4), account.LastModifiedLedger)
 	tt.Assert.NotNil(account.LastModifiedTime)
 	tt.Assert.Equal(ledgerFourCloseTime, account.LastModifiedTime.Unix())

--- a/services/horizon/internal/integration/db_test.go
+++ b/services/horizon/internal/integration/db_test.go
@@ -363,12 +363,10 @@ func submitAccountOps(itest *integration.Test, tt *assert.Assertions) (submitted
 	allOps := ops
 	itest.MustSubmitOperations(itest.MasterAccount(), itest.Master(), ops...)
 	account := itest.MustGetAccount(accountPair)
-	seq, err := strconv.ParseInt(account.Sequence, 10, 64)
-	tt.NoError(err)
 	domain := "www.example.com"
 	ops = []txnbuild.Operation{
 		&txnbuild.BumpSequence{
-			BumpTo: seq + 1000,
+			BumpTo: account.Sequence + 1000,
 		},
 		&txnbuild.SetOptions{
 			HomeDomain: &domain,

--- a/services/horizon/internal/resourceadapter/account_entry.go
+++ b/services/horizon/internal/resourceadapter/account_entry.go
@@ -3,7 +3,6 @@ package resourceadapter
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	protocol "github.com/stellar/go/protocols/horizon"
 	horizonContext "github.com/stellar/go/services/horizon/internal/context"
@@ -26,7 +25,7 @@ func PopulateAccountEntry(
 	dest.ID = account.AccountID
 	dest.PT = account.AccountID
 	dest.AccountID = account.AccountID
-	dest.Sequence = strconv.FormatInt(account.SequenceNumber, 10)
+	dest.Sequence = account.SequenceNumber
 	if account.SequenceLedger.Valid && account.SequenceTime.Valid {
 		dest.SequenceLedger = uint32(account.SequenceLedger.Int64)
 		dest.SequenceTime = fmt.Sprintf("%d", account.SequenceTime.Int64)

--- a/services/horizon/internal/resourceadapter/account_entry_test.go
+++ b/services/horizon/internal/resourceadapter/account_entry_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"testing"
 	"time"
 
@@ -146,7 +145,7 @@ func TestPopulateAccountEntry(t *testing.T) {
 	tt.Equal(account.AccountID, hAccount.ID)
 	tt.Equal(account.AccountID, hAccount.AccountID)
 	tt.Equal(account.AccountID, hAccount.PT)
-	tt.Equal(strconv.FormatInt(account.SequenceNumber, 10), hAccount.Sequence)
+	tt.Equal(account.SequenceNumber, hAccount.Sequence)
 	tt.Equal(uint32(account.SequenceLedger.Int64), hAccount.SequenceLedger)
 	tt.Equal(fmt.Sprintf("%d", account.SequenceTime.Int64), hAccount.SequenceTime)
 	tt.Equal(account.NumSubEntries, uint32(hAccount.SubentryCount))

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -575,17 +575,13 @@ func (i *Test) CreateAccounts(count int, initialBalance string) ([]*keypair.Full
 	// Two paths here: either caller already did some stuff with the master
 	// account so we should retrieve the sequence number, or caller hasn't and
 	// we start from scratch.
-	seq := int64(0)
 	request := sdk.AccountRequest{AccountID: master.Address()}
 	account, err := client.AccountDetail(request)
-	if err == nil {
-		seq, err = strconv.ParseInt(account.Sequence, 10, 64) // str -> bigint
-		panicIf(err)
-	}
+	panicIf(err)
 
 	masterAccount := txnbuild.SimpleAccount{
 		AccountID: master.Address(),
-		Sequence:  seq,
+		Sequence:  account.Sequence,
 	}
 
 	for i := 0; i < count; i++ {

--- a/services/regulated-assets-approval-server/internal/configureissuer/configureissuer_test.go
+++ b/services/regulated-assets-approval-server/internal/configureissuer/configureissuer_test.go
@@ -43,7 +43,7 @@ func TestSetup_accountAlreadyConfigured(t *testing.T) {
 				AuthRevocable: true,
 			},
 			HomeDomain: "domain.test.com",
-			Sequence:   "10",
+			Sequence:   10,
 		}, nil)
 	horizonMock.
 		On("Assets", horizonclient.AssetRequest{
@@ -93,7 +93,7 @@ func TestSetup(t *testing.T) {
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: issuerKP.Address()}).
 		Return(horizon.Account{
 			AccountID: issuerKP.Address(),
-			Sequence:  "10",
+			Sequence:  10,
 		}, nil)
 	horizonMock.
 		On("Assets", horizonclient.AssetRequest{

--- a/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
@@ -86,7 +86,7 @@ func TestAPI_txApprove_revised(t *testing.T) {
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence: ,
+			Sequence:  5,
 		}, nil)
 
 	handler := txApproveHandler{

--- a/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/api_tx_approve_test.go
@@ -86,7 +86,7 @@ func TestAPI_txApprove_revised(t *testing.T) {
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "5",
+			Sequence: ,
 		}, nil)
 
 	handler := txApproveHandler{
@@ -103,7 +103,7 @@ func TestAPI_txApprove_revised(t *testing.T) {
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
 				AccountID: senderKP.Address(),
-				Sequence:  "5",
+				Sequence:  5,
 			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
@@ -201,7 +201,7 @@ func TestAPI_txAprove_actionRequired(t *testing.T) {
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "1",
+			Sequence:  1,
 		}, nil)
 
 	handler := txApproveHandler{
@@ -223,7 +223,7 @@ func TestAPI_txAprove_actionRequired(t *testing.T) {
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
 				AccountID: senderKP.Address(),
-				Sequence:  "1",
+				Sequence:  1,
 			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
@@ -293,7 +293,7 @@ func TestAPI_txAprove_actionRequiredFlow(t *testing.T) {
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "1",
+			Sequence:  1,
 		}, nil)
 
 	handler := txApproveHandler{
@@ -316,7 +316,7 @@ func TestAPI_txAprove_actionRequiredFlow(t *testing.T) {
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
 				AccountID: senderKP.Address(),
-				Sequence:  "1",
+				Sequence:  1,
 			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
@@ -485,7 +485,7 @@ func TestAPI_txApprove_success(t *testing.T) {
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "5",
+			Sequence:  5,
 		}, nil)
 
 	handler := txApproveHandler{
@@ -504,7 +504,7 @@ func TestAPI_txApprove_success(t *testing.T) {
 	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "5",
+			Sequence:  5,
 		},
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{

--- a/services/regulated-assets-approval-server/internal/serve/friendbot_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/friendbot_test.go
@@ -295,7 +295,7 @@ func TestFriendbotHandler_serveHTTP(t *testing.T) {
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: "GDDIO6SFRD4SJEQFJOSKPIDYTDM7LM4METFBKN4NFGVR5DTGB7H75N5S"}).
 		Return(horizon.Account{
 			AccountID: "GDDIO6SFRD4SJEQFJOSKPIDYTDM7LM4METFBKN4NFGVR5DTGB7H75N5S",
-			Sequence:  "1",
+			Sequence:  1,
 		}, nil)
 	horizonMock.
 		On("SubmitTransaction", mock.AnythingOfType("*txnbuild.Transaction")).

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve.go
@@ -182,7 +182,7 @@ func (h txApproveHandler) txApprove(ctx context.Context, in txApproveRequest) (r
 
 	// validate the sequence number
 	if tx.SourceAccount().Sequence != acc.Sequence+1 {
-		log.Ctx(ctx).Errorf(`invalid transaction sequence number tx.SourceAccount().Sequence: %d, accountSequence+1: %d`, tx.SourceAccount().Sequence, accountSequence+1)
+		log.Ctx(ctx).Errorf(`invalid transaction sequence number tx.SourceAccount().Sequence: %d, accountSequence+1: %d`, tx.SourceAccount().Sequence, acc.Sequence+1)
 		return NewRejectedTxApprovalResponse("Invalid transaction sequence number."), nil
 	}
 
@@ -325,7 +325,7 @@ func (h txApproveHandler) handleSuccessResponseIfNeeded(ctx context.Context, tx 
 		return nil, errors.Wrapf(err, "getting detail for payment source account %s", paymentSource)
 	}
 	if tx.SourceAccount().Sequence != acc.Sequence+1 {
-		log.Ctx(ctx).Errorf(`invalid transaction sequence number tx.SourceAccount().Sequence: %d, accountSequence+1: %d`, tx.SourceAccount().Sequence, accountSequence+1)
+		log.Ctx(ctx).Errorf(`invalid transaction sequence number tx.SourceAccount().Sequence: %d, accountSequence+1: %d`, tx.SourceAccount().Sequence, acc.Sequence+1)
 		return NewRejectedTxApprovalResponse("Invalid transaction sequence number."), nil
 	}
 

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve.go
@@ -181,11 +181,7 @@ func (h txApproveHandler) txApprove(ctx context.Context, in txApproveRequest) (r
 	}
 
 	// validate the sequence number
-	accountSequence, err := strconv.ParseInt(acc.Sequence, 10, 64)
-	if err != nil {
-		return nil, errors.Wrapf(err, "parsing account sequence number %q from string to int64", acc.Sequence)
-	}
-	if tx.SourceAccount().Sequence != accountSequence+1 {
+	if tx.SourceAccount().Sequence != acc.Sequence+1 {
 		log.Ctx(ctx).Errorf(`invalid transaction sequence number tx.SourceAccount().Sequence: %d, accountSequence+1: %d`, tx.SourceAccount().Sequence, accountSequence+1)
 		return NewRejectedTxApprovalResponse("Invalid transaction sequence number."), nil
 	}
@@ -328,11 +324,7 @@ func (h txApproveHandler) handleSuccessResponseIfNeeded(ctx context.Context, tx 
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting detail for payment source account %s", paymentSource)
 	}
-	accountSequence, err := strconv.ParseInt(acc.Sequence, 10, 64)
-	if err != nil {
-		return nil, errors.Wrapf(err, "parsing account sequence number %q from string to int64", acc.Sequence)
-	}
-	if tx.SourceAccount().Sequence != accountSequence+1 {
+	if tx.SourceAccount().Sequence != acc.Sequence+1 {
 		log.Ctx(ctx).Errorf(`invalid transaction sequence number tx.SourceAccount().Sequence: %d, accountSequence+1: %d`, tx.SourceAccount().Sequence, accountSequence+1)
 		return NewRejectedTxApprovalResponse("Invalid transaction sequence number."), nil
 	}

--- a/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
+++ b/services/regulated-assets-approval-server/internal/serve/tx_approve_test.go
@@ -140,7 +140,7 @@ func TestTxApproveHandler_validateInput(t *testing.T) {
 	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: h.issuerKP.Address(),
-			Sequence:  "1",
+			Sequence:  1,
 		},
 		IncrementSequenceNum: true,
 		Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()},
@@ -166,7 +166,7 @@ func TestTxApproveHandler_validateInput(t *testing.T) {
 	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: clientKP.Address(),
-			Sequence:  "1",
+			Sequence:  1,
 		},
 		IncrementSequenceNum: true,
 		Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()},
@@ -194,7 +194,7 @@ func TestTxApproveHandler_validateInput(t *testing.T) {
 	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: clientKP.Address(),
-			Sequence:  "1",
+			Sequence:  1,
 		},
 		IncrementSequenceNum: true,
 		Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()},
@@ -332,7 +332,7 @@ func TestTxApproveHandler_txApprove_rejected(t *testing.T) {
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "2",
+			Sequence:  2,
 		}, nil)
 
 	handler := txApproveHandler{
@@ -360,7 +360,7 @@ func TestTxApproveHandler_txApprove_rejected(t *testing.T) {
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
 				AccountID: senderKP.Address(),
-				Sequence:  "2",
+				Sequence:  2,
 			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
@@ -388,7 +388,7 @@ func TestTxApproveHandler_txApprove_rejected(t *testing.T) {
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
 				AccountID: senderKP.Address(),
-				Sequence:  "2",
+				Sequence:  2,
 			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
@@ -411,7 +411,7 @@ func TestTxApproveHandler_txApprove_rejected(t *testing.T) {
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
 				AccountID: senderKP.Address(),
-				Sequence:  "2",
+				Sequence:  2,
 			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
@@ -441,7 +441,7 @@ func TestTxApproveHandler_txApprove_rejected(t *testing.T) {
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
 				AccountID: senderKP.Address(),
-				Sequence:  "2",
+				Sequence:  2,
 			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
@@ -471,7 +471,7 @@ func TestTxApproveHandler_txApprove_rejected(t *testing.T) {
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
 				AccountID: senderKP.Address(),
-				Sequence:  "20",
+				Sequence:  20,
 			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
@@ -516,7 +516,7 @@ func TestTxApproveHandler_txApprove_success(t *testing.T) {
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "2",
+			Sequence:  2,
 		}, nil)
 
 	handler := txApproveHandler{
@@ -533,7 +533,7 @@ func TestTxApproveHandler_txApprove_success(t *testing.T) {
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
 				AccountID: senderKP.Address(),
-				Sequence:  "2",
+				Sequence:  2,
 			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
@@ -603,7 +603,7 @@ func TestTxApproveHandler_txApprove_actionRequired(t *testing.T) {
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "2",
+			Sequence:  2,
 		}, nil)
 
 	handler := txApproveHandler{
@@ -620,7 +620,7 @@ func TestTxApproveHandler_txApprove_actionRequired(t *testing.T) {
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
 				AccountID: senderKP.Address(),
-				Sequence:  "2",
+				Sequence:  2,
 			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
@@ -679,7 +679,7 @@ func TestTxApproveHandler_txApprove_revised(t *testing.T) {
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "2",
+			Sequence:  2,
 		}, nil)
 
 	handler := txApproveHandler{
@@ -696,7 +696,7 @@ func TestTxApproveHandler_txApprove_revised(t *testing.T) {
 		txnbuild.TransactionParams{
 			SourceAccount: &horizon.Account{
 				AccountID: senderKP.Address(),
-				Sequence:  "2",
+				Sequence:  2,
 			},
 			IncrementSequenceNum: true,
 			Operations: []txnbuild.Operation{
@@ -773,7 +773,7 @@ func TestValidateTransactionOperationsForSuccess(t *testing.T) {
 	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "5",
+			Sequence:  5,
 		},
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
@@ -798,7 +798,7 @@ func TestValidateTransactionOperationsForSuccess(t *testing.T) {
 	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "5",
+			Sequence:  5,
 		},
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
@@ -822,7 +822,7 @@ func TestValidateTransactionOperationsForSuccess(t *testing.T) {
 	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "5",
+			Sequence:  5,
 		},
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
@@ -851,7 +851,7 @@ func TestValidateTransactionOperationsForSuccess(t *testing.T) {
 	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "5",
+			Sequence:  5,
 		},
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
@@ -900,7 +900,7 @@ func TestValidateTransactionOperationsForSuccess(t *testing.T) {
 	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "5",
+			Sequence:  5,
 		},
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
@@ -974,7 +974,7 @@ func TestTxApproveHandler_handleSuccessResponseIfNeeded_revisable(t *testing.T) 
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "2",
+			Sequence:  2,
 		}, nil)
 
 	handler := txApproveHandler{
@@ -990,7 +990,7 @@ func TestTxApproveHandler_handleSuccessResponseIfNeeded_revisable(t *testing.T) 
 	revisableTx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "2",
+			Sequence:  2,
 		},
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
@@ -1033,7 +1033,7 @@ func TestTxApproveHandler_handleSuccessResponseIfNeeded_rejected(t *testing.T) {
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "2",
+			Sequence:  2,
 		}, nil)
 
 	handler := txApproveHandler{
@@ -1050,7 +1050,7 @@ func TestTxApproveHandler_handleSuccessResponseIfNeeded_rejected(t *testing.T) {
 	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "2",
+			Sequence:  2,
 		},
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
@@ -1078,7 +1078,7 @@ func TestTxApproveHandler_handleSuccessResponseIfNeeded_rejected(t *testing.T) {
 	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "2",
+			Sequence:  2,
 		},
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
@@ -1158,7 +1158,7 @@ func TestTxApproveHandler_handleSuccessResponseIfNeeded_rejected(t *testing.T) {
 	tx, err = txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "3",
+			Sequence:  3,
 		},
 		IncrementSequenceNum: true,
 		Operations:           compliantOps,
@@ -1194,7 +1194,7 @@ func TestTxApproveHandler_handleSuccessResponseIfNeeded_actionRequired(t *testin
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "2",
+			Sequence:  2,
 		}, nil)
 
 	handler := txApproveHandler{
@@ -1211,7 +1211,7 @@ func TestTxApproveHandler_handleSuccessResponseIfNeeded_actionRequired(t *testin
 	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "2",
+			Sequence:  2,
 		},
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{
@@ -1334,7 +1334,7 @@ func TestTxApproveHandler_handleSuccessResponseIfNeeded_success(t *testing.T) {
 		On("AccountDetail", horizonclient.AccountRequest{AccountID: senderKP.Address()}).
 		Return(horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "2",
+			Sequence:  2,
 		}, nil)
 
 	handler := txApproveHandler{
@@ -1350,7 +1350,7 @@ func TestTxApproveHandler_handleSuccessResponseIfNeeded_success(t *testing.T) {
 	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount: &horizon.Account{
 			AccountID: senderKP.Address(),
-			Sequence:  "2",
+			Sequence:  2,
 		},
 		IncrementSequenceNum: true,
 		Operations: []txnbuild.Operation{

--- a/txnbuild/examplehorizonclient/examplehorizonclient.go
+++ b/txnbuild/examplehorizonclient/examplehorizonclient.go
@@ -21,7 +21,7 @@ var DefaultTestNetClient = Client{}
 func (client *Client) AccountDetail(req AccountRequest) (hProtocol.Account, error) {
 	return hProtocol.Account{
 		AccountID: req.AccountID,
-		Sequence:  "3556091187167235",
+		Sequence:  3556091187167235,
 	}, nil
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Change `protocols/horizon/Account.Sequence` to `int64` from `string`.

### Why

There shouldn't be any extra parsing required in Go since `Account.Sequence` returned by Horizon will be always a valid int64 value. We can make sure the value is rendered as a string to support JS using `string` tag.

Similar to: https://github.com/stellar/go/pull/4409

### Known limitations

[TODO or N/A]
