### PR TITLE
exp/lighthorizon/index: Allow accounts to be indexed by ledger.

### DIFF
--- a/exp/lighthorizon/index/builder.go
+++ b/exp/lighthorizon/index/builder.go
@@ -88,9 +88,14 @@ func BuildIndices(
 		case "transactions":
 			indexBuilder.RegisterModule(ProcessTransaction)
 		case "accounts":
-			indexBuilder.RegisterModule(ProcessAccounts)
+			indexBuilder.RegisterModule(ProcessAccountsByCheckpoint)
+		case "accounts_by_ledger":
+			indexBuilder.RegisterModule(ProcessAccountsByLedger)
 		case "accounts_unbacked":
-			indexBuilder.RegisterModule(ProcessAccountsWithoutBackend)
+			indexBuilder.RegisterModule(ProcessAccountsByCheckpointWithoutBackend)
+			indexStore.ClearMemory(false)
+		case "accounts_by_ledger_unbacked":
+			indexBuilder.RegisterModule(ProcessAccountsByLedgerWithoutBackend)
 			indexStore.ClearMemory(false)
 		default:
 			return indexBuilder, fmt.Errorf("unknown module '%s'", part)

--- a/exp/lighthorizon/index/cmd/batch/map/main.go
+++ b/exp/lighthorizon/index/cmd/batch/map/main.go
@@ -118,7 +118,7 @@ func main() {
 
 	parsedModules := []string{}
 	if modules := os.Getenv(modulesEnv); modules == "" {
-		parsedModules = []string{"accounts_unbacked", "transactions"}
+		parsedModules = []string{"accounts_unbacked"}
 	} else {
 		parsedModules = strings.Split(modulesEnv, ",")
 	}

--- a/exp/lighthorizon/index/cmd/batch/map/main.go
+++ b/exp/lighthorizon/index/cmd/batch/map/main.go
@@ -118,9 +118,9 @@ func main() {
 
 	parsedModules := []string{}
 	if modules := os.Getenv(modulesEnv); modules == "" {
-		parsedModules = []string{"accounts_unbacked"}
+		parsedModules = append(parsedModules, "accounts_unbacked")
 	} else {
-		parsedModules = strings.Split(modulesEnv, ",")
+		parsedModules = append(parsedModules, strings.Split(modules, ",")...)
 	}
 
 	log.Infof("Uploading ledger range [%d, %d] to %s",

--- a/exp/lighthorizon/index/cmd/batch/map/main.go
+++ b/exp/lighthorizon/index/cmd/batch/map/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/stellar/go/exp/lighthorizon/index"
 	"github.com/stellar/go/historyarchive"
@@ -29,6 +30,7 @@ const (
 	indexTargetUrlEnv    = "INDEX_TARGET"
 	workerCountEnv       = "WORKER_COUNT"
 	networkPassphraseEnv = "NETWORK_PASSPHRASE"
+	modulesEnv           = "MODULES"
 )
 
 func NewBatchConfig() (*BatchConfig, error) {
@@ -68,28 +70,12 @@ func NewBatchConfig() (*BatchConfig, error) {
 		return nil, errors.New("required parameter " + txmetaSourceUrlEnv)
 	}
 
-	networkPassphrase := os.Getenv(networkPassphraseEnv)
-	switch networkPassphrase {
-	case "":
-		log.Warnf("%s not specified, defaulting to 'testnet'", networkPassphraseEnv)
-		fallthrough
-	case "testnet":
-		networkPassphrase = network.TestNetworkPassphrase
-	case "pubnet":
-		networkPassphrase = network.PublicNetworkPassphrase
-	default:
-		log.Warnf("%s is not a recognized shortcut ('pubnet' or 'testnet')",
-			networkPassphraseEnv)
-	}
-	log.Infof("Using network passphrase '%s'", networkPassphrase)
-
 	firstLedger := uint32(firstCheckpoint + batchSize*jobIndex)
 	lastLedger := firstLedger + uint32(batchSize) - 1
 	return &BatchConfig{
-		Range:             historyarchive.Range{Low: firstLedger, High: lastLedger},
-		TxMetaSourceUrl:   txmetaSourceUrl,
-		IndexTargetUrl:    fmt.Sprintf("%s%cjob_%d", indexTargetRootUrl, os.PathSeparator, jobIndex),
-		NetworkPassphrase: networkPassphrase,
+		Range:           historyarchive.Range{Low: firstLedger, High: lastLedger},
+		TxMetaSourceUrl: txmetaSourceUrl,
+		IndexTargetUrl:  fmt.Sprintf("%s%cjob_%d", indexTargetRootUrl, os.PathSeparator, jobIndex),
 	}, nil
 }
 
@@ -115,6 +101,28 @@ func main() {
 		workerCount = int(workerCountParsed)
 	}
 
+	networkPassphrase := os.Getenv(networkPassphraseEnv)
+	switch networkPassphrase {
+	case "":
+		log.Warnf("%s not specified, defaulting to 'testnet'", networkPassphraseEnv)
+		fallthrough
+	case "testnet":
+		networkPassphrase = network.TestNetworkPassphrase
+	case "pubnet":
+		networkPassphrase = network.PublicNetworkPassphrase
+	default:
+		log.Warnf("%s is not a recognized shortcut ('pubnet' or 'testnet')",
+			networkPassphraseEnv)
+	}
+	log.Infof("Using network passphrase '%s'", networkPassphrase)
+
+	parsedModules := []string{}
+	if modules := os.Getenv(modulesEnv); modules == "" {
+		parsedModules = []string{"accounts_unbacked", "transactions"}
+	} else {
+		parsedModules = strings.Split(modulesEnv, ",")
+	}
+
 	log.Infof("Uploading ledger range [%d, %d] to %s",
 		batch.Range.Low, batch.Range.High, batch.IndexTargetUrl)
 
@@ -122,12 +130,9 @@ func main() {
 		context.Background(),
 		batch.TxMetaSourceUrl,
 		batch.IndexTargetUrl,
-		batch.NetworkPassphrase,
+		networkPassphrase,
 		batch.Range,
-		[]string{
-			"accounts_unbacked",
-			"transactions",
-		},
+		parsedModules,
 		workerCount,
 	); err != nil {
 		panic(err)

--- a/exp/lighthorizon/index/cmd/map.sh
+++ b/exp/lighthorizon/index/cmd/map.sh
@@ -68,7 +68,7 @@ for (( i=0; i < $BATCH_COUNT; i++ ))
 do
     echo -n "Creating map job $i... "
 
-    NETWORK_PASSPHRASE='testnet' \
+    NETWORK_PASSPHRASE='testnet' MODULES='accounts_unbacked,transactions' \
     AWS_BATCH_JOB_ARRAY_INDEX=$i BATCH_SIZE=$BATCH_SIZE FIRST_CHECKPOINT=$FIRST \
     TXMETA_SOURCE=file://$1 INDEX_TARGET=file://$2 WORKER_COUNT=1 \
         ./map &


### PR DESCRIPTION
### What
This adds `Module`s to build indices by ledger in addition to by checkpoint for account indices.

It also extends the map job to have a `MODULES` environmental variable to control which modules are built. To build without indices, you would pass `MODULES="accounts_by_ledger_unbacked"`.

It also removes building transaction indices by default.


### Why
We need to evaluate the difference in size / latency / etc. in using by-checkpoint or by-ledger indices for accounts.

### Known limitations
n/a