### PR TITLE
exp/lighthorizon: Add basic scaffolding for metrics.

### DIFF
--- a/exp/lighthorizon/actions/transaction.go
+++ b/exp/lighthorizon/actions/transaction.go
@@ -93,6 +93,7 @@ func Transactions(archiveWrapper archive.Wrapper, indexStore index.Store) func(h
 
 		for _, txn := range txns {
 			var response hProtocol.Transaction
+			txn.NetworkPassphrase = archiveWrapper.Passphrase
 			response, err = adapters.PopulateTransaction(r, &txn)
 			if err != nil {
 				log.Error(err)

--- a/exp/lighthorizon/actions/transaction.go
+++ b/exp/lighthorizon/actions/transaction.go
@@ -2,10 +2,15 @@ package actions
 
 import (
 	"encoding/hex"
-	"github.com/stellar/go/support/log"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/stellar/go/support/log"
 
 	"github.com/stellar/go/exp/lighthorizon/adapters"
 	"github.com/stellar/go/exp/lighthorizon/archive"
@@ -15,8 +20,30 @@ import (
 	"github.com/stellar/go/toid"
 )
 
+var (
+	requestCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "horizon_lite_request_count",
+		Help: "How many requests have occurred?",
+	})
+	requestTime = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "horizon_lite_request_duration",
+		Help: "How long do requests take?",
+		Buckets: append(
+			prometheus.LinearBuckets(0, 50, 20),
+			prometheus.LinearBuckets(1000, 1000, 8)...,
+		),
+	})
+)
+
 func Transactions(archiveWrapper archive.Wrapper, indexStore index.Store) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		defer func() {
+			duration := time.Since(start)
+			requestTime.Observe(float64(duration.Milliseconds()))
+		}()
+		requestCount.Inc()
+
 		// For _links rendering, imitate horizon.stellar.org links for horizon-cmp
 		r.URL.Scheme = "http"
 		r.URL.Host = "localhost:8080"
@@ -58,29 +85,37 @@ func Transactions(archiveWrapper archive.Wrapper, indexStore index.Store) func(h
 		}
 
 		if txId != "" {
-			// if 'id' is on request, it overrides any paging cursor that may be on request.
+			// if 'id' is on request, it overrides any paging parameters on the request.
 			var b []byte
 			b, err = hex.DecodeString(txId)
 			if err != nil {
-				sendErrorResponse(w, http.StatusBadRequest, "Invalid transaction id request parameter, not valid hex encoding")
+				sendErrorResponse(w, http.StatusBadRequest,
+					"Invalid transaction id request parameter, not valid hex encoding")
 				return
 			}
 			if len(b) != 32 {
-				sendErrorResponse(w, http.StatusBadRequest, "Invalid transaction id request parameter, the encoded hex value must decode to length of 32 bytes")
+				sendErrorResponse(w, http.StatusBadRequest,
+					"Invalid transaction id request parameter, the encoded hex value must decode to length of 32 bytes")
 				return
 			}
 			var hash [32]byte
 			copy(hash[:], b)
 
-			if paginate.Cursor, err = indexStore.TransactionTOID(hash); err != nil {
+			var foundTOID int64
+			foundTOID, err = indexStore.TransactionTOID(hash)
+			if err == io.EOF {
+				log.Error(err)
+				sendErrorResponse(w, http.StatusNotFound,
+					fmt.Sprintf("Transaction with ID %x does not exist", hash))
+				return
+			} else if err != nil {
 				log.Error(err)
 				sendErrorResponse(w, http.StatusInternalServerError, "")
-			}
-			if err == io.EOF {
-				page.PopulateLinks()
-				sendPageResponse(w, page)
 				return
 			}
+
+			paginate.Cursor = foundTOID
+			paginate.Limit = 1
 		}
 
 		//TODO - implement paginate.Order(asc/desc)

--- a/exp/lighthorizon/archive/ingest_archive.go
+++ b/exp/lighthorizon/archive/ingest_archive.go
@@ -60,3 +60,5 @@ func NewIngestArchive(sourceUrl string, networkPassphrase string) (Archive, erro
 	ledgerBackend := ledgerbackend.NewHistoryArchiveBackend(source)
 	return ingestArchive{ledgerBackend}, nil
 }
+
+var _ Archive = (*ingestArchive)(nil) // ensure conformity to the interface

--- a/exp/lighthorizon/common/transaction.go
+++ b/exp/lighthorizon/common/transaction.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"encoding/hex"
+	"errors"
 
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/toid"
@@ -13,10 +14,16 @@ type Transaction struct {
 	TransactionResult   *xdr.TransactionResult
 	LedgerHeader        *xdr.LedgerHeader
 	TxIndex             int32
+
+	NetworkPassphrase string
 }
 
 func (o *Transaction) TransactionHash() (string, error) {
-	hash, err := network.HashTransactionInEnvelope(*o.TransactionEnvelope, network.PublicNetworkPassphrase)
+	if o.NetworkPassphrase == "" {
+		return "", errors.New("network passphrase unspecified")
+	}
+
+	hash, err := network.HashTransactionInEnvelope(*o.TransactionEnvelope, o.NetworkPassphrase)
 	if err != nil {
 		return "", err
 	}

--- a/exp/lighthorizon/index/builder.go
+++ b/exp/lighthorizon/index/builder.go
@@ -103,8 +103,8 @@ func BuildIndices(
 		checkpoints := historyarchive.NewCheckpointManager(0)
 		for ledger := range ledgerRange.GenerateCheckpoints(checkpoints) {
 			chunk := checkpoints.GetCheckpointRange(ledger)
-			chunk.High = min(chunk.High, ledgerRange.High)
-			chunk.Low = max(chunk.Low, ledgerRange.Low)
+			chunk.High = min(chunk.High, ledgerRange.High) // don't exceed upper bound
+			chunk.Low = max(chunk.Low, ledgerRange.Low)    // nor the lower bound
 
 			ch <- chunk
 		}
@@ -121,11 +121,15 @@ func BuildIndices(
 					ledgerRange.Low, ledgerRange.High, count)
 
 				if err := indexBuilder.Build(ctx, ledgerRange); err != nil {
-					return errors.Wrap(err, "building indices failed")
+					return errors.Wrapf(err,
+						"building indices for ledger range [%d, %d] failed",
+						ledgerRange.Low, ledgerRange.High)
 				}
 
 				nprocessed := atomic.AddUint64(&processed, uint64(count))
-				printProgress("Reading ledgers", nprocessed, uint64(ledgerCount), startTime)
+				if nprocessed%19 == 0 {
+					printProgress("Reading ledgers", nprocessed, uint64(ledgerCount), startTime)
+				}
 
 				// Upload indices once per checkpoint to save memory
 				if err := indexStore.Flush(); err != nil {
@@ -140,17 +144,17 @@ func BuildIndices(
 		return indexBuilder, errors.Wrap(err, "one or more workers failed")
 	}
 
-	printProgress("Reading ledgers", uint64(ledgerCount), uint64(ledgerCount), startTime)
-
-	// Assertion for testing
-	if processed != uint64(ledgerCount) {
-		L.Fatalf("processed %d but expected %d", processed, ledgerCount)
-	}
+	printProgress("Reading ledgers", processed, uint64(ledgerCount), startTime)
 
 	L.Infof("Processed %d ledgers via %d workers", processed, parallel)
 	L.Infof("Uploading indices to %s", targetUrl)
 	if err := indexStore.Flush(); err != nil {
 		return indexBuilder, errors.Wrap(err, "flushing indices failed")
+	}
+
+	// Assertion for testing
+	if processed != uint64(ledgerCount) {
+		L.Warnf("processed %d but expected %d", processed, ledgerCount)
 	}
 
 	return indexBuilder, nil
@@ -218,7 +222,7 @@ func (builder *IndexBuilder) Build(ctx context.Context, ledgerRange historyarchi
 		ledger, err := builder.ledgerBackend.GetLedger(ctx, ledgerSeq)
 		if err != nil {
 			if !os.IsNotExist(err) {
-				log.WithField("error", err).Errorf("error getting ledger %d", ledgerSeq)
+				log.Errorf("error getting ledger %d: %v", ledgerSeq, err)
 			}
 			return err
 		}
@@ -317,13 +321,6 @@ func (builder *IndexBuilder) Watch(ctx context.Context) error {
 }
 
 func printProgress(prefix string, done, total uint64, startTime time.Time) {
-	// This should never happen, more of a runtime assertion for now.
-	// We can remove it when production-ready.
-	if done > total {
-		panic(fmt.Errorf("error for %s: done > total (%d > %d)",
-			prefix, done, total))
-	}
-
 	progress := float64(done) / float64(total)
 	elapsed := time.Since(startTime)
 

--- a/exp/lighthorizon/index/builder.go
+++ b/exp/lighthorizon/index/builder.go
@@ -29,9 +29,13 @@ func BuildIndices(
 	modules []string,
 	workerCount int,
 ) (*IndexBuilder, error) {
-	L := log.Ctx(ctx)
+	L := log.Ctx(ctx).WithField("service", "builder")
 
-	indexStore, err := Connect(targetUrl)
+	indexStore, err := ConnectWithConfig(StoreConfig{
+		Url:     targetUrl,
+		Workers: uint32(workerCount),
+		Log:     L.WithField("subservice", "index"),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/exp/lighthorizon/index/store.go
+++ b/exp/lighthorizon/index/store.go
@@ -6,9 +6,12 @@ import (
 	"io"
 	"os"
 	"sync"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	backend "github.com/stellar/go/exp/lighthorizon/index/backend"
 	types "github.com/stellar/go/exp/lighthorizon/index/types"
+	"github.com/stellar/go/support/log"
 )
 
 type Store interface {
@@ -29,25 +32,53 @@ type Store interface {
 	ReadTransactions(prefix string) (*types.TrieIndex, error)
 
 	MergeTransactions(prefix string, other *types.TrieIndex) error
+
+	RegisterMetrics(registry *prometheus.Registry)
+}
+
+type StoreConfig struct {
+	// init time config
+	Url     string
+	Workers uint32
+
+	// runtime config
+	ClearMemoryOnFlush bool
+
+	// logging & metrics
+	Log     *log.Entry // TODO: unused for now
+	Metrics *prometheus.Registry
 }
 
 type store struct {
-	mutex     sync.RWMutex
+	mutex  sync.RWMutex
+	config StoreConfig
+
+	// data
 	indexes   map[string]types.NamedIndices
 	txIndexes map[string]*types.TrieIndex
 	backend   backend.Backend
 
-	clearMemoryOnFlush bool
+	// metrics
+	indexWorkingSet     prometheus.Gauge
+	indexWorkingSetTime prometheus.Gauge // to check if the above takes too long lmao
 }
 
-func NewStore(backend backend.Backend) (Store, error) {
-	return &store{
+func NewStore(backend backend.Backend, config StoreConfig) (Store, error) {
+	result := &store{
 		indexes:   map[string]types.NamedIndices{},
 		txIndexes: map[string]*types.TrieIndex{},
 		backend:   backend,
 
-		clearMemoryOnFlush: true,
-	}, nil
+		config: config,
+
+		indexWorkingSet: newHorizonLiteGauge("working_set",
+			"Approximately how much memory (kiB) are indices using?"),
+		indexWorkingSetTime: newHorizonLiteGauge("working_set_time",
+			"How long did it take (μs) to calculate the working set size?"),
+	}
+	result.RegisterMetrics(config.Metrics)
+
+	return result, nil
 }
 
 func (s *store) accounts() []string {
@@ -77,6 +108,8 @@ func (s *store) ReadTransactions(prefix string) (*types.TrieIndex, error) {
 }
 
 func (s *store) MergeTransactions(prefix string, other *types.TrieIndex) error {
+	defer s.approximateWorkingSet()
+
 	index, err := s.getCreateTrieIndex(prefix)
 	if err != nil {
 		return err
@@ -91,9 +124,43 @@ func (s *store) MergeTransactions(prefix string, other *types.TrieIndex) error {
 	return nil
 }
 
+func (s *store) approximateWorkingSet() {
+	if s.config.Metrics == nil {
+		return
+	}
+
+	start := time.Now()
+	approx := float64(0)
+
+	for _, indices := range s.indexes {
+		firstIndexSize := 0
+		for _, index := range indices {
+			firstIndexSize = index.Size()
+			break
+		}
+
+		// There may be multiple indices for each account, but we can do a rough
+		// approximation for now by just assuming they're all around the same
+		// size.
+		approx += float64(len(indices) * firstIndexSize)
+	}
+
+	for _, trie := range s.txIndexes {
+		// FIXME: Is this too slow? We probably want a TrieIndex.Size() method,
+		// but that's not trivial to determine for a trie.
+		trie.Iterate(func(key, value []byte) {
+			approx += float64(len(key) + len(value))
+		})
+	}
+
+	s.indexWorkingSet.Set(approx / 1024)                                 // kiB
+	s.indexWorkingSetTime.Set(float64(time.Since(start).Microseconds())) // μs
+}
+
 func (s *store) Flush() error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+	defer s.approximateWorkingSet()
 
 	if err := s.backend.Flush(s.indexes); err != nil {
 		return err
@@ -101,13 +168,13 @@ func (s *store) Flush() error {
 
 	if err := s.backend.FlushAccounts(s.accounts()); err != nil {
 		return err
-	} else if s.clearMemoryOnFlush {
+	} else if s.config.ClearMemoryOnFlush {
 		s.indexes = map[string]types.NamedIndices{}
 	}
 
 	if err := s.backend.FlushTransactions(s.txIndexes); err != nil {
 		return err
-	} else if s.clearMemoryOnFlush {
+	} else if s.config.ClearMemoryOnFlush {
 		s.txIndexes = map[string]*types.TrieIndex{}
 	}
 
@@ -115,7 +182,7 @@ func (s *store) Flush() error {
 }
 
 func (s *store) ClearMemory(doClear bool) {
-	s.clearMemoryOnFlush = doClear
+	s.config.ClearMemoryOnFlush = doClear
 }
 
 func (s *store) AddTransactionToIndexes(txnTOID int64, hash [32]byte) error {
@@ -126,7 +193,12 @@ func (s *store) AddTransactionToIndexes(txnTOID int64, hash [32]byte) error {
 
 	value := make([]byte, 8)
 	binary.BigEndian.PutUint64(value, uint64(txnTOID))
-	index.Upsert(hash[1:], value)
+
+	// We don't have to re-calculate the whole working set size for metrics
+	// since we're adding a known size.
+	if _, replaced := index.Upsert(hash[1:], value); !replaced {
+		s.indexWorkingSet.Add(float64(len(hash) - 1 + len(value)))
+	}
 
 	return nil
 }
@@ -136,6 +208,7 @@ func (s *store) TransactionTOID(hash [32]byte) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
+
 	value, ok := index.Get(hash[1:])
 	if !ok {
 		return 0, io.EOF
@@ -149,6 +222,7 @@ func (s *store) TransactionTOID(hash [32]byte) (int64, error) {
 func (s *store) AddParticipantsToIndexesNoBackend(checkpoint uint32, index string, participants []string) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+	defer s.approximateWorkingSet()
 
 	var err error
 	for _, participant := range participants {
@@ -174,10 +248,14 @@ func (s *store) AddParticipantsToIndexesNoBackend(checkpoint uint32, index strin
 func (s *store) AddParticipantToIndexesNoBackend(participant string, indexes types.NamedIndices) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+	defer s.approximateWorkingSet()
+
 	s.indexes[participant] = indexes
 }
 
 func (s *store) AddParticipantsToIndexes(checkpoint uint32, index string, participants []string) error {
+	defer s.approximateWorkingSet()
+
 	for _, participant := range participants {
 		ind, err := s.getCreateIndex(participant, index)
 		if err != nil {
@@ -194,6 +272,7 @@ func (s *store) AddParticipantsToIndexes(checkpoint uint32, index string, partic
 func (s *store) getCreateIndex(account, id string) (*types.CheckpointIndex, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+	defer s.approximateWorkingSet()
 
 	// Check if we already have it loaded
 	accountIndexes, ok := s.indexes[account]
@@ -238,6 +317,8 @@ func (s *store) getCreateIndex(account, id string) (*types.CheckpointIndex, erro
 }
 
 func (s *store) NextActive(account, indexId string, afterCheckpoint uint32) (uint32, error) {
+	defer s.approximateWorkingSet()
+
 	ind, err := s.getCreateIndex(account, indexId)
 	if err != nil {
 		return 0, err
@@ -248,6 +329,7 @@ func (s *store) NextActive(account, indexId string, afterCheckpoint uint32) (uin
 func (s *store) getCreateTrieIndex(prefix string) (*types.TrieIndex, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+	defer s.approximateWorkingSet()
 
 	// Check if we already have it loaded
 	index, ok := s.txIndexes[prefix]
@@ -271,4 +353,20 @@ func (s *store) getCreateTrieIndex(prefix string) (*types.TrieIndex, error) {
 	}
 
 	return index, nil
+}
+
+func (s *store) RegisterMetrics(registry *prometheus.Registry) {
+	s.config.Metrics = registry
+
+	registry.Register(s.indexWorkingSet)
+	registry.Register(s.indexWorkingSetTime)
+}
+
+func newHorizonLiteGauge(name, help string) prometheus.Gauge {
+	return prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "horizon_lite",
+		Subsystem: "index_store",
+		Name:      name,
+		Help:      help,
+	})
 }

--- a/exp/lighthorizon/index/store.go
+++ b/exp/lighthorizon/index/store.go
@@ -358,8 +358,10 @@ func (s *store) getCreateTrieIndex(prefix string) (*types.TrieIndex, error) {
 func (s *store) RegisterMetrics(registry *prometheus.Registry) {
 	s.config.Metrics = registry
 
-	registry.Register(s.indexWorkingSet)
-	registry.Register(s.indexWorkingSetTime)
+	if registry != nil {
+		registry.Register(s.indexWorkingSet)
+		registry.Register(s.indexWorkingSetTime)
+	}
 }
 
 func newHorizonLiteGauge(name, help string) prometheus.Gauge {

--- a/exp/lighthorizon/index/types/bitmap.go
+++ b/exp/lighthorizon/index/types/bitmap.go
@@ -37,6 +37,10 @@ func NewCheckpointIndexFromXDR(index xdr.CheckpointIndex) *CheckpointIndex {
 	}
 }
 
+func (i *CheckpointIndex) Size() int {
+	return len(i.bitmap)
+}
+
 func (i *CheckpointIndex) SetActive(checkpoint uint32) error {
 	i.mutex.Lock()
 	defer i.mutex.Unlock()

--- a/exp/lighthorizon/index/types/trie.go
+++ b/exp/lighthorizon/index/types/trie.go
@@ -192,7 +192,7 @@ func (index *TrieIndex) Get(key []byte) ([]byte, bool) {
 	return nil, false
 }
 
-func (index *TrieIndex) iterate(f func(key, value []byte)) {
+func (index *TrieIndex) Iterate(f func(key, value []byte)) {
 	index.RLock()
 	defer index.RUnlock()
 	if index.Root != nil {
@@ -218,7 +218,7 @@ func (i *TrieIndex) Merge(other *TrieIndex) error {
 	i.Lock()
 	defer i.Unlock()
 
-	other.iterate(func(key, value []byte) {
+	other.Iterate(func(key, value []byte) {
 		i.doUpsert(key, value)
 	})
 

--- a/exp/lighthorizon/main.go
+++ b/exp/lighthorizon/main.go
@@ -4,6 +4,9 @@ import (
 	"flag"
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/stellar/go/exp/lighthorizon/actions"
 	"github.com/stellar/go/exp/lighthorizon/archive"
 	"github.com/stellar/go/exp/lighthorizon/index"
@@ -18,13 +21,19 @@ func main() {
 	networkPassphrase := flag.String("network-passphrase", network.TestNetworkPassphrase, "network passphrase")
 	flag.Parse()
 
-	indexStore, err := index.Connect(*indexesUrl)
+	L := log.WithField("service", "horizon-lite")
+	// L.SetLevel(log.DebugLevel)
+	L.Info("Starting lighthorizon!")
+
+	registry := prometheus.NewRegistry()
+	indexStore, err := index.ConnectWithConfig(index.StoreConfig{
+		Url:     *indexesUrl,
+		Metrics: registry,
+		Log:     L.WithField("subservice", "index"),
+	})
 	if err != nil {
 		panic(err)
 	}
-
-	log.SetLevel(log.DebugLevel)
-	log.Info("Starting lighthorizon!")
 
 	ingestArchive, err := archive.NewIngestArchive(*sourceUrl, *networkPassphrase)
 	if err != nil {
@@ -33,9 +42,12 @@ func main() {
 	defer ingestArchive.Close()
 
 	archiveWrapper := archive.Wrapper{Archive: ingestArchive, Passphrase: *networkPassphrase}
+
+	http.HandleFunc("/", actions.ApiDocs())
 	http.HandleFunc("/operations", actions.Operations(archiveWrapper, indexStore))
 	http.HandleFunc("/transactions", actions.Transactions(archiveWrapper, indexStore))
-	http.HandleFunc("/", actions.ApiDocs())
+
+	http.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }


### PR DESCRIPTION
### What
Two major changes:
  - adding a `ConnectWithConfig` helper that enables passing a config to `index.Store`
  - adding a preliminary metric to demonstrate scaffolding: the size of the index working set

### Why
Metrics are good! Plus #4451.

I'd like to get :heavy_check_mark: on the way I've set up metrics before investing too much time into the metrics themselves.

### Known limitations
n/a