### PR TITLE
Refactor access to meta archive

### DIFF
--- a/exp/lighthorizon/index/builder.go
+++ b/exp/lighthorizon/index/builder.go
@@ -15,8 +15,10 @@ import (
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/ingest/ledgerbackend"
+	"github.com/stellar/go/metaarchive"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
+	"github.com/stellar/go/support/storage"
 	"github.com/stellar/go/xdr"
 )
 
@@ -44,18 +46,18 @@ func BuildIndices(
 	// with the filesystem directly.
 	source, err := historyarchive.ConnectBackend(
 		sourceUrl,
-		historyarchive.ConnectOptions{
-			Context:           ctx,
-			NetworkPassphrase: networkPassphrase,
-			S3Region:          "us-east-1",
+		storage.ConnectOptions{
+			Context:  ctx,
+			S3Region: "us-east-1",
 		},
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	ledgerBackend := ledgerbackend.NewHistoryArchiveBackend(source)
-	defer ledgerBackend.Close()
+	metaArchive := metaarchive.NewMetaArchive(source)
+
+	ledgerBackend := ledgerbackend.NewHistoryArchiveBackend(metaArchive)
 
 	if ledgerRange.High == 0 {
 		var backendErr error
@@ -82,7 +84,7 @@ func BuildIndices(
 	wg, ctx := errgroup.WithContext(ctx)
 	ch := make(chan historyarchive.Range, parallel)
 
-	indexBuilder := NewIndexBuilder(indexStore, ledgerBackend, networkPassphrase)
+	indexBuilder := NewIndexBuilder(indexStore, *metaArchive, networkPassphrase)
 	for _, part := range modules {
 		switch part {
 		case "transactions":
@@ -170,7 +172,7 @@ type Module func(
 // IndexBuilder contains everything needed to build indices from ledger ranges.
 type IndexBuilder struct {
 	store             Store
-	ledgerBackend     ledgerbackend.LedgerBackend
+	metaArchive       metaarchive.MetaArchive
 	networkPassphrase string
 
 	lastBuiltLedgerWriteLock sync.Mutex
@@ -181,12 +183,12 @@ type IndexBuilder struct {
 
 func NewIndexBuilder(
 	indexStore Store,
-	backend ledgerbackend.LedgerBackend,
+	metaArchive metaarchive.MetaArchive,
 	networkPassphrase string,
 ) *IndexBuilder {
 	return &IndexBuilder{
 		store:             indexStore,
-		ledgerBackend:     backend,
+		metaArchive:       metaArchive,
 		networkPassphrase: networkPassphrase,
 	}
 }
@@ -219,7 +221,7 @@ func (builder *IndexBuilder) RunModules(
 // portion.
 func (builder *IndexBuilder) Build(ctx context.Context, ledgerRange historyarchive.Range) error {
 	for ledgerSeq := ledgerRange.Low; ledgerSeq <= ledgerRange.High; ledgerSeq++ {
-		ledger, err := builder.ledgerBackend.GetLedger(ctx, ledgerSeq)
+		ledger, err := builder.metaArchive.GetLedger(ctx, ledgerSeq)
 		if err != nil {
 			if !os.IsNotExist(err) {
 				log.Errorf("error getting ledger %d: %v", ledgerSeq, err)
@@ -228,7 +230,7 @@ func (builder *IndexBuilder) Build(ctx context.Context, ledgerRange historyarchi
 		}
 
 		reader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(
-			builder.networkPassphrase, ledger)
+			builder.networkPassphrase, *ledger.V0)
 		if err != nil {
 			return err
 		}
@@ -241,7 +243,7 @@ func (builder *IndexBuilder) Build(ctx context.Context, ledgerRange historyarchi
 				return err
 			}
 
-			if err := builder.RunModules(ledger, tx); err != nil {
+			if err := builder.RunModules(*ledger.V0, tx); err != nil {
 				return err
 			}
 		}
@@ -255,7 +257,7 @@ func (builder *IndexBuilder) Build(ctx context.Context, ledgerRange historyarchi
 }
 
 func (builder *IndexBuilder) Watch(ctx context.Context) error {
-	latestLedger, err := builder.ledgerBackend.GetLatestLedgerSequence(ctx)
+	latestLedger, err := builder.metaArchive.GetLatestLedgerSequence(ctx)
 	if err != nil {
 		log.Errorf("Failed to retrieve latest ledger: %v", err)
 		return err

--- a/exp/lighthorizon/index/cmd/single_test.go
+++ b/exp/lighthorizon/index/cmd/single_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/ingest/ledgerbackend"
+	"github.com/stellar/go/metaarchive"
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/support/storage"
 	"github.com/stellar/go/toid"
 	"github.com/stretchr/testify/require"
 
@@ -183,14 +185,16 @@ func IndexLedgerRange(
 	ctx := context.Background()
 	backend, err := historyarchive.ConnectBackend(
 		txmetaSource,
-		historyarchive.ConnectOptions{
-			Context:           ctx,
-			NetworkPassphrase: network.TestNetworkPassphrase,
-			S3Region:          "us-east-1",
+		storage.ConnectOptions{
+			Context:  ctx,
+			S3Region: "us-east-1",
 		},
 	)
 	require.NoError(t, err)
-	ledgerBackend := ledgerbackend.NewHistoryArchiveBackend(backend)
+
+	metaArchive := metaarchive.NewMetaArchive(backend)
+
+	ledgerBackend := ledgerbackend.NewHistoryArchiveBackend(metaArchive)
 	defer ledgerBackend.Close()
 
 	participation := make(map[string][]uint32)

--- a/exp/services/ledgerexporter/main.go
+++ b/exp/services/ledgerexporter/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stellar/go/ingest/ledgerbackend"
 	"github.com/stellar/go/network"
 	supportlog "github.com/stellar/go/support/log"
+	"github.com/stellar/go/support/storage"
 	"github.com/stellar/go/xdr"
 )
 
@@ -57,9 +58,8 @@ func main() {
 
 	target, err := historyarchive.ConnectBackend(
 		*targetUrl,
-		historyarchive.ConnectOptions{
-			Context:           context.Background(),
-			NetworkPassphrase: params.NetworkPassphrase,
+		storage.ConnectOptions{
+			Context: context.Background(),
 		},
 	)
 	logFatalIf(err, "Could not connect to target")
@@ -119,7 +119,7 @@ func main() {
 
 // readLatestLedger determines the latest ledger in the given backend (at the
 // /latest path), defaulting to Ledger #2 if one doesn't exist
-func readLatestLedger(backend historyarchive.ArchiveBackend) uint32 {
+func readLatestLedger(backend storage.Storage) uint32 {
 	r, err := backend.GetFile("latest")
 	if os.IsNotExist(err) {
 		return 2
@@ -140,7 +140,7 @@ func readLatestLedger(backend historyarchive.ArchiveBackend) uint32 {
 // writeLedger stores the given LedgerCloseMeta instance as a raw binary at the
 // /ledgers/<seqNum> path. If an error is returned, it may be transient so you
 // should attempt to retry.
-func writeLedger(backend historyarchive.ArchiveBackend, ledger xdr.LedgerCloseMeta) error {
+func writeLedger(backend storage.Storage, ledger xdr.LedgerCloseMeta) error {
 	toSerialize := xdr.SerializedLedgerCloseMeta{
 		V:  0,
 		V0: &ledger,
@@ -153,7 +153,7 @@ func writeLedger(backend historyarchive.ArchiveBackend, ledger xdr.LedgerCloseMe
 	)
 }
 
-func writeLatestLedger(backend historyarchive.ArchiveBackend, ledger uint32) error {
+func writeLatestLedger(backend storage.Storage, ledger uint32) error {
 	return backend.PutFile(
 		"latest",
 		io.NopCloser(

--- a/exp/tools/dump-ledger-state/main.go
+++ b/exp/tools/dump-ledger-state/main.go
@@ -307,13 +307,13 @@ func archive(testnet bool) (*historyarchive.Archive, error) {
 	if testnet {
 		return historyarchive.Connect(
 			"https://history.stellar.org/prd/core-testnet/core_testnet_001",
-			historyarchive.ConnectOptions{},
+			historyarchive.ArchiveOptions{},
 		)
 	}
 
 	return historyarchive.Connect(
 		fmt.Sprintf("https://history.stellar.org/prd/core-live/core_live_001/"),
-		historyarchive.ConnectOptions{},
+		historyarchive.ArchiveOptions{},
 	)
 }
 

--- a/exp/tools/dump-orderbook/main.go
+++ b/exp/tools/dump-orderbook/main.go
@@ -109,12 +109,12 @@ func archive(testnet bool) (*historyarchive.Archive, error) {
 	if testnet {
 		return historyarchive.Connect(
 			"https://history.stellar.org/prd/core-testnet/core_testnet_001",
-			historyarchive.ConnectOptions{},
+			historyarchive.ArchiveOptions{},
 		)
 	}
 
 	return historyarchive.Connect(
 		fmt.Sprintf("https://history.stellar.org/prd/core-live/core_live_001/"),
-		historyarchive.ConnectOptions{},
+		historyarchive.ArchiveOptions{},
 	)
 }

--- a/historyarchive/archive_pool.go
+++ b/historyarchive/archive_pool.go
@@ -21,7 +21,7 @@ type ArchivePool []ArchiveInterface
 // If none of the archives work, this returns the error message of the last
 // failed archive. Note that the errors for each individual archive are hard to
 // track if there's success overall.
-func NewArchivePool(archiveURLs []string, config ConnectOptions) (ArchivePool, error) {
+func NewArchivePool(archiveURLs []string, opts ArchiveOptions) (ArchivePool, error) {
 	if len(archiveURLs) <= 0 {
 		return nil, errors.New("No history archives provided")
 	}
@@ -33,11 +33,7 @@ func NewArchivePool(archiveURLs []string, config ConnectOptions) (ArchivePool, e
 	for _, url := range archiveURLs {
 		archive, err := Connect(
 			url,
-			ConnectOptions{
-				NetworkPassphrase:   config.NetworkPassphrase,
-				CheckpointFrequency: config.CheckpointFrequency,
-				Context:             config.Context,
-			},
+			opts,
 		)
 
 		if err != nil {

--- a/historyarchive/archive_test.go
+++ b/historyarchive/archive_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stellar/go/support/storage"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 )
@@ -35,11 +36,17 @@ func GetTestS3Archive() *Archive {
 	if env_region := os.Getenv("ARCHIVIST_TEST_S3_REGION"); env_region != "" {
 		region = env_region
 	}
-	return MustConnect(bucket, ConnectOptions{S3Region: region, CheckpointFrequency: 64})
+	return MustConnect(
+		bucket,
+		ArchiveOptions{
+			CheckpointFrequency: 64,
+			ConnectOptions:      storage.ConnectOptions{S3Region: region},
+		},
+	)
 }
 
 func GetTestMockArchive() *Archive {
-	return MustConnect("mock://test", ConnectOptions{CheckpointFrequency: 64})
+	return MustConnect("mock://test", ArchiveOptions{CheckpointFrequency: 64})
 }
 
 var tmpdirs []string
@@ -54,7 +61,7 @@ func GetTestFileArchive() *Archive {
 	} else {
 		tmpdirs = append(tmpdirs, d)
 	}
-	return MustConnect("file://"+d, ConnectOptions{CheckpointFrequency: 64})
+	return MustConnect("file://"+d, ArchiveOptions{CheckpointFrequency: 64})
 }
 
 func cleanup() {
@@ -381,14 +388,14 @@ func TestNetworkPassphrase(t *testing.T) {
 	}
 
 	// No network passphrase set in options
-	archive := MustConnect("mock://test", ConnectOptions{CheckpointFrequency: 64})
+	archive := MustConnect("mock://test", ArchiveOptions{CheckpointFrequency: 64})
 	err := archive.backend.PutFile("has.json", makeHASReader())
 	assert.NoError(t, err)
 	_, err = archive.GetPathHAS("has.json")
 	assert.NoError(t, err)
 
 	// No network passphrase set in HAS
-	archive = MustConnect("mock://test", ConnectOptions{
+	archive = MustConnect("mock://test", ArchiveOptions{
 		NetworkPassphrase:   "Public Global Stellar Network ; September 2015",
 		CheckpointFrequency: 64,
 	})
@@ -398,7 +405,7 @@ func TestNetworkPassphrase(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Correct network passphrase set in options
-	archive = MustConnect("mock://test", ConnectOptions{
+	archive = MustConnect("mock://test", ArchiveOptions{
 		NetworkPassphrase:   "Public Global Stellar Network ; September 2015",
 		CheckpointFrequency: 64,
 	})
@@ -408,7 +415,7 @@ func TestNetworkPassphrase(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Incorrect network passphrase set in options
-	archive = MustConnect("mock://test", ConnectOptions{
+	archive = MustConnect("mock://test", ArchiveOptions{
 		NetworkPassphrase:   "Test SDF Network ; September 2015",
 		CheckpointFrequency: 64,
 	})
@@ -500,7 +507,7 @@ type xdrEntry interface {
 	MarshalBinary() ([]byte, error)
 }
 
-func writeCategoryFile(t *testing.T, backend ArchiveBackend, path string, entries []xdrEntry) {
+func writeCategoryFile(t *testing.T, backend storage.Storage, path string, entries []xdrEntry) {
 	file := &bytes.Buffer{}
 	writer := gzip.NewWriter(file)
 

--- a/historyarchive/archive_test.go
+++ b/historyarchive/archive_test.go
@@ -39,14 +39,14 @@ func GetTestS3Archive() *Archive {
 	return MustConnect(
 		bucket,
 		ArchiveOptions{
-			CheckpointFrequency: 64,
+			CheckpointFrequency: DefaultCheckpointFrequency,
 			ConnectOptions:      storage.ConnectOptions{S3Region: region},
 		},
 	)
 }
 
 func GetTestMockArchive() *Archive {
-	return MustConnect("mock://test", ArchiveOptions{CheckpointFrequency: 64})
+	return MustConnect("mock://test", ArchiveOptions{CheckpointFrequency: DefaultCheckpointFrequency})
 }
 
 var tmpdirs []string
@@ -61,7 +61,7 @@ func GetTestFileArchive() *Archive {
 	} else {
 		tmpdirs = append(tmpdirs, d)
 	}
-	return MustConnect("file://"+d, ArchiveOptions{CheckpointFrequency: 64})
+	return MustConnect("file://"+d, ArchiveOptions{CheckpointFrequency: DefaultCheckpointFrequency})
 }
 
 func cleanup() {
@@ -388,7 +388,7 @@ func TestNetworkPassphrase(t *testing.T) {
 	}
 
 	// No network passphrase set in options
-	archive := MustConnect("mock://test", ArchiveOptions{CheckpointFrequency: 64})
+	archive := MustConnect("mock://test", ArchiveOptions{CheckpointFrequency: DefaultCheckpointFrequency})
 	err := archive.backend.PutFile("has.json", makeHASReader())
 	assert.NoError(t, err)
 	_, err = archive.GetPathHAS("has.json")
@@ -397,7 +397,7 @@ func TestNetworkPassphrase(t *testing.T) {
 	// No network passphrase set in HAS
 	archive = MustConnect("mock://test", ArchiveOptions{
 		NetworkPassphrase:   "Public Global Stellar Network ; September 2015",
-		CheckpointFrequency: 64,
+		CheckpointFrequency: DefaultCheckpointFrequency,
 	})
 	err = archive.backend.PutFile("has.json", makeHASReaderNoNetwork())
 	assert.NoError(t, err)
@@ -407,7 +407,7 @@ func TestNetworkPassphrase(t *testing.T) {
 	// Correct network passphrase set in options
 	archive = MustConnect("mock://test", ArchiveOptions{
 		NetworkPassphrase:   "Public Global Stellar Network ; September 2015",
-		CheckpointFrequency: 64,
+		CheckpointFrequency: DefaultCheckpointFrequency,
 	})
 	err = archive.backend.PutFile("has.json", makeHASReader())
 	assert.NoError(t, err)
@@ -417,7 +417,7 @@ func TestNetworkPassphrase(t *testing.T) {
 	// Incorrect network passphrase set in options
 	archive = MustConnect("mock://test", ArchiveOptions{
 		NetworkPassphrase:   "Test SDF Network ; September 2015",
-		CheckpointFrequency: 64,
+		CheckpointFrequency: DefaultCheckpointFrequency,
 	})
 	err = archive.backend.PutFile("has.json", makeHASReader())
 	assert.NoError(t, err)

--- a/historyarchive/mock_archive.go
+++ b/historyarchive/mock_archive.go
@@ -11,6 +11,8 @@ import (
 	"io/ioutil"
 	"strings"
 	"sync"
+
+	"github.com/stellar/go/support/storage"
 )
 
 type MockArchiveBackend struct {
@@ -87,7 +89,7 @@ func (b *MockArchiveBackend) Close() error {
 	return nil
 }
 
-func makeMockBackend(opts ConnectOptions) ArchiveBackend {
+func makeMockBackend() storage.Storage {
 	b := new(MockArchiveBackend)
 	b.files = make(map[string][]byte)
 	return b

--- a/historyarchive/util.go
+++ b/historyarchive/util.go
@@ -7,10 +7,11 @@ package historyarchive
 import (
 	"bufio"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"net/http"
 	"path"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func makeTicker(onTick func(uint)) chan bool {

--- a/historyarchive/util.go
+++ b/historyarchive/util.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"net/http"
 	"path"
 
 	log "github.com/sirupsen/logrus"
@@ -137,24 +136,4 @@ func drainErrors(errs chan error) uint32 {
 		count += noteError(e)
 	}
 	return count
-}
-
-func logReq(r *http.Request) {
-	if r == nil {
-		return
-	}
-	logFields := log.Fields{"method": r.Method, "url": r.URL.String()}
-	log.WithFields(logFields).Trace("http: Req")
-}
-
-func logResp(r *http.Response) {
-	if r == nil || r.Request == nil {
-		return
-	}
-	logFields := log.Fields{"method": r.Request.Method, "status": r.Status, "url": r.Request.URL.String()}
-	if r.StatusCode >= 200 && r.StatusCode < 400 {
-		log.WithFields(logFields).Trace("http: OK")
-	} else {
-		log.WithFields(logFields).Warn("http: Bad")
-	}
 }

--- a/ingest/doc_test.go
+++ b/ingest/doc_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest/ledgerbackend"
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/support/storage"
 	"github.com/stellar/go/xdr"
 )
 
@@ -18,7 +19,11 @@ func Example_ledgerentrieshistoryarchive() {
 
 	archive, err := historyarchive.Connect(
 		archiveURL,
-		historyarchive.ConnectOptions{Context: context.TODO()},
+		historyarchive.ArchiveOptions{
+			ConnectOptions: storage.ConnectOptions{
+				Context: context.TODO()
+			},
+		},
 	)
 	if err != nil {
 		panic(err)

--- a/ingest/doc_test.go
+++ b/ingest/doc_test.go
@@ -21,7 +21,7 @@ func Example_ledgerentrieshistoryarchive() {
 		archiveURL,
 		historyarchive.ArchiveOptions{
 			ConnectOptions: storage.ConnectOptions{
-				Context: context.TODO()
+				Context: context.TODO(),
 			},
 		},
 	)

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/support/log"
+	"github.com/stellar/go/support/storage"
 	"github.com/stellar/go/xdr"
 )
 
@@ -154,10 +155,12 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 
 	archivePool, err := historyarchive.NewArchivePool(
 		config.HistoryArchiveURLs,
-		historyarchive.ConnectOptions{
+		historyarchive.ArchiveOptions{
 			NetworkPassphrase:   config.NetworkPassphrase,
 			CheckpointFrequency: config.CheckpointFrequency,
-			Context:             config.Context,
+			ConnectOptions: storage.ConnectOptions{
+				Context: config.Context,
+			},
 		},
 	)
 

--- a/ingest/ledgerbackend/history_archive_backend.go
+++ b/ingest/ledgerbackend/history_archive_backend.go
@@ -1,45 +1,25 @@
 package ledgerbackend
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"os"
-	"strconv"
 
-	"github.com/pkg/errors"
-	"github.com/stellar/go/historyarchive"
+	"github.com/stellar/go/metaarchive"
 	"github.com/stellar/go/xdr"
 )
 
 type HistoryArchiveBackend struct {
-	historyarchive.ArchiveBackend
+	metaArchive *metaarchive.MetaArchive
 }
 
-func NewHistoryArchiveBackend(b historyarchive.ArchiveBackend) *HistoryArchiveBackend {
+func NewHistoryArchiveBackend(metaArchive *metaarchive.MetaArchive) *HistoryArchiveBackend {
 	return &HistoryArchiveBackend{
-		ArchiveBackend: b,
+		metaArchive: metaArchive,
 	}
 }
 
 func (b *HistoryArchiveBackend) GetLatestLedgerSequence(ctx context.Context) (uint32, error) {
-	r, err := b.GetFile("latest")
-	if os.IsNotExist(err) {
-		return 2, nil
-	} else if err != nil {
-		return 0, errors.Wrap(err, "could not open latest ledger bucket")
-	}
-	defer r.Close()
-	var buf bytes.Buffer
-	if _, err = io.Copy(&buf, r); err != nil {
-		return 0, errors.Wrap(err, "could not read latest ledger")
-	}
-	parsed, err := strconv.ParseUint(buf.String(), 10, 32)
-	if err != nil {
-		return 0, errors.Wrapf(err, "could not parse latest ledger: %q", buf.String())
-	}
-	return uint32(parsed), nil
+	return b.metaArchive.GetLatestLedgerSequence(ctx)
 }
 
 func (b *HistoryArchiveBackend) PrepareRange(ctx context.Context, ledgerRange Range) error {
@@ -53,22 +33,19 @@ func (b *HistoryArchiveBackend) IsPrepared(ctx context.Context, ledgerRange Rang
 }
 
 func (b *HistoryArchiveBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error) {
-	var ledger xdr.SerializedLedgerCloseMeta
-	r, err := b.GetFile("ledgers/" + strconv.FormatUint(uint64(sequence), 10))
+	serializedLedger, err := b.metaArchive.GetLedger(ctx, sequence)
 	if err != nil {
 		return xdr.LedgerCloseMeta{}, err
 	}
-	defer r.Close()
-	var buf bytes.Buffer
-	if _, err = io.Copy(&buf, r); err != nil {
-		return xdr.LedgerCloseMeta{}, err
-	}
-	if err = ledger.UnmarshalBinary(buf.Bytes()); err != nil {
-		return xdr.LedgerCloseMeta{}, err
-	}
-	output, isV0 := ledger.GetV0()
+
+	output, isV0 := serializedLedger.GetV0()
 	if !isV0 {
-		return xdr.LedgerCloseMeta{}, fmt.Errorf("unexpected serialized ledger version number (0x%x)", ledger.V)
+		return xdr.LedgerCloseMeta{}, fmt.Errorf("unexpected serialized ledger version number (0x%x)", serializedLedger.V)
 	}
 	return output, nil
+}
+
+func (b *HistoryArchiveBackend) Close() error {
+	// Noop
+	return nil
 }

--- a/ingest/tutorial/example_claimables.go
+++ b/ingest/tutorial/example_claimables.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest"
+	"github.com/stellar/go/support/storage"
 	"github.com/stellar/go/xdr"
 )
 
@@ -15,10 +16,12 @@ func claimables() {
 	// Open a history archive using our existing configuration details.
 	historyArchive, err := historyarchive.Connect(
 		config.HistoryArchiveURLs[0],
-		historyarchive.ConnectOptions{
+		historyarchive.ArchiveOptions{
 			NetworkPassphrase: config.NetworkPassphrase,
-			S3Region:          "us-west-1",
-			UnsignedRequests:  false,
+			ConnectOptions: storage.ConnectOptions{
+				S3Region:         "us-west-1",
+				UnsignedRequests: false,
+			},
 		},
 	)
 	panicIf(err)

--- a/metaarchive/main.go
+++ b/metaarchive/main.go
@@ -1,0 +1,59 @@
+package metaarchive
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/storage"
+	"github.com/stellar/go/xdr"
+)
+
+type MetaArchive struct {
+	s storage.Storage
+}
+
+func NewMetaArchive(b storage.Storage) *MetaArchive {
+	return &MetaArchive{
+		s: b,
+	}
+}
+
+func (m *MetaArchive) GetLatestLedgerSequence(ctx context.Context) (uint32, error) {
+	r, err := m.s.GetFile("latest")
+	if os.IsNotExist(err) {
+		return 2, nil
+	} else if err != nil {
+		return 0, errors.Wrap(err, "could not open latest ledger bucket")
+	}
+	defer r.Close()
+	var buf bytes.Buffer
+	if _, err = io.Copy(&buf, r); err != nil {
+		return 0, errors.Wrap(err, "could not read latest ledger")
+	}
+	parsed, err := strconv.ParseUint(buf.String(), 10, 32)
+	if err != nil {
+		return 0, errors.Wrapf(err, "could not parse latest ledger: %q", buf.String())
+	}
+	return uint32(parsed), nil
+}
+
+func (m *MetaArchive) GetLedger(ctx context.Context, sequence uint32) (xdr.SerializedLedgerCloseMeta, error) {
+	var ledger xdr.SerializedLedgerCloseMeta
+	r, err := m.s.GetFile("ledgers/" + strconv.FormatUint(uint64(sequence), 10))
+	if err != nil {
+		return xdr.SerializedLedgerCloseMeta{}, err
+	}
+	defer r.Close()
+	var buf bytes.Buffer
+	if _, err = io.Copy(&buf, r); err != nil {
+		return xdr.SerializedLedgerCloseMeta{}, err
+	}
+	if err = ledger.UnmarshalBinary(buf.Bytes()); err != nil {
+		return xdr.SerializedLedgerCloseMeta{}, err
+	}
+	return ledger, nil
+}

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	logpkg "github.com/stellar/go/support/log"
+	"github.com/stellar/go/support/storage"
 )
 
 const (
@@ -206,10 +207,12 @@ func NewSystem(config Config) (System, error) {
 
 	archive, err := historyarchive.Connect(
 		config.HistoryArchiveURL,
-		historyarchive.ConnectOptions{
-			Context:             ctx,
+		historyarchive.ArchiveOptions{
 			NetworkPassphrase:   config.NetworkPassphrase,
 			CheckpointFrequency: config.CheckpointFrequency,
+			ConnectOptions: storage.ConnectOptions{
+				Context: ctx,
+			},
 		},
 	)
 	if err != nil {

--- a/services/horizon/internal/integration/db_test.go
+++ b/services/horizon/internal/integration/db_test.go
@@ -461,7 +461,7 @@ func TestReingestDB(t *testing.T) {
 	// cap reachedLedger to the nearest checkpoint ledger because reingest range cannot ingest past the most
 	// recent checkpoint ledger when using captive core
 	toLedger := uint32(reachedLedger)
-	archive, err := historyarchive.Connect(horizonConfig.HistoryArchiveURLs[0], historyarchive.ConnectOptions{
+	archive, err := historyarchive.Connect(horizonConfig.HistoryArchiveURLs[0], historyarchive.ArchiveOptions{
 		NetworkPassphrase:   horizonConfig.NetworkPassphrase,
 		CheckpointFrequency: horizonConfig.CheckpointFrequency,
 	})
@@ -558,7 +558,7 @@ func TestFillGaps(t *testing.T) {
 	// cap reachedLedger to the nearest checkpoint ledger because reingest range cannot ingest past the most
 	// recent checkpoint ledger when using captive core
 	toLedger := uint32(reachedLedger)
-	archive, err := historyarchive.Connect(horizonConfig.HistoryArchiveURLs[0], historyarchive.ConnectOptions{
+	archive, err := historyarchive.Connect(horizonConfig.HistoryArchiveURLs[0], historyarchive.ArchiveOptions{
 		NetworkPassphrase:   horizonConfig.NetworkPassphrase,
 		CheckpointFrequency: horizonConfig.CheckpointFrequency,
 	})

--- a/support/storage/main.go
+++ b/support/storage/main.go
@@ -1,0 +1,109 @@
+package storage
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stellar/go/support/errors"
+)
+
+type Storage interface {
+	Exists(path string) (bool, error)
+	Size(path string) (int64, error)
+	GetFile(path string) (io.ReadCloser, error)
+	PutFile(path string, in io.ReadCloser) error
+	ListFiles(path string) (chan string, chan error)
+	CanListFiles() bool
+	Close() error
+}
+
+type ConnectOptions struct {
+	Context          context.Context
+	S3Region         string
+	S3Endpoint       string
+	UnsignedRequests bool
+	GCSEndpoint      string
+
+	// Wrap the Storage after connection. For example, to add a caching or introspection layer.
+	Wrap func(Storage) (Storage, error)
+}
+
+func ConnectBackend(u string, opts ConnectOptions) (Storage, error) {
+	if u == "" {
+		return nil, errors.New("URL is empty")
+	}
+
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Context == nil {
+		opts.Context = context.Background()
+	}
+
+	pth := parsed.Path
+	var backend Storage
+	switch parsed.Scheme {
+	case "s3":
+		// Inside s3, all paths start _without_ the leading /
+		pth = strings.TrimPrefix(pth, "/")
+		backend, err = NewS3Storage(
+			opts.Context,
+			parsed.Host,
+			pth,
+			opts.S3Region,
+			opts.S3Endpoint,
+			opts.UnsignedRequests,
+		)
+
+	case "gcs":
+		// Inside gcs, all paths start _without_ the leading /
+		pth = strings.TrimPrefix(pth, "/")
+		backend, err = NewGCSBackend(
+			opts.Context,
+			parsed.Host,
+			pth,
+			opts.GCSEndpoint,
+		)
+
+	case "file":
+		pth = path.Join(parsed.Host, pth)
+		backend = NewFilesystemStorage(pth)
+
+	case "http", "https":
+		backend = NewHttpStorage(opts.Context, parsed)
+
+	default:
+		err = errors.New("unknown URL scheme: '" + parsed.Scheme + "'")
+	}
+	if err == nil && opts.Wrap != nil {
+		backend, err = opts.Wrap(backend)
+	}
+	return backend, err
+}
+
+func logReq(r *http.Request) {
+	if r == nil {
+		return
+	}
+	logFields := log.Fields{"method": r.Method, "url": r.URL.String()}
+	log.WithFields(logFields).Trace("http: Req")
+}
+
+func logResp(r *http.Response) {
+	if r == nil || r.Request == nil {
+		return
+	}
+	logFields := log.Fields{"method": r.Request.Method, "status": r.Status, "url": r.Request.URL.String()}
+	if r.StatusCode >= 200 && r.StatusCode < 400 {
+		log.WithFields(logFields).Trace("http: OK")
+	} else {
+		log.WithFields(logFields).Warn("http: Bad")
+	}
+}

--- a/tools/archive-reader/archive_reader.go
+++ b/tools/archive-reader/archive_reader.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest"
+	"github.com/stellar/go/support/storage"
 )
 
 func main() {
@@ -64,9 +65,11 @@ func main() {
 func archive() (*historyarchive.Archive, error) {
 	return historyarchive.Connect(
 		fmt.Sprintf("s3://history.stellar.org/prd/core-live/core_live_001/"),
-		historyarchive.ConnectOptions{
-			S3Region:         "eu-west-1",
-			UnsignedRequests: true,
+		historyarchive.ArchiveOptions{
+			ConnectOptions: storage.ConnectOptions{
+				S3Region:         "eu-west-1",
+				UnsignedRequests: true,
+			},
 		},
 	)
 }

--- a/tools/stellar-archivist/main.go
+++ b/tools/stellar-archivist/main.go
@@ -51,7 +51,7 @@ type Options struct {
 	Debug       bool
 	Trace       bool
 	CommandOpts historyarchive.CommandOptions
-	ConnectOpts historyarchive.ConnectOptions
+	ConnectOpts historyarchive.ArchiveOptions
 }
 
 func (opts *Options) SetRange(srcArch *historyarchive.Archive, dstArch *historyarchive.Archive) {

--- a/tools/stellar-archivist/main_test.go
+++ b/tools/stellar-archivist/main_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestLastOption(t *testing.T) {
-	src_arch := historyarchive.MustConnect("mock://test", historyarchive.ConnectOptions{CheckpointFrequency: 64})
+	src_arch := historyarchive.MustConnect("mock://test", historyarchive.ArchiveOptions{CheckpointFrequency: 64})
 	assert.NotEqual(t, nil, src_arch)
 
 	var src_has historyarchive.HistoryArchiveState
@@ -28,8 +28,8 @@ func TestLastOption(t *testing.T) {
 }
 
 func TestRecentOption(t *testing.T) {
-	src_arch := historyarchive.MustConnect("mock://test1", historyarchive.ConnectOptions{CheckpointFrequency: 64})
-	dst_arch := historyarchive.MustConnect("mock://test2", historyarchive.ConnectOptions{CheckpointFrequency: 64})
+	src_arch := historyarchive.MustConnect("mock://test1", historyarchive.ArchiveOptions{CheckpointFrequency: 64})
+	dst_arch := historyarchive.MustConnect("mock://test2", historyarchive.ArchiveOptions{CheckpointFrequency: 64})
 	assert.NotEqual(t, nil, src_arch)
 	assert.NotEqual(t, nil, dst_arch)
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Refactor `historyarchive` and `ledgerbackend` to allow better access to the new meta archives:
* Created `metaarchive` package that connects to the new meta archives (and allows accessing `xdr.SerializedLedgerCloseMeta`).
* Extracted `ArchiveBackend` to the new `support/storage` package as it contains only storage related methods. New package is used in both `historyarchive` and `metaarchive`.

Close #4460.

### Why

Improve code separation, allow access to `metaarchive` specific objects.

### Known limitations

[TODO or N/A]
