### PR TITLE
exp/lighthorizon/index: Drop building indices for successful transactions.

### DIFF
--- a/exp/lighthorizon/index/cmd/single_test.go
+++ b/exp/lighthorizon/index/cmd/single_test.go
@@ -216,7 +216,7 @@ func IndexLedgerRange(
 			require.NoError(t, err)
 
 			for _, participant := range participants {
-				checkpoint := 1 + (ledger.LedgerSequence() / 64)
+				checkpoint := index.GetCheckpointNumber(ledgerSeq)
 
 				// Track the checkpoint in which activity occurred, keeping the
 				// list duplicate-free.

--- a/exp/lighthorizon/index/modules.go
+++ b/exp/lighthorizon/index/modules.go
@@ -3,9 +3,14 @@ package index
 import (
 	"fmt"
 
+	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/toid"
 	"github.com/stellar/go/xdr"
+)
+
+var (
+	checkpointManager = historyarchive.NewCheckpointManager(0)
 )
 
 func ProcessTransaction(
@@ -19,12 +24,19 @@ func ProcessTransaction(
 	)
 }
 
+// GetCheckpointNumber returns the next checkpoint NUMBER (NOT the checkpoint
+// ledger sequence) corresponding to a given ledger sequence.
+func GetCheckpointNumber(ledger uint32) uint32 {
+	return checkpointManager.GetCheckpoint(ledger) / checkpointManager.GetCheckpointFrequency()
+}
+
 func ProcessAccounts(
 	indexStore Store,
 	ledger xdr.LedgerCloseMeta,
 	tx ingest.LedgerTransaction,
 ) error {
-	checkpoint := (ledger.LedgerSequence() / 64) + 1
+	checkpoint := GetCheckpointNumber(ledger.LedgerSequence())
+
 	allParticipants, err := GetTransactionParticipants(tx)
 	if err != nil {
 		return err
@@ -45,17 +57,17 @@ func ProcessAccounts(
 		return err
 	}
 
-	if tx.Result.Successful() {
-		err = indexStore.AddParticipantsToIndexes(checkpoint, "successful/all", allParticipants)
-		if err != nil {
-			return err
-		}
+	// if tx.Result.Successful() {
+	// 	err = indexStore.AddParticipantsToIndexes(checkpoint, "successful/all", allParticipants)
+	// 	if err != nil {
+	// 		return err
+	// 	}
 
-		err = indexStore.AddParticipantsToIndexes(checkpoint, "successful/payments", paymentsParticipants)
-		if err != nil {
-			return err
-		}
-	}
+	// 	err = indexStore.AddParticipantsToIndexes(checkpoint, "successful/payments", paymentsParticipants)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// }
 
 	return nil
 }
@@ -65,7 +77,8 @@ func ProcessAccountsWithoutBackend(
 	ledger xdr.LedgerCloseMeta,
 	tx ingest.LedgerTransaction,
 ) error {
-	checkpoint := (ledger.LedgerSequence() / 64) + 1
+	checkpoint := GetCheckpointNumber(ledger.LedgerSequence())
+
 	allParticipants, err := GetTransactionParticipants(tx)
 	if err != nil {
 		return err
@@ -86,17 +99,17 @@ func ProcessAccountsWithoutBackend(
 		return err
 	}
 
-	if tx.Result.Successful() {
-		err = indexStore.AddParticipantsToIndexesNoBackend(checkpoint, "successful/all", allParticipants)
-		if err != nil {
-			return err
-		}
+	// if tx.Result.Successful() {
+	// 	err = indexStore.AddParticipantsToIndexesNoBackend(checkpoint, "successful/all", allParticipants)
+	// 	if err != nil {
+	// 		return err
+	// 	}
 
-		err = indexStore.AddParticipantsToIndexesNoBackend(checkpoint, "successful/payments", paymentsParticipants)
-		if err != nil {
-			return err
-		}
-	}
+	// 	err = indexStore.AddParticipantsToIndexesNoBackend(checkpoint, "successful/payments", paymentsParticipants)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// }
 
 	return nil
 }

--- a/exp/lighthorizon/index/modules.go
+++ b/exp/lighthorizon/index/modules.go
@@ -27,7 +27,7 @@ func ProcessTransaction(
 // GetCheckpointNumber returns the next checkpoint NUMBER (NOT the checkpoint
 // ledger sequence) corresponding to a given ledger sequence.
 func GetCheckpointNumber(ledger uint32) uint32 {
-	return checkpointManager.GetCheckpoint(ledger) / checkpointManager.GetCheckpointFrequency()
+	return 1 + (ledger / checkpointManager.GetCheckpointFrequency())
 }
 
 func ProcessAccounts(

--- a/historyarchive/range.go
+++ b/historyarchive/range.go
@@ -39,6 +39,7 @@ func (c CheckpointManager) IsCheckpoint(i uint32) bool {
 	return (i+1)%c.checkpointFreq == 0
 }
 
+// PrevCheckpoint returns the checkpoint ledger preceding `i`.
 func (c CheckpointManager) PrevCheckpoint(i uint32) uint32 {
 	freq := c.checkpointFreq
 	if i < freq {
@@ -47,6 +48,7 @@ func (c CheckpointManager) PrevCheckpoint(i uint32) uint32 {
 	return (((i + 1) / freq) * freq) - 1
 }
 
+// NextCheckpoint returns the checkpoint ledger following `i`.
 func (c CheckpointManager) NextCheckpoint(i uint32) uint32 {
 	if i == 0 {
 		return c.checkpointFreq - 1


### PR DESCRIPTION
### What
For the MVP described in #4317, we don't need indices for successful transactions. We only need them for all transactions and payments, should we decide to expand to that endpoint.

This also slightly unifies the code & its tests to do checkpoint number math consistently.

### Why
This will reduce the index sizes for the MVP.