### PR TITLE
exp/lighthorizon: Add metrics middleware to collect request duration metrics

### DIFF
--- a/exp/lighthorizon/http.go
+++ b/exp/lighthorizon/http.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/stellar/go/exp/lighthorizon/actions"
+	"github.com/stellar/go/exp/lighthorizon/services"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+func newWrapResponseWriter(w http.ResponseWriter, r *http.Request) middleware.WrapResponseWriter {
+	mw, ok := w.(middleware.WrapResponseWriter)
+	if !ok {
+		mw = middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+	}
+
+	return mw
+}
+
+func prometheusMiddleware(requestDurationMetric *prometheus.SummaryVec) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mw := newWrapResponseWriter(w, r)
+
+			then := time.Now()
+			next.ServeHTTP(mw, r)
+			duration := time.Since(then)
+
+			requestDurationMetric.With(prometheus.Labels{
+				"status": strconv.FormatInt(int64(mw.Status()), 10),
+				"method": r.Method,
+			}).Observe(float64(duration.Seconds()))
+		})
+	}
+}
+
+func lightHorizonHTTPHandler(registry *prometheus.Registry, lightHorizon services.LightHorizon) http.Handler {
+	requestDurationMetric := prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace: "horizon_lite", Subsystem: "http", Name: "requests_duration_seconds",
+			Help: "HTTP requests durations, sliding window = 10m",
+		},
+		[]string{"status", "method"},
+	)
+	registry.MustRegister(requestDurationMetric)
+
+	router := chi.NewMux()
+	router.Use(prometheusMiddleware(requestDurationMetric))
+
+	router.Route("/accounts/{account_id}", func(r chi.Router) {
+		r.MethodFunc(http.MethodGet, "/transactions", actions.NewTXByAccountHandler(lightHorizon))
+		r.MethodFunc(http.MethodGet, "/operations", actions.NewOpsByAccountHandler(lightHorizon))
+	})
+
+	router.MethodFunc(http.MethodGet, "/", actions.ApiDocs())
+	router.Method(http.MethodGet, "/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+
+	return router
+}

--- a/exp/lighthorizon/main.go
+++ b/exp/lighthorizon/main.go
@@ -4,11 +4,7 @@ import (
 	"flag"
 	"net/http"
 
-	"github.com/go-chi/chi"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-
-	"github.com/stellar/go/exp/lighthorizon/actions"
 	"github.com/stellar/go/exp/lighthorizon/archive"
 	"github.com/stellar/go/exp/lighthorizon/index"
 	"github.com/stellar/go/exp/lighthorizon/services"
@@ -71,14 +67,5 @@ if left empty, uses a temporary directory`)
 		},
 	}
 
-	router := chi.NewMux()
-	router.Route("/accounts/{account_id}", func(r chi.Router) {
-		r.MethodFunc(http.MethodGet, "/transactions", actions.NewTXByAccountHandler(lightHorizon))
-		r.MethodFunc(http.MethodGet, "/operations", actions.NewOpsByAccountHandler(lightHorizon))
-	})
-
-	router.MethodFunc(http.MethodGet, "/", actions.ApiDocs())
-	router.Method(http.MethodGet, "/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
-
-	log.Fatal(http.ListenAndServe(":8080", router))
+	log.Fatal(http.ListenAndServe(":8080", lightHorizonHTTPHandler(registry, lightHorizon)))
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add metrics middleware to collect request duration metrics.

### Why

Implements part of https://github.com/stellar/go/issues/4451

### Known limitations

[N/A]
