### PR TITLE
protocols/horizon: Add GetBase() to Operation interface

### DIFF
--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -346,11 +346,17 @@ type LiquidityPoolWithdraw struct {
 
 // Operation interface contains methods implemented by the operation types
 type Operation interface {
+	GetBase() Base
 	PagingToken() string
 	GetType() string
 	GetID() string
 	GetTransactionHash() string
 	IsTransactionSuccessful() bool
+}
+
+// GetBase returns the base object of operation
+func (base Base) GetBase() Base {
+	return base
 }
 
 // GetType returns the type of operation


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Adds `Operation.GetBase()` method.

### Why

`Base` struct contains some fields that are not exposes by getters (ex. `SourceAccount`). This means it's impossible to get them without type asserting to one of the concrete operation structs.

### Known limitations

[TODO or N/A]
