### PR TITLE
services/horizon/docker/ledgerexporter: deploy ledgerexporter image as service

### DIFF
--- a/exp/services/ledgerexporter/main.go
+++ b/exp/services/ledgerexporter/main.go
@@ -72,18 +72,23 @@ func main() {
 	// Build the appropriate range for the given backend state.
 	startLedger := uint32(*startingLedger)
 	endLedger := uint32(*endingLedger)
+
+	logger.Infof("processing requested range of -start-ledger=%v, -end-ledger=%v", startLedger, endLedger)
+	if *continueFromLatestLedger {
+		if startLedger != 0 {
+			logger.Fatalf("-start-ledger and -continue cannot both be set")
+		}
+		startLedger = readLatestLedger(target)
+		logger.Infof("continue flag was enabled, next ledger found was %v", startLedger)
+	}
+
 	if startLedger < 2 {
 		logger.Fatalf("-start-ledger must be >= 2")
 	}
 	if endLedger != 0 && endLedger < startLedger {
 		logger.Fatalf("-end-ledger must be >= -start-ledger")
 	}
-	if *continueFromLatestLedger {
-		if startLedger != 0 {
-			logger.Fatalf("-start-ledger and -continue cannot both be set")
-		}
-		startLedger = readLatestLedger(target)
-	}
+
 	var ledgerRange ledgerbackend.Range
 	if endLedger == 0 {
 		ledgerRange = ledgerbackend.UnboundedRange(startLedger)

--- a/exp/services/ledgerexporter/main.go
+++ b/exp/services/ledgerexporter/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest/ledgerbackend"
 	"github.com/stellar/go/network"
@@ -61,7 +62,8 @@ func main() {
 	target, err := historyarchive.ConnectBackend(
 		*targetUrl,
 		storage.ConnectOptions{
-			Context: context.Background(),
+			Context:    context.Background(),
+			S3WriteACL: s3.ObjectCannedACLBucketOwnerFullControl,
 		},
 	)
 	logFatalIf(err, "Could not connect to target")

--- a/historyarchive/s3_archive.go
+++ b/historyarchive/s3_archive.go
@@ -121,7 +121,6 @@ func (b *S3ArchiveBackend) PutFile(pth string, in io.ReadCloser) error {
 	params := &s3.PutObjectInput{
 		Bucket: aws.String(b.bucket),
 		Key:    aws.String(key),
-		ACL:    aws.String(s3.ObjectCannedACLPublicRead),
 		Body:   bytes.NewReader(buf.Bytes()),
 	}
 	req, _ := b.svc.PutObjectRequest(params)

--- a/services/horizon/docker/ledgerexporter/Dockerfile
+++ b/services/horizon/docker/ledgerexporter/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
 RUN apt-get clean
 
 ADD captive-core-pubnet.cfg /
+ADD captive-core-testnet.cfg /
 
 ADD start /
 RUN ["chmod", "+x", "start"]

--- a/services/horizon/docker/ledgerexporter/captive-core-testnet.cfg
+++ b/services/horizon/docker/ledgerexporter/captive-core-testnet.cfg
@@ -1,0 +1,30 @@
+PEER_PORT=11725
+DATABASE = "sqlite3:///cc/stellar.db"
+
+UNSAFE_QUORUM=true
+FAILURE_SAFETY=1
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN="testnet.stellar.org"
+QUALITY="HIGH"
+
+[[VALIDATORS]]
+NAME="sdf_testnet_1"
+HOME_DOMAIN="testnet.stellar.org"
+PUBLIC_KEY="GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"
+ADDRESS="core-testnet1.stellar.org"
+HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_001/{0} -o {1}"
+
+[[VALIDATORS]]
+NAME="sdf_testnet_2"
+HOME_DOMAIN="testnet.stellar.org"
+PUBLIC_KEY="GCUCJTIYXSOXKBSNFGNFWW5MUQ54HKRPGJUTQFJ5RQXZXNOLNXYDHRAP"
+ADDRESS="core-testnet2.stellar.org"
+HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_002/{0} -o {1}"
+
+[[VALIDATORS]]
+NAME="sdf_testnet_3"
+HOME_DOMAIN="testnet.stellar.org"
+PUBLIC_KEY="GC2V2EFSXN6SQTWVYA5EPJPBWWIMSD2XQNKUOHGEKB535AQE2I6IXV2Z"
+ADDRESS="core-testnet3.stellar.org"
+HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_003/{0} -o {1}"

--- a/services/horizon/docker/ledgerexporter/ledgerexporter.yml
+++ b/services/horizon/docker/ledgerexporter/ledgerexporter.yml
@@ -18,11 +18,11 @@ data:
   # when using core 'on disk', the earliest ledger to get streamed out after catchup to 2, is 3
   # whereas on in-memory it streas out 2, adjusted here, otherwise horizon ingest will abort
   # and stop process with error that ledger 3 is not <= expected ledger of 2.    
-  START: "3"
+  #START: "3"
   END: "0"
 
   # can only have CONTINUE or START set, not both.
-  #CONTINUE: "true"
+  CONTINUE: "true"
   WRITE_LATEST_PATH: "true"
   CAPTIVE_CORE_USE_DB: "true"
 
@@ -42,7 +42,7 @@ data:
 
   # provide the url for the external s3 bucket to be populated
   # update the ledgerexporter-pubnet-secret to have correct aws key/secret for access to the bucket
-  ARCHIVE_TARGET: "s3://horizon-ledgermeta-pubnet"
+  ARCHIVE_TARGET: "s3://horizon-ledgermeta-prodnet-test"
 ---
 apiVersion: v1
 kind: Secret

--- a/services/horizon/docker/ledgerexporter/ledgerexporter.yml
+++ b/services/horizon/docker/ledgerexporter/ledgerexporter.yml
@@ -1,12 +1,11 @@
 # this file contains the ledgerexporter deployment and it's config artifacts.
-# when importing the manifest with kubectl, will only create, skips any that already exist.
 #
-# make sure to include namespace destination, the manifest does not specify, 
-# otherwise it'll go in your current kubectl context.
+# when applying the manifest on a cluster, make sure to include namespace destination, 
+# as the manifest does not specify namespace, otherwise it'll go in your current kubectl context.
 #
-# if defining the secrets for first time, substitue <base64 encoded value here> placeholders.
+# make sure to set the secrets values, substitue <base64 encoded value here> placeholders.
 #
-# $ kubectl create -f ledgerexporter.yml -n horizon-dev
+# $ kubectl apply -f ledgerexporter.yml -n horizon-dev
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,7 +15,10 @@ metadata:
     app: ledgerexporter
   name: ledgerexporter-pubnet-env
 data:
-  START: "2"
+  # when using core 'on disk', the earliest ledger to get streamed out after catchup to 2, is 3
+  # whereas on in-memory it streas out 2, adjusted here, otherwise horizon ingest will abort
+  # and stop process with error that ledger 3 is not <= expected ledger of 2.    
+  START: "3"
   END: "0"
   # can only have CONTINUE or START set, not both.
   #CONTINUE: "true"
@@ -36,7 +38,7 @@ type: Opaque
 data:
   AWS_REGION: <base64 encoded value here>
   AWS_ACCESS_KEY_ID: <base64 encoded value here>
-  AWS_SECRET_ACCESS_KEY: <base64 encoded value here>  
+  AWS_SECRET_ACCESS_KEY: <base64 encoded value here> 
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -74,8 +76,8 @@ spec:
         name: ledgerexporter
         resources:  
           limits:
-            cpu:     1
-            memory:  4Gi
+            cpu:     3
+            memory:  8Gi
           requests:
             cpu:      250m
             memory:   500m

--- a/services/horizon/docker/ledgerexporter/ledgerexporter.yml
+++ b/services/horizon/docker/ledgerexporter/ledgerexporter.yml
@@ -61,7 +61,7 @@ data:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: ledgerexporter-core-storage
+  name: ledgerexporter-pubnet-core-storage
 spec:
   accessModes:
   - ReadWriteOnce
@@ -78,12 +78,12 @@ metadata:
     fluxcd.io/ignore: "true"
     deployment.kubernetes.io/revision: "3"
   labels:
-    app: ledgerexporter
-  name: ledgerexporter-deployment
+    app: ledgerexporter-pubnet
+  name: ledgerexporter-pubnet-deployment
 spec:
   selector:
     matchLabels:
-      app: ledgerexporter
+      app: ledgerexporter-pubnet
   replicas: 1
   template:
     metadata:
@@ -94,7 +94,7 @@ spec:
         prometheus.io/port: "6060"
         prometheus.io/scrape: "false"
       labels:
-        app: ledgerexporter
+        app: ledgerexporter-pubnet
     spec:
       containers:
       - envFrom:
@@ -104,7 +104,7 @@ spec:
             name: ledgerexporter-pubnet-env
         image: stellar/horizon-ledgerexporter:latest
         imagePullPolicy: Always
-        name: ledgerexporter
+        name: ledgerexporter-pubnet
         resources:  
           limits:
             cpu:     3
@@ -119,7 +119,7 @@ spec:
       volumes:
       - name: core-storage
         persistentVolumeClaim:
-          claimName: ledgerexporter-core-storage 
+          claimName: ledgerexporter-pubnet-core-storage 
 
 
  

--- a/services/horizon/docker/ledgerexporter/ledgerexporter.yml
+++ b/services/horizon/docker/ledgerexporter/ledgerexporter.yml
@@ -36,7 +36,7 @@ type: Opaque
 data:
   AWS_REGION: <base64 encoded value here>
   AWS_ACCESS_KEY_ID: <base64 encoded value here>
-  AWS_SECRET_ACCESS_KEY: <base64 encoded value here>=  
+  AWS_SECRET_ACCESS_KEY: <base64 encoded value here>  
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -56,6 +56,8 @@ spec:
     metadata:
       annotations:
         fluxcd.io/ignore: "true"
+        # if we expect to add metrics at some point to ledgerexporter
+        # this just needs to be set to true
         prometheus.io/port: "6060"
         prometheus.io/scrape: "false"
       labels:

--- a/services/horizon/docker/ledgerexporter/ledgerexporter.yml
+++ b/services/horizon/docker/ledgerexporter/ledgerexporter.yml
@@ -18,7 +18,7 @@ data:
   # when using core 'on disk', the earliest ledger to get streamed out after catchup to 2, is 3
   # whereas on in-memory it streas out 2, adjusted here, otherwise horizon ingest will abort
   # and stop process with error that ledger 3 is not <= expected ledger of 2.    
-  #START: "3"
+  START: "0"
   END: "0"
 
   # can only have CONTINUE or START set, not both.

--- a/services/horizon/docker/ledgerexporter/ledgerexporter.yml
+++ b/services/horizon/docker/ledgerexporter/ledgerexporter.yml
@@ -20,12 +20,28 @@ data:
   # and stop process with error that ledger 3 is not <= expected ledger of 2.    
   START: "3"
   END: "0"
+
   # can only have CONTINUE or START set, not both.
   #CONTINUE: "true"
   WRITE_LATEST_PATH: "true"
   CAPTIVE_CORE_USE_DB: "true"
+
+  # configure the network to export
   HISTORY_ARCHIVE_URLS: "https://history.stellar.org/prd/core-live/core_live_001,https://history.stellar.org/prd/core-live/core_live_002,https://history.stellar.org/prd/core-live/core_live_003"
   NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015"
+  # can refer to canned cfg's for pubnet and testnet which are included on the image 
+  # `/captive-core-pubnet.cfg` or `/captive-core-testnet.cfg`. 
+  # If exporting a standalone network, then mount a volume to the pod container with your standalone core's .cfg,
+  # and set full path to that volume here
+  CAPTIVE_CORE_CONFIG: "/captive-core-pubnet.cfg"
+  
+  # example of testnet network config. 
+  # HISTORY_ARCHIVE_URLS: "https://history.stellar.org/prd/core-testnet/core_testnet_001,https://history.stellar.org/prd/core-testnet/core_testnet_002"
+  # NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+  # CAPTIVE_CORE_CONFIG: "/captive-core-testnet.cfg"
+
+  # provide the url for the external s3 bucket to be populated
+  # update the ledgerexporter-pubnet-secret to have correct aws key/secret for access to the bucket
   ARCHIVE_TARGET: "s3://horizon-ledgermeta-pubnet"
 ---
 apiVersion: v1

--- a/services/horizon/docker/ledgerexporter/ledgerexporter.yml
+++ b/services/horizon/docker/ledgerexporter/ledgerexporter.yml
@@ -56,6 +56,21 @@ data:
   AWS_ACCESS_KEY_ID: <base64 encoded value here>
   AWS_SECRET_ACCESS_KEY: <base64 encoded value here> 
 ---
+# running captive core with on-disk mode limits RAM to around 2G usage, but 
+# requires some dedicated disk storage space that has at least 3k IOPS for read/write.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ledgerexporter-core-storage
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Gi
+  storageClassName: default
+  volumeMode: Filesystem
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -95,16 +110,16 @@ spec:
             cpu:     3
             memory:  8Gi
           requests:
-            cpu:      250m
-            memory:   500m
+            cpu:      500m
+            memory:   2Gi
         volumeMounts:
         - mountPath: /cc
-          name: tempfs-volume
+          name: core-storage
       dnsPolicy: ClusterFirst
       volumes:
-      - name: tempfs-volume
-        emptyDir: 
-          medium: Memory
+      - name: core-storage
+        persistentVolumeClaim:
+          claimName: ledgerexporter-core-storage 
 
 
  

--- a/services/horizon/docker/ledgerexporter/ledgerexporter.yml
+++ b/services/horizon/docker/ledgerexporter/ledgerexporter.yml
@@ -1,0 +1,90 @@
+# this file contains the ledgerexporter deployment and it's config artifacts.
+# when importing the manifest with kubectl, will only create, skips any that already exist.
+#
+# make sure to include namespace destination, the manifest does not specify, 
+# otherwise it'll go in your current kubectl context.
+#
+# if defining the secrets for first time, substitue <base64 encoded value here> placeholders.
+#
+# $ kubectl create -f ledgerexporter.yml -n horizon-dev
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    fluxcd.io/ignore: "true"
+  labels:
+    app: ledgerexporter
+  name: ledgerexporter-pubnet-env
+data:
+  START: "2"
+  END: "0"
+  # can only have CONTINUE or START set, not both.
+  #CONTINUE: "true"
+  WRITE_LATEST_PATH: "true"
+  CAPTIVE_CORE_USE_DB: "true"
+  HISTORY_ARCHIVE_URLS: "https://history.stellar.org/prd/core-live/core_live_001,https://history.stellar.org/prd/core-live/core_live_002,https://history.stellar.org/prd/core-live/core_live_003"
+  NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015"
+  ARCHIVE_TARGET: "s3://horizon-ledgermeta-pubnet"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: ledgerexporter
+  name: ledgerexporter-pubnet-secret
+type: Opaque
+data:
+  AWS_REGION: <base64 encoded value here>
+  AWS_ACCESS_KEY_ID: <base64 encoded value here>
+  AWS_SECRET_ACCESS_KEY: <base64 encoded value here>=  
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    fluxcd.io/ignore: "true"
+    deployment.kubernetes.io/revision: "3"
+  labels:
+    app: ledgerexporter
+  name: ledgerexporter-deployment
+spec:
+  selector:
+    matchLabels:
+      app: ledgerexporter
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        fluxcd.io/ignore: "true"
+        prometheus.io/port: "6060"
+        prometheus.io/scrape: "false"
+      labels:
+        app: ledgerexporter
+    spec:
+      containers:
+      - envFrom:
+        - secretRef:
+            name: ledgerexporter-pubnet-secret
+        - configMapRef:
+            name: ledgerexporter-pubnet-env
+        image: stellar/horizon-ledgerexporter:latest
+        imagePullPolicy: Always
+        name: ledgerexporter
+        resources:  
+          limits:
+            cpu:     1
+            memory:  4Gi
+          requests:
+            cpu:      250m
+            memory:   500m
+        volumeMounts:
+        - mountPath: /cc
+          name: tempfs-volume
+      dnsPolicy: ClusterFirst
+      volumes:
+      - name: tempfs-volume
+        emptyDir: 
+          medium: Memory
+
+
+ 

--- a/services/horizon/docker/ledgerexporter/start
+++ b/services/horizon/docker/ledgerexporter/start
@@ -50,6 +50,6 @@ export TRACY_NO_INVARIANT_CHECK=1
                 --captive-core-toml-path "$CAPTIVE_CORE_CONFIG" \
                 --history-archive-urls "$HISTORY_ARCHIVE_URLS" --network-passphrase "$NETWORK_PASSPHRASE" \
                 --continue="$CONTINUE" --write-latest-path="$WRITE_LATEST_PATH" \
-				--start-ledger "$START" --end-ledger "$END" --captive-core-use-db "$CAPTIVE_CORE_USE_DB"
+				--start-ledger "$START" --end-ledger "$END" --captive-core-use-db="$CAPTIVE_CORE_USE_DB"
 
 echo "OK"

--- a/services/horizon/docker/ledgerexporter/start
+++ b/services/horizon/docker/ledgerexporter/start
@@ -6,10 +6,17 @@ END="${END:=0}"
 CONTINUE="${CONTINUE:=false}"
 # Writing to /latest is disabled by default to avoid race conditions between parallel container runs
 WRITE_LATEST_PATH="${WRITE_LATEST_PATH:=false}"
+NETWORK_PASSPHRASE="${NETWORK_PASSPHRASE:=Public Global Stellar Network ; September 2015}"
+HISTORY_ARCHIVE_URLS="${HISTORY_ARCHIVE_URLS:=https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_001}"
+CAPTIVE_CORE_CONFIG="/captive-core-pubnet.cfg"
 
 if [ -z "$ARCHIVE_TARGET" ]; then
   echo "error: undefined ARCHIVE_TARGET env variable"
   exit 1
+fi
+
+if [ "$NETWORK_PASSPHRASE" = "Test SDF Network ; September 2015" ]; then
+  CAPTIVE_CORE_CONFIG="/captive-core-testnet.cfg"
 fi
 
 # Calculate params for AWS Batch
@@ -39,9 +46,9 @@ fi
 echo "START: $START END: $END"
 
 export TRACY_NO_INVARIANT_CHECK=1
-/ledgerexporter --target $ARCHIVE_TARGET \
-                --captive-core-toml-path /captive-core-pubnet.cfg \
-                --history-archive-urls 'https://history.stellar.org/prd/core-live/core_live_001' --network-passphrase 'Public Global Stellar Network ; September 2015' \
+/ledgerexporter --target "$ARCHIVE_TARGET" \
+                --captive-core-toml-path "$CAPTIVE_CORE_CONFIG" \
+                --history-archive-urls "$HISTORY_ARCHIVE_URLS" --network-passphrase "$NETWORK_PASSPHRASE" \
                 --continue="$CONTINUE" --write-latest-path="$WRITE_LATEST_PATH" --start-ledger "$START" --end-ledger "$END"
 
 echo "OK"

--- a/services/horizon/docker/ledgerexporter/start
+++ b/services/horizon/docker/ledgerexporter/start
@@ -8,7 +8,7 @@ CONTINUE="${CONTINUE:=false}"
 WRITE_LATEST_PATH="${WRITE_LATEST_PATH:=false}"
 NETWORK_PASSPHRASE="${NETWORK_PASSPHRASE:=Public Global Stellar Network ; September 2015}"
 HISTORY_ARCHIVE_URLS="${HISTORY_ARCHIVE_URLS:=https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_001}"
-CAPTIVE_CORE_CONFIG="/captive-core-pubnet.cfg"
+CAPTIVE_CORE_CONFIG="${CAPTIVE_CORE_CONFIG:=/captive-core-pubnet.cfg}"
 
 if [ -z "$ARCHIVE_TARGET" ]; then
   echo "error: undefined ARCHIVE_TARGET env variable"

--- a/services/horizon/docker/ledgerexporter/start
+++ b/services/horizon/docker/ledgerexporter/start
@@ -9,6 +9,7 @@ WRITE_LATEST_PATH="${WRITE_LATEST_PATH:=false}"
 NETWORK_PASSPHRASE="${NETWORK_PASSPHRASE:=Public Global Stellar Network ; September 2015}"
 HISTORY_ARCHIVE_URLS="${HISTORY_ARCHIVE_URLS:=https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_001}"
 CAPTIVE_CORE_CONFIG="${CAPTIVE_CORE_CONFIG:=/captive-core-pubnet.cfg}"
+CAPTIVE_CORE_USE_DB="${CAPTIVE_CORE_USE_DB:=true}"
 
 if [ -z "$ARCHIVE_TARGET" ]; then
   echo "error: undefined ARCHIVE_TARGET env variable"
@@ -49,6 +50,7 @@ export TRACY_NO_INVARIANT_CHECK=1
 /ledgerexporter --target "$ARCHIVE_TARGET" \
                 --captive-core-toml-path "$CAPTIVE_CORE_CONFIG" \
                 --history-archive-urls "$HISTORY_ARCHIVE_URLS" --network-passphrase "$NETWORK_PASSPHRASE" \
-                --continue="$CONTINUE" --write-latest-path="$WRITE_LATEST_PATH" --start-ledger "$START" --end-ledger "$END"
+                --continue="$CONTINUE" --write-latest-path="$WRITE_LATEST_PATH" \
+				--start-ledger "$START" --end-ledger "$END" --captive-core-use-db "$CAPTIVE_CORE_USE_DB"
 
 echo "OK"

--- a/services/horizon/docker/ledgerexporter/start
+++ b/services/horizon/docker/ledgerexporter/start
@@ -6,18 +6,17 @@ END="${END:=0}"
 CONTINUE="${CONTINUE:=false}"
 # Writing to /latest is disabled by default to avoid race conditions between parallel container runs
 WRITE_LATEST_PATH="${WRITE_LATEST_PATH:=false}"
+
+# config defaults to pubnet core, any other network requires setting all 3 of these in container env
 NETWORK_PASSPHRASE="${NETWORK_PASSPHRASE:=Public Global Stellar Network ; September 2015}"
 HISTORY_ARCHIVE_URLS="${HISTORY_ARCHIVE_URLS:=https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_001}"
 CAPTIVE_CORE_CONFIG="${CAPTIVE_CORE_CONFIG:=/captive-core-pubnet.cfg}"
+
 CAPTIVE_CORE_USE_DB="${CAPTIVE_CORE_USE_DB:=true}"
 
 if [ -z "$ARCHIVE_TARGET" ]; then
   echo "error: undefined ARCHIVE_TARGET env variable"
   exit 1
-fi
-
-if [ "$NETWORK_PASSPHRASE" = "Test SDF Network ; September 2015" ]; then
-  CAPTIVE_CORE_CONFIG="/captive-core-testnet.cfg"
 fi
 
 # Calculate params for AWS Batch

--- a/services/horizon/docker/ledgerexporter/start
+++ b/services/horizon/docker/ledgerexporter/start
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 set -e
 
-START="${START:=0}"
+START="${START:=2}"
 END="${END:=0}"
 CONTINUE="${CONTINUE:=false}"
 # Writing to /latest is disabled by default to avoid race conditions between parallel container runs

--- a/support/storage/main.go
+++ b/support/storage/main.go
@@ -31,6 +31,9 @@ type ConnectOptions struct {
 
 	// Wrap the Storage after connection. For example, to add a caching or introspection layer.
 	Wrap func(Storage) (Storage, error)
+
+	// When putting file object to s3 bucket, specify the ACL for the object.
+	S3WriteACL string
 }
 
 func ConnectBackend(u string, opts ConnectOptions) (Storage, error) {
@@ -60,6 +63,7 @@ func ConnectBackend(u string, opts ConnectOptions) (Storage, error) {
 			opts.S3Region,
 			opts.S3Endpoint,
 			opts.UnsignedRequests,
+			opts.S3WriteACL,
 		)
 
 	case "gcs":

--- a/support/storage/s3_test.go
+++ b/support/storage/s3_test.go
@@ -1,0 +1,52 @@
+// Copyright 2016 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockS3 struct {
+	mock.Mock
+	s3iface.S3API
+}
+
+func TestWriteACLRuleOverride(t *testing.T) {
+
+	mockS3 := &MockS3{}
+	s3Storage := S3Storage{
+		ctx:              context.Background(),
+		svc:              mockS3,
+		bucket:           "bucket",
+		prefix:           "prefix",
+		unsignedRequests: false,
+		writeACLrule:     s3.ObjectCannedACLBucketOwnerFullControl,
+	}
+
+	aclRule := s3Storage.GetACLWriteRule()
+	assert.Equal(t, aclRule, s3.ObjectCannedACLBucketOwnerFullControl)
+}
+
+func TestWriteACLRuleDefault(t *testing.T) {
+
+	mockS3 := &MockS3{}
+	s3Storage := S3Storage{
+		ctx:              context.Background(),
+		svc:              mockS3,
+		bucket:           "bucket",
+		prefix:           "prefix",
+		unsignedRequests: false,
+		writeACLrule:     "",
+	}
+
+	aclRule := s3Storage.GetACLWriteRule()
+	assert.Equal(t, aclRule, s3.ObjectCannedACLPublicRead)
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Enable the ledgerexporter image to be deployed/run as service in container orchestration, enable more env settings for configurability between testnet/pubnet. Create deployment on kubernetes that emits to S3 bucket.


### Why

Will enable latest txmeta from network to be constantly exported to s3 buckets.

### Known limitations


