### PR TITLE
exp/lighthorizon: Add response age prometheus metrics

### DIFF
--- a/exp/lighthorizon/http.go
+++ b/exp/lighthorizon/http.go
@@ -1,15 +1,18 @@
 package main
 
 import (
+	"net/http"
+	"strconv"
+	"time"
+
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/stellar/go/exp/lighthorizon/actions"
 	"github.com/stellar/go/exp/lighthorizon/services"
-	"net/http"
-	"strconv"
-	"time"
+	supportHttp "github.com/stellar/go/support/http"
 )
 
 func newWrapResponseWriter(w http.ResponseWriter, r *http.Request) middleware.WrapResponseWriter {
@@ -24,6 +27,7 @@ func newWrapResponseWriter(w http.ResponseWriter, r *http.Request) middleware.Wr
 func prometheusMiddleware(requestDurationMetric *prometheus.SummaryVec) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			route := supportHttp.GetChiRoutePattern(r)
 			mw := newWrapResponseWriter(w, r)
 
 			then := time.Now()
@@ -33,6 +37,7 @@ func prometheusMiddleware(requestDurationMetric *prometheus.SummaryVec) func(nex
 			requestDurationMetric.With(prometheus.Labels{
 				"status": strconv.FormatInt(int64(mw.Status()), 10),
 				"method": r.Method,
+				"route":  route,
 			}).Observe(float64(duration.Seconds()))
 		})
 	}
@@ -44,7 +49,7 @@ func lightHorizonHTTPHandler(registry *prometheus.Registry, lightHorizon service
 			Namespace: "horizon_lite", Subsystem: "http", Name: "requests_duration_seconds",
 			Help: "HTTP requests durations, sliding window = 10m",
 		},
-		[]string{"status", "method"},
+		[]string{"status", "method", "route"},
 	)
 	registry.MustRegister(requestDurationMetric)
 

