### PR TITLE
historyarchive: Add User-Agent header to history archive HTTP requests

### DIFF
--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -139,6 +139,7 @@ func main() {
 				CheckpointFrequency: checkpointFrequency,
 				Log:                 logger.WithField("subservice", "stellar-core"),
 				Toml:                captiveCoreToml,
+				UserAgent:           "captivecore",
 			}
 
 			var dbConn *db.Session

--- a/exp/tools/dump-ledger-state/main.go
+++ b/exp/tools/dump-ledger-state/main.go
@@ -307,13 +307,17 @@ func archive(testnet bool) (*historyarchive.Archive, error) {
 	if testnet {
 		return historyarchive.Connect(
 			"https://history.stellar.org/prd/core-testnet/core_testnet_001",
-			historyarchive.ConnectOptions{},
+			historyarchive.ConnectOptions{
+				UserAgent: "dump-ledger-state",
+			},
 		)
 	}
 
 	return historyarchive.Connect(
 		fmt.Sprintf("https://history.stellar.org/prd/core-live/core_live_001/"),
-		historyarchive.ConnectOptions{},
+		historyarchive.ConnectOptions{
+			UserAgent: "dump-ledger-state",
+		},
 	)
 }
 

--- a/exp/tools/dump-orderbook/main.go
+++ b/exp/tools/dump-orderbook/main.go
@@ -109,12 +109,16 @@ func archive(testnet bool) (*historyarchive.Archive, error) {
 	if testnet {
 		return historyarchive.Connect(
 			"https://history.stellar.org/prd/core-testnet/core_testnet_001",
-			historyarchive.ConnectOptions{},
+			historyarchive.ConnectOptions{
+				UserAgent: "dump-orderbook",
+			},
 		)
 	}
 
 	return historyarchive.Connect(
 		fmt.Sprintf("https://history.stellar.org/prd/core-live/core_live_001/"),
-		historyarchive.ConnectOptions{},
+		historyarchive.ConnectOptions{
+			UserAgent: "dump-orderbook",
+		},
 	)
 }

--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -49,6 +49,8 @@ type ConnectOptions struct {
 	// CheckpointFrequency is the number of ledgers between checkpoints
 	// if unset, DefaultCheckpointFrequency will be used
 	CheckpointFrequency uint32
+	// UserAgent is the value of `User-Agent` header. Applicable only for HTTP client.
+	UserAgent string
 }
 
 type Ledger struct {

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -103,7 +103,9 @@ type CaptiveCoreConfig struct {
 	NetworkPassphrase string
 	// HistoryArchiveURLs are a list of history archive urls
 	HistoryArchiveURLs []string
-	Toml               *CaptiveCoreToml
+	// UserAgent is the value of `User-Agent` header that will be send along http archive requests.
+	UserAgent string
+	Toml      *CaptiveCoreToml
 
 	// Optional fields
 

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"runtime"
 	"sync"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/stellar/go/ingest/ledgerbackend"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/ingest/filters"
+	apkg "github.com/stellar/go/support/app"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	logpkg "github.com/stellar/go/support/log"
@@ -210,6 +212,7 @@ func NewSystem(config Config) (System, error) {
 			Context:             ctx,
 			NetworkPassphrase:   config.NetworkPassphrase,
 			CheckpointFrequency: config.CheckpointFrequency,
+			UserAgent:           fmt.Sprintf("horizon/%s golang/%s", apkg.Version(), runtime.Version()),
 		},
 	)
 	if err != nil {
@@ -239,6 +242,7 @@ func NewSystem(config Config) (System, error) {
 					LedgerHashStore:     ledgerbackend.NewHorizonDBLedgerHashStore(config.HistorySession),
 					Log:                 logger,
 					Context:             ctx,
+					UserAgent:           fmt.Sprintf("captivecore horizon/%s golang/%s", apkg.Version(), runtime.Version()),
 				},
 			)
 			if err != nil {

--- a/tools/archive-reader/archive_reader.go
+++ b/tools/archive-reader/archive_reader.go
@@ -67,6 +67,7 @@ func archive() (*historyarchive.Archive, error) {
 		historyarchive.ConnectOptions{
 			S3Region:         "eu-west-1",
 			UnsignedRequests: true,
+			UserAgent:        "archive-reader",
 		},
 	)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add `UserAgent` to `historyarchive.ConnectOptions`. The value will be propagated to `User-Agent` header send along http requests to history achive.

### Why

This will allow better tracking of clients using history achives.

### Known limitations

[TODO or N/A]
