### PR TITLE
services/horizon: Improve state verifier error message

### DIFF
--- a/services/horizon/internal/ingest/verify/main.go
+++ b/services/horizon/internal/ingest/verify/main.go
@@ -157,7 +157,7 @@ func (v *StateVerifier) Write(entry xdr.LedgerEntry) error {
 
 	if !bytes.Equal(actualEntryMarshaled, expectedEntryMarshaled) {
 		return ingest.NewStateError(errors.Errorf(
-			"Entry does not match the fetched entry. Expected: %s (pretransform = %s), actual: %s",
+			"Entry does not match the fetched entry. Expected (history archive): %s (pretransform = %s), actual (horizon): %s",
 			base64.StdEncoding.EncodeToString(expectedEntryMarshaled),
 			base64.StdEncoding.EncodeToString(preTransformExpectedEntryMarshaled),
 			base64.StdEncoding.EncodeToString(actualEntryMarshaled),

--- a/services/horizon/internal/ingest/verify/main_test.go
+++ b/services/horizon/internal/ingest/verify/main_test.go
@@ -236,7 +236,7 @@ func (s *StateVerifierTestSuite) TestActualExpectedEntryNotEqualWrite() {
 	s.Assert().NoError(err)
 
 	errorMsg := fmt.Sprintf(
-		"Entry does not match the fetched entry. Expected: %s (pretransform = %s), actual: %s",
+		"Entry does not match the fetched entry. Expected (history archive): %s (pretransform = %s), actual (horizon): %s",
 		expectedEntryBase64,
 		expectedEntryBase64,
 		actualEntryBase64,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Improve error message to explicitly say where a given ledger entry come from.

### Why

It's easy to confuse what is expected and what is actual ledger entry.

### Known limitations

[TODO or N/A]