--- a/exp/lighthorizon/main.go
+++ b/exp/lighthorizon/main.go
@@ -54,10 +54,10 @@ if left empty, uses a temporary directory`)
 	defer ingestArchive.Close()
 
 	Config := services.Config{
-		Archive:              ingestArchive,
-		Passphrase:           *networkPassphrase,
-		IndexStore:           indexStore,
-		ResponseAgeHistogram: services.NewResponseAgeHistogramMetric(registry),
+		Archive:    ingestArchive,
+		Passphrase: *networkPassphrase,
+		IndexStore: indexStore,
+		Metrics:    services.NewMetrics(registry),
 	}
 
 	lightHorizon := services.LightHorizon{

--- a/exp/lighthorizon/main.go
+++ b/exp/lighthorizon/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/stellar/go/exp/lighthorizon/archive"
 	"github.com/stellar/go/exp/lighthorizon/index"
 	"github.com/stellar/go/exp/lighthorizon/services"
@@ -53,9 +54,10 @@ if left empty, uses a temporary directory`)
 	defer ingestArchive.Close()
 
 	Config := services.Config{
-		Archive:    ingestArchive,
-		Passphrase: *networkPassphrase,
-		IndexStore: indexStore,
+		Archive:              ingestArchive,
+		Passphrase:           *networkPassphrase,
+		IndexStore:           indexStore,
+		ResponseAgeHistogram: services.NewResponseAgeHistogramMetric(registry),
 	}
 
 	lightHorizon := services.LightHorizon{

--- a/exp/lighthorizon/services/main.go
+++ b/exp/lighthorizon/services/main.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"io"
+	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,9 +27,9 @@ var (
 	checkpointManager = historyarchive.NewCheckpointManager(0)
 )
 
-// NewResponseAgeHistogramMetric creates a new prometheus histogram metric to measure
-// the age of response for a service.
-func NewResponseAgeHistogramMetric(registry *prometheus.Registry) *prometheus.HistogramVec {
+// NewMetrics returns a Metrics instance containing all the prometheus
+// metrics necessary for running light horizon services.
+func NewMetrics(registry *prometheus.Registry) Metrics {
 	const minute = 60
 	const day = 24 * 60 * minute
 	responseAgeHistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -50,7 +51,9 @@ func NewResponseAgeHistogramMetric(registry *prometheus.Registry) *prometheus.Hi
 		[]string{"request", "successful"},
 	)
 	registry.MustRegister(responseAgeHistogram)
-	return responseAgeHistogram
+	return Metrics{
+		ResponseAgeHistogram: responseAgeHistogram,
+	}
 }
 
 type LightHorizon struct {
@@ -58,11 +61,15 @@ type LightHorizon struct {
 	Transactions TransactionsService
 }
 
-type Config struct {
-	Archive              archive.Archive
-	IndexStore           index.Store
-	Passphrase           string
+type Metrics struct {
 	ResponseAgeHistogram *prometheus.HistogramVec
+}
+
+type Config struct {
+	Archive    archive.Archive
+	IndexStore index.Store
+	Passphrase string
+	Metrics    Metrics
 }
 
 type TransactionsService struct {
@@ -92,7 +99,15 @@ func operationsResponseAgeSeconds(ops []common.Operation) float64 {
 	if len(ops) == 0 {
 		return -1
 	}
-	lastCloseTime := time.Unix(int64(ops[len(ops)-1].LedgerHeader.ScpValue.CloseTime), 0).UTC()
+
+	oldest := ops[0].LedgerHeader.ScpValue.CloseTime
+	for i := 1; i < len(ops); i++ {
+		if closeTime := ops[i].LedgerHeader.ScpValue.CloseTime; closeTime > oldest {
+			oldest = closeTime
+		}
+	}
+
+	lastCloseTime := time.Unix(int64(oldest), 0).UTC()
 	now := time.Now().UTC()
 	if now.Before(lastCloseTime) {
 		log.Errorf("current time %v is before oldest operation close time %v", now, lastCloseTime)
@@ -132,30 +147,30 @@ func (os *OperationsService) GetOperationsByAccount(ctx context.Context,
 		return false, nil
 	}
 
-	if err := searchTxByAccount(ctx, cursor, accountId, os.Config, opsCallback); err != nil {
-		if age := operationsResponseAgeSeconds(ops); age >= 0 {
-			os.Config.ResponseAgeHistogram.With(prometheus.Labels{
-				"request":    "GetOperationsByAccount",
-				"successful": "false",
-			}).Observe(age)
-		}
-		return nil, err
-	}
-
+	err := searchTxByAccount(ctx, cursor, accountId, os.Config, opsCallback)
 	if age := operationsResponseAgeSeconds(ops); age >= 0 {
-		os.Config.ResponseAgeHistogram.With(prometheus.Labels{
+		os.Config.Metrics.ResponseAgeHistogram.With(prometheus.Labels{
 			"request":    "GetOperationsByAccount",
-			"successful": "true",
+			"successful": strconv.FormatBool(err == nil),
 		}).Observe(age)
 	}
-	return ops, nil
+
+	return ops, err
 }
 
 func transactionsResponseAgeSeconds(txs []common.Transaction) float64 {
 	if len(txs) == 0 {
 		return -1
 	}
-	lastCloseTime := time.Unix(int64(txs[len(txs)-1].LedgerHeader.ScpValue.CloseTime), 0).UTC()
+
+	oldest := txs[0].LedgerHeader.ScpValue.CloseTime
+	for i := 1; i < len(txs); i++ {
+		if closeTime := txs[i].LedgerHeader.ScpValue.CloseTime; closeTime > oldest {
+			oldest = closeTime
+		}
+	}
+
+	lastCloseTime := time.Unix(int64(oldest), 0).UTC()
 	now := time.Now().UTC()
 	if now.Before(lastCloseTime) {
 		log.Errorf("current time %v is before oldest transaction close time %v", now, lastCloseTime)
@@ -182,23 +197,15 @@ func (ts *TransactionsService) GetTransactionsByAccount(ctx context.Context,
 		return uint64(len(txs)) == limit, nil
 	}
 
-	if err := searchTxByAccount(ctx, cursor, accountId, ts.Config, txsCallback); err != nil {
-		if age := transactionsResponseAgeSeconds(txs); age >= 0 {
-			ts.Config.ResponseAgeHistogram.With(prometheus.Labels{
-				"request":    "GetTransactionsByAccount",
-				"successful": "false",
-			}).Observe(age)
-		}
-		return nil, err
-	}
-
+	err := searchTxByAccount(ctx, cursor, accountId, ts.Config, txsCallback)
 	if age := transactionsResponseAgeSeconds(txs); age >= 0 {
-		ts.Config.ResponseAgeHistogram.With(prometheus.Labels{
+		ts.Config.Metrics.ResponseAgeHistogram.With(prometheus.Labels{
 			"request":    "GetTransactionsByAccount",
-			"successful": "true",
+			"successful": strconv.FormatBool(err == nil),
 		}).Observe(age)
 	}
-	return txs, nil
+
+	return txs, err
 }
 
 func searchTxByAccount(ctx context.Context, cursor int64, accountId string, config Config, callback searchCallback) error {

--- a/exp/lighthorizon/services/main.go
+++ b/exp/lighthorizon/services/main.go
@@ -3,6 +3,9 @@ package services
 import (
 	"context"
 	"io"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stellar/go/exp/lighthorizon/archive"
 	"github.com/stellar/go/exp/lighthorizon/common"
@@ -23,15 +26,43 @@ var (
 	checkpointManager = historyarchive.NewCheckpointManager(0)
 )
 
+// NewResponseAgeHistogramMetric creates a new prometheus histogram metric to measure
+// the age of response for a service.
+func NewResponseAgeHistogramMetric(registry *prometheus.Registry) *prometheus.HistogramVec {
+	const minute = 60
+	const day = 24 * 60 * minute
+	responseAgeHistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "horizon_lite",
+		Subsystem: "services",
+		Name:      "response_age",
+		Buckets: []float64{
+			5 * minute,
+			60 * minute,
+			day,
+			7 * day,
+			30 * day,
+			90 * day,
+			180 * day,
+			365 * day,
+		},
+		Help: "Age of the response for each service, sliding window = 10m",
+	},
+		[]string{"request", "successful"},
+	)
+	registry.MustRegister(responseAgeHistogram)
+	return responseAgeHistogram
+}
+
 type LightHorizon struct {
 	Operations   OperationsService
 	Transactions TransactionsService
 }
 
 type Config struct {
-	Archive    archive.Archive
-	IndexStore index.Store
-	Passphrase string
+	Archive              archive.Archive
+	IndexStore           index.Store
+	Passphrase           string
+	ResponseAgeHistogram *prometheus.HistogramVec
 }
 
 type TransactionsService struct {
@@ -56,6 +87,19 @@ type TransactionRepository interface {
 // its corresponding ledger. It should return whether or not we should stop
 // processing (e.g. when a limit is reached) and any error that occurred.
 type searchCallback func(archive.LedgerTransaction, *xdr.LedgerHeader) (finished bool, err error)
+
+func operationsResponseAgeSeconds(ops []common.Operation) float64 {
+	if len(ops) == 0 {
+		return -1
+	}
+	lastCloseTime := time.Unix(int64(ops[len(ops)-1].LedgerHeader.ScpValue.CloseTime), 0).UTC()
+	now := time.Now().UTC()
+	if now.Before(lastCloseTime) {
+		log.Errorf("current time %v is before oldest operation close time %v", now, lastCloseTime)
+		return -1
+	}
+	return now.Sub(lastCloseTime).Seconds()
+}
 
 func (os *OperationsService) GetOperationsByAccount(ctx context.Context,
 	cursor int64, limit uint64,
@@ -89,10 +133,35 @@ func (os *OperationsService) GetOperationsByAccount(ctx context.Context,
 	}
 
 	if err := searchTxByAccount(ctx, cursor, accountId, os.Config, opsCallback); err != nil {
+		if age := operationsResponseAgeSeconds(ops); age >= 0 {
+			os.Config.ResponseAgeHistogram.With(prometheus.Labels{
+				"request":    "GetOperationsByAccount",
+				"successful": "false",
+			}).Observe(age)
+		}
 		return nil, err
 	}
 
+	if age := operationsResponseAgeSeconds(ops); age >= 0 {
+		os.Config.ResponseAgeHistogram.With(prometheus.Labels{
+			"request":    "GetOperationsByAccount",
+			"successful": "true",
+		}).Observe(age)
+	}
 	return ops, nil
+}
+
+func transactionsResponseAgeSeconds(txs []common.Transaction) float64 {
+	if len(txs) == 0 {
+		return -1
+	}
+	lastCloseTime := time.Unix(int64(txs[len(txs)-1].LedgerHeader.ScpValue.CloseTime), 0).UTC()
+	now := time.Now().UTC()
+	if now.Before(lastCloseTime) {
+		log.Errorf("current time %v is before oldest transaction close time %v", now, lastCloseTime)
+		return -1
+	}
+	return now.Sub(lastCloseTime).Seconds()
 }
 
 func (ts *TransactionsService) GetTransactionsByAccount(ctx context.Context,
@@ -114,7 +183,20 @@ func (ts *TransactionsService) GetTransactionsByAccount(ctx context.Context,
 	}
 
 	if err := searchTxByAccount(ctx, cursor, accountId, ts.Config, txsCallback); err != nil {
+		if age := transactionsResponseAgeSeconds(txs); age >= 0 {
+			ts.Config.ResponseAgeHistogram.With(prometheus.Labels{
+				"request":    "GetTransactionsByAccount",
+				"successful": "false",
+			}).Observe(age)
+		}
 		return nil, err
+	}
+
+	if age := transactionsResponseAgeSeconds(txs); age >= 0 {
+		ts.Config.ResponseAgeHistogram.With(prometheus.Labels{
+			"request":    "GetTransactionsByAccount",
+			"successful": "true",
+		}).Observe(age)
 	}
 	return txs, nil
 }

--- a/exp/lighthorizon/services/main.go
+++ b/exp/lighthorizon/services/main.go
@@ -102,7 +102,7 @@ func operationsResponseAgeSeconds(ops []common.Operation) float64 {
 
 	oldest := ops[0].LedgerHeader.ScpValue.CloseTime
 	for i := 1; i < len(ops); i++ {
-		if closeTime := ops[i].LedgerHeader.ScpValue.CloseTime; closeTime > oldest {
+		if closeTime := ops[i].LedgerHeader.ScpValue.CloseTime; closeTime < oldest {
 			oldest = closeTime
 		}
 	}
@@ -165,7 +165,7 @@ func transactionsResponseAgeSeconds(txs []common.Transaction) float64 {
 
 	oldest := txs[0].LedgerHeader.ScpValue.CloseTime
 	for i := 1; i < len(txs); i++ {
-		if closeTime := txs[i].LedgerHeader.ScpValue.CloseTime; closeTime > oldest {
+		if closeTime := txs[i].LedgerHeader.ScpValue.CloseTime; closeTime < oldest {
 			oldest = closeTime
 		}
 	}

--- a/exp/lighthorizon/services/main_test.go
+++ b/exp/lighthorizon/services/main_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/stellar/go/exp/lighthorizon/archive"
 	"github.com/stellar/go/exp/lighthorizon/index"
 	"github.com/stellar/go/toid"
@@ -227,9 +229,10 @@ func newTransactionService(ctx context.Context) TransactionsService {
 	archive, store := mockArchiveAndIndex(ctx, passphrase)
 	return TransactionsService{
 		Config: Config{
-			Archive:    archive,
-			IndexStore: store,
-			Passphrase: passphrase,
+			Archive:              archive,
+			IndexStore:           store,
+			Passphrase:           passphrase,
+			ResponseAgeHistogram: NewResponseAgeHistogramMetric(prometheus.NewRegistry()),
 		},
 	}
 }
@@ -239,9 +242,10 @@ func newOperationService(ctx context.Context) OperationsService {
 	archive, store := mockArchiveAndIndex(ctx, passphrase)
 	return OperationsService{
 		Config: Config{
-			Archive:    archive,
-			IndexStore: store,
-			Passphrase: passphrase,
+			Archive:              archive,
+			IndexStore:           store,
+			Passphrase:           passphrase,
+			ResponseAgeHistogram: NewResponseAgeHistogramMetric(prometheus.NewRegistry()),
 		},
 	}
 }

--- a/exp/lighthorizon/services/main_test.go
+++ b/exp/lighthorizon/services/main_test.go
@@ -229,10 +229,10 @@ func newTransactionService(ctx context.Context) TransactionsService {
 	archive, store := mockArchiveAndIndex(ctx, passphrase)
 	return TransactionsService{
 		Config: Config{
-			Archive:              archive,
-			IndexStore:           store,
-			Passphrase:           passphrase,
-			ResponseAgeHistogram: NewResponseAgeHistogramMetric(prometheus.NewRegistry()),
+			Archive:    archive,
+			IndexStore: store,
+			Passphrase: passphrase,
+			Metrics:    NewMetrics(prometheus.NewRegistry()),
 		},
 	}
 }
@@ -242,10 +242,10 @@ func newOperationService(ctx context.Context) OperationsService {
 	archive, store := mockArchiveAndIndex(ctx, passphrase)
 	return OperationsService{
 		Config: Config{
-			Archive:              archive,
-			IndexStore:           store,
-			Passphrase:           passphrase,
-			ResponseAgeHistogram: NewResponseAgeHistogramMetric(prometheus.NewRegistry()),
+			Archive:    archive,
+			IndexStore: store,
+			Passphrase: passphrase,
+			Metrics:    NewMetrics(prometheus.NewRegistry()),
 		},
 	}
 }

--- a/support/http/sanitize_route_test.go
+++ b/support/http/sanitize_route_test.go
@@ -1,12 +1,11 @@
-package httpx
+package http
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
-func TestMiddlewareSanitizesRoutesForPrometheus(t *testing.T) {
+func TestSanitizesRoutesForPrometheus(t *testing.T) {
 	for _, setup := range []struct {
 		name     string
 		route    string


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

As part of https://github.com/stellar/go/issues/4451 , this PR adds a metric to keep track of the age of the data contained in the service response. The response age is defined as the difference between the current time and the ledger close time of the oldest item in the service response.

This PR also adds the HTTP route for the request duration metric which is something I forgot to do in https://github.com/stellar/go/pull/4486 .

### Why

So we can know how far back in time we need to go for the requests served by horizon lite.

### Known limitations

We have preset the buckets to be:

5 minutes
1 hour
1 day
1 week
30 days
90 days
180 days
1 year