### PR TITLE
exp/lighthorizon/index: More testing for batch indexing and off-by-one bugfix.

### DIFF
--- a/exp/lighthorizon/index/cmd/batch/reduce/main.go
+++ b/exp/lighthorizon/index/cmd/batch/reduce/main.go
@@ -253,19 +253,20 @@ func mergeAllIndices(finalIndexStore index.Store, config *ReduceConfig) error {
 					WithField("indexed", transactionsProcessed).
 					WithField("skipped", transactionsSkipped)
 
-				for i := byte(0x00); i < 0xff; i++ {
+				for i := int(0x00); i <= 0xff; i++ {
+					b := byte(i) // can't loop over range bc overflow
 					if i%97 == 0 {
 						logger.Infof("%d transactions processed (%d skipped)",
 							transactionsProcessed, transactionsSkipped)
 					}
 
-					if !config.shouldProcessTx(i, routineIndex) {
+					if !config.shouldProcessTx(b, routineIndex) {
 						transactionsSkipped++
 						continue
 					}
 					transactionsProcessed++
 
-					prefix := hex.EncodeToString([]byte{i})
+					prefix := hex.EncodeToString([]byte{b})
 
 					for k := uint32(0); k < config.MapJobCount; k++ {
 						url := filepath.Join(config.IndexRootSource, fmt.Sprintf("job_%d", k))

--- a/exp/lighthorizon/index/cmd/batch/reduce/main.go
+++ b/exp/lighthorizon/index/cmd/batch/reduce/main.go
@@ -181,14 +181,14 @@ func mergeAllIndices(finalIndexStore index.Store, config *ReduceConfig) error {
 
 					// First, open the "final merged indices" at the root level
 					// for this account.
-					mergedIndices, err := outerJobStore.Read(account)
+					mergedIndices, readErr := outerJobStore.Read(account)
 
 					// TODO: in final version this should be critical error, now just skip it
-					if os.IsNotExist(err) {
+					if os.IsNotExist(readErr) {
 						accountLog.Errorf("Account %s is unavailable - TODO fix", account)
 						continue
 					} else if err != nil {
-						panic(err)
+						panic(readErr)
 					}
 
 					// Then, iterate through all of the job folders and merge
@@ -237,9 +237,9 @@ func mergeAllIndices(finalIndexStore index.Store, config *ReduceConfig) error {
 					// Periodically flush to disk to save memory.
 					if accountsProcessed%ACCOUNT_FLUSH_FREQUENCY == 0 {
 						accountLog.Infof("Flushing indexed accounts.")
-						if err = finalIndexStore.Flush(); err != nil {
-							accountLog.WithError(err).Errorf("Flush error.")
-							panic(err)
+						if flushErr := finalIndexStore.Flush(); flushErr != nil {
+							accountLog.WithError(flushErr).Errorf("Flush error.")
+							panic(flushErr)
 						}
 					}
 				}

--- a/exp/lighthorizon/index/cmd/batch/reduce/main.go
+++ b/exp/lighthorizon/index/cmd/batch/reduce/main.go
@@ -159,66 +159,70 @@ func mergeAllIndices(finalIndexStore index.Store, config *ReduceConfig) error {
 		for j := uint32(0); j < config.Workers; j++ {
 			go func(routineIndex uint32) {
 				defer wg.Done()
-				logger := jobLogger.
+				accountLog := jobLogger.
 					WithField("worker", routineIndex).
-					WithField("total", len(accounts))
-				logger.Info("Started worker")
+					WithField("subservice", "accounts")
+				accountLog.Info("Started worker")
 
 				var accountsProcessed, accountsSkipped uint64
 				for account := range workQueues[routineIndex] {
-					logger.Infof("Account: %s", account)
+					accountLog.
+						WithField("total", len(accounts)).
+						WithField("indexed", accountsProcessed).
+						WithField("skipped", accountsSkipped)
+
+					accountLog.Debugf("Account: %s", account)
 					if (accountsProcessed+accountsSkipped)%97 == 0 {
-						logger.
-							WithField("indexed", accountsProcessed).
-							WithField("skipped", accountsSkipped).
-							Infof("Processed %d/%d accounts",
-								accountsProcessed+accountsSkipped, len(accounts))
+						accountLog.Infof("Processed %d/%d accounts",
+							accountsProcessed+accountsSkipped, len(accounts))
 					}
 
-					logger.Infof("Reading index for account: %s", account)
+					accountLog.Debugf("Reading index for account: %s", account)
 
 					// First, open the "final merged indices" at the root level
 					// for this account.
-					mergedIndices, mergeErr := outerJobStore.Read(account)
+					mergedIndices, err := outerJobStore.Read(account)
 
 					// TODO: in final version this should be critical error, now just skip it
-					if os.IsNotExist(mergeErr) {
-						logger.Errorf("Account %s is unavailable - TODO fix", account)
+					if os.IsNotExist(err) {
+						accountLog.Errorf("Account %s is unavailable - TODO fix", account)
 						continue
-					} else if mergeErr != nil {
-						panic(mergeErr)
+					} else if err != nil {
+						panic(err)
 					}
 
 					// Then, iterate through all of the job folders and merge
 					// indices from all jobs that touched this account.
 					for k := uint32(0); k < config.MapJobCount; k++ {
+						var jobErr error
 						url := filepath.Join(config.IndexRootSource, fmt.Sprintf("job_%d", k))
 
 						// FIXME: This could probably come from a pool. Every
 						// worker needs to have a connection to every index
 						// store, so there's no reason to re-open these for each
 						// inner loop.
-						innerJobStore, indexErr := index.Connect(url)
-						if indexErr != nil {
-							logger.WithError(indexErr).
+						innerJobStore, jobErr := index.Connect(url)
+						if jobErr != nil {
+							accountLog.WithError(jobErr).
 								Errorf("Failed to open index at %s", url)
-							panic(indexErr)
+							panic(jobErr)
 						}
 
-						jobIndices, innerJobErr := innerJobStore.Read(account)
+						jobIndices, jobErr := innerJobStore.Read(account)
+
 						// This job never touched this account; skip.
-						if os.IsNotExist(innerJobErr) {
+						if os.IsNotExist(jobErr) {
 							continue
-						} else if innerJobErr != nil {
-							logger.WithError(innerJobErr).
+						} else if jobErr != nil {
+							accountLog.WithError(jobErr).
 								Errorf("Failed to read index for %s", account)
-							panic(innerJobErr)
+							panic(jobErr)
 						}
 
-						if mergeIndexErr := mergeIndices(mergedIndices, jobIndices); mergeIndexErr != nil {
-							logger.WithError(mergeIndexErr).
+						if jobErr = mergeIndices(mergedIndices, jobIndices); jobErr != nil {
+							accountLog.WithError(jobErr).
 								Errorf("Merge failure for index at %s", url)
-							panic(mergeIndexErr)
+							panic(jobErr)
 						}
 					}
 
@@ -228,72 +232,82 @@ func mergeAllIndices(finalIndexStore index.Store, config *ReduceConfig) error {
 					// Mark this account for other workers to ignore.
 					doneAccounts.Add(account)
 					accountsProcessed++
-					logger = logger.WithField("processed", accountsProcessed)
+					accountLog = accountLog.WithField("processed", accountsProcessed)
 
 					// Periodically flush to disk to save memory.
 					if accountsProcessed%ACCOUNT_FLUSH_FREQUENCY == 0 {
-						logger.Infof("Flushing indexed accounts.")
+						accountLog.Infof("Flushing indexed accounts.")
 						if err = finalIndexStore.Flush(); err != nil {
-							logger.WithError(err).Errorf("Flush error.")
+							accountLog.WithError(err).Errorf("Flush error.")
 							panic(err)
 						}
 					}
 				}
 
-				jobLogger.Infof("Final account flush.")
+				accountLog.Infof("Final account flush.")
 				if err = finalIndexStore.Flush(); err != nil {
-					logger.WithError(err).Errorf("Flush error.")
+					accountLog.WithError(err).Errorf("Flush error.")
 					panic(err)
 				}
 
 				// Merge the transaction indexes
 				// There's 256 files, (one for each first byte of the txn hash)
-				var transactionsProcessed, transactionsSkipped uint64
-				logger = jobLogger.
-					WithField("indexed", transactionsProcessed).
-					WithField("skipped", transactionsSkipped)
+				txLog := jobLogger.
+					WithField("worker", routineIndex).
+					WithField("subservice", "transactions")
 
+				var prefixesProcessed, prefixesSkipped uint64
 				for i := int(0x00); i <= 0xff; i++ {
 					b := byte(i) // can't loop over range bc overflow
-					if i%97 == 0 {
-						logger.Infof("%d transactions processed (%d skipped)",
-							transactionsProcessed, transactionsSkipped)
+					if b%97 == 0 {
+						txLog.Infof("Processed %d/%d prefixes (%d skipped)",
+							prefixesProcessed, 0xff, prefixesSkipped)
 					}
 
 					if !config.shouldProcessTx(b, routineIndex) {
-						transactionsSkipped++
+						prefixesSkipped++
 						continue
 					}
-					transactionsProcessed++
+
+					txLog = txLog.
+						WithField("indexed", prefixesProcessed).
+						WithField("skipped", prefixesSkipped)
 
 					prefix := hex.EncodeToString([]byte{b})
-
 					for k := uint32(0); k < config.MapJobCount; k++ {
 						url := filepath.Join(config.IndexRootSource, fmt.Sprintf("job_%d", k))
-						innerJobStore, jobErr := index.Connect(url)
-						if jobErr != nil {
-							logger.WithError(jobErr).Errorf("Failed to open index at %s", url)
-							panic(jobErr)
+						var innerErr error
+
+						innerJobStore, innerErr := index.Connect(url)
+						if innerErr != nil {
+							txLog.WithError(innerErr).Errorf("Failed to open index at %s", url)
+							panic(innerErr)
 						}
 
-						innerTxnIndexes, innerJobErr := innerJobStore.ReadTransactions(prefix)
-						if os.IsNotExist(innerJobErr) {
+						innerTxnIndexes, innerErr := innerJobStore.ReadTransactions(prefix)
+						if os.IsNotExist(innerErr) {
 							continue
-						} else if innerJobErr != nil {
-							logger.WithError(innerJobErr).Errorf("Error reading tx prefix %s", prefix)
-							panic(innerJobErr)
+						} else if innerErr != nil {
+							txLog.WithError(innerErr).Errorf("Error reading tx prefix %s", prefix)
+							panic(innerErr)
 						}
 
-						if prefixErr := finalIndexStore.MergeTransactions(prefix, innerTxnIndexes); err != nil {
-							logger.WithError(prefixErr).Errorf("Error merging txs at prefix %s", prefix)
-							panic(prefixErr)
+						if innerErr = finalIndexStore.MergeTransactions(prefix, innerTxnIndexes); innerErr != nil {
+							txLog.WithError(innerErr).Errorf("Error merging txs at prefix %s", prefix)
+							panic(innerErr)
 						}
 					}
+
+					prefixesProcessed++
 				}
 
-				jobLogger.Infof("Final transaction flush (%d processed)", transactionsProcessed)
+				txLog = txLog.
+					WithField("indexed", prefixesProcessed).
+					WithField("skipped", prefixesSkipped)
+
+				txLog.Infof("Final transaction flush...")
 				if err = finalIndexStore.Flush(); err != nil {
-					logger.Errorf("Error flushing transactions: %v", err)
+					txLog.Errorf("Error flushing transactions: %v", err)
 					panic(err)
 				}
 			}(j)

--- a/exp/lighthorizon/index/cmd/map.sh
+++ b/exp/lighthorizon/index/cmd/map.sh
@@ -66,7 +66,7 @@ fi
 pids=( )
 for (( i=0; i < $BATCH_COUNT; i++ ))
 do
-    echo -n "Creating job $i... "
+    echo -n "Creating map job $i... "
 
     AWS_BATCH_JOB_ARRAY_INDEX=$i BATCH_SIZE=$BATCH_SIZE FIRST_CHECKPOINT=$FIRST \
     TXMETA_SOURCE=file://$1 INDEX_TARGET=file://$2 WORKER_COUNT=1 \

--- a/exp/lighthorizon/index/cmd/reduce.sh
+++ b/exp/lighthorizon/index/cmd/reduce.sh
@@ -18,26 +18,28 @@ if [[ ! -d "$2" ]]; then
     mkdir -p $2
 fi
 
-
 go build -o reduce ./batch/reduce/...
 if [[ "$?" -ne "0" ]]; then 
     echo "Build failed"
     exit 1
 fi
 
-JOB_COUNT=$(ls $1 | grep -E 'job_[0-9]+' | wc -l)
-if [[ "$JOB_COUNT" -le "0" ]]; then 
+MAP_JOB_COUNT=$(ls $1 | grep -E 'job_[0-9]+' | wc -l)
+if [[ "$MAP_JOB_COUNT" -le "0" ]]; then 
     echo "No jobs in index src root ('$1') found."
     exit 1 
 fi
+REDUCE_JOB_COUNT=$MAP_JOB_COUNT
+
+echo "Coalescing $MAP_JOB_COUNT discovered job outputs from $1 into $2..."
 
 pids=( )
-for (( i=0; i < $JOB_COUNT; i++ ))
+for (( i=0; i < $REDUCE_JOB_COUNT; i++ ))
 do
-    echo -n "Creating job $i... "
+    echo -n "Creating reduce job $i... "
 
-    AWS_BATCH_JOB_ARRAY_INDEX=$i MAP_JOB_COUNT=$JOB_COUNT \
-    REDUCE_JOB_COUNT=$JOB_COUNT WORKER_COUNT=4 \
+    AWS_BATCH_JOB_ARRAY_INDEX=$i MAP_JOB_COUNT=$MAP_JOB_COUNT \
+    REDUCE_JOB_COUNT=$REDUCE_JOB_COUNT WORKER_COUNT=4 \
     INDEX_SOURCE_ROOT=file://$1 INDEX_TARGET=file://$2 \
         ./reduce &
     
@@ -45,7 +47,7 @@ do
     pids+=($!)
 done
 
-sleep $JOB_COUNT
+sleep $REDUCE_JOB_COUNT
 
 # Check the status codes for all of the map processes.
 for i in "${!pids[@]}"; do

--- a/exp/lighthorizon/index/cmd/reduce.sh
+++ b/exp/lighthorizon/index/cmd/reduce.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# check parameters and their validity (types, existence, etc.)
+
+if [[ "$#" -ne "2" ]]; then 
+    echo "Usage: $0 <index src root> <index dest>"
+    exit 1
+fi
+
+if [[ ! -d "$1" ]]; then 
+    echo "Error: index src root ('$1') does not exist"
+    echo "Usage: $0 <index src root> <index dest>"
+    exit 1
+fi
+
+if [[ ! -d "$2" ]]; then 
+    echo "Warning: index dest ('$2') does not exist, creating..."
+    mkdir -p $2
+fi
+
+
+go build -o reduce ./batch/reduce/...
+if [[ "$?" -ne "0" ]]; then 
+    echo "Build failed"
+    exit 1
+fi
+
+JOB_COUNT=$(ls $1 | grep -E 'job_[0-9]+' | wc -l)
+if [[ "$JOB_COUNT" -le "0" ]]; then 
+    echo "No jobs in index src root ('$1') found."
+    exit 1 
+fi
+
+pids=( )
+for (( i=0; i < $JOB_COUNT; i++ ))
+do
+    echo -n "Creating job $i... "
+
+    AWS_BATCH_JOB_ARRAY_INDEX=$i MAP_JOB_COUNT=$JOB_COUNT \
+    REDUCE_JOB_COUNT=$JOB_COUNT WORKER_COUNT=4 \
+    INDEX_SOURCE_ROOT=file://$1 INDEX_TARGET=file://$2 \
+        ./reduce &
+    
+    echo "pid=$!"
+    pids+=($!)
+done
+
+sleep $JOB_COUNT
+
+# Check the status codes for all of the map processes.
+for i in "${!pids[@]}"; do
+    pid=${pids[$i]}
+    echo -n "Checking job $i (pid=$pid)... "
+    if ! wait "$pid"; then
+        echo "failed"
+        exit 1
+    else
+        echo "succeeded!"
+    fi
+done
+
+rm ./reduce
+echo "All jobs succeeded!"
+exit 0


### PR DESCRIPTION
### What
This adds a test, `TestReduce`, that ensures that running parallel reduce jobs on previously-map'd jobs results in a complete and valid set of indices. It also extends the existing `TestMap` test to ensure that TOIDs are indexed properly.

This test uncovered an off-by-one bug that segues into an overflow bug, summarized by this (pseudo)diff:

```diff
-	for i := byte(0x00); i < 0xff; i++ {
+	for ii := int(0x00); ii <= 0xff; ii++ {
+		i := byte(ii) // can't loop over byte range bc overflow
```

### Why
Testing is important and bugs are bad.

### Known limitations
This introduces another Bash script to compile & run binaries in parallel, which means dependence on *nix-based systems.