### PR TITLE
exp/lighthorizon/index: Better errors, comments, small looping refactor.

### DIFF
--- a/ingest/ledger_transaction_reader.go
+++ b/ingest/ledger_transaction_reader.go
@@ -30,7 +30,7 @@ func NewLedgerTransactionReader(ctx context.Context, backend ledgerbackend.Ledge
 	return NewLedgerTransactionReaderFromLedgerCloseMeta(networkPassphrase, ledgerCloseMeta)
 }
 
-// NewLedgerTransactionReaderFromXdr creates a new TransactionReader instance from xdr.LedgerCloseMeta.
+// NewLedgerTransactionReaderFromLedgerCloseMeta creates a new TransactionReader instance from xdr.LedgerCloseMeta.
 // Note that TransactionReader is not thread safe and should not be shared by multiple goroutines.
 func NewLedgerTransactionReaderFromLedgerCloseMeta(networkPassphrase string, ledgerCloseMeta xdr.LedgerCloseMeta) (*LedgerTransactionReader, error) {
 	reader := &LedgerTransactionReader{ledgerCloseMeta: ledgerCloseMeta}


### PR DESCRIPTION
### What
Besides more verbosity on error messages and better comments, I refactored the job loops to build the URLs once rather than whenever they're needed. 

### Why
This is faster (less string building), cleaner (less code), and safer (range-based rather than index-based loops).