### PR TITLE
exp/lighthorizon: Isolate cursor advancement code to its own interface

### DIFF
--- a/exp/lighthorizon/index/types/bitmap.go
+++ b/exp/lighthorizon/index/types/bitmap.go
@@ -166,7 +166,9 @@ func (i *CheckpointIndex) Merge(other *CheckpointIndex) error {
 	return err
 }
 
-// NextActive returns the next checkpoint (inclusive) where this index is active.
+// NextActive returns the next checkpoint (inclusive) where this index is
+// active. "Inclusive" means that if the index is active at `checkpoint`, this
+// returns `checkpoint`.
 func (i *CheckpointIndex) NextActive(checkpoint uint32) (uint32, error) {
 	i.mutex.RLock()
 	defer i.mutex.RUnlock()

--- a/exp/lighthorizon/services/cursor.go
+++ b/exp/lighthorizon/services/cursor.go
@@ -1,0 +1,96 @@
+package services
+
+import (
+	"fmt"
+
+	"github.com/stellar/go/exp/lighthorizon/index"
+	"github.com/stellar/go/toid"
+)
+
+// CursorManager describes a way to control how a cursor advances for a
+// particular indexing strategy.
+type CursorManager interface {
+	Begin(cursor int64) (int64, error)
+	Advance() (int64, error)
+}
+
+type AccountTransactionCursorManager struct {
+	AccountId string
+
+	store      index.Store
+	lastCursor *toid.ID
+}
+
+func NewCursorManagerForAccountTransactions(store index.Store, accountId string) *AccountTransactionCursorManager {
+	return &AccountTransactionCursorManager{AccountId: accountId, store: store}
+}
+
+func (c *AccountTransactionCursorManager) Begin(cursor int64) (int64, error) {
+	freq := checkpointManager.GetCheckpointFrequency()
+	id := toid.Parse(cursor)
+	lastCheckpoint := uint32(0)
+	if id.LedgerSequence >= int32(checkpointManager.GetCheckpointFrequency()) {
+		lastCheckpoint = index.GetCheckpointNumber(uint32(id.LedgerSequence))
+	}
+
+	fmt.Println("got", id.LedgerSequence, "checkpoint #", lastCheckpoint)
+
+	// We shouldn't take the provided cursor for granted: instead, we should
+	// skip ahead to the first active ledger that's >= the given cursor.
+	//
+	// For example, someone might say ?cursor=0 but the first active checkpoint
+	// is actually 40M ledgers in.
+	firstCheckpoint, err := c.store.NextActive(c.AccountId, allTransactionsIndex, lastCheckpoint)
+	if err != nil {
+		return cursor, err
+	}
+
+	nextLedger := (firstCheckpoint - 1) * freq
+
+	// However, if the given cursor is actually *more* specific than the index
+	// can give us (e.g. somewhere *within* an active checkpoint range), prefer
+	// it rather than starting over.
+	if nextLedger < uint32(id.LedgerSequence) {
+		better := toid.Parse(cursor)
+		c.lastCursor = &better
+		return cursor, nil
+	}
+
+	c.lastCursor = toid.New(int32(nextLedger), 1, 1)
+	return c.lastCursor.ToInt64(), nil
+}
+
+func (c *AccountTransactionCursorManager) Advance() (int64, error) {
+	if c.lastCursor == nil {
+		panic("invalid cursor, call Begin() first")
+	}
+
+	// Advancing the cursor means deciding whether or not we need to query the
+	// index.
+
+	lastLedger := uint32(c.lastCursor.LedgerSequence)
+	freq := checkpointManager.GetCheckpointFrequency()
+
+	if checkpointManager.IsCheckpoint(lastLedger) {
+		// If the last cursor we looked at was a checkpoint ledger, then we need
+		// to jump ahead to the next checkpoint.
+		checkpoint := index.GetCheckpointNumber(uint32(c.lastCursor.LedgerSequence))
+		checkpoint, err := c.store.NextActive(c.AccountId, allTransactionsIndex, checkpoint+1)
+
+		if err != nil {
+			return c.lastCursor.ToInt64(), err
+		}
+
+		// We add a -1 here because an active checkpoint indicates that an
+		// account had activity in the *previous* 64 ledgers, so we need to
+		// backtrack to that ledger range.
+		c.lastCursor = toid.New(int32((checkpoint-1)*freq), 1, 1)
+	} else {
+		// Otherwise, we can just bump the ledger number.
+		c.lastCursor = toid.New(int32(lastLedger+1), 1, 1)
+	}
+
+	return c.lastCursor.ToInt64(), nil
+}
+
+var _ CursorManager = (*AccountTransactionCursorManager)(nil) // ensure conformity to the interface

--- a/exp/lighthorizon/services/cursor.go
+++ b/exp/lighthorizon/services/cursor.go
@@ -14,18 +14,18 @@ type CursorManager interface {
 	Advance() (int64, error)
 }
 
-type AccountTransactionCursorManager struct {
+type AccountActivityCursorManager struct {
 	AccountId string
 
 	store      index.Store
 	lastCursor *toid.ID
 }
 
-func NewCursorManagerForAccountTransactions(store index.Store, accountId string) *AccountTransactionCursorManager {
-	return &AccountTransactionCursorManager{AccountId: accountId, store: store}
+func NewCursorManagerForAccountActivity(store index.Store, accountId string) *AccountActivityCursorManager {
+	return &AccountActivityCursorManager{AccountId: accountId, store: store}
 }
 
-func (c *AccountTransactionCursorManager) Begin(cursor int64) (int64, error) {
+func (c *AccountActivityCursorManager) Begin(cursor int64) (int64, error) {
 	freq := checkpointManager.GetCheckpointFrequency()
 	id := toid.Parse(cursor)
 	lastCheckpoint := uint32(0)
@@ -60,7 +60,7 @@ func (c *AccountTransactionCursorManager) Begin(cursor int64) (int64, error) {
 	return c.lastCursor.ToInt64(), nil
 }
 
-func (c *AccountTransactionCursorManager) Advance() (int64, error) {
+func (c *AccountActivityCursorManager) Advance() (int64, error) {
 	if c.lastCursor == nil {
 		panic("invalid cursor, call Begin() first")
 	}
@@ -93,4 +93,4 @@ func (c *AccountTransactionCursorManager) Advance() (int64, error) {
 	return c.lastCursor.ToInt64(), nil
 }
 
-var _ CursorManager = (*AccountTransactionCursorManager)(nil) // ensure conformity to the interface
+var _ CursorManager = (*AccountActivityCursorManager)(nil) // ensure conformity to the interface

--- a/exp/lighthorizon/services/cursor.go
+++ b/exp/lighthorizon/services/cursor.go
@@ -1,8 +1,6 @@
 package services
 
 import (
-	"fmt"
-
 	"github.com/stellar/go/exp/lighthorizon/index"
 	"github.com/stellar/go/toid"
 )
@@ -32,8 +30,6 @@ func (c *AccountActivityCursorManager) Begin(cursor int64) (int64, error) {
 	if id.LedgerSequence >= int32(checkpointManager.GetCheckpointFrequency()) {
 		lastCheckpoint = index.GetCheckpointNumber(uint32(id.LedgerSequence))
 	}
-
-	fmt.Println("got", id.LedgerSequence, "checkpoint #", lastCheckpoint)
 
 	// We shouldn't take the provided cursor for granted: instead, we should
 	// skip ahead to the first active ledger that's >= the given cursor.
@@ -73,10 +69,11 @@ func (c *AccountActivityCursorManager) Advance() (int64, error) {
 
 	if checkpointManager.IsCheckpoint(lastLedger) {
 		// If the last cursor we looked at was a checkpoint ledger, then we need
-		// to jump ahead to the next checkpoint.
+		// to jump ahead to the next checkpoint. Note that NextActive() is
+		// "inclusive" so if the parameter is an active checkpoint it will
+		// return itself.
 		checkpoint := index.GetCheckpointNumber(uint32(c.lastCursor.LedgerSequence))
 		checkpoint, err := c.store.NextActive(c.AccountId, allTransactionsIndex, checkpoint+1)
-
 		if err != nil {
 			return c.lastCursor.ToInt64(), err
 		}
@@ -94,3 +91,8 @@ func (c *AccountActivityCursorManager) Advance() (int64, error) {
 }
 
 var _ CursorManager = (*AccountActivityCursorManager)(nil) // ensure conformity to the interface
+
+// getLedgerFromCursor is a helpful way to turn a cursor into a ledger number
+func getLedgerFromCursor(cursor int64) uint32 {
+	return uint32(toid.Parse(cursor).LedgerSequence)
+}

--- a/exp/lighthorizon/services/cursor_test.go
+++ b/exp/lighthorizon/services/cursor_test.go
@@ -1,0 +1,74 @@
+package services
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stellar/go/exp/lighthorizon/index"
+	"github.com/stellar/go/historyarchive"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/toid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	checkpointMgr = historyarchive.NewCheckpointManager(0)
+)
+
+func TestAccountTransactionCursorManager(t *testing.T) {
+	freq := int32(checkpointMgr.GetCheckpointFrequency())
+	accountId := keypair.MustRandom().Address()
+
+	// Create an index and fill it with some checkpoint details.
+	store, err := index.NewFileStore(index.StoreConfig{
+		Url:     "file://" + t.TempDir(),
+		Workers: 4,
+	})
+	require.NoError(t, err)
+
+	for _, checkpoint := range []uint32{
+		1, 5, 10,
+	} {
+		require.NoError(t, store.AddParticipantsToIndexes(
+			checkpoint, allTransactionsIndex, []string{accountId}))
+	}
+
+	cursorMgr := NewCursorManagerForAccountTransactions(store, accountId)
+
+	cursor := toid.New(1, 1, 1)
+	var nextCursor int64
+
+	nextCursor, err = cursorMgr.Begin(cursor.ToInt64())
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, getLedgerFromCursor(nextCursor))
+
+	cursor.LedgerSequence = freq / 2
+	nextCursor, err = cursorMgr.Begin(cursor.ToInt64())
+	require.NoError(t, err)
+	assert.EqualValues(t, cursor.LedgerSequence, getLedgerFromCursor(nextCursor))
+
+	cursor.LedgerSequence = 2 * freq
+	nextCursor, err = cursorMgr.Begin(cursor.ToInt64())
+	require.NoError(t, err)
+	assert.EqualValues(t, 4*freq, getLedgerFromCursor(nextCursor))
+
+	for i := int32(1); i < freq; i++ {
+		nextCursor, err = cursorMgr.Advance()
+		require.NoError(t, err)
+		assert.EqualValues(t, 4*freq+i, getLedgerFromCursor(nextCursor))
+	}
+
+	nextCursor, err = cursorMgr.Advance()
+	require.NoError(t, err)
+	assert.EqualValues(t, 9*freq, getLedgerFromCursor(nextCursor))
+
+	for i := int32(1); i < freq; i++ {
+		nextCursor, err = cursorMgr.Advance()
+		require.NoError(t, err)
+		assert.EqualValues(t, 9*freq+i, getLedgerFromCursor(nextCursor))
+	}
+
+	_, err = cursorMgr.Advance()
+	assert.ErrorIs(t, err, io.EOF)
+}

--- a/exp/lighthorizon/services/cursor_test.go
+++ b/exp/lighthorizon/services/cursor_test.go
@@ -34,7 +34,7 @@ func TestAccountTransactionCursorManager(t *testing.T) {
 			checkpoint, allTransactionsIndex, []string{accountId}))
 	}
 
-	cursorMgr := NewCursorManagerForAccountTransactions(store, accountId)
+	cursorMgr := NewCursorManagerForAccountActivity(store, accountId)
 
 	cursor := toid.New(1, 1, 1)
 	var nextCursor int64

--- a/exp/lighthorizon/services/cursor_test.go
+++ b/exp/lighthorizon/services/cursor_test.go
@@ -27,9 +27,7 @@ func TestAccountTransactionCursorManager(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	for _, checkpoint := range []uint32{
-		1, 5, 10,
-	} {
+	for _, checkpoint := range []uint32{1, 5, 10} {
 		require.NoError(t, store.AddParticipantsToIndexes(
 			checkpoint, allTransactionsIndex, []string{accountId}))
 	}
@@ -39,15 +37,18 @@ func TestAccountTransactionCursorManager(t *testing.T) {
 	cursor := toid.New(1, 1, 1)
 	var nextCursor int64
 
+	// first checkpoint works
 	nextCursor, err = cursorMgr.Begin(cursor.ToInt64())
 	require.NoError(t, err)
 	assert.EqualValues(t, 1, getLedgerFromCursor(nextCursor))
 
+	// cursor is preserved if mid-active-range
 	cursor.LedgerSequence = freq / 2
 	nextCursor, err = cursorMgr.Begin(cursor.ToInt64())
 	require.NoError(t, err)
 	assert.EqualValues(t, cursor.LedgerSequence, getLedgerFromCursor(nextCursor))
 
+	// cursor jumps ahead if not active
 	cursor.LedgerSequence = 2 * freq
 	nextCursor, err = cursorMgr.Begin(cursor.ToInt64())
 	require.NoError(t, err)
@@ -59,16 +60,19 @@ func TestAccountTransactionCursorManager(t *testing.T) {
 		assert.EqualValues(t, 4*freq+i, getLedgerFromCursor(nextCursor))
 	}
 
+	// cursor jumps to next active checkpoint
 	nextCursor, err = cursorMgr.Advance()
 	require.NoError(t, err)
 	assert.EqualValues(t, 9*freq, getLedgerFromCursor(nextCursor))
 
+	// cursor increments
 	for i := int32(1); i < freq; i++ {
 		nextCursor, err = cursorMgr.Advance()
 		require.NoError(t, err)
 		assert.EqualValues(t, 9*freq+i, getLedgerFromCursor(nextCursor))
 	}
 
+	// cursor stops when no more actives
 	_, err = cursorMgr.Advance()
 	assert.ErrorIs(t, err, io.EOF)
 }

--- a/exp/lighthorizon/services/main.go
+++ b/exp/lighthorizon/services/main.go
@@ -53,10 +53,10 @@ type TransactionRepository interface {
 	GetTransactionsByAccount(ctx context.Context, cursor int64, limit uint64, accountId string) ([]common.Transaction, error)
 }
 
-// SearchCallback is a generic way for any endpoint to process a transaction and
+// searchCallback is a generic way for any endpoint to process a transaction and
 // its corresponding ledger. It should return whether or not we should stop
 // processing (e.g. when a limit is reached) and any error that occurred.
-type SearchCallback func(archive.LedgerTransaction, *xdr.LedgerHeader) (finished bool, err error)
+type searchCallback func(archive.LedgerTransaction, *xdr.LedgerHeader) (finished bool, err error)
 
 func (os *OperationsService) GetOperationsByAccount(ctx context.Context,
 	cursor int64, limit uint64,
@@ -120,7 +120,7 @@ func (ts *TransactionsService) GetTransactionsByAccount(ctx context.Context,
 	return txs, nil
 }
 
-func searchTxByAccount(ctx context.Context, cursor int64, accountId string, config Config, callback SearchCallback) error {
+func searchTxByAccount(ctx context.Context, cursor int64, accountId string, config Config, callback searchCallback) error {
 	cursorMgr := NewCursorManagerForAccountTransactions(config.IndexStore, accountId)
 	cursor, err := cursorMgr.Begin(cursor)
 	if err == io.EOF {

--- a/exp/lighthorizon/services/main.go
+++ b/exp/lighthorizon/services/main.go
@@ -121,7 +121,7 @@ func (ts *TransactionsService) GetTransactionsByAccount(ctx context.Context,
 }
 
 func searchTxByAccount(ctx context.Context, cursor int64, accountId string, config Config, callback searchCallback) error {
-	cursorMgr := NewCursorManagerForAccountTransactions(config.IndexStore, accountId)
+	cursorMgr := NewCursorManagerForAccountActivity(config.IndexStore, accountId)
 	cursor, err := cursorMgr.Begin(cursor)
 	if err == io.EOF {
 		return nil

--- a/exp/lighthorizon/services/main.go
+++ b/exp/lighthorizon/services/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stellar/go/exp/lighthorizon/common"
 	"github.com/stellar/go/exp/lighthorizon/index"
 	"github.com/stellar/go/historyarchive"
-	"github.com/stellar/go/toid"
 	"github.com/stellar/go/xdr"
 
 	"github.com/stellar/go/support/errors"
@@ -80,7 +79,7 @@ func (os *OperationsService) GetOperationsByAccount(ctx context.Context,
 					OpIndex:             int32(operationOrder),
 				})
 
-				if uint64(len(ops)) >= limit {
+				if uint64(len(ops)) == limit {
 					return true, nil
 				}
 			}
@@ -111,7 +110,7 @@ func (ts *TransactionsService) GetTransactionsByAccount(ctx context.Context,
 			NetworkPassphrase:   ts.Config.Passphrase,
 		})
 
-		return (uint64(len(txs)) >= limit), nil
+		return uint64(len(txs)) == limit, nil
 	}
 
 	if err := searchTxByAccount(ctx, cursor, accountId, ts.Config, txsCallback); err != nil {
@@ -180,8 +179,4 @@ func searchTxByAccount(ctx context.Context, cursor int64, accountId string, conf
 
 		nextLedger = getLedgerFromCursor(cursor)
 	}
-}
-
-func getLedgerFromCursor(cursor int64) uint32 {
-	return uint32(toid.Parse(cursor).LedgerSequence)
 }

--- a/exp/lighthorizon/services/main_test.go
+++ b/exp/lighthorizon/services/main_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stellar/go/exp/lighthorizon/archive"
 	"github.com/stellar/go/exp/lighthorizon/index"
-	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/toid"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
@@ -16,78 +15,80 @@ import (
 
 var (
 	accountId      = "GDCXSQPVE45DVGT2ZRFFIIHSJ2EJED65W6AELGWIDRMPMWNXCEBJ4FKX"
-	checkpointFreq = int32(historyarchive.DefaultCheckpointFrequency)
+	startLedgerSeq = 1586112
 )
 
-func TestItGetsTransactionsByAccount(tt *testing.T) {
+func TestItGetsTransactionsByAccount(t *testing.T) {
 	ctx := context.Background()
-	txService := newTransactionService(ctx)
 
-	// l=1586045, t=1, o=1
-	// cursor = 6812011404988417, checkpoint=24781
-	ledgerSeq := uint32(1586045)
+	// this is in the checkpoint range prior to the first active checkpoint
+	ledgerSeq := checkpointMgr.PrevCheckpoint(uint32(startLedgerSeq))
 	cursor := toid.New(int32(ledgerSeq), 1, 1).ToInt64()
-	require.Equal(tt, 24782, int(index.GetCheckpointNumber(ledgerSeq))) // sanity
-	require.Equal(tt, int64(6812011404988417), cursor)                  // sanity
 
-	// this should start at next checkpoint
-	txs, err := txService.GetTransactionsByAccount(ctx, cursor, 1, accountId)
-	require.NoError(tt, err)
-	require.Len(tt, txs, 1)
-	require.Equal(tt, txs[0].LedgerHeader.LedgerSeq, xdr.Uint32(1586113))
-	require.Equal(tt, txs[0].TxIndex, int32(2))
+	t.Run("first", func(tt *testing.T) {
+		txService := newTransactionService(ctx)
+
+		txs, err := txService.GetTransactionsByAccount(ctx, cursor, 1, accountId)
+		require.NoError(tt, err)
+		require.Len(tt, txs, 1)
+		require.Equal(tt, txs[0].LedgerHeader.LedgerSeq, xdr.Uint32(1586113))
+		require.EqualValues(tt, txs[0].TxIndex, 2)
+	})
+
+	t.Run("without cursor", func(tt *testing.T) {
+		txService := newTransactionService(ctx)
+
+		txs, err := txService.GetTransactionsByAccount(ctx, 0, 1, accountId)
+		require.NoError(tt, err)
+		require.Len(tt, txs, 1)
+		require.Equal(tt, txs[0].LedgerHeader.LedgerSeq, xdr.Uint32(1586113))
+		require.EqualValues(tt, txs[0].TxIndex, 2)
+	})
+
+	t.Run("with limit", func(tt *testing.T) {
+		txService := newTransactionService(ctx)
+
+		txs, err := txService.GetTransactionsByAccount(ctx, cursor, 5, accountId)
+		require.NoError(tt, err)
+		require.Len(tt, txs, 2)
+		require.Equal(tt, txs[0].LedgerHeader.LedgerSeq, xdr.Uint32(1586113))
+		require.EqualValues(tt, txs[0].TxIndex, 2)
+		require.Equal(tt, txs[1].LedgerHeader.LedgerSeq, xdr.Uint32(1586114))
+		require.EqualValues(tt, txs[1].TxIndex, 1)
+	})
 }
 
-func TestItGetsTransactionsByAccountAndPageLimit(tt *testing.T) {
+func TestItGetsOperationsByAccount(t *testing.T) {
 	ctx := context.Background()
-	txService := newTransactionService(ctx)
 
-	checkpoint := int32(24781)
-	cursor := toid.New(checkpoint*checkpointFreq, 1, 1).ToInt64()
-	require.Equal(tt, int64(6812011404988417), cursor)
+	// this is in the checkpoint range prior to the first active checkpoint
+	ledgerSeq := checkpointMgr.PrevCheckpoint(uint32(startLedgerSeq))
+	cursor := toid.New(int32(ledgerSeq), 1, 1).ToInt64()
 
-	// this should start at next checkpoint
-	txs, err := txService.GetTransactionsByAccount(ctx, cursor, 5, accountId)
-	require.NoError(tt, err)
-	require.Len(tt, txs, 2)
-	require.Equal(tt, txs[0].LedgerHeader.LedgerSeq, xdr.Uint32(1586113))
-	require.Equal(tt, txs[0].TxIndex, int32(2))
-	require.Equal(tt, txs[1].LedgerHeader.LedgerSeq, xdr.Uint32(1586114))
-	require.Equal(tt, txs[1].TxIndex, int32(1))
-}
+	t.Run("first", func(tt *testing.T) {
+		opsService := newOperationService(ctx)
 
-func TestItGetsOperationsByAccount(tt *testing.T) {
-	ctx := context.Background()
-	opsService := newOperationService(ctx)
+		// this should start at next checkpoint
+		ops, err := opsService.GetOperationsByAccount(ctx, cursor, 1, accountId)
+		require.NoError(tt, err)
+		require.Len(tt, ops, 1)
+		require.Equal(tt, ops[0].LedgerHeader.LedgerSeq, xdr.Uint32(1586113))
+		require.Equal(tt, ops[0].TxIndex, int32(2))
 
-	// l=1586045, t=1, o=1
-	// cursor = 6812011404988417, checkpoint=24781
-	cursor := int64(6812011404988417)
+	})
 
-	// this should start at next checkpoint
-	ops, err := opsService.GetOperationsByAccount(ctx, cursor, 1, accountId)
-	require.NoError(tt, err)
-	require.Len(tt, ops, 1)
-	require.Equal(tt, ops[0].LedgerHeader.LedgerSeq, xdr.Uint32(1586113))
-	require.Equal(tt, ops[0].TxIndex, int32(2))
-}
+	t.Run("with limit", func(tt *testing.T) {
+		opsService := newOperationService(ctx)
 
-func TestItGetsOperationsByAccountAndPageLimit(tt *testing.T) {
-	ctx := context.Background()
-	opsService := newOperationService(ctx)
-
-	// cursor = 6812011404988417, checkpoint=24781
-	cursor := toid.New(1586045, 1, 1).ToInt64()
-	require.Equal(tt, int64(6812011404988417), cursor)
-
-	// this should start at next checkpoint
-	ops, err := opsService.GetOperationsByAccount(ctx, cursor, 5, accountId)
-	require.NoError(tt, err)
-	require.Len(tt, ops, 2)
-	require.Equal(tt, ops[0].LedgerHeader.LedgerSeq, xdr.Uint32(1586113))
-	require.Equal(tt, ops[0].TxIndex, int32(2))
-	require.Equal(tt, ops[1].LedgerHeader.LedgerSeq, xdr.Uint32(1586114))
-	require.Equal(tt, ops[1].TxIndex, int32(1))
+		// this should start at next checkpoint
+		ops, err := opsService.GetOperationsByAccount(ctx, cursor, 5, accountId)
+		require.NoError(tt, err)
+		require.Len(tt, ops, 2)
+		require.Equal(tt, ops[0].LedgerHeader.LedgerSeq, xdr.Uint32(1586113))
+		require.Equal(tt, ops[0].TxIndex, int32(2))
+		require.Equal(tt, ops[1].LedgerHeader.LedgerSeq, xdr.Uint32(1586114))
+		require.Equal(tt, ops[1].TxIndex, int32(1))
+	})
 }
 
 func mockArchiveAndIndex(ctx context.Context, passphrase string) (archive.Archive, index.Store) {
@@ -97,10 +98,9 @@ func mockArchiveAndIndex(ctx context.Context, passphrase string) (archive.Archiv
 	mockReaderLedger3 := &archive.MockLedgerTransactionReader{}
 	mockReaderLedgerTheRest := &archive.MockLedgerTransactionReader{}
 
-	ledgerSeq := 1586112
-	expectedLedger1 := testLedger(ledgerSeq)
-	expectedLedger2 := testLedger(ledgerSeq + 1)
-	expectedLedger3 := testLedger(ledgerSeq + 2)
+	expectedLedger1 := testLedger(startLedgerSeq)
+	expectedLedger2 := testLedger(startLedgerSeq + 1)
+	expectedLedger3 := testLedger(startLedgerSeq + 2)
 
 	// throw an irrelevant account in there to make sure it's filtered
 	source := xdr.MustAddress("GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU")
@@ -168,12 +168,16 @@ func mockArchiveAndIndex(ctx context.Context, passphrase string) (archive.Archiv
 	mockReaderLedgerTheRest.
 		On("Read").Return(archive.LedgerTransaction{}, io.EOF)
 
-	checkpoint := index.GetCheckpointNumber(uint32(ledgerSeq))
+	// should be 24784
+	firstActiveChk := uint32(index.GetCheckpointNumber(uint32(startLedgerSeq)))
 	mockStore := &index.MockStore{}
 	mockStore.
-		On("NextActive", accountId, mock.Anything, uint32(checkpoint)).Return(uint32(checkpoint+1), nil).
-		On("NextActive", accountId, mock.Anything, uint32(checkpoint+1)).Return(uint32(checkpoint+2), nil).
-		On("NextActive", accountId, mock.Anything, uint32(checkpoint+2)).Return(uint32(0), io.EOF)
+		On("NextActive", accountId, mock.Anything, uint32(0)).Return(firstActiveChk, nil).
+		On("NextActive", accountId, mock.Anything, firstActiveChk-2).Return(firstActiveChk, nil).
+		On("NextActive", accountId, mock.Anything, firstActiveChk-1).Return(firstActiveChk, nil).
+		On("NextActive", accountId, mock.Anything, firstActiveChk).Return(firstActiveChk+1, nil).
+		On("NextActive", accountId, mock.Anything, firstActiveChk+1).Return(firstActiveChk+2, nil).
+		On("NextActive", accountId, mock.Anything, firstActiveChk+2).Return(0, io.EOF)
 
 	return mockArchive, mockStore
 }

--- a/exp/lighthorizon/services/main_test.go
+++ b/exp/lighthorizon/services/main_test.go
@@ -173,11 +173,10 @@ func mockArchiveAndIndex(ctx context.Context, passphrase string) (archive.Archiv
 	mockStore := &index.MockStore{}
 	mockStore.
 		On("NextActive", accountId, mock.Anything, uint32(0)).Return(firstActiveChk, nil).
-		On("NextActive", accountId, mock.Anything, firstActiveChk-2).Return(firstActiveChk, nil).
 		On("NextActive", accountId, mock.Anything, firstActiveChk-1).Return(firstActiveChk, nil).
-		On("NextActive", accountId, mock.Anything, firstActiveChk).Return(firstActiveChk+1, nil).
-		On("NextActive", accountId, mock.Anything, firstActiveChk+1).Return(firstActiveChk+2, nil).
-		On("NextActive", accountId, mock.Anything, firstActiveChk+2).Return(0, io.EOF)
+		On("NextActive", accountId, mock.Anything, firstActiveChk).Return(firstActiveChk, nil).
+		On("NextActive", accountId, mock.Anything, firstActiveChk+1).Return(firstActiveChk+1, nil).
+		On("NextActive", accountId, mock.Anything, firstActiveChk+2).Return(uint32(0), io.EOF)
 
 	return mockArchive, mockStore
 }

--- a/exp/lighthorizon/services/main_test.go
+++ b/exp/lighthorizon/services/main_test.go
@@ -7,27 +7,29 @@ import (
 
 	"github.com/stellar/go/exp/lighthorizon/archive"
 	"github.com/stellar/go/exp/lighthorizon/index"
+	"github.com/stellar/go/historyarchive"
+	"github.com/stellar/go/toid"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	accountId      = "GDCXSQPVE45DVGT2ZRFFIIHSJ2EJED65W6AELGWIDRMPMWNXCEBJ4FKX"
+	checkpointFreq = int32(historyarchive.DefaultCheckpointFrequency)
+)
+
 func TestItGetsTransactionsByAccount(tt *testing.T) {
+	ctx := context.Background()
+	txService := newTransactionService(ctx)
+
 	// l=1586045, t=1, o=1
 	// cursor = 6812011404988417, checkpoint=24781
+	ledgerSeq := uint32(1586045)
+	cursor := toid.New(int32(ledgerSeq), 1, 1).ToInt64()
+	require.Equal(tt, 24782, int(index.GetCheckpointNumber(ledgerSeq))) // sanity
+	require.Equal(tt, int64(6812011404988417), cursor)                  // sanity
 
-	cursor := int64(6812011404988417)
-	ctx := context.Background()
-	passphrase := "White New England clam chowder"
-	archive, store := mockArchiveAndIndex(ctx, passphrase)
-	txService := TransactionsService{
-		Config: Config{
-			Archive:    archive,
-			IndexStore: store,
-			Passphrase: passphrase,
-		},
-	}
-	accountId := "GDCXSQPVE45DVGT2ZRFFIIHSJ2EJED65W6AELGWIDRMPMWNXCEBJ4FKX"
 	// this should start at next checkpoint
 	txs, err := txService.GetTransactionsByAccount(ctx, cursor, 1, accountId)
 	require.NoError(tt, err)
@@ -37,21 +39,13 @@ func TestItGetsTransactionsByAccount(tt *testing.T) {
 }
 
 func TestItGetsTransactionsByAccountAndPageLimit(tt *testing.T) {
-	// l=1586045, t=1, o=1
-	// cursor = 6812011404988417, checkpoint=24781
-
-	cursor := int64(6812011404988417)
 	ctx := context.Background()
-	passphrase := "White New England clam chowder"
-	archive, store := mockArchiveAndIndex(ctx, passphrase)
-	txService := TransactionsService{
-		Config: Config{
-			Archive:    archive,
-			IndexStore: store,
-			Passphrase: passphrase,
-		},
-	}
-	accountId := "GDCXSQPVE45DVGT2ZRFFIIHSJ2EJED65W6AELGWIDRMPMWNXCEBJ4FKX"
+	txService := newTransactionService(ctx)
+
+	checkpoint := int32(24781)
+	cursor := toid.New(checkpoint*checkpointFreq, 1, 1).ToInt64()
+	require.Equal(tt, int64(6812011404988417), cursor)
+
 	// this should start at next checkpoint
 	txs, err := txService.GetTransactionsByAccount(ctx, cursor, 5, accountId)
 	require.NoError(tt, err)
@@ -63,21 +57,13 @@ func TestItGetsTransactionsByAccountAndPageLimit(tt *testing.T) {
 }
 
 func TestItGetsOperationsByAccount(tt *testing.T) {
+	ctx := context.Background()
+	opsService := newOperationService(ctx)
+
 	// l=1586045, t=1, o=1
 	// cursor = 6812011404988417, checkpoint=24781
-
 	cursor := int64(6812011404988417)
-	ctx := context.Background()
-	passphrase := "White New England clam chowder"
-	archive, store := mockArchiveAndIndex(ctx, passphrase)
-	opsService := OperationsService{
-		Config: Config{
-			Archive:    archive,
-			IndexStore: store,
-			Passphrase: passphrase,
-		},
-	}
-	accountId := "GDCXSQPVE45DVGT2ZRFFIIHSJ2EJED65W6AELGWIDRMPMWNXCEBJ4FKX"
+
 	// this should start at next checkpoint
 	ops, err := opsService.GetOperationsByAccount(ctx, cursor, 1, accountId)
 	require.NoError(tt, err)
@@ -87,21 +73,13 @@ func TestItGetsOperationsByAccount(tt *testing.T) {
 }
 
 func TestItGetsOperationsByAccountAndPageLimit(tt *testing.T) {
-	// l=1586045, t=1, o=1
-	// cursor = 6812011404988417, checkpoint=24781
-
-	cursor := int64(6812011404988417)
 	ctx := context.Background()
-	passphrase := "White New England clam chowder"
-	archive, store := mockArchiveAndIndex(ctx, passphrase)
-	opsService := OperationsService{
-		Config: Config{
-			Archive:    archive,
-			IndexStore: store,
-			Passphrase: passphrase,
-		},
-	}
-	accountId := "GDCXSQPVE45DVGT2ZRFFIIHSJ2EJED65W6AELGWIDRMPMWNXCEBJ4FKX"
+	opsService := newOperationService(ctx)
+
+	// cursor = 6812011404988417, checkpoint=24781
+	cursor := toid.New(1586045, 1, 1).ToInt64()
+	require.Equal(tt, int64(6812011404988417), cursor)
+
 	// this should start at next checkpoint
 	ops, err := opsService.GetOperationsByAccount(ctx, cursor, 5, accountId)
 	require.NoError(tt, err)
@@ -113,72 +91,89 @@ func TestItGetsOperationsByAccountAndPageLimit(tt *testing.T) {
 }
 
 func mockArchiveAndIndex(ctx context.Context, passphrase string) (archive.Archive, index.Store) {
-
 	mockArchive := &archive.MockArchive{}
 	mockReaderLedger1 := &archive.MockLedgerTransactionReader{}
 	mockReaderLedger2 := &archive.MockLedgerTransactionReader{}
 	mockReaderLedger3 := &archive.MockLedgerTransactionReader{}
 	mockReaderLedgerTheRest := &archive.MockLedgerTransactionReader{}
 
-	expectedLedger1 := testLedger(1586112)
-	expectedLedger2 := testLedger(1586113)
-	expectedLedger3 := testLedger(1586114)
+	ledgerSeq := 1586112
+	expectedLedger1 := testLedger(ledgerSeq)
+	expectedLedger2 := testLedger(ledgerSeq + 1)
+	expectedLedger3 := testLedger(ledgerSeq + 2)
+
+	// throw an irrelevant account in there to make sure it's filtered
 	source := xdr.MustAddress("GCXKG6RN4ONIEPCMNFB732A436Z5PNDSRLGWK7GBLCMQLIFO4S7EYWVU")
-	source2 := xdr.MustAddress("GDCXSQPVE45DVGT2ZRFFIIHSJ2EJED65W6AELGWIDRMPMWNXCEBJ4FKX")
+	source2 := xdr.MustAddress(accountId)
+
 	// assert results iterate sequentially across ops-tx-ledgers
-	expectedLedger1Transaction1 := testLedgerTx(source, []int{34, 34}, 1)
-	expectedLedger1Transaction2 := testLedgerTx(source, []int{34}, 2)
-	expectedLedger2Transaction1 := testLedgerTx(source, []int{34}, 1)
-	expectedLedger2Transaction2 := testLedgerTx(source2, []int{34}, 2)
-	expectedLedger3Transaction1 := testLedgerTx(source2, []int{34}, 1)
-	expectedLedger3Transaction2 := testLedgerTx(source, []int{34}, 2)
+	expectedLedger1Tx1 := testLedgerTx(source, 1, 34, 35)
+	expectedLedger1Tx2 := testLedgerTx(source, 2, 34)
+	expectedLedger2Tx1 := testLedgerTx(source, 1, 34)
+	expectedLedger2Tx2 := testLedgerTx(source2, 2, 34)
+	expectedLedger3Tx1 := testLedgerTx(source2, 1, 34)
+	expectedLedger3Tx2 := testLedgerTx(source, 2, 34)
 
-	mockArchive.On("GetLedger", ctx, uint32(1586112)).Return(expectedLedger1, nil)
-	mockArchive.On("GetLedger", ctx, uint32(1586113)).Return(expectedLedger2, nil)
-	mockArchive.On("GetLedger", ctx, uint32(1586114)).Return(expectedLedger3, nil)
-	mockArchive.On("GetLedger", ctx, mock.Anything).Return(xdr.LedgerCloseMeta{}, nil)
+	mockArchive.
+		On("GetLedger", ctx, uint32(1586112)).Return(expectedLedger1, nil).
+		On("GetLedger", ctx, uint32(1586113)).Return(expectedLedger2, nil).
+		On("GetLedger", ctx, uint32(1586114)).Return(expectedLedger3, nil).
+		On("GetLedger", ctx, mock.Anything).Return(xdr.LedgerCloseMeta{}, nil)
 
-	mockArchive.On("NewLedgerTransactionReaderFromLedgerCloseMeta", passphrase, expectedLedger1).Return(mockReaderLedger1, nil)
-	mockArchive.On("NewLedgerTransactionReaderFromLedgerCloseMeta", passphrase, expectedLedger2).Return(mockReaderLedger2, nil)
-	mockArchive.On("NewLedgerTransactionReaderFromLedgerCloseMeta", passphrase, expectedLedger3).Return(mockReaderLedger3, nil)
-	mockArchive.On("NewLedgerTransactionReaderFromLedgerCloseMeta", passphrase, mock.Anything).Return(mockReaderLedgerTheRest, nil)
+	mockArchive.
+		On("NewLedgerTransactionReaderFromLedgerCloseMeta", passphrase, expectedLedger1).Return(mockReaderLedger1, nil).
+		On("NewLedgerTransactionReaderFromLedgerCloseMeta", passphrase, expectedLedger2).Return(mockReaderLedger2, nil).
+		On("NewLedgerTransactionReaderFromLedgerCloseMeta", passphrase, expectedLedger3).Return(mockReaderLedger3, nil).
+		On("NewLedgerTransactionReaderFromLedgerCloseMeta", passphrase, mock.Anything).Return(mockReaderLedgerTheRest, nil)
 
 	partialParticipants := make(map[string]struct{})
 	partialParticipants[source.Address()] = struct{}{}
+
 	allParticipants := make(map[string]struct{})
 	allParticipants[source.Address()] = struct{}{}
 	allParticipants[source2.Address()] = struct{}{}
 
-	mockArchive.On("GetTransactionParticipants", expectedLedger1Transaction1).Return(partialParticipants, nil)
-	mockArchive.On("GetTransactionParticipants", expectedLedger1Transaction2).Return(partialParticipants, nil)
-	mockArchive.On("GetTransactionParticipants", expectedLedger2Transaction1).Return(partialParticipants, nil)
-	mockArchive.On("GetTransactionParticipants", expectedLedger2Transaction2).Return(allParticipants, nil)
-	mockArchive.On("GetTransactionParticipants", expectedLedger3Transaction1).Return(allParticipants, nil)
-	mockArchive.On("GetTransactionParticipants", expectedLedger3Transaction2).Return(partialParticipants, nil)
+	mockArchive.
+		On("GetTransactionParticipants", expectedLedger1Tx1).Return(partialParticipants, nil).
+		On("GetTransactionParticipants", expectedLedger1Tx2).Return(partialParticipants, nil).
+		On("GetTransactionParticipants", expectedLedger2Tx1).Return(partialParticipants, nil).
+		On("GetTransactionParticipants", expectedLedger2Tx2).Return(allParticipants, nil).
+		On("GetTransactionParticipants", expectedLedger3Tx1).Return(allParticipants, nil).
+		On("GetTransactionParticipants", expectedLedger3Tx2).Return(partialParticipants, nil)
 
-	mockArchive.On("GetOperationParticipants", expectedLedger1Transaction1, mock.Anything, int(0)).Return(partialParticipants, nil)
-	mockArchive.On("GetOperationParticipants", expectedLedger1Transaction1, mock.Anything, int(1)).Return(partialParticipants, nil)
-	mockArchive.On("GetOperationParticipants", expectedLedger1Transaction2, mock.Anything, int(0)).Return(partialParticipants, nil)
-	mockArchive.On("GetOperationParticipants", expectedLedger2Transaction1, mock.Anything, int(0)).Return(partialParticipants, nil)
-	mockArchive.On("GetOperationParticipants", expectedLedger2Transaction2, mock.Anything, int(0)).Return(allParticipants, nil)
-	mockArchive.On("GetOperationParticipants", expectedLedger3Transaction1, mock.Anything, int(0)).Return(allParticipants, nil)
-	mockArchive.On("GetOperationParticipants", expectedLedger3Transaction2, mock.Anything, int(0)).Return(partialParticipants, nil)
+	mockArchive.
+		On("GetOperationParticipants", expectedLedger1Tx1, mock.Anything, int(0)).Return(partialParticipants, nil).
+		On("GetOperationParticipants", expectedLedger1Tx1, mock.Anything, int(1)).Return(partialParticipants, nil).
+		On("GetOperationParticipants", expectedLedger1Tx2, mock.Anything, int(0)).Return(partialParticipants, nil).
+		On("GetOperationParticipants", expectedLedger2Tx1, mock.Anything, int(0)).Return(partialParticipants, nil).
+		On("GetOperationParticipants", expectedLedger2Tx2, mock.Anything, int(0)).Return(allParticipants, nil).
+		On("GetOperationParticipants", expectedLedger3Tx1, mock.Anything, int(0)).Return(allParticipants, nil).
+		On("GetOperationParticipants", expectedLedger3Tx2, mock.Anything, int(0)).Return(partialParticipants, nil)
 
-	mockReaderLedger1.On("Read").Return(expectedLedger1Transaction1, nil).Once()
-	mockReaderLedger1.On("Read").Return(expectedLedger1Transaction2, nil).Once()
-	mockReaderLedger1.On("Read").Return(archive.LedgerTransaction{}, io.EOF).Once()
-	mockReaderLedger2.On("Read").Return(expectedLedger2Transaction1, nil).Once()
-	mockReaderLedger2.On("Read").Return(expectedLedger2Transaction2, nil).Once()
-	mockReaderLedger2.On("Read").Return(archive.LedgerTransaction{}, io.EOF).Once()
-	mockReaderLedger3.On("Read").Return(expectedLedger3Transaction1, nil).Once()
-	mockReaderLedger3.On("Read").Return(expectedLedger3Transaction2, nil).Once()
-	mockReaderLedger3.On("Read").Return(archive.LedgerTransaction{}, io.EOF).Once()
-	mockReaderLedgerTheRest.On("Read").Return(archive.LedgerTransaction{}, io.EOF)
+	mockReaderLedger1.
+		On("Read").Return(expectedLedger1Tx1, nil).Once().
+		On("Read").Return(expectedLedger1Tx2, nil).Once().
+		On("Read").Return(archive.LedgerTransaction{}, io.EOF).Once()
 
+	mockReaderLedger2.
+		On("Read").Return(expectedLedger2Tx1, nil).Once().
+		On("Read").Return(expectedLedger2Tx2, nil).Once().
+		On("Read").Return(archive.LedgerTransaction{}, io.EOF).Once()
+
+	mockReaderLedger3.
+		On("Read").Return(expectedLedger3Tx1, nil).Once().
+		On("Read").Return(expectedLedger3Tx2, nil).Once().
+		On("Read").Return(archive.LedgerTransaction{}, io.EOF).Once()
+
+	mockReaderLedgerTheRest.
+		On("Read").Return(archive.LedgerTransaction{}, io.EOF)
+
+	checkpoint := index.GetCheckpointNumber(uint32(ledgerSeq))
 	mockStore := &index.MockStore{}
-	mockStore.On("NextActive", "GDCXSQPVE45DVGT2ZRFFIIHSJ2EJED65W6AELGWIDRMPMWNXCEBJ4FKX", mock.Anything, uint32(24782)).Return(uint32(24783), nil)
-	mockStore.On("NextActive", "GDCXSQPVE45DVGT2ZRFFIIHSJ2EJED65W6AELGWIDRMPMWNXCEBJ4FKX", mock.Anything, uint32(24783)).Return(uint32(24784), nil)
-	mockStore.On("NextActive", "GDCXSQPVE45DVGT2ZRFFIIHSJ2EJED65W6AELGWIDRMPMWNXCEBJ4FKX", mock.Anything, uint32(24784)).Return(uint32(0), io.EOF)
+	mockStore.
+		On("NextActive", accountId, mock.Anything, uint32(checkpoint)).Return(uint32(checkpoint+1), nil).
+		On("NextActive", accountId, mock.Anything, uint32(checkpoint+1)).Return(uint32(checkpoint+2), nil).
+		On("NextActive", accountId, mock.Anything, uint32(checkpoint+2)).Return(uint32(0), io.EOF)
 
 	return mockArchive, mockStore
 }
@@ -195,8 +190,7 @@ func testLedger(seq int) xdr.LedgerCloseMeta {
 	}
 }
 
-func testLedgerTx(source xdr.AccountId, bumpTos []int, txIndex uint32) archive.LedgerTransaction {
-
+func testLedgerTx(source xdr.AccountId, txIndex uint32, bumpTos ...int) archive.LedgerTransaction {
 	ops := []xdr.Operation{}
 	for _, bumpTo := range bumpTos {
 		ops = append(ops, xdr.Operation{
@@ -223,4 +217,28 @@ func testLedgerTx(source xdr.AccountId, bumpTos []int, txIndex uint32) archive.L
 	}
 
 	return tx
+}
+
+func newTransactionService(ctx context.Context) TransactionsService {
+	passphrase := "White New England clam chowder"
+	archive, store := mockArchiveAndIndex(ctx, passphrase)
+	return TransactionsService{
+		Config: Config{
+			Archive:    archive,
+			IndexStore: store,
+			Passphrase: passphrase,
+		},
+	}
+}
+
+func newOperationService(ctx context.Context) OperationsService {
+	passphrase := "White New England clam chowder"
+	archive, store := mockArchiveAndIndex(ctx, passphrase)
+	return OperationsService{
+		Config: Config{
+			Archive:    archive,
+			IndexStore: store,
+			Passphrase: passphrase,
+		},
+	}
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
This introduces the `CursorManager` interface which describes how a cursor advances for a particular set of indices, and adds the `AccountTransactionCursorManager` to handle cursor advancement for the MVP endpoint.

### Why
This isolates that code and adds tests to ensure it works correctly.

### Known limitations
n/a