### PR TITLE
exp/lighthorizon: Add an on-disk cache for frequently accessed ledgers.

### DIFF
--- a/exp/lighthorizon/archive/ingest_archive.go
+++ b/exp/lighthorizon/archive/ingest_archive.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 
 	"github.com/stellar/go/exp/lighthorizon/index"
@@ -14,25 +15,32 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-const (
-	maxLedgersToCache = (60 * 60 * 24) / 6 // 1 day of ledgers @ 6s each
-)
-
 type ArchiveConfig struct {
 	SourceUrl         string
 	NetworkPassphrase string
 	CacheDir          string
+	CacheSize         int
 }
 
 func NewIngestArchive(config ArchiveConfig) (Archive, error) {
-	// If the source URL is an S3 url and it has a region specified, we should
-	// try to extract it.
+	if config.CacheSize <= 0 {
+		return nil, fmt.Errorf("invalid cache size: %d", config.CacheSize)
+	}
+
 	parsed, err := url.Parse(config.SourceUrl)
 	if err != nil {
 		return nil, errors.Wrapf(err, "%s is not a valid URL", config.SourceUrl)
 	}
+
 	region := ""
-	if parsed.Scheme == "s3" {
+	needsCache := true
+	switch parsed.Scheme {
+	case "file":
+		// We should only avoid a cache if the ledgers are already local.
+		needsCache = false
+
+	case "s3":
+		// We need to extract the region if it's specified.
 		region = parsed.Query().Get("region")
 	}
 
@@ -50,17 +58,22 @@ func NewIngestArchive(config ArchiveConfig) (Archive, error) {
 		return nil, err
 	}
 
-	cache, err := historyarchive.MakeFsCacheBackend(source, config.CacheDir, maxLedgersToCache)
-	if err != nil { // warn but continue w/o cache
-		log.WithField("path", config.CacheDir).
-			WithError(err).
-			Warnf("Failed to create cached ledger backend")
-		cache = source
-	} else {
-		log.WithField("path", config.CacheDir).Infof("On-disk cache configured")
+	if needsCache {
+		cache, err := historyarchive.MakeFsCacheBackend(source,
+			config.CacheDir, uint(config.CacheSize))
+
+		if err != nil { // warn but continue w/o cache
+			log.WithField("path", config.CacheDir).
+				WithError(err).
+				Warnf("Failed to create cached ledger backend")
+		} else {
+			log.WithField("path", config.CacheDir).
+				Infof("On-disk cache configured")
+			source = cache
+		}
 	}
 
-	ledgerBackend := ledgerbackend.NewHistoryArchiveBackend(cache)
+	ledgerBackend := ledgerbackend.NewHistoryArchiveBackend(source)
 	return ingestArchive{ledgerBackend}, nil
 }
 

--- a/exp/lighthorizon/archive/ingest_archive.go
+++ b/exp/lighthorizon/archive/ingest_archive.go
@@ -2,13 +2,20 @@ package archive
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/stellar/go/exp/lighthorizon/index"
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/ingest/ledgerbackend"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/log"
 
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/xdr"
+)
+
+const (
+	maxLedgersToCache = (60 * 60 * 24) / 6 // 1 day of ledgers @ 6s each
 )
 
 // This is an implementation of LightHorizon Archive that uses the existing horizon ingestion backend.
@@ -82,19 +89,49 @@ func (adaptation *ingestTransactionReaderAdaption) Read() (LedgerTransaction, er
 	return tx, nil
 }
 
-func NewIngestArchive(sourceUrl string, networkPassphrase string) (Archive, error) {
-	// Simple file os access
+type ArchiveConfig struct {
+	SourceUrl         string
+	NetworkPassphrase string
+	CacheDir          string
+}
+
+func NewIngestArchive(config ArchiveConfig) (Archive, error) {
+	// If the source URL is an S3 url and it has a region specified, we should
+	// try to extract it.
+	parsed, err := url.Parse(config.SourceUrl)
+	if err != nil {
+		return nil, errors.Wrapf(err, "%s is not a valid URL", config.SourceUrl)
+	}
+	region := ""
+	if parsed.Scheme == "s3" {
+		region = parsed.Query().Get("region")
+	}
+
+	// Now, set up a simple filesystem-like access to the backend and wrap it in
+	// a local on-disk LRU cache if we can.
 	source, err := historyarchive.ConnectBackend(
-		sourceUrl,
+		config.SourceUrl,
 		historyarchive.ConnectOptions{
 			Context:           context.Background(),
-			NetworkPassphrase: networkPassphrase,
+			NetworkPassphrase: config.NetworkPassphrase,
+			S3Region:          region,
 		},
 	)
 	if err != nil {
 		return nil, err
 	}
-	ledgerBackend := ledgerbackend.NewHistoryArchiveBackend(source)
+
+	cache, err := historyarchive.MakeFsCacheBackend(source, config.CacheDir, maxLedgersToCache)
+	if err != nil { // warn but continue w/o cache
+		log.WithField("path", config.CacheDir).
+			WithError(err).
+			Warnf("Failed to create cached ledger backend")
+		cache = source
+	} else {
+		log.WithField("path", config.CacheDir).Infof("On-disk cache configured")
+	}
+
+	ledgerBackend := ledgerbackend.NewHistoryArchiveBackend(cache)
 	return ingestArchive{ledgerBackend}, nil
 }
 

--- a/exp/lighthorizon/archive/ingest_archive.go
+++ b/exp/lighthorizon/archive/ingest_archive.go
@@ -18,6 +18,52 @@ const (
 	maxLedgersToCache = (60 * 60 * 24) / 6 // 1 day of ledgers @ 6s each
 )
 
+type ArchiveConfig struct {
+	SourceUrl         string
+	NetworkPassphrase string
+	CacheDir          string
+}
+
+func NewIngestArchive(config ArchiveConfig) (Archive, error) {
+	// If the source URL is an S3 url and it has a region specified, we should
+	// try to extract it.
+	parsed, err := url.Parse(config.SourceUrl)
+	if err != nil {
+		return nil, errors.Wrapf(err, "%s is not a valid URL", config.SourceUrl)
+	}
+	region := ""
+	if parsed.Scheme == "s3" {
+		region = parsed.Query().Get("region")
+	}
+
+	// Now, set up a simple filesystem-like access to the backend and wrap it in
+	// a local on-disk LRU cache if we can.
+	source, err := historyarchive.ConnectBackend(
+		config.SourceUrl,
+		historyarchive.ConnectOptions{
+			Context:           context.Background(),
+			NetworkPassphrase: config.NetworkPassphrase,
+			S3Region:          region,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	cache, err := historyarchive.MakeFsCacheBackend(source, config.CacheDir, maxLedgersToCache)
+	if err != nil { // warn but continue w/o cache
+		log.WithField("path", config.CacheDir).
+			WithError(err).
+			Warnf("Failed to create cached ledger backend")
+		cache = source
+	} else {
+		log.WithField("path", config.CacheDir).Infof("On-disk cache configured")
+	}
+
+	ledgerBackend := ledgerbackend.NewHistoryArchiveBackend(cache)
+	return ingestArchive{ledgerBackend}, nil
+}
+
 // This is an implementation of LightHorizon Archive that uses the existing horizon ingestion backend.
 type ingestArchive struct {
 	*ledgerbackend.HistoryArchiveBackend
@@ -87,52 +133,6 @@ func (adaptation *ingestTransactionReaderAdaption) Read() (LedgerTransaction, er
 	tx.UnsafeMeta = ingestLedgerTransaction.UnsafeMeta
 
 	return tx, nil
-}
-
-type ArchiveConfig struct {
-	SourceUrl         string
-	NetworkPassphrase string
-	CacheDir          string
-}
-
-func NewIngestArchive(config ArchiveConfig) (Archive, error) {
-	// If the source URL is an S3 url and it has a region specified, we should
-	// try to extract it.
-	parsed, err := url.Parse(config.SourceUrl)
-	if err != nil {
-		return nil, errors.Wrapf(err, "%s is not a valid URL", config.SourceUrl)
-	}
-	region := ""
-	if parsed.Scheme == "s3" {
-		region = parsed.Query().Get("region")
-	}
-
-	// Now, set up a simple filesystem-like access to the backend and wrap it in
-	// a local on-disk LRU cache if we can.
-	source, err := historyarchive.ConnectBackend(
-		config.SourceUrl,
-		historyarchive.ConnectOptions{
-			Context:           context.Background(),
-			NetworkPassphrase: config.NetworkPassphrase,
-			S3Region:          region,
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	cache, err := historyarchive.MakeFsCacheBackend(source, config.CacheDir, maxLedgersToCache)
-	if err != nil { // warn but continue w/o cache
-		log.WithField("path", config.CacheDir).
-			WithError(err).
-			Warnf("Failed to create cached ledger backend")
-		cache = source
-	} else {
-		log.WithField("path", config.CacheDir).Infof("On-disk cache configured")
-	}
-
-	ledgerBackend := ledgerbackend.NewHistoryArchiveBackend(cache)
-	return ingestArchive{ledgerBackend}, nil
 }
 
 var _ Archive = (*ingestArchive)(nil) // ensure conformity to the interface

--- a/exp/lighthorizon/archive/main.go
+++ b/exp/lighthorizon/archive/main.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"context"
+
 	"github.com/stellar/go/xdr"
 )
 

--- a/exp/lighthorizon/main.go
+++ b/exp/lighthorizon/main.go
@@ -21,10 +21,11 @@ func main() {
 	sourceUrl := flag.String("source", "gcs://horizon-archive-poc", "history archive url to read txmeta files")
 	indexesUrl := flag.String("indexes", "file://indexes", "url of the indexes")
 	networkPassphrase := flag.String("network-passphrase", network.TestNetworkPassphrase, "network passphrase")
+	cacheDir := flag.String("ledger-cache", "", "path to cache frequently-used ledgers")
 	flag.Parse()
 
 	L := log.WithField("service", "horizon-lite")
-	// L.SetLevel(log.DebugLevel)
+	L.SetLevel(log.InfoLevel)
 	L.Info("Starting lighthorizon!")
 
 	registry := prometheus.NewRegistry()
@@ -37,7 +38,11 @@ func main() {
 		panic(err)
 	}
 
-	ingestArchive, err := archive.NewIngestArchive(*sourceUrl, *networkPassphrase)
+	ingestArchive, err := archive.NewIngestArchive(archive.ArchiveConfig{
+		SourceUrl:         *sourceUrl,
+		NetworkPassphrase: *networkPassphrase,
+		CacheDir:          *cacheDir,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/exp/lighthorizon/main.go
+++ b/exp/lighthorizon/main.go
@@ -17,11 +17,18 @@ import (
 	"github.com/stellar/go/support/log"
 )
 
+const (
+	defaultCacheSize = (60 * 60 * 24) / 6 // 1 day of ledgers @ 6s each
+)
+
 func main() {
 	sourceUrl := flag.String("source", "gcs://horizon-archive-poc", "history archive url to read txmeta files")
 	indexesUrl := flag.String("indexes", "file://indexes", "url of the indexes")
-	networkPassphrase := flag.String("network-passphrase", network.TestNetworkPassphrase, "network passphrase")
-	cacheDir := flag.String("ledger-cache", "", "path to cache frequently-used ledgers")
+	networkPassphrase := flag.String("network-passphrase", network.PublicNetworkPassphrase, "network passphrase")
+	cacheDir := flag.String("ledger-cache", "", `path to cache frequently-used ledgers;
+if left empty, uses a temporary directory`)
+	cacheSize := flag.Int("ledger-cache-size", defaultCacheSize,
+		"number of ledgers to store in the cache")
 	flag.Parse()
 
 	L := log.WithField("service", "horizon-lite")
@@ -31,8 +38,8 @@ func main() {
 	registry := prometheus.NewRegistry()
 	indexStore, err := index.ConnectWithConfig(index.StoreConfig{
 		Url:     *indexesUrl,
-		Metrics: registry,
 		Log:     L.WithField("subservice", "index"),
+		Metrics: registry,
 	})
 	if err != nil {
 		panic(err)
@@ -42,6 +49,7 @@ func main() {
 		SourceUrl:         *sourceUrl,
 		NetworkPassphrase: *networkPassphrase,
 		CacheDir:          *cacheDir,
+		CacheSize:         *cacheSize,
 	})
 	if err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-querystring v0.0.0-20160401233042-9235644dd9e5 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
-	github.com/hashicorp/golang-lru v0.5.1 // indirect
+	github.com/hashicorp/golang-lru v0.5.1
 	github.com/hpcloud/tail v1.0.0 // indirect
 	github.com/imkira/go-interpol v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/historyarchive/fs_cache.go
+++ b/historyarchive/fs_cache.go
@@ -172,12 +172,11 @@ func (b *FsCacheBackend) PutFile(filepath string, in io.ReadCloser) error {
 	return b.ArchiveBackend.PutFile(filepath, in)
 }
 
-// Close forwards the call to the wrapped backend.
+// Close purges the cache, then forwards the call to the wrapped backend.
 func (b *FsCacheBackend) Close() error {
-	// This means nothing for the cached side of things unless we start storing
-	// file handles in the cache.
-	//
-	// TODO: Actually, should we purge the cache here?
+	// We only purge the cache, leaving the filesystem untouched:
+	// https://github.com/stellar/go/pull/4457#discussion_r929352643
+	b.lru.Purge()
 	return b.ArchiveBackend.Close()
 }
 

--- a/historyarchive/fs_cache.go
+++ b/historyarchive/fs_cache.go
@@ -62,6 +62,9 @@ func MakeFsCacheBackend(upstream ArchiveBackend, dir string, maxFiles uint) (Arc
 	return backend, nil
 }
 
+// GetFile retrieves the file contents from the local cache if present.
+// Otherwise, it returns the same result that the wrapped backend returns and
+// adds that result into the local cache, if possible.
 func (b *FsCacheBackend) GetFile(filepath string) (io.ReadCloser, error) {
 	L := b.log.WithField("key", filepath)
 	localPath := path.Join(b.dir, filepath)
@@ -112,6 +115,9 @@ func (b *FsCacheBackend) GetFile(filepath string) (io.ReadCloser, error) {
 	return local, nil
 }
 
+// Exists shortcuts an existence check by checking if it exists in the cache.
+// Otherwise, it returns the same result as the wrapped backend. Note that in
+// the latter case, the cache isn't modified.
 func (b *FsCacheBackend) Exists(filepath string) (bool, error) {
 	localPath := path.Join(b.dir, filepath)
 	b.log.WithField("key", filepath).Debug("checking existence")
@@ -125,6 +131,9 @@ func (b *FsCacheBackend) Exists(filepath string) (bool, error) {
 	return b.ArchiveBackend.Exists(filepath)
 }
 
+// Size will return the size of the file found in the cache if possible.
+// Otherwise, it returns the same result as the wrapped backend. Note that in
+// the latter case, the cache isn't modified.
 func (b *FsCacheBackend) Size(filepath string) (int64, error) {
 	localPath := path.Join(b.dir, filepath)
 	L := b.log.WithField("key", filepath)
@@ -144,6 +153,9 @@ func (b *FsCacheBackend) Size(filepath string) (int64, error) {
 	return b.ArchiveBackend.Size(filepath)
 }
 
+// PutFile writes to the given `filepath` from the given `in` reader, also
+// writing it to the local cache if possible. It returns the same result as the
+// wrapped backend.
 func (b *FsCacheBackend) PutFile(filepath string, in io.ReadCloser) error {
 	L := log.WithField("key", filepath)
 	L.Debug("putting file")
@@ -160,6 +172,7 @@ func (b *FsCacheBackend) PutFile(filepath string, in io.ReadCloser) error {
 	return b.ArchiveBackend.PutFile(filepath, in)
 }
 
+// Close forwards the call to the wrapped backend.
 func (b *FsCacheBackend) Close() error {
 	// This means nothing for the cached side of things unless we start storing
 	// file handles in the cache.

--- a/historyarchive/fs_cache.go
+++ b/historyarchive/fs_cache.go
@@ -5,24 +5,195 @@
 package historyarchive
 
 import (
-	"container/heap"
 	"io"
 	"os"
 	"path"
-	"time"
 
-	log "github.com/sirupsen/logrus"
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/stellar/go/support/log"
 )
 
 // FsCacheBackend fronts another backend with a local filesystem cache
 type FsCacheBackend struct {
 	ArchiveBackend
-	dir string
-	//lint:ignore U1000 Ignore unused temporarily
-	knownFiles lruCache
-	maxFiles   int
-	lru        lruCache
+	dir      string
+	maxFiles int
+	lru      *lru.Cache
+
+	log *log.Entry
 }
+
+// MakeFsCacheBackend wraps an ArchiveBackend with a local filesystem cache in
+// `dir`. If dir is blank, a temporary directory will be created. If `maxFiles`
+// is zero, a default (90 days of ledgers) is used.
+func MakeFsCacheBackend(upstream ArchiveBackend, dir string, maxFiles uint) (ArchiveBackend, error) {
+	if dir == "" {
+		tmp, err := os.MkdirTemp(os.TempDir(), "stellar-horizon-*")
+		if err != nil {
+			return nil, err
+		}
+		dir = tmp
+	}
+	if maxFiles == 0 {
+		// A guess at a reasonable number of checkpoints. This is 90 days of
+		// ledgers. (90*86_400)/(5*64) = 24_300
+		maxFiles = 24_300
+	}
+
+	backendLog := log.
+		WithField("subservice", "fs-cache").
+		WithField("path", dir).
+		WithField("size", maxFiles)
+	backendLog.Info("Filesystem cache configured")
+
+	backend := &FsCacheBackend{
+		ArchiveBackend: upstream,
+		dir:            dir,
+		maxFiles:       int(maxFiles),
+		log:            backendLog,
+	}
+
+	cache, err := lru.NewWithEvict(int(maxFiles), backend.onEviction)
+	if err != nil {
+		return nil, err
+	}
+
+	backend.lru = cache
+	return backend, nil
+}
+
+func (b *FsCacheBackend) GetFile(filepath string) (io.ReadCloser, error) {
+	L := b.log.WithField("key", filepath)
+	localPath := path.Join(b.dir, filepath)
+
+	if _, ok := b.lru.Get(localPath); !ok {
+		// If it doesn't exist in the cache, it might still exist on the disk if
+		// we've restarted from an existing directory.
+		local, err := os.Open(localPath)
+		if err == nil {
+			L.Debug("found file on disk but not in cache, adding")
+			b.lru.Add(localPath, struct{}{})
+			return local, nil
+		}
+
+		b.log.WithField("key", filepath).
+			Debug("retrieving file from remote backend")
+
+		// Since it's not on-disk, pull it from the remote backend, shove it
+		// into the cache, and write it to disk.
+		remote, err := b.ArchiveBackend.GetFile(filepath)
+		if err != nil {
+			return remote, err
+		}
+
+		local, err = b.createLocal(filepath)
+		if err != nil {
+			// If there's some local FS error, we can still continue with the
+			// remote version, so just log it and continue.
+			L.WithError(err).Error("caching ledger failed")
+
+			return remote, nil
+		}
+
+		return teeReadCloser(remote, local), nil
+	}
+
+	// The cache claims it exists, so just give it a read and send it.
+	local, err := os.Open(localPath)
+	if err != nil {
+		// Uh-oh, the cache and the disk are not in sync somehow? Let's evict
+		// this value and try again (recurse) w/ the remote version.
+		L.WithError(err).Warn("opening cached ledger failed")
+		b.lru.Remove(localPath)
+		return b.GetFile(filepath)
+	}
+
+	L.Debug("Found file in cache")
+	return local, nil
+}
+
+func (b *FsCacheBackend) Exists(filepath string) (bool, error) {
+	localPath := path.Join(b.dir, filepath)
+	b.log.WithField("key", filepath).Debug("checking existence")
+
+	if _, ok := b.lru.Get(localPath); ok {
+		// If the cache says it's there, we can definitively say that this path
+		// exists, even if we'd fail to `os.Stat()/Read()/etc.` it locally.
+		return true, nil
+	}
+
+	return b.ArchiveBackend.Exists(filepath)
+}
+
+func (b *FsCacheBackend) Size(filepath string) (int64, error) {
+	localPath := path.Join(b.dir, filepath)
+	L := b.log.WithField("key", filepath)
+
+	L.Debug("retrieving size")
+	if _, ok := b.lru.Get(localPath); ok {
+		stats, err := os.Stat(localPath)
+		if err == nil {
+			L.Debugf("retrieved cached size: %d", stats.Size())
+			return stats.Size(), nil
+		}
+
+		L.WithError(err).Debug("retrieving size of cached ledger failed")
+		b.lru.Remove(localPath) // stale cache?
+	}
+
+	return b.ArchiveBackend.Size(filepath)
+}
+
+func (b *FsCacheBackend) PutFile(filepath string, in io.ReadCloser) error {
+	L := log.WithField("key", filepath)
+	L.Debug("putting file")
+
+	// Best effort to tee the upload off to the local cache as well
+	local, err := b.createLocal(filepath)
+	if err != nil {
+		L.WithError(err).Error("failed to put file locally")
+	} else {
+		// tee upload data into our local file
+		in = teeReadCloser(in, local)
+	}
+
+	return b.ArchiveBackend.PutFile(filepath, in)
+}
+
+func (b *FsCacheBackend) Close() error {
+	// This means nothing for the cached side of things unless we start storing
+	// file handles in the cache.
+	//
+	// TODO: Actually, should we purge the cache here?
+	return b.ArchiveBackend.Close()
+}
+
+func (b *FsCacheBackend) onEviction(key, value interface{}) {
+	path := key.(string)
+	if err := os.Remove(path); err != nil { // best effort removal
+		b.log.WithError(err).
+			WithField("key", path).
+			Error("removal failed after cache eviction")
+	}
+}
+
+func (b *FsCacheBackend) createLocal(filepath string) (*os.File, error) {
+	localPath := path.Join(b.dir, filepath)
+	if err := os.MkdirAll(path.Dir(localPath), 0755 /* drwxr-xr-x */); err != nil {
+		return nil, err
+	}
+
+	local, err := os.Create(localPath) /* mode -rw-rw-rw- */
+	if err != nil {
+		return nil, err
+	}
+
+	b.lru.Add(localPath, struct{}{}) // just use the cache as an array
+	return local, nil
+}
+
+// The below is a helper interface so that we can use io.TeeReader to write
+// data locally immediately as we read it remotely.
 
 type trc struct {
 	io.Reader
@@ -41,186 +212,4 @@ func teeReadCloser(r io.ReadCloser, w io.WriteCloser) io.ReadCloser {
 			return w.Close()
 		},
 	}
-}
-
-func (b *FsCacheBackend) GetFile(pth string) (r io.ReadCloser, err error) {
-	localPath := path.Join(b.dir, pth)
-	local, err := os.Open(localPath)
-	if err == nil {
-		b.updateLRU(localPath)
-		return local, nil
-	}
-	if !os.IsNotExist(err) {
-		// Some local fs error.. log and continue?
-		log.WithField("path", pth).WithError(err).Error("fs-cache: get file")
-	}
-
-	remote, err := b.ArchiveBackend.GetFile(pth)
-	if err != nil {
-		return remote, err
-	}
-	local, err = b.createLocal(pth)
-	if err != nil {
-		// Some local fs error.. log and continue?
-		log.WithField("path", pth).WithError(err).Error("fs-cache: get file")
-		return remote, nil
-	}
-	return teeReadCloser(remote, local), nil
-}
-
-func (b *FsCacheBackend) createLocal(pth string) (*os.File, error) {
-	localPath := path.Join(b.dir, pth)
-
-	if err := os.MkdirAll(path.Dir(localPath), 0755); err != nil {
-		return nil, err
-	}
-
-	local, err := os.Create(localPath)
-	if err != nil {
-		return nil, err
-	}
-	b.updateLRU(localPath)
-	return local, err
-}
-
-func (b *FsCacheBackend) Exists(pth string) (bool, error) {
-	localPath := path.Join(b.dir, pth)
-	log.WithField("path", pth).Trace("fs-cache: check exists")
-	if _, err := os.Stat(localPath); err == nil {
-		b.updateLRU(localPath)
-		return true, nil
-	}
-	return b.ArchiveBackend.Exists(pth)
-}
-
-func (b *FsCacheBackend) Size(pth string) (int64, error) {
-	localPath := path.Join(b.dir, pth)
-	log.WithField("path", pth).Trace("fs-cache: check exists")
-	fi, err := os.Stat(localPath)
-	if err == nil {
-		log.WithField("path", pth).WithField("size", fi.Size()).Trace("fs-cache: got size")
-		b.updateLRU(localPath)
-		return fi.Size(), nil
-	}
-	log.WithField("path", pth).WithError(err).Error("fs-cache: get size")
-	return b.ArchiveBackend.Size(pth)
-}
-
-func (b *FsCacheBackend) PutFile(pth string, in io.ReadCloser) error {
-	log.WithField("path", pth).Trace("fs-cache: put file")
-	in = b.tryLocalPutFile(pth, in)
-	return b.ArchiveBackend.PutFile(pth, in)
-}
-
-// Best effort to tee the upload off to the local cache as well
-func (b *FsCacheBackend) tryLocalPutFile(pth string, in io.ReadCloser) io.ReadCloser {
-	local, err := b.createLocal(pth)
-	if err != nil {
-		log.WithField("path", pth).WithError(err).Error("fs-cache: put file")
-		return in
-	}
-
-	// tee upload data into our local file
-	return teeReadCloser(in, local)
-}
-
-func (b *FsCacheBackend) updateLRU(pth string) {
-	b.lru.bump(pth)
-	for i := b.lru.Len(); i > b.maxFiles; i-- {
-		item := b.lru.Pop().(*lruCacheItem)
-		if err := os.Remove(item.path); err != nil {
-			log.WithField("path", item.path).WithError(err).Error("fs-cache: evict")
-		}
-	}
-}
-
-func (b *FsCacheBackend) Close() error {
-	return b.ArchiveBackend.Close()
-}
-
-// MakeFsCacheBackend, wraps an ArchiveBackend with a local filesystem cache in
-// `dir`. If dir is blank, a temporary directory will be created.
-func MakeFsCacheBackend(upstream ArchiveBackend, dir string, maxFiles uint) (ArchiveBackend, error) {
-	if dir == "" {
-		tmp, err := os.MkdirTemp(os.TempDir(), "stellar-horizon-*")
-		if err != nil {
-			return nil, err
-		}
-		dir = tmp
-		log.WithField("dir", dir).Info("fs-cache: temp dir")
-	}
-	if maxFiles == 0 {
-		// A guess at a reasonable number of checkpoints. This is 90 days of
-		// ledgers. (90*86_400)/(5*64) = 24_300
-		maxFiles = 24_300
-	}
-	// Add 10 here, cause we need a bit of spare room for pending evictions.
-	var lru lruCache
-	heap.Init(&lru)
-	return &FsCacheBackend{
-		ArchiveBackend: upstream,
-		dir:            dir,
-		maxFiles:       int(maxFiles),
-		lru:            lru,
-	}, nil
-}
-
-// lruCache is a heap-based LRU cache that we use to limit the on-disk size
-type lruCache []*lruCacheItem
-
-type lruCacheItem struct {
-	path       string
-	lastUsedAt time.Time
-	index      int
-}
-
-func (c lruCache) Len() int { return len(c) }
-
-func (c lruCache) Less(i, j int) bool {
-	// We want Pop to give us the oldest, so we use before than here.
-	return c[i].lastUsedAt.Before(c[j].lastUsedAt)
-}
-
-func (c lruCache) Swap(i, j int) {
-	c[i], c[j] = c[j], c[i]
-	c[i].index = i
-	c[j].index = j
-}
-
-func (c *lruCache) Push(x interface{}) {
-	n := len(*c)
-	item := x.(*lruCacheItem)
-	item.index = n
-	*c = append(*c, item)
-}
-
-func (c *lruCache) Pop() interface{} {
-	old := *c
-	n := len(old)
-	item := old[n-1]
-	old[n-1] = nil  // avoid memory leak
-	item.index = -1 // for safety
-	*c = old[0 : n-1]
-	return item
-}
-
-func (c *lruCache) bump(pth string) {
-	c.upsert(pth, time.Now())
-}
-
-// upsert modifies the priority and value of an item in the heap, or inserts it.
-func (c *lruCache) upsert(pth string, lastUsedAt time.Time) {
-	// Try to find by path and update
-	for _, item := range *c {
-		if item.path == pth {
-			item.lastUsedAt = lastUsedAt
-			heap.Fix(c, item.index)
-			return
-		}
-	}
-	// not found, add this item
-	heap.Push(c, &lruCacheItem{
-		path:       pth,
-		lastUsedAt: lastUsedAt,
-	})
 }


### PR DESCRIPTION
### What
Two changes:
 - Update `historyarchive.FsCacheBackend` to use an off-the-shelf package ([`hashicorp/golang-lru`](https://pkg.go.dev/github.com/hashicorp/golang-lru#Cache)) over a custom solution.
 - Use the above to wrap the ledger backend

### Why
This nearly eliminates request latency if the ledgers are cached locally.

### Known limitations
We should think about a best practice for cache eviction when we upgrade the exported meta, though maybe this just means operators delete their caches.