### PR TITLE
services/ticker: fix "panic: runtime error: index out of range [-1]"

### DIFF
--- a/services/ticker/internal/scraper/main.go
+++ b/services/ticker/internal/scraper/main.go
@@ -135,7 +135,9 @@ func (c *ScraperConfig) FetchAllTrades(since time.Time, limit int) (trades []hPr
 
 	trades, err = c.retrieveTrades(since, limit)
 
-	c.Logger.Info("Last close time ingested:", trades[len(trades)-1].LedgerCloseTime)
+	if len(trades) > 0 {
+		c.Logger.Info("Last close time ingested:", trades[len(trades)-1].LedgerCloseTime)
+	}
 	c.Logger.Infof("Fetched: %d trades\n", len(trades))
 	return
 }

--- a/services/ticker/internal/scraper/main.go
+++ b/services/ticker/internal/scraper/main.go
@@ -134,6 +134,9 @@ func (c *ScraperConfig) FetchAllTrades(since time.Time, limit int) (trades []hPr
 	c.Logger.Info("Fetching trades from Horizon")
 
 	trades, err = c.retrieveTrades(since, limit)
+	if err != nil {
+		return
+	}
 
 	if len(trades) > 0 {
 		c.Logger.Info("Last close time ingested:", trades[len(trades)-1].LedgerCloseTime)

--- a/services/ticker/internal/scraper/main.go
+++ b/services/ticker/internal/scraper/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 type ScraperConfig struct {
-	Client *horizonclient.Client
+	Client horizonclient.ClientInterface
 	Logger *hlog.Entry
 	Ctx    *context.Context
 }

--- a/services/ticker/internal/scraper/main.go
+++ b/services/ticker/internal/scraper/main.go
@@ -134,9 +134,6 @@ func (c *ScraperConfig) FetchAllTrades(since time.Time, limit int) (trades []hPr
 	c.Logger.Info("Fetching trades from Horizon")
 
 	trades, err = c.retrieveTrades(since, limit)
-	if err != nil {
-		return
-	}
 
 	if len(trades) > 0 {
 		c.Logger.Info("Last close time ingested:", trades[len(trades)-1].LedgerCloseTime)

--- a/services/ticker/internal/scraper/main_test.go
+++ b/services/ticker/internal/scraper/main_test.go
@@ -1,0 +1,44 @@
+package scraper
+
+import (
+	"testing"
+	"time"
+
+	horizonclient "github.com/stellar/go/clients/horizonclient"
+	hProtocol "github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ScraperConfig_FetchAllTrades_doesntCrashWhenReceivesAnError(t *testing.T) {
+	horizonClient := &horizonclient.MockClient{}
+	horizonClient.
+		On("Trades", horizonclient.TradeRequest{Limit: 200, Order: horizonclient.OrderDesc}).
+		Return(hProtocol.TradesPage{}, errors.New("something went wrong"))
+
+	sc := ScraperConfig{
+		Logger: log.DefaultLogger,
+		Client: horizonClient,
+	}
+
+	trades, err := sc.FetchAllTrades(time.Now(), 0)
+	assert.EqualError(t, err, "something went wrong")
+	assert.Empty(t, trades)
+}
+
+func Test_ScraperConfig_FetchAllTrades_doesntCrashWhenReceivesEmptyList(t *testing.T) {
+	horizonClient := &horizonclient.MockClient{}
+	horizonClient.
+		On("Trades", horizonclient.TradeRequest{Limit: 200, Order: horizonclient.OrderDesc}).
+		Return(hProtocol.TradesPage{}, nil)
+
+	sc := ScraperConfig{
+		Logger: log.DefaultLogger,
+		Client: horizonClient,
+	}
+
+	trades, err := sc.FetchAllTrades(time.Now(), 0)
+	assert.NoError(t, err)
+	assert.Empty(t, trades)
+}

--- a/services/ticker/internal/scraper/trade_scraper.go
+++ b/services/ticker/internal/scraper/trade_scraper.go
@@ -90,7 +90,7 @@ func (c *ScraperConfig) streamTrades(h horizonclient.TradeHandler, cursor string
 		Cursor: cursor,
 	}
 
-	return r.StreamTrades(*c.Ctx, c.Client, h)
+	return c.Client.StreamTrades(*c.Ctx, r, h)
 }
 
 // addNativeData adds additional fields when one of the assets is native.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fix `panic: runtime error: index out of range [-1]` issue happening in:
https://github.com/stellar/go/blob/9d9d81ecd855a20d5e2dd2a205e3745959d91e27/services/ticker/internal/scraper/main.go#L138

We were not checking the size of the `trades` array before trying to access its elements. An empty array would throw the `index out of range [-1]` error.

Also, added some tests to make sure this issue will be gracefully handled.

### Why

Some kind of error or empty Ledger resulted in an empty array of trades, which led to the application crashing with `index out of range [-1]`.

Close https://github.com/stellar/java-stellar-anchor-sdk/issues/425.

### Known limitations

I didn't manage to add any tests for this part of the code. AFAIU, we'd need to rewrite part of the code to make it mockable and testable.
