### PR TITLE
all: Bumps minimum Golang version to 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.18]
+        go: [1.19]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.17, 1.18]
+        go: [1.18, 1.19]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.17, 1.18]
+        go: [1.18, 1.19]
         pg: [9.6.5, 10]
     runs-on: ${{ matrix.os }}
     services:

--- a/.github/workflows/horizon-release.yml
+++ b/.github/workflows/horizon-release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./.github/actions/setup-go
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Check dependencies
         run: ./gomod.sh

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.17, 1.18]
+        go: [1.18, 1.19]
         pg: [9.6.5]
         ingestion-backend: [db, captive-core, captive-core-remote-storage]
         protocol-version: [18, 19]

--- a/exp/orderbook/pools.go
+++ b/exp/orderbook/pools.go
@@ -87,7 +87,7 @@ func makeTrade(
 // CalculatePoolPayout calculates the amount of `reserveB` disbursed from the
 // pool for a `received` amount of `reserveA` . From CAP-38:
 //
-//      y = floor[(1 - F) Yx / (X + x - Fx)]
+//	y = floor[(1 - F) Yx / (X + x - Fx)]
 //
 // It returns false if the calculation overflows.
 func CalculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int32, calculateRoundingSlippage bool) (xdr.Int64, xdr.Int64, bool) {
@@ -160,7 +160,7 @@ func CalculatePoolPayout(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int
 // CalculatePoolExpectation determines how much of `reserveA` you would need to
 // put into a pool to get the `disbursed` amount of `reserveB`.
 //
-//      x = ceil[Xy / ((Y - y)(1 - F))]
+//	x = ceil[Xy / ((Y - y)(1 - F))]
 //
 // It returns false if the calculation overflows.
 func CalculatePoolExpectation(

--- a/exp/orderbook/pools_test.go
+++ b/exp/orderbook/pools_test.go
@@ -336,7 +336,7 @@ func TestCalculatePoolPayoutRoundingSlippage(t *testing.T) {
 // CalculatePoolPayout calculates the amount of `reserveB` disbursed from the
 // pool for a `received` amount of `reserveA` . From CAP-38:
 //
-//      y = floor[(1 - F) Yx / (X + x - Fx)]
+//	y = floor[(1 - F) Yx / (X + x - Fx)]
 //
 // It returns false if the calculation overflows.
 func calculatePoolPayoutBig(reserveA, reserveB, received xdr.Int64, feeBips xdr.Int32) (xdr.Int64, xdr.Int64, bool) {
@@ -387,7 +387,7 @@ func calculatePoolPayoutBig(reserveA, reserveB, received xdr.Int64, feeBips xdr.
 // calculatePoolExpectation determines how much of `reserveA` you would need to
 // put into a pool to get the `disbursed` amount of `reserveB`.
 //
-//      x = ceil[Xy / ((Y - y)(1 - F))]
+//	x = ceil[Xy / ((Y - y)(1 - F))]
 //
 // It returns false if the calculation overflows.
 func calculatePoolExpectationBig(

--- a/exp/orderbook/search.go
+++ b/exp/orderbook/search.go
@@ -237,11 +237,11 @@ func search(
 // edges in `graph.edgesForSellingAsset` are traversed.
 //
 // The DFS maintains the following invariants:
-//  - no node is repeated
-//  - no offers are consumed from the `ignoreOffersFrom` account
-//  - each payment path must begin with an asset in `targetAssets`
-//  - also, the required source asset amount cannot exceed the balance in
-//    `targetAssets`
+//   - no node is repeated
+//   - no offers are consumed from the `ignoreOffersFrom` account
+//   - each payment path must begin with an asset in `targetAssets`
+//   - also, the required source asset amount cannot exceed the balance in
+//     `targetAssets`
 type sellingGraphSearchState struct {
 	graph                  *OrderBookGraph
 	destinationAssetString string
@@ -339,10 +339,10 @@ func (state *sellingGraphSearchState) consumePool(
 // edges in `graph.edgesForBuyingAsset` are traversed.
 //
 // The DFS maintains the following invariants:
-//  - no node is repeated
-//  - no offers are consumed from the `ignoreOffersFrom` account
-//  - each payment path must terminate with an asset in `targetAssets`
-//  - each payment path must begin with `sourceAsset`
+//   - no node is repeated
+//   - no offers are consumed from the `ignoreOffersFrom` account
+//   - each payment path must terminate with an asset in `targetAssets`
+//   - each payment path must begin with `sourceAsset`
 type buyingGraphSearchState struct {
 	graph             *OrderBookGraph
 	sourceAssetString string

--- a/exp/services/recoverysigner/internal/db/dbmigrate/dbmigrate_generated.go
+++ b/exp/services/recoverysigner/internal/db/dbmigrate/dbmigrate_generated.go
@@ -341,11 +341,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/exp/services/recoverysigner/internal/db/dbmigrate/dbmigrate_generated.go
+++ b/exp/services/recoverysigner/internal/db/dbmigrate/dbmigrate_generated.go
@@ -341,13 +341,11 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stellar/go
 
-go 1.17
+go 1.18
 
 require (
 	firebase.google.com/go v3.12.0+incompatible

--- a/gogenerate.sh
+++ b/gogenerate.sh
@@ -2,7 +2,7 @@
 set -e
 
 printf "Running go generate...\n"
-go generate ./...
+go generate ./... && go fmt ./...
 
 printf "Checking for no diff...\n"
 git diff --exit-code || (echo "Files changed after running go generate. Run go generate ./... locally and update generated files." && exit 1)

--- a/gxdr/xdr_generated.go
+++ b/gxdr/xdr_generated.go
@@ -284,13 +284,13 @@ type XdrAnon_AccountEntryExtensionV1_Ext struct {
 	_u interface{}
 }
 
-/* AccountEntry
+/*
+AccountEntry
 
-   Main entry representing a user in Stellar. All transactions are
-   performed using an account.
+	Main entry representing a user in Stellar. All transactions are
+	performed using an account.
 
-   Other ledger entries created require an account.
-
+	Other ledger entries created require an account.
 */
 type AccountEntry struct {
 	// master public key for this account
@@ -427,12 +427,13 @@ const (
 // Mask for OfferEntry flags
 const MASK_OFFERENTRY_FLAGS = 1
 
-/* OfferEntry
-   An offer is the building block of the offer book, they are automatically
-   claimed by payments when the price set by the owner is met.
+/*
+OfferEntry
 
-   For example an Offer is selling 10A where 1A is priced at 1.5B
+	An offer is the building block of the offer book, they are automatically
+	claimed by payments when the price set by the owner is met.
 
+	For example an Offer is selling 10A where 1A is priced at 1.5B
 */
 type OfferEntry struct {
 	SellerID AccountID
@@ -463,8 +464,10 @@ type XdrAnon_OfferEntry_Ext struct {
 	_u interface{}
 }
 
-/* DataEntry
-   Data can be attached to accounts.
+/*
+DataEntry
+
+	Data can be attached to accounts.
 */
 type DataEntry struct {
 	// account this data belongs to
@@ -837,7 +840,9 @@ type XdrAnon_LedgerHeader_Ext struct {
 	_u interface{}
 }
 
-/* Ledger upgrades
+/*
+	Ledger upgrades
+
 note that the `upgrades` field from StellarValue is normalized such that
 it only contains one entry per LedgerUpgradeType, and entries are sorted
 in ascending order
@@ -1375,13 +1380,14 @@ const (
 	LIQUIDITY_POOL_WITHDRAW          OperationType = 23
 )
 
-/* CreateAccount
+/*
+	CreateAccount
+
 Creates and funds a new account with the specified starting balance.
 
 Threshold: med
 
 Result: CreateAccountResult
-
 */
 type CreateAccountOp struct {
 	// account to create
@@ -1390,13 +1396,14 @@ type CreateAccountOp struct {
 	StartingBalance Int64
 }
 
-/* Payment
+/*
+Payment
 
-   Send an amount in specified asset to a destination account.
+	Send an amount in specified asset to a destination account.
 
-   Threshold: med
+	Threshold: med
 
-   Result: PaymentResult
+	Result: PaymentResult
 */
 type PaymentOp struct {
 	// recipient of the payment
@@ -1407,7 +1414,8 @@ type PaymentOp struct {
 	Amount Int64
 }
 
-/* PathPaymentStrictReceive
+/*
+	PathPaymentStrictReceive
 
 send an amount to a destination account through a path.
 (up to sendMax, sendAsset)
@@ -1433,7 +1441,8 @@ type PathPaymentStrictReceiveOp struct {
 	Path []Asset // bound 5
 }
 
-/* PathPaymentStrictSend
+/*
+	PathPaymentStrictSend
 
 send an amount to a destination account through a path.
 (sendMax, sendAsset)
@@ -1459,12 +1468,12 @@ type PathPaymentStrictSendOp struct {
 	Path []Asset // bound 5
 }
 
-/* Creates, updates or deletes an offer
+/*
+	Creates, updates or deletes an offer
 
 Threshold: med
 
 Result: ManageSellOfferResult
-
 */
 type ManageSellOfferOp struct {
 	Selling Asset
@@ -1477,12 +1486,12 @@ type ManageSellOfferOp struct {
 	OfferID Int64
 }
 
-/* Creates, updates or deletes an offer with amount in terms of buying asset
+/*
+	Creates, updates or deletes an offer with amount in terms of buying asset
 
 Threshold: med
 
 Result: ManageBuyOfferResult
-
 */
 type ManageBuyOfferOp struct {
 	Selling Asset
@@ -1495,12 +1504,12 @@ type ManageBuyOfferOp struct {
 	OfferID Int64
 }
 
-/* Creates an offer that doesn't take offers of the same price
+/*
+	Creates an offer that doesn't take offers of the same price
 
 Threshold: med
 
 Result: CreatePassiveSellOfferResult
-
 */
 type CreatePassiveSellOfferOp struct {
 	// A
@@ -1513,14 +1522,15 @@ type CreatePassiveSellOfferOp struct {
 	Price Price
 }
 
-/* Set Account Options
+/*
+Set Account Options
 
-   updates "AccountEntry" fields.
-   note: updating thresholds or signers requires high threshold
+	updates "AccountEntry" fields.
+	note: updating thresholds or signers requires high threshold
 
-   Threshold: med or high
+	Threshold: med or high
 
-   Result: SetOptionsResult
+	Result: SetOptionsResult
 */
 type SetOptionsOp struct {
 	// sets the inflation destination
@@ -1555,12 +1565,12 @@ type ChangeTrustAsset struct {
 	_u   interface{}
 }
 
-/* Creates, updates or deletes a trust line
+/*
+Creates, updates or deletes a trust line
 
-   Threshold: med
+	Threshold: med
 
-   Result: ChangeTrustResult
-
+	Result: ChangeTrustResult
 */
 type ChangeTrustOp struct {
 	Line ChangeTrustAsset
@@ -1568,14 +1578,16 @@ type ChangeTrustOp struct {
 	Limit Int64
 }
 
-/* Updates the "authorized" flag of an existing trust line
-   this is called by the issuer of the related asset.
+/*
+Updates the "authorized" flag of an existing trust line
 
-   note that authorize can only be set (and not cleared) if
-   the issuer account does not have the AUTH_REVOCABLE_FLAG set
-   Threshold: low
+	this is called by the issuer of the related asset.
 
-   Result: AllowTrustResult
+	note that authorize can only be set (and not cleared) if
+	the issuer account does not have the AUTH_REVOCABLE_FLAG set
+	Threshold: low
+
+	Result: AllowTrustResult
 */
 type AllowTrustOp struct {
 	Trustor AccountID
@@ -1584,13 +1596,15 @@ type AllowTrustOp struct {
 	Authorize Uint32
 }
 
-/* ManageData
-   Adds, Updates, or Deletes a key value pair associated with a particular
-       account.
+/*
+ManageData
 
-   Threshold: med
+	Adds, Updates, or Deletes a key value pair associated with a particular
+	    account.
 
-   Result: ManageDataResult
+	Threshold: med
+
+	Result: ManageDataResult
 */
 type ManageDataOp struct {
 	DataName String64
@@ -1598,23 +1612,25 @@ type ManageDataOp struct {
 	DataValue *DataValue
 }
 
-/* Bump Sequence
+/*
+Bump Sequence
 
-   increases the sequence to a given level
+	increases the sequence to a given level
 
-   Threshold: low
+	Threshold: low
 
-   Result: BumpSequenceResult
+	Result: BumpSequenceResult
 */
 type BumpSequenceOp struct {
 	BumpTo SequenceNumber
 }
 
-/* Creates a claimable balance entry
+/*
+Creates a claimable balance entry
 
-   Threshold: med
+	Threshold: med
 
-   Result: CreateClaimableBalanceResult
+	Result: CreateClaimableBalanceResult
 */
 type CreateClaimableBalanceOp struct {
 	Asset     Asset
@@ -1622,39 +1638,42 @@ type CreateClaimableBalanceOp struct {
 	Claimants []Claimant // bound 10
 }
 
-/* Claims a claimable balance entry
+/*
+Claims a claimable balance entry
 
-   Threshold: low
+	Threshold: low
 
-   Result: ClaimClaimableBalanceResult
+	Result: ClaimClaimableBalanceResult
 */
 type ClaimClaimableBalanceOp struct {
 	BalanceID ClaimableBalanceID
 }
 
-/* BeginSponsoringFutureReserves
+/*
+BeginSponsoringFutureReserves
 
-   Establishes the is-sponsoring-future-reserves-for relationship between
-   the source account and sponsoredID
+	Establishes the is-sponsoring-future-reserves-for relationship between
+	the source account and sponsoredID
 
-   Threshold: med
+	Threshold: med
 
-   Result: BeginSponsoringFutureReservesResult
+	Result: BeginSponsoringFutureReservesResult
 */
 type BeginSponsoringFutureReservesOp struct {
 	SponsoredID AccountID
 }
 
-/* RevokeSponsorship
+/*
+RevokeSponsorship
 
-   If source account is not sponsored or is sponsored by the owner of the
-   specified entry or sub-entry, then attempt to revoke the sponsorship.
-   If source account is sponsored, then attempt to transfer the sponsorship
-   to the sponsor of source account.
+	If source account is not sponsored or is sponsored by the owner of the
+	specified entry or sub-entry, then attempt to revoke the sponsorship.
+	If source account is sponsored, then attempt to transfer the sponsorship
+	to the sponsor of source account.
 
-   Threshold: med
+	Threshold: med
 
-   Result: RevokeSponsorshipResult
+	Result: RevokeSponsorshipResult
 */
 type RevokeSponsorshipType int32
 
@@ -1677,11 +1696,12 @@ type XdrAnon_RevokeSponsorshipOp_Signer struct {
 	SignerKey SignerKey
 }
 
-/* Claws back an amount of an asset from an account
+/*
+Claws back an amount of an asset from an account
 
-   Threshold: med
+	Threshold: med
 
-   Result: ClawbackResult
+	Result: ClawbackResult
 */
 type ClawbackOp struct {
 	Asset  Asset
@@ -1689,24 +1709,26 @@ type ClawbackOp struct {
 	Amount Int64
 }
 
-/* Claws back a claimable balance
+/*
+Claws back a claimable balance
 
-   Threshold: med
+	Threshold: med
 
-   Result: ClawbackClaimableBalanceResult
+	Result: ClawbackClaimableBalanceResult
 */
 type ClawbackClaimableBalanceOp struct {
 	BalanceID ClaimableBalanceID
 }
 
-/* SetTrustLineFlagsOp
+/*
+SetTrustLineFlagsOp
 
-   Updates the flags of an existing trust line.
-   This is called by the issuer of the related asset.
+	Updates the flags of an existing trust line.
+	This is called by the issuer of the related asset.
 
-   Threshold: low
+	Threshold: low
 
-   Result: SetTrustLineFlagsResult
+	Result: SetTrustLineFlagsResult
 */
 type SetTrustLineFlagsOp struct {
 	Trustor AccountID
@@ -1719,11 +1741,12 @@ type SetTrustLineFlagsOp struct {
 
 const LIQUIDITY_POOL_FEE_V18 = 30
 
-/* Deposit assets into a liquidity pool
+/*
+Deposit assets into a liquidity pool
 
-   Threshold: med
+	Threshold: med
 
-   Result: LiquidityPoolDepositResult
+	Result: LiquidityPoolDepositResult
 */
 type LiquidityPoolDepositOp struct {
 	LiquidityPoolID PoolID
@@ -1737,11 +1760,12 @@ type LiquidityPoolDepositOp struct {
 	MaxPrice Price
 }
 
-/* Withdraw assets from a liquidity pool
+/*
+Withdraw assets from a liquidity pool
 
-   Threshold: med
+	Threshold: med
 
-   Result: LiquidityPoolWithdrawResult
+	Result: LiquidityPoolWithdrawResult
 */
 type LiquidityPoolWithdrawOp struct {
 	LiquidityPoolID PoolID
@@ -1955,12 +1979,13 @@ type TransactionV0Envelope struct {
 	Signatures []DecoratedSignature // bound 20
 }
 
-/* a transaction is a container for a set of operations
-   - is executed by an account
-   - fees are collected from the account
-   - operations are executed in order as one ACID transaction
-         either all operations are applied or none are
-         if any returns a failing code
+/*
+a transaction is a container for a set of operations
+  - is executed by an account
+  - fees are collected from the account
+  - operations are executed in order as one ACID transaction
+    either all operations are applied or none are
+    if any returns a failing code
 */
 type Transaction struct {
 	// account used to run the transaction
@@ -2094,8 +2119,10 @@ type ClaimLiquidityAtom struct {
 	AmountBought Int64
 }
 
-/* This result is used when offers are taken or liquidity is exchanged with a
-   liquidity pool during an operation
+/*
+This result is used when offers are taken or liquidity is exchanged with a
+
+	liquidity pool during an operation
 */
 type ClaimAtom struct {
 	// The union discriminant Type selects among the following arms:

--- a/ingest/change_compactor.go
+++ b/ingest/change_compactor.go
@@ -17,36 +17,36 @@ import (
 //
 // It applies changes to the cache using the following algorithm:
 //
-// 1. If the change is CREATED it checks if any change connected to given entry
-//    is already in the cache. If not, it adds CREATED change. Otherwise, if
-//    existing change is:
-//    a. CREATED it returns error because we can't add an entry that already
-//       exists.
-//    b. UPDATED it returns error because we can't add an entry that already
-//       exists.
-//    c. REMOVED it means that due to previous transitions we want to remove
-//       this from a DB what means that it already exists in a DB so we need to
-//       update the type of change to UPDATED.
-// 2. If the change is UPDATE it checks if any change connected to given entry
-//    is already in the cache. If not, it adds UPDATE change. Otherwise, if
-//    existing change is:
-//    a. CREATED it means that due to previous transitions we want to create
-//       this in a DB what means that it doesn't exist in a DB so we need to
-//       update the entry but stay with CREATED type.
-//    b. UPDATED we simply update it with the new value.
-//    c. REMOVED it means that at this point in the ledger the entry is removed
-//       so updating it returns an error.
-// 3. If the change is REMOVE it checks if any change connected to given entry
-//    is already in the cache. If not, it adds REMOVE change. Otherwise, if
-//    existing change is:
-//    a. CREATED it means that due to previous transitions we want to create
-//       this in a DB what means that it doesn't exist in a DB. If it was
-//       created and removed in the same ledger it's a noop so we remove entry
-//       from the cache.
-//    b. UPDATED we simply update it to be a REMOVE change because the UPDATE
-//       change means the entry exists in a DB.
-//    c. REMOVED it returns error because we can't remove an entry that was
-//       already removed.
+//  1. If the change is CREATED it checks if any change connected to given entry
+//     is already in the cache. If not, it adds CREATED change. Otherwise, if
+//     existing change is:
+//     a. CREATED it returns error because we can't add an entry that already
+//     exists.
+//     b. UPDATED it returns error because we can't add an entry that already
+//     exists.
+//     c. REMOVED it means that due to previous transitions we want to remove
+//     this from a DB what means that it already exists in a DB so we need to
+//     update the type of change to UPDATED.
+//  2. If the change is UPDATE it checks if any change connected to given entry
+//     is already in the cache. If not, it adds UPDATE change. Otherwise, if
+//     existing change is:
+//     a. CREATED it means that due to previous transitions we want to create
+//     this in a DB what means that it doesn't exist in a DB so we need to
+//     update the entry but stay with CREATED type.
+//     b. UPDATED we simply update it with the new value.
+//     c. REMOVED it means that at this point in the ledger the entry is removed
+//     so updating it returns an error.
+//  3. If the change is REMOVE it checks if any change connected to given entry
+//     is already in the cache. If not, it adds REMOVE change. Otherwise, if
+//     existing change is:
+//     a. CREATED it means that due to previous transitions we want to create
+//     this in a DB what means that it doesn't exist in a DB. If it was
+//     created and removed in the same ledger it's a noop so we remove entry
+//     from the cache.
+//     b. UPDATED we simply update it to be a REMOVE change because the UPDATE
+//     change means the entry exists in a DB.
+//     c. REMOVED it returns error because we can't remove an entry that was
+//     already removed.
 type ChangeCompactor struct {
 	// ledger key => Change
 	cache          map[string]Change

--- a/ingest/checkpoint_change_reader.go
+++ b/ingest/checkpoint_change_reader.go
@@ -156,12 +156,12 @@ func (r *CheckpointChangeReader) bucketExists(hash historyarchive.Hash) (bool, e
 //
 // However, we can modify this algorithm to work from newest to oldest ledgers:
 //
-//   1. For each `INITENTRY`/`LIVEENTRY` we check if we've seen the key before
-//      (stored in `tempStore`). If the key hasn't been seen, we write that bucket
-//      entry to the stream and add it to the `tempStore` (we don't mark `INITENTRY`,
-//      see the inline comment or CAP-20).
-//   2. For each `DEADENTRY` we keep track of removed bucket entries in
-//      `tempStore` map.
+//  1. For each `INITENTRY`/`LIVEENTRY` we check if we've seen the key before
+//     (stored in `tempStore`). If the key hasn't been seen, we write that bucket
+//     entry to the stream and add it to the `tempStore` (we don't mark `INITENTRY`,
+//     see the inline comment or CAP-20).
+//  2. For each `DEADENTRY` we keep track of removed bucket entries in
+//     `tempStore` map.
 //
 // In such algorithm we just need to store a set of keys that require much less space.
 // The memory requirements will be lowered when CAP-0020 is live and older buckets are

--- a/ingest/doc.go
+++ b/ingest/doc.go
@@ -1,12 +1,11 @@
 /*
-
 Package ingest provides primitives for building custom ingestion engines.
 
 Very often developers need features that are outside of Horizon's scope. While
 it provides APIs for building the most common apps, it's not possible to add all
 possible features. This is why this package was created.
 
-Ledger Backend
+# Ledger Backend
 
 Ledger backends are sources of information about Stellar network ledgers. This
 can be, for example: a Stellar-Core database, (possibly-remote) Captive
@@ -14,31 +13,31 @@ Stellar-Core instances, or History Archives. Please consult the "ledgerbackend"
 package docs for more information about each backend.
 
 Warning: Ledger backends provide low-level xdr.LedgerCloseMeta that should not
-         be used directly unless the developer really understands this data
-         structure. Read on to understand how to use ledger backend in higher
-         level objects.
 
-Readers
+	be used directly unless the developer really understands this data
+	structure. Read on to understand how to use ledger backend in higher
+	level objects.
+
+# Readers
 
 Readers are objects that wrap ledger backend and provide higher level, developer
 friendly APIs for reading ledger data.
 
 Currently there are three types of readers:
- * CheckpointChangeReader reads ledger entries from history buckets for a given
-   checkpoint ledger. Allow building state (all accounts, trust lines etc.) at
-   any checkpoint ledger.
- * LedgerTransactionReader reads transactions for a given ledger sequence.
- * LedgerChangeReader reads all changes to ledger entries created as a result of
-   transactions (fees and meta) and protocol upgrades in a given ledger.
+  - CheckpointChangeReader reads ledger entries from history buckets for a given
+    checkpoint ledger. Allow building state (all accounts, trust lines etc.) at
+    any checkpoint ledger.
+  - LedgerTransactionReader reads transactions for a given ledger sequence.
+  - LedgerChangeReader reads all changes to ledger entries created as a result of
+    transactions (fees and meta) and protocol upgrades in a given ledger.
 
 Warning: Readers stream BOTH successful and failed transactions; check
 transactions status in your application if required.
 
-Tutorial
+# Tutorial
 
 Refer to the examples below for simple use cases, or check out the README (and
 its corresponding tutorial/ subfolder) in the repository for a Getting Started
 guide: https://github.com/stellar/go/blob/master/ingest/README.md
-
 */
 package ingest

--- a/ingest/ledgerbackend/buffered_meta_pipe_reader.go
+++ b/ingest/ledgerbackend/buffered_meta_pipe_reader.go
@@ -48,11 +48,11 @@ type metaResult struct {
 //
 // It solves the following issues:
 //
-//   * Decouples buffering from stellarCoreRunner so it can focus on running core.
-//   * Decouples unmarshalling and buffering of LedgerCloseMeta's from CaptiveCore.
-//   * By adding buffering it allows unmarshaling the ledgers available in Stellar-Core
+//   - Decouples buffering from stellarCoreRunner so it can focus on running core.
+//   - Decouples unmarshalling and buffering of LedgerCloseMeta's from CaptiveCore.
+//   - By adding buffering it allows unmarshaling the ledgers available in Stellar-Core
 //     while previous ledger are being processed.
-//   * Limits memory usage in case of large ledgers are closed by the network.
+//   - Limits memory usage in case of large ledgers are closed by the network.
 //
 // Internally, it keeps two buffers: bufio.Reader with binary ledger data and
 // buffered channel with unmarshaled xdr.LedgerCloseMeta objects ready for
@@ -82,8 +82,8 @@ func newBufferedLedgerMetaReader(reader io.Reader) *bufferedLedgerMetaReader {
 
 // readLedgerMetaFromPipe unmarshalls the next ledger from meta pipe.
 // It can block for two reasons:
-//   * Meta pipe buffer is full so it will wait until it refills.
-//   * The next ledger available in the buffer exceeds the meta pipe buffer size.
+//   - Meta pipe buffer is full so it will wait until it refills.
+//   - The next ledger available in the buffer exceeds the meta pipe buffer size.
 //     In such case the method will block until LedgerCloseMeta buffer is empty.
 func (b *bufferedLedgerMetaReader) readLedgerMetaFromPipe() (*xdr.LedgerCloseMeta, error) {
 	frameLength, err := xdr.ReadFrameLength(b.decoder)

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -32,10 +32,10 @@ func (c *CaptiveStellarCore) roundDownToFirstReplayAfterCheckpointStart(ledger u
 // than DatabaseBackend but requires some extra init time.
 //
 // It operates in two modes:
-//   * When a BoundedRange is prepared it starts Stellar-Core in catchup mode that
+//   - When a BoundedRange is prepared it starts Stellar-Core in catchup mode that
 //     replays ledgers in memory. This is very fast but requires Stellar-Core to
 //     keep ledger state in RAM. It requires around 3GB of RAM as of August 2020.
-//   * When a UnboundedRange is prepared it runs Stellar-Core catchup mode to
+//   - When a UnboundedRange is prepared it runs Stellar-Core catchup mode to
 //     sync with the first ledger and then runs it in a normal mode. This
 //     requires the configAppendPath to be provided because a quorum set needs to
 //     be selected.
@@ -52,9 +52,9 @@ func (c *CaptiveStellarCore) roundDownToFirstReplayAfterCheckpointStart(ledger u
 //
 // While using BoundedRanges is straightforward there are a few gotchas connected
 // to UnboundedRanges:
-//   * PrepareRange takes more time because all ledger entries must be stored on
+//   - PrepareRange takes more time because all ledger entries must be stored on
 //     disk instead of RAM.
-//   * If GetLedger is not called frequently (every 5 sec. on average) the
+//   - If GetLedger is not called frequently (every 5 sec. on average) the
 //     Stellar-Core process can go out of sync with the network. This happens
 //     because there is no buffering of communication pipe and CaptiveStellarCore
 //     has a very small internal buffer and Stellar-Core will not close the new
@@ -362,9 +362,10 @@ func (c *CaptiveStellarCore) startPreparingRange(ctx context.Context, ledgerRang
 // Captive stellar-core backend needs to initialize Stellar-Core state to be
 // able to stream ledgers.
 // Stellar-Core mode depends on the provided ledgerRange:
-//   * For BoundedRange it will start Stellar-Core in catchup mode.
-//   * For UnboundedRange it will first catchup to starting ledger and then run
+//   - For BoundedRange it will start Stellar-Core in catchup mode.
+//   - For UnboundedRange it will first catchup to starting ledger and then run
 //     it normally (including connecting to the Stellar network).
+//
 // Please note that using a BoundedRange, currently, requires a full-trust on
 // history archive. This issue is being fixed in Stellar-Core.
 func (c *CaptiveStellarCore) PrepareRange(ctx context.Context, ledgerRange Range) error {
@@ -447,7 +448,7 @@ func (c *CaptiveStellarCore) isPrepared(ledgerRange Range) bool {
 // is less than the last requested sequence number, an error will be returned.
 //
 // This function behaves differently for bounded and unbounded ranges:
-//   * BoundedRange: After getting the last ledger in a range this method will
+//   - BoundedRange: After getting the last ledger in a range this method will
 //     also Close() the backend.
 func (c *CaptiveStellarCore) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error) {
 	c.stellarCoreLock.RLock()

--- a/ingest/ledgerbackend/remote_captive_core.go
+++ b/ingest/ledgerbackend/remote_captive_core.go
@@ -157,9 +157,10 @@ func (c RemoteCaptiveStellarCore) Close() error {
 // Captive stellar-core backend needs to initalize Stellar-Core state to be
 // able to stream ledgers.
 // Stellar-Core mode depends on the provided ledgerRange:
-//   * For BoundedRange it will start Stellar-Core in catchup mode.
-//   * For UnboundedRange it will first catchup to starting ledger and then run
+//   - For BoundedRange it will start Stellar-Core in catchup mode.
+//   - For UnboundedRange it will first catchup to starting ledger and then run
 //     it normally (including connecting to the Stellar network).
+//
 // Please note that using a BoundedRange, currently, requires a full-trust on
 // history archive. This issue is being fixed in Stellar-Core.
 func (c RemoteCaptiveStellarCore) PrepareRange(ctx context.Context, ledgerRange Range) error {

--- a/ingest/ledgerbackend/toml.go
+++ b/ingest/ledgerbackend/toml.go
@@ -140,8 +140,10 @@ type CaptiveCoreToml struct {
 // path with a placeholder. For example:
 //
 // text := `[QUORUM_SET.a.b.c]
-//         THRESHOLD_PERCENT=67
-//         VALIDATORS=["a","b"]`
+//
+//	THRESHOLD_PERCENT=67
+//	VALIDATORS=["a","b"]`
+//
 // flattenTables(text, []string{"QUORUM_SET"}) ->
 //
 // `[__placeholder_label_0__]

--- a/price/main.go
+++ b/price/main.go
@@ -122,7 +122,7 @@ func floor(n *big.Rat) *big.Rat {
 	return f
 }
 
-//StringFromFloat64 will format a float64 to decimal representation with 7 digits after the decimal point
+// StringFromFloat64 will format a float64 to decimal representation with 7 digits after the decimal point
 func StringFromFloat64(v float64) string {
 	return strconv.FormatFloat(v, 'f', 7, 64)
 }
@@ -131,17 +131,17 @@ func StringFromFloat64(v float64) string {
 // the price and returns (buyingUnits, sellingUnits) that can be taken from the
 // offer
 //
-//     offerSellingBound = (offer.price.n > offer.price.d)
-//         ? offer.amount
-//         : ceil(floor(offer.amount * offer.price) / offer.price)
-//     pathPaymentAmountBought = min(offerSellingBound, pathPaymentBuyingBound)
-//     pathPaymentAmountSold = ceil(pathPaymentAmountBought * offer.price)
+//	offerSellingBound = (offer.price.n > offer.price.d)
+//	    ? offer.amount
+//	    : ceil(floor(offer.amount * offer.price) / offer.price)
+//	pathPaymentAmountBought = min(offerSellingBound, pathPaymentBuyingBound)
+//	pathPaymentAmountSold = ceil(pathPaymentAmountBought * offer.price)
 //
-//     offer.amount = amount selling
-//     offerSellingBound = roundingCorrectedOffer
-//     pathPaymentBuyingBound = needed
-//     pathPaymentAmountBought = what we are consuming from offer
-//     pathPaymentAmountSold = amount we are giving to the buyer
+//	offer.amount = amount selling
+//	offerSellingBound = roundingCorrectedOffer
+//	pathPaymentBuyingBound = needed
+//	pathPaymentAmountBought = what we are consuming from offer
+//	pathPaymentAmountSold = amount we are giving to the buyer
 //
 // Sell units = pathPaymentAmountSold and buy units = pathPaymentAmountBought
 //

--- a/randxdr/presets.go
+++ b/randxdr/presets.go
@@ -49,12 +49,14 @@ var IsPtr Selector = func(name string, xdrType goxdr.XdrType) bool {
 }
 
 // IsNestedInnerSet is a Selector which identifies nesting for the following xdr type:
+//
 //	struct SCPQuorumSet
 //	{
 //		uint32 threshold;
 //		PublicKey validators<>;
 //		SCPQuorumSet innerSets<>;
 //	};
+//
 // supports things like: A,B,C,(D,E,F),(G,H,(I,J,K,L))
 // only allows 2 levels of nesting
 var IsNestedInnerSet Selector = func(name string, xdrType goxdr.XdrType) bool {

--- a/services/horizon/docker/Dockerfile.dev
+++ b/services/horizon/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS builder
+FROM golang:1.18 AS builder
 
 WORKDIR /go/src/github.com/stellar/go
 COPY go.mod go.sum ./

--- a/services/horizon/internal/actions_trade_test.go
+++ b/services/horizon/internal/actions_trade_test.go
@@ -341,7 +341,7 @@ func unsetAssetQuery(q *url.Values, prefix string) {
 	q.Del(prefix + "asset_issuer")
 }
 
-//testPrice ensures that the price float string is equal to the rational price
+// testPrice ensures that the price float string is equal to the rational price
 func testPrice(t *HTTPT, priceStr string, priceR horizon.TradePrice) {
 	price, err := strconv.ParseFloat(priceStr, 64)
 	if t.Assert.NoError(err) {
@@ -757,7 +757,7 @@ func TestTradeActions_AggregationOffset(t *testing.T) {
 	}
 }
 
-//GetTestAsset generates an issuer on the fly and creates a CreditAlphanum4 Asset with given code
+// GetTestAsset generates an issuer on the fly and creates a CreditAlphanum4 Asset with given code
 func GetTestAsset(code string) xdr.Asset {
 	var codeBytes [4]byte
 	copy(codeBytes[:], []byte(code))
@@ -765,7 +765,7 @@ func GetTestAsset(code string) xdr.Asset {
 	return xdr.Asset{Type: xdr.AssetTypeAssetTypeCreditAlphanum4, AlphaNum4: &ca4, AlphaNum12: nil}
 }
 
-//Get generates and returns an account on the fly
+// Get generates and returns an account on the fly
 func GetTestAccount() xdr.AccountId {
 	var key xdr.Uint256
 	kp, _ := keypair.Random()
@@ -781,7 +781,7 @@ func abs(a xdr.Int32) xdr.Int32 {
 	return a
 }
 
-//IngestTestTrade mock ingests a trade
+// IngestTestTrade mock ingests a trade
 func IngestTestTrade(
 	q *history.Q,
 	assetSold xdr.Asset,
@@ -852,7 +852,7 @@ func IngestTestTrade(
 	return nil
 }
 
-//PopulateTestTrades generates and ingests trades between two assets according to given parameters
+// PopulateTestTrades generates and ingests trades between two assets according to given parameters
 func PopulateTestTrades(
 	q *history.Q,
 	startTs int64,

--- a/services/horizon/internal/assets/main.go
+++ b/services/horizon/internal/assets/main.go
@@ -1,4 +1,4 @@
-//Package assets is a simple helper package to help convert to/from xdr.AssetType values
+// Package assets is a simple helper package to help convert to/from xdr.AssetType values
 package assets
 
 import (
@@ -9,7 +9,7 @@ import (
 // ErrInvalidString gets returns when the string form of the asset type is invalid
 var ErrInvalidString = errors.New("invalid asset type: was not one of 'native', 'credit_alphanum4', 'credit_alphanum12', 'liquidity_pool_shares'")
 
-//ErrInvalidValue gets returned when the xdr.AssetType int value is not one of the valid enum values
+// ErrInvalidValue gets returned when the xdr.AssetType int value is not one of the valid enum values
 var ErrInvalidValue = errors.New("unknown asset type, cannot convert to string")
 
 // AssetTypeMap is the read-only (i.e. don't modify it) map from string names to
@@ -20,7 +20,7 @@ var AssetTypeMap = map[string]xdr.AssetType{
 	"credit_alphanum12": xdr.AssetTypeAssetTypeCreditAlphanum12,
 }
 
-//Parse creates an asset from the provided strings.  See AssetTypeMap for valid strings for aType.
+// Parse creates an asset from the provided strings.  See AssetTypeMap for valid strings for aType.
 func Parse(aType string) (result xdr.AssetType, err error) {
 	result, ok := AssetTypeMap[aType]
 	if !ok {
@@ -30,7 +30,7 @@ func Parse(aType string) (result xdr.AssetType, err error) {
 	return
 }
 
-//String returns the appropriate string representation of the provided xdr.AssetType.
+// String returns the appropriate string representation of the provided xdr.AssetType.
 func String(aType xdr.AssetType) (string, error) {
 	for s, v := range AssetTypeMap {
 		if v == aType {

--- a/services/horizon/internal/codes/main.go
+++ b/services/horizon/internal/codes/main.go
@@ -1,5 +1,5 @@
-//Package codes is a helper package to help convert to transaction and operation result codes
-//to strings used in horizon.
+// Package codes is a helper package to help convert to transaction and operation result codes
+// to strings used in horizon.
 package codes
 
 import (
@@ -37,7 +37,7 @@ const (
 	OpDoesNotExist = "op_does_not_exist"
 )
 
-//String returns the appropriate string representation of the provided result code
+// String returns the appropriate string representation of the provided result code
 func String(code interface{}) (string, error) {
 	switch code := code.(type) {
 	case xdr.TransactionResultCode:

--- a/services/horizon/internal/db2/history/accounts.go
+++ b/services/horizon/internal/db2/history/accounts.go
@@ -225,7 +225,7 @@ func selectUnionBySponsor(tables []string, sponsor string, page db2.PageQuery) (
 		Limit(page.Limit), nil
 }
 
-// AccountsForSponsor return all the accounts where `sponsor`` is sponsoring the account entry or
+// AccountsForSponsor return all the accounts where `sponsor“ is sponsoring the account entry or
 // any of its subentries (trust lines, signers, data, or account entry)
 func (q *Q) AccountsForSponsor(ctx context.Context, sponsor string, page db2.PageQuery) ([]AccountEntry, error) {
 	sql, err := selectUnionBySponsor(

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -904,15 +904,16 @@ func (q Q) ReapLookupTables(ctx context.Context, offsets map[string]int64) (map[
 // as an example):
 //
 // delete from history_claimable_balances where id in
-//  (select id from
-//    (select id,
-// 		(select count(*) from history_operation_claimable_balances
-// 		 where history_claimable_balance_id = hcb.id) as c1,
-// 		(select count(*) from history_transaction_claimable_balances
-// 		 where history_claimable_balance_id = hcb.id) as c2,
-//		1 as cx,
-//      from history_claimable_balances hcb order by id limit 100 offset 1000)
-//  as sub where c1 = 0 and c2 = 0 and 1=1);
+//
+//	 (select id from
+//	   (select id,
+//			(select count(*) from history_operation_claimable_balances
+//			 where history_claimable_balance_id = hcb.id) as c1,
+//			(select count(*) from history_transaction_claimable_balances
+//			 where history_claimable_balance_id = hcb.id) as c2,
+//			1 as cx,
+//	     from history_claimable_balances hcb order by id limit 100 offset 1000)
+//	 as sub where c1 = 0 and c2 = 0 and 1=1);
 //
 // In short it checks the 100 rows omiting 1000 row of history_claimable_balances
 // and counts occurences of each row in corresponding history tables.
@@ -994,23 +995,24 @@ func (q *Q) DeleteRangeAll(ctx context.Context, start, end int64) error {
 // to a given table. The final query is of form:
 //
 // WITH r AS
-// 		(SELECT
+//
+//		(SELECT
 //			/* unnestPart */
-// 			unnest(?::type1[]), /* field1 */
-// 			unnest(?::type2[]), /* field2 */
+//			unnest(?::type1[]), /* field1 */
+//			unnest(?::type2[]), /* field2 */
 //			...
-// 		)
-// 	INSERT INTO table (
+//		)
+//	INSERT INTO table (
 //		/* insertFieldsPart */
-// 		field1,
-// 		field2,
+//		field1,
+//		field2,
 //		...
-// 	)
-// 	SELECT * from r
-// 	ON CONFLICT (conflictField) DO UPDATE SET
+//	)
+//	SELECT * from r
+//	ON CONFLICT (conflictField) DO UPDATE SET
 //		/* onConflictPart */
-// 		field1 = excluded.field1,
-// 		field2 = excluded.field2,
+//		field1 = excluded.field1,
+//		field2 = excluded.field2,
 //		...
 func (q *Q) upsertRows(ctx context.Context, table string, conflictField string, fields []upsertField) error {
 	unnestPart := make([]string, 0, len(fields))

--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -1485,11 +1485,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -1485,13 +1485,11 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -488,14 +488,15 @@ func (s *system) RegisterMetrics(registry *prometheus.Registry) {
 // Finally, 1a and 1b are tricky because we need to keep the latest version
 // of order book graph in memory of each Horizon instance. To solve this:
 // * For state init:
-//   * If instance is a leader, we update the order book graph by running state
+//   - If instance is a leader, we update the order book graph by running state
 //     pipeline normally.
-//   * If instance is NOT a leader, we build a graph from offers present in a
+//   - If instance is NOT a leader, we build a graph from offers present in a
 //     database. We completely omit state pipeline in this case.
+//
 // * For resuming:
-//   * If instances is a leader, it runs full ledger pipeline, including updating
+//   - If instances is a leader, it runs full ledger pipeline, including updating
 //     a database.
-//   * If instances is a NOT leader, it runs ledger pipeline without updating a
+//   - If instances is a NOT leader, it runs ledger pipeline without updating a
 //     a database so order book graph is updated but database is not overwritten.
 func (s *system) Run() {
 	s.runStateMachine(startState{})

--- a/services/horizon/internal/ingest/processors/synt_offer_id.go
+++ b/services/horizon/internal/ingest/processors/synt_offer_id.go
@@ -21,8 +21,9 @@ const (
 // Due to the 2nd bit being used, the largest possible toid is:
 // 0011111111111111111111111111111100000000000000000001000000000001
 // \          ledger              /\    transaction   /\    op    /
-//            = 1073741823
-//              with avg. 5 sec close time will reach in ~170 years
+//
+//	= 1073741823
+//	  with avg. 5 sec close time will reach in ~170 years
 func EncodeOfferId(id uint64, typ OfferIDType) int64 {
 	// First ensure the bits we're going to change are 0s
 	if id&mask != 0 {

--- a/services/horizon/internal/ingest/verify/main.go
+++ b/services/horizon/internal/ingest/verify/main.go
@@ -23,14 +23,15 @@ type TransformLedgerEntryFunction func(xdr.LedgerEntry) (ignore bool, newEntry x
 // StateVerifier verifies if ledger entries provided by Add method are the same
 // as in the checkpoint ledger entries provided by CheckpointChangeReader.
 // The algorithm works in the following way:
-//   0. Develop `transformFunction`. It should remove all fields and objects not
-//      stored in your app. For example, if you only store accounts, all other
-//      ledger entry types should be ignored (return ignore = true).
-//   1. In a loop, get entries from history archive by calling GetEntries()
-//      and Write() your version of entries found in the batch (in any order).
-//   2. When GetEntries() return no more entries, call Verify with a number of
-//      entries in your storage (to find if some extra entires exist in your
-//      storage).
+//  0. Develop `transformFunction`. It should remove all fields and objects not
+//     stored in your app. For example, if you only store accounts, all other
+//     ledger entry types should be ignored (return ignore = true).
+//  1. In a loop, get entries from history archive by calling GetEntries()
+//     and Write() your version of entries found in the batch (in any order).
+//  2. When GetEntries() return no more entries, call Verify with a number of
+//     entries in your storage (to find if some extra entires exist in your
+//     storage).
+//
 // Functions will return StateError type if state is found to be incorrect.
 // It's user responsibility to call `stateReader.Close()` when reading is done.
 // Check Horizon for an example how to use this tool.
@@ -170,10 +171,11 @@ func (v *StateVerifier) Write(entry xdr.LedgerEntry) error {
 // Verify should be run after all GetEntries/Write calls. If there were no errors
 // so far it means that all entries present in history buckets matches the entries
 // in application storage. However, it's still possible that state is invalid when:
-//   * Not all entries have been read from history buckets (ex. due to a bug).
-//   * Some entries were not compared using Write.
-//   * There are some extra entries in application storage not present in history
+//   - Not all entries have been read from history buckets (ex. due to a bug).
+//   - Some entries were not compared using Write.
+//   - There are some extra entries in application storage not present in history
 //     buckets.
+//
 // Any `StateError` returned by this method indicates invalid state!
 func (v *StateVerifier) Verify(countAll int) error {
 	err := v.checkUnreadEntries()

--- a/services/horizon/internal/scripts/check_release_hash/Dockerfile
+++ b/services/horizon/internal/scripts/check_release_hash/Dockerfile
@@ -1,5 +1,5 @@
 # Change to Go version used in CI or rebuild with --build-arg.
-ARG GO_IMAGE=golang:1.17
+ARG GO_IMAGE=golang:1.18
 FROM $GO_IMAGE
 
 WORKDIR /go/src/github.com/stellar/go

--- a/services/horizon/internal/simplepath/doc.go
+++ b/services/horizon/internal/simplepath/doc.go
@@ -2,16 +2,17 @@
 // a breadth first search for paths against an orderbook.
 //
 // The core algorithm works as follows:
-// 1. `search` object contains a queue of currently extended paths. Queue is
-//    initialized with a single-asset path containing destination asset. Paths
-//    are linked lists, head of the path is a newly extended source asset, tail
-//    of the path is always the destination asset.
-// 2. Every iteration of search does the following:
-//    - pops a path from the queue,
-//    - checks if the path starts with a source asset, if it does, it appends
-//      the path to results,
-//    - finds all assets connected to the head of the current path and prepends
-//      the path, calculating the current cost.
+//  1. `search` object contains a queue of currently extended paths. Queue is
+//     initialized with a single-asset path containing destination asset. Paths
+//     are linked lists, head of the path is a newly extended source asset, tail
+//     of the path is always the destination asset.
+//  2. Every iteration of search does the following:
+//     - pops a path from the queue,
+//     - checks if the path starts with a source asset, if it does, it appends
+//     the path to results,
+//     - finds all assets connected to the head of the current path and prepends
+//     the path, calculating the current cost.
+//
 // Algorithm ends when there is no more paths to extend (len(queue) = 0) or
 // `maxResults` has been reached.
 //
@@ -22,17 +23,18 @@
 // front.
 // 2. Because we are going from the tail to the head of the path, given the path
 // A -> B -> C. we are interested in finding:
-//    - amount of B needed to buy `DestinationAmount` of C,
-//    - amount of A needed to by above amount of B.
+//   - amount of B needed to buy `DestinationAmount` of C,
+//   - amount of A needed to by above amount of B.
+//
 // 3. Finally, the actual path payment will sell A, buy B, sell B, buy C. So we
 // need to check the following orderbooks:
-//    - sell C, buy B (the user will sell B, buy C),
-//    - sell B, buy A (the user will sell A, buy B).
+//   - sell C, buy B (the user will sell B, buy C),
+//   - sell B, buy A (the user will sell A, buy B).
 //
 // The algorithm works as follows:
-// 1. Because the head of the path is source account, we build a stack of assets
-//    to reverse that order.
-// 2. We start with the last asset (pop the stack), calculate it's cost (if not
-//    cached) and continue towards the source asset (bottom of the stack).
-// 3. We return the final cost.
+//  1. Because the head of the path is source account, we build a stack of assets
+//     to reverse that order.
+//  2. We start with the last asset (pop the stack), calculate it's cost (if not
+//     cached) and continue towards the source asset (bottom of the stack).
+//  3. We return the final cost.
 package simplepath

--- a/services/horizon/internal/test/scenarios/bindata.go
+++ b/services/horizon/internal/test/scenarios/bindata.go
@@ -649,11 +649,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/services/horizon/internal/test/scenarios/bindata.go
+++ b/services/horizon/internal/test/scenarios/bindata.go
@@ -649,13 +649,11 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/services/horizon/internal/test/transactions/main.go
+++ b/services/horizon/internal/test/transactions/main.go
@@ -1,4 +1,4 @@
-//Package transactions offers common infrastructure for testing Transactions
+// Package transactions offers common infrastructure for testing Transactions
 package transactions
 
 import (

--- a/services/horizon/internal/txsub/open_submission_list_test.go
+++ b/services/horizon/internal/txsub/open_submission_list_test.go
@@ -137,7 +137,7 @@ func (suite *SubmissionListTestSuite) TestSubmissionList_Clean() {
 	}
 }
 
-//Tests that Pending works as expected
+// Tests that Pending works as expected
 func (suite *SubmissionListTestSuite) TestSubmissionList_Pending() {
 	assert.Equal(suite.T(), 0, len(suite.list.Pending(suite.ctx)))
 	suite.list.Add(suite.ctx, suite.hashes[0], suite.listeners[0])

--- a/services/horizon/internal/txsub/sequence/account_tx_submission_queue.go
+++ b/services/horizon/internal/txsub/sequence/account_tx_submission_queue.go
@@ -12,7 +12,6 @@ import (
 // AccountTxSubmissionQueue maintains a priority queue of pending submissions, and when updated
 // (via the NotifyLastAccountSequence() method) with the current sequence number of the account
 // being managed, queued submissions that can be acted upon will be unblocked.
-//
 type AccountTxSubmissionQueue struct {
 	lastActiveAt            time.Time
 	timeout                 time.Duration
@@ -50,10 +49,10 @@ func (q *AccountTxSubmissionQueue) Size() int {
 // the same as the provided sequence, to keep internal complexity much lower.
 // Given that, the recommended usage pattern is:
 //
-// 1. Push the submission onto the queue
-// 2. Load the current sequence number for the source account from the DB
-// 3. Call NotifyLastAccountSequence() with the result from step 2 to trigger the submission if
-//		possible
+//  1. Push the submission onto the queue
+//  2. Load the current sequence number for the source account from the DB
+//  3. Call NotifyLastAccountSequence() with the result from step 2 to trigger the submission if
+//     possible
 func (q *AccountTxSubmissionQueue) Push(sequence uint64, minSeqNum *uint64) <-chan error {
 	// From CAP 21: If minSeqNum is nil, the txToSubmit is only valid when sourceAccount's sequence number is seqNum - 1.
 	// Otherwise, valid when sourceAccount's sequence number n satisfies minSeqNum <= n < txToSubmit.seqNum.

--- a/services/horizon/internal/utf8/main.go
+++ b/services/horizon/internal/utf8/main.go
@@ -1,4 +1,4 @@
-//Package utf8 contains utilities for working with utf8 data.
+// Package utf8 contains utilities for working with utf8 data.
 package utf8
 
 import (

--- a/services/keystore/db_test.go
+++ b/services/keystore/db_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stellar/go/support/db/dbtest"
 )
 
-//TODO: creating a DB for every single test is inefficient. Maybe we can
-//improve our dbtest package so that we can just get a transaction.
+// TODO: creating a DB for every single test is inefficient. Maybe we can
+// improve our dbtest package so that we can just get a transaction.
 func openKeystoreDB(t *testing.T) *dbtest.DB {
 	db := dbtest.Postgres(t)
 	migrations := &migrate.FileMigrationSource{

--- a/services/regulated-assets-approval-server/internal/db/dbmigrate/dbmigrate_generated.go
+++ b/services/regulated-assets-approval-server/internal/db/dbmigrate/dbmigrate_generated.go
@@ -231,11 +231,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/services/regulated-assets-approval-server/internal/db/dbmigrate/dbmigrate_generated.go
+++ b/services/regulated-assets-approval-server/internal/db/dbmigrate/dbmigrate_generated.go
@@ -231,13 +231,11 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/services/ticker/internal/gql/static/bindata.go
+++ b/services/ticker/internal/gql/static/bindata.go
@@ -209,11 +209,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/services/ticker/internal/gql/static/bindata.go
+++ b/services/ticker/internal/gql/static/bindata.go
@@ -209,13 +209,11 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/services/ticker/internal/tickerdb/migrations/bindata.go
+++ b/services/ticker/internal/tickerdb/migrations/bindata.go
@@ -385,11 +385,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/services/ticker/internal/tickerdb/migrations/bindata.go
+++ b/services/ticker/internal/tickerdb/migrations/bindata.go
@@ -385,13 +385,11 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/support/db/table.go
+++ b/support/db/table.go
@@ -3,7 +3,6 @@ package db
 import sq "github.com/Masterminds/squirrel"
 
 // Delete returns a new query builder configured to delete rows from the table.
-//
 func (tbl *Table) Delete(
 	pred interface{},
 	args ...interface{},

--- a/support/http/httptest/client_expectation.go
+++ b/support/http/httptest/client_expectation.go
@@ -56,7 +56,7 @@ func (ce *ClientExpectation) ReturnJSON(
 
 // ReturnNotFound is a simple helper that causes this expectation to resolve to
 // a 404 error.  If a customized body is needed, use something like
-// `ReturnString`` instead.
+// `ReturnString“ instead.
 func (ce *ClientExpectation) ReturnNotFound() *ClientExpectation {
 	return ce.ReturnString(http.StatusNotFound, "not found")
 }

--- a/support/http/main.go
+++ b/support/http/main.go
@@ -2,7 +2,6 @@
 // http servers.  The primary method to use is `Serve`, which sets up
 // an server that can support http/2 and can gracefully quit after receiving a
 // SIGINT signal.
-//
 package http
 
 import (

--- a/support/http/xff_middleware.go
+++ b/support/http/xff_middleware.go
@@ -14,10 +14,10 @@ type XFFMiddlewareConfig struct {
 // XFFMiddleware is a middleware that replaces http.Request.RemoteAddr with a
 // visitor value based on a given config:
 //
-//   * If BehindCloudflare is true CF-Connecting-IP header is used.
-//   * If BehindAWSLoadBalancer is true the last value of X-Forwarded-For header
+//   - If BehindCloudflare is true CF-Connecting-IP header is used.
+//   - If BehindAWSLoadBalancer is true the last value of X-Forwarded-For header
 //     is used.
-//   * If none of above is set the first value of X-Forwarded-For header is
+//   - If none of above is set the first value of X-Forwarded-For header is
 //     used. Note: it's easy to spoof the real IP address if the application is
 //     not behind a proxy that maintains a X-Forwarded-For header.
 //

--- a/support/log/doc.go
+++ b/support/log/doc.go
@@ -6,5 +6,4 @@
 // to logging within the context of an http server, and our chosen path for
 // responding to "Oh my god something is horribly wrong" within the context
 // of an HTTP request is to panic on that request.
-//
 package log

--- a/support/render/httpjson/encoding.go
+++ b/support/render/httpjson/encoding.go
@@ -18,10 +18,10 @@ var ErrNotJSONObject = errors.New("input is not a json object")
 //
 // It can also be used as a field in a struct:
 //
-// type example struct {
-//  	name string
-//   	extra httpjson.RawObject
-// }
+//	type example struct {
+//	 	name string
+//	  	extra httpjson.RawObject
+//	}
 //
 // In this case, Unmarshaler will check whether extra is a json object ot not.
 // It will error if extra is a json number/string/array/boolean.

--- a/support/render/httpjson/handler.go
+++ b/support/render/httpjson/handler.go
@@ -140,7 +140,7 @@ func ExecuteFunc(ctx context.Context, fn, param interface{}, cType contentType) 
 // functions with certain signatures.
 // The allowed function signature is as following:
 //
-//   func fn(ctx context.Context, an_optional_param) (at_most_two_return_values)
+//	func fn(ctx context.Context, an_optional_param) (at_most_two_return_values)
 //
 // The caller must provide a function with at least 1 input (request context)
 // and up to 2 inputs, and up to 2 return values. If there are two return

--- a/support/time/main.go
+++ b/support/time/main.go
@@ -5,26 +5,26 @@ import (
 	goTime "time"
 )
 
-//Millis represents time as milliseconds since epoch without any timezone adjustments
+// Millis represents time as milliseconds since epoch without any timezone adjustments
 type Millis int64
 
-//MillisFromString generates a Millis struct from a string representing an int64
+// MillisFromString generates a Millis struct from a string representing an int64
 func MillisFromString(s string) (Millis, error) {
 	millis, err := strconv.ParseInt(s, 10, 64)
 	return Millis(int64(millis)), err
 }
 
-//MillisFromInt64 generates a Millis struct from given millis int64
+// MillisFromInt64 generates a Millis struct from given millis int64
 func MillisFromInt64(millis int64) Millis {
 	return Millis(millis)
 }
 
-//MillisFromTime generates a Millis struct from given go time
+// MillisFromTime generates a Millis struct from given go time
 func MillisFromTime(t goTime.Time) Millis {
 	return Millis(t.UTC().UnixNano() / int64(goTime.Millisecond))
 }
 
-//MillisFromSeconds generates a Millis struct from given seconds int64
+// MillisFromSeconds generates a Millis struct from given seconds int64
 func MillisFromSeconds(seconds int64) Millis {
 	return Millis(seconds * 1000)
 }
@@ -33,12 +33,12 @@ func (t Millis) increment(millisToAdd int64) Millis {
 	return Millis(int64(t) + millisToAdd)
 }
 
-//IsNil returns true if the timeMillis has not been initialized to a date other then 0 from epoch
+// IsNil returns true if the timeMillis has not been initialized to a date other then 0 from epoch
 func (t Millis) IsNil() bool {
 	return t == 0
 }
 
-//RoundUp returns a new Millis instance with a rounded up to d millis
+// RoundUp returns a new Millis instance with a rounded up to d millis
 func (t Millis) RoundUp(d int64) Millis {
 	if d == 0 {
 		return t
@@ -49,18 +49,18 @@ func (t Millis) RoundUp(d int64) Millis {
 	return t
 }
 
-//RoundUp returns a new ToInt64 instance with a down to d millis
+// RoundUp returns a new ToInt64 instance with a down to d millis
 func (t Millis) RoundDown(d int64) Millis {
 	//round down to the nearest d
 	return Millis(int64(int64(t)/d) * d)
 }
 
-//ToInt64 returns the actual int64 millis since epoch
+// ToInt64 returns the actual int64 millis since epoch
 func (t Millis) ToInt64() int64 {
 	return int64(t)
 }
 
-//ToTime returns a go time.Time timestamp, UTC adjusted
+// ToTime returns a go time.Time timestamp, UTC adjusted
 func (t Millis) ToTime() goTime.Time {
 	// Milliseconds   1510831636149
 	// Nanoseconds    1510831636149000000
@@ -69,7 +69,7 @@ func (t Millis) ToTime() goTime.Time {
 	return goTime.Unix(int64(t)/1000, int64(t)%1000*int64(goTime.Millisecond)).UTC()
 }
 
-//Now returns current time in millis
+// Now returns current time in millis
 func Now() Millis {
 	return MillisFromTime(goTime.Now())
 }

--- a/toid/main.go
+++ b/toid/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 )
 
-//
 // ID represents the total order of Ledgers, Transactions and
 // Operations. This is an implementation of SEP-35:
 // https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0035.md
@@ -20,43 +19,41 @@ import (
 //
 // The follow diagram shows this format:
 //
-//    0                   1                   2                   3
-//    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//   |                    Ledger Sequence Number                     |
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//   |     Transaction Application Order     |       Op Index        |
-//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//	 0                   1                   2                   3
+//	 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//	|                    Ledger Sequence Number                     |
+//	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//	|     Transaction Application Order     |       Op Index        |
+//	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 //
 // By component:
 //
 // Ledger Sequence: 32-bits
 //
-//   A complete ledger sequence number in which the operation was validated.
+//	A complete ledger sequence number in which the operation was validated.
 //
-//   Expressed in network byte order.
+//	Expressed in network byte order.
 //
 // Transaction Application Order: 20-bits
 //
-//   The order that the transaction was applied within the ledger it was
-//   validated.  Accommodates up to 1,048,575 transactions in a single ledger.
+//	The order that the transaction was applied within the ledger it was
+//	validated.  Accommodates up to 1,048,575 transactions in a single ledger.
 //
-//   Expressed in network byte order.
+//	Expressed in network byte order.
 //
 // Operation Index: 12-bits
 //
-//   The index of the operation within its parent transaction. Accommodates up
-//   to 4095 operations per transaction.
+//	The index of the operation within its parent transaction. Accommodates up
+//	to 4095 operations per transaction.
 //
-//   Expressed in network byte order.
-//
+//	Expressed in network byte order.
 //
 // Note: This does not uniquely identify an object.  Given a ledger, it will
 // share its id with its first transaction and the first operation of that
 // transaction as well.  Given that this ID is only meant for ordering within a
 // single type of object, the sharing of ids across object types seems
 // acceptable.
-//
 type ID struct {
 	LedgerSequence   int32
 	TransactionOrder int32

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -1236,11 +1236,11 @@ func ReadChallengeTx(challengeTx, serverAccountID, network, webAuthDomain string
 // provided. If it does not match the function will return an error.
 //
 // Errors will be raised if:
-//  - The transaction is invalid according to ReadChallengeTx.
-//  - No client signatures are found on the transaction.
-//  - One or more signatures in the transaction are not identifiable as the
-//    server account or one of the signers provided in the arguments.
-//  - The signatures are all valid but do not meet the threshold.
+//   - The transaction is invalid according to ReadChallengeTx.
+//   - No client signatures are found on the transaction.
+//   - One or more signatures in the transaction are not identifiable as the
+//     server account or one of the signers provided in the arguments.
+//   - The signatures are all valid but do not meet the threshold.
 func VerifyChallengeTxThreshold(challengeTx, serverAccountID, network, webAuthDomain string, homeDomains []string, threshold Threshold, signerSummary SignerSummary) (signersFound []string, err error) {
 	signers := make([]string, 0, len(signerSummary))
 	for s := range signerSummary {
@@ -1282,10 +1282,10 @@ func VerifyChallengeTxThreshold(challengeTx, serverAccountID, network, webAuthDo
 // provided. If it does not match the function will return an error.
 //
 // Errors will be raised if:
-//  - The transaction is invalid according to ReadChallengeTx.
-//  - No client signatures are found on the transaction.
-//  - One or more signatures in the transaction are not identifiable as the
-//    server account or one of the signers provided in the arguments.
+//   - The transaction is invalid according to ReadChallengeTx.
+//   - No client signatures are found on the transaction.
+//   - One or more signatures in the transaction are not identifiable as the
+//     server account or one of the signers provided in the arguments.
 func VerifyChallengeTxSigners(challengeTx, serverAccountID, network, webAuthDomain string, homeDomains []string, signers ...string) ([]string, error) {
 	// Read the transaction which validates its structure.
 	tx, _, _, err := ReadChallengeTx(challengeTx, serverAccountID, network, webAuthDomain, homeDomains)

--- a/xdr/asset.go
+++ b/xdr/asset.go
@@ -92,9 +92,9 @@ func NewCreditAsset(code string, issuer string) (Asset, error) {
 // BuildAsset creates a new asset from a given `assetType`, `code`, and `issuer`.
 //
 // Valid assetTypes are:
-// 		- `native`
-//		- `credit_alphanum4`
-//		- `credit_alphanum12`
+//   - `native`
+//   - `credit_alphanum4`
+//   - `credit_alphanum12`
 func BuildAsset(assetType, issuer, code string) (Asset, error) {
 	t, ok := StringToAssetType[assetType]
 

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -3,12 +3,12 @@
 
 // Package xdr is generated from:
 //
-//  xdr/Stellar-SCP.x
-//  xdr/Stellar-ledger-entries.x
-//  xdr/Stellar-ledger.x
-//  xdr/Stellar-overlay.x
-//  xdr/Stellar-transaction.x
-//  xdr/Stellar-types.x
+//	xdr/Stellar-SCP.x
+//	xdr/Stellar-ledger-entries.x
+//	xdr/Stellar-ledger.x
+//	xdr/Stellar-overlay.x
+//	xdr/Stellar-transaction.x
+//	xdr/Stellar-types.x
 //
 // DO NOT EDIT or your changes may be overwritten
 package xdr
@@ -57,8 +57,7 @@ func Marshal(w io.Writer, v interface{}) (int, error) {
 
 // Value is an XDR Typedef defines as:
 //
-//   typedef opaque Value<>;
-//
+//	typedef opaque Value<>;
 type Value []byte
 
 // EncodeTo encodes this value using the Encoder.
@@ -113,12 +112,11 @@ var _ xdrType = (*Value)(nil)
 
 // ScpBallot is an XDR Struct defines as:
 //
-//   struct SCPBallot
-//    {
-//        uint32 counter; // n
-//        Value value;    // x
-//    };
-//
+//	struct SCPBallot
+//	 {
+//	     uint32 counter; // n
+//	     Value value;    // x
+//	 };
 type ScpBallot struct {
 	Counter Uint32
 	Value   Value
@@ -184,14 +182,13 @@ var _ xdrType = (*ScpBallot)(nil)
 
 // ScpStatementType is an XDR Enum defines as:
 //
-//   enum SCPStatementType
-//    {
-//        SCP_ST_PREPARE = 0,
-//        SCP_ST_CONFIRM = 1,
-//        SCP_ST_EXTERNALIZE = 2,
-//        SCP_ST_NOMINATE = 3
-//    };
-//
+//	enum SCPStatementType
+//	 {
+//	     SCP_ST_PREPARE = 0,
+//	     SCP_ST_CONFIRM = 1,
+//	     SCP_ST_EXTERNALIZE = 2,
+//	     SCP_ST_NOMINATE = 3
+//	 };
 type ScpStatementType int32
 
 const (
@@ -274,13 +271,12 @@ var _ xdrType = (*ScpStatementType)(nil)
 
 // ScpNomination is an XDR Struct defines as:
 //
-//   struct SCPNomination
-//    {
-//        Hash quorumSetHash; // D
-//        Value votes<>;      // X
-//        Value accepted<>;   // Y
-//    };
-//
+//	struct SCPNomination
+//	 {
+//	     Hash quorumSetHash; // D
+//	     Value votes<>;      // X
+//	     Value accepted<>;   // Y
+//	 };
 type ScpNomination struct {
 	QuorumSetHash Hash
 	Votes         []Value
@@ -388,16 +384,15 @@ var _ xdrType = (*ScpNomination)(nil)
 
 // ScpStatementPrepare is an XDR NestedStruct defines as:
 //
-//   struct
-//            {
-//                Hash quorumSetHash;       // D
-//                SCPBallot ballot;         // b
-//                SCPBallot* prepared;      // p
-//                SCPBallot* preparedPrime; // p'
-//                uint32 nC;                // c.n
-//                uint32 nH;                // h.n
-//            }
-//
+//	struct
+//	         {
+//	             Hash quorumSetHash;       // D
+//	             SCPBallot ballot;         // b
+//	             SCPBallot* prepared;      // p
+//	             SCPBallot* preparedPrime; // p'
+//	             uint32 nC;                // c.n
+//	             uint32 nH;                // h.n
+//	         }
 type ScpStatementPrepare struct {
 	QuorumSetHash Hash
 	Ballot        ScpBallot
@@ -528,15 +523,14 @@ var _ xdrType = (*ScpStatementPrepare)(nil)
 
 // ScpStatementConfirm is an XDR NestedStruct defines as:
 //
-//   struct
-//            {
-//                SCPBallot ballot;   // b
-//                uint32 nPrepared;   // p.n
-//                uint32 nCommit;     // c.n
-//                uint32 nH;          // h.n
-//                Hash quorumSetHash; // D
-//            }
-//
+//	struct
+//	         {
+//	             SCPBallot ballot;   // b
+//	             uint32 nPrepared;   // p.n
+//	             uint32 nCommit;     // c.n
+//	             uint32 nH;          // h.n
+//	             Hash quorumSetHash; // D
+//	         }
 type ScpStatementConfirm struct {
 	Ballot        ScpBallot
 	NPrepared     Uint32
@@ -629,13 +623,12 @@ var _ xdrType = (*ScpStatementConfirm)(nil)
 
 // ScpStatementExternalize is an XDR NestedStruct defines as:
 //
-//   struct
-//            {
-//                SCPBallot commit;         // c
-//                uint32 nH;                // h.n
-//                Hash commitQuorumSetHash; // D used before EXTERNALIZE
-//            }
-//
+//	struct
+//	         {
+//	             SCPBallot commit;         // c
+//	             uint32 nH;                // h.n
+//	             Hash commitQuorumSetHash; // D used before EXTERNALIZE
+//	         }
 type ScpStatementExternalize struct {
 	Commit              ScpBallot
 	NH                  Uint32
@@ -710,38 +703,37 @@ var _ xdrType = (*ScpStatementExternalize)(nil)
 
 // ScpStatementPledges is an XDR NestedUnion defines as:
 //
-//   union switch (SCPStatementType type)
-//        {
-//        case SCP_ST_PREPARE:
-//            struct
-//            {
-//                Hash quorumSetHash;       // D
-//                SCPBallot ballot;         // b
-//                SCPBallot* prepared;      // p
-//                SCPBallot* preparedPrime; // p'
-//                uint32 nC;                // c.n
-//                uint32 nH;                // h.n
-//            } prepare;
-//        case SCP_ST_CONFIRM:
-//            struct
-//            {
-//                SCPBallot ballot;   // b
-//                uint32 nPrepared;   // p.n
-//                uint32 nCommit;     // c.n
-//                uint32 nH;          // h.n
-//                Hash quorumSetHash; // D
-//            } confirm;
-//        case SCP_ST_EXTERNALIZE:
-//            struct
-//            {
-//                SCPBallot commit;         // c
-//                uint32 nH;                // h.n
-//                Hash commitQuorumSetHash; // D used before EXTERNALIZE
-//            } externalize;
-//        case SCP_ST_NOMINATE:
-//            SCPNomination nominate;
-//        }
-//
+//	union switch (SCPStatementType type)
+//	     {
+//	     case SCP_ST_PREPARE:
+//	         struct
+//	         {
+//	             Hash quorumSetHash;       // D
+//	             SCPBallot ballot;         // b
+//	             SCPBallot* prepared;      // p
+//	             SCPBallot* preparedPrime; // p'
+//	             uint32 nC;                // c.n
+//	             uint32 nH;                // h.n
+//	         } prepare;
+//	     case SCP_ST_CONFIRM:
+//	         struct
+//	         {
+//	             SCPBallot ballot;   // b
+//	             uint32 nPrepared;   // p.n
+//	             uint32 nCommit;     // c.n
+//	             uint32 nH;          // h.n
+//	             Hash quorumSetHash; // D
+//	         } confirm;
+//	     case SCP_ST_EXTERNALIZE:
+//	         struct
+//	         {
+//	             SCPBallot commit;         // c
+//	             uint32 nH;                // h.n
+//	             Hash commitQuorumSetHash; // D used before EXTERNALIZE
+//	         } externalize;
+//	     case SCP_ST_NOMINATE:
+//	         SCPNomination nominate;
+//	     }
 type ScpStatementPledges struct {
 	Type        ScpStatementType
 	Prepare     *ScpStatementPrepare
@@ -1016,45 +1008,44 @@ var _ xdrType = (*ScpStatementPledges)(nil)
 
 // ScpStatement is an XDR Struct defines as:
 //
-//   struct SCPStatement
-//    {
-//        NodeID nodeID;    // v
-//        uint64 slotIndex; // i
+//	struct SCPStatement
+//	 {
+//	     NodeID nodeID;    // v
+//	     uint64 slotIndex; // i
 //
-//        union switch (SCPStatementType type)
-//        {
-//        case SCP_ST_PREPARE:
-//            struct
-//            {
-//                Hash quorumSetHash;       // D
-//                SCPBallot ballot;         // b
-//                SCPBallot* prepared;      // p
-//                SCPBallot* preparedPrime; // p'
-//                uint32 nC;                // c.n
-//                uint32 nH;                // h.n
-//            } prepare;
-//        case SCP_ST_CONFIRM:
-//            struct
-//            {
-//                SCPBallot ballot;   // b
-//                uint32 nPrepared;   // p.n
-//                uint32 nCommit;     // c.n
-//                uint32 nH;          // h.n
-//                Hash quorumSetHash; // D
-//            } confirm;
-//        case SCP_ST_EXTERNALIZE:
-//            struct
-//            {
-//                SCPBallot commit;         // c
-//                uint32 nH;                // h.n
-//                Hash commitQuorumSetHash; // D used before EXTERNALIZE
-//            } externalize;
-//        case SCP_ST_NOMINATE:
-//            SCPNomination nominate;
-//        }
-//        pledges;
-//    };
-//
+//	     union switch (SCPStatementType type)
+//	     {
+//	     case SCP_ST_PREPARE:
+//	         struct
+//	         {
+//	             Hash quorumSetHash;       // D
+//	             SCPBallot ballot;         // b
+//	             SCPBallot* prepared;      // p
+//	             SCPBallot* preparedPrime; // p'
+//	             uint32 nC;                // c.n
+//	             uint32 nH;                // h.n
+//	         } prepare;
+//	     case SCP_ST_CONFIRM:
+//	         struct
+//	         {
+//	             SCPBallot ballot;   // b
+//	             uint32 nPrepared;   // p.n
+//	             uint32 nCommit;     // c.n
+//	             uint32 nH;          // h.n
+//	             Hash quorumSetHash; // D
+//	         } confirm;
+//	     case SCP_ST_EXTERNALIZE:
+//	         struct
+//	         {
+//	             SCPBallot commit;         // c
+//	             uint32 nH;                // h.n
+//	             Hash commitQuorumSetHash; // D used before EXTERNALIZE
+//	         } externalize;
+//	     case SCP_ST_NOMINATE:
+//	         SCPNomination nominate;
+//	     }
+//	     pledges;
+//	 };
 type ScpStatement struct {
 	NodeId    NodeId
 	SlotIndex Uint64
@@ -1129,12 +1120,11 @@ var _ xdrType = (*ScpStatement)(nil)
 
 // ScpEnvelope is an XDR Struct defines as:
 //
-//   struct SCPEnvelope
-//    {
-//        SCPStatement statement;
-//        Signature signature;
-//    };
-//
+//	struct SCPEnvelope
+//	 {
+//	     SCPStatement statement;
+//	     Signature signature;
+//	 };
 type ScpEnvelope struct {
 	Statement ScpStatement
 	Signature Signature
@@ -1200,13 +1190,12 @@ var _ xdrType = (*ScpEnvelope)(nil)
 
 // ScpQuorumSet is an XDR Struct defines as:
 //
-//   struct SCPQuorumSet
-//    {
-//        uint32 threshold;
-//        NodeID validators<>;
-//        SCPQuorumSet innerSets<>;
-//    };
-//
+//	struct SCPQuorumSet
+//	 {
+//	     uint32 threshold;
+//	     NodeID validators<>;
+//	     SCPQuorumSet innerSets<>;
+//	 };
 type ScpQuorumSet struct {
 	Threshold  Uint32
 	Validators []NodeId
@@ -1314,8 +1303,7 @@ var _ xdrType = (*ScpQuorumSet)(nil)
 
 // AccountId is an XDR Typedef defines as:
 //
-//   typedef PublicKey AccountID;
-//
+//	typedef PublicKey AccountID;
 type AccountId PublicKey
 
 // SwitchFieldName returns the field name in which this union's
@@ -1401,8 +1389,7 @@ var _ xdrType = (*AccountId)(nil)
 
 // Thresholds is an XDR Typedef defines as:
 //
-//   typedef opaque Thresholds[4];
-//
+//	typedef opaque Thresholds[4];
 type Thresholds [4]byte
 
 // XDRMaxSize implements the Sized interface for Thresholds
@@ -1462,8 +1449,7 @@ var _ xdrType = (*Thresholds)(nil)
 
 // String32 is an XDR Typedef defines as:
 //
-//   typedef string string32<32>;
-//
+//	typedef string string32<32>;
 type String32 string
 
 // XDRMaxSize implements the Sized interface for String32
@@ -1525,8 +1511,7 @@ var _ xdrType = (*String32)(nil)
 
 // String64 is an XDR Typedef defines as:
 //
-//   typedef string string64<64>;
-//
+//	typedef string string64<64>;
 type String64 string
 
 // XDRMaxSize implements the Sized interface for String64
@@ -1588,8 +1573,7 @@ var _ xdrType = (*String64)(nil)
 
 // SequenceNumber is an XDR Typedef defines as:
 //
-//   typedef int64 SequenceNumber;
-//
+//	typedef int64 SequenceNumber;
 type SequenceNumber Int64
 
 // EncodeTo encodes this value using the Encoder.
@@ -1644,8 +1628,7 @@ var _ xdrType = (*SequenceNumber)(nil)
 
 // TimePoint is an XDR Typedef defines as:
 //
-//   typedef uint64 TimePoint;
-//
+//	typedef uint64 TimePoint;
 type TimePoint Uint64
 
 // EncodeTo encodes this value using the Encoder.
@@ -1700,8 +1683,7 @@ var _ xdrType = (*TimePoint)(nil)
 
 // Duration is an XDR Typedef defines as:
 //
-//   typedef uint64 Duration;
-//
+//	typedef uint64 Duration;
 type Duration Uint64
 
 // EncodeTo encodes this value using the Encoder.
@@ -1756,8 +1738,7 @@ var _ xdrType = (*Duration)(nil)
 
 // DataValue is an XDR Typedef defines as:
 //
-//   typedef opaque DataValue<64>;
-//
+//	typedef opaque DataValue<64>;
 type DataValue []byte
 
 // XDRMaxSize implements the Sized interface for DataValue
@@ -1817,8 +1798,7 @@ var _ xdrType = (*DataValue)(nil)
 
 // PoolId is an XDR Typedef defines as:
 //
-//   typedef Hash PoolID;
-//
+//	typedef Hash PoolID;
 type PoolId Hash
 
 // EncodeTo encodes this value using the Encoder.
@@ -1873,8 +1853,7 @@ var _ xdrType = (*PoolId)(nil)
 
 // AssetCode4 is an XDR Typedef defines as:
 //
-//   typedef opaque AssetCode4[4];
-//
+//	typedef opaque AssetCode4[4];
 type AssetCode4 [4]byte
 
 // XDRMaxSize implements the Sized interface for AssetCode4
@@ -1934,8 +1913,7 @@ var _ xdrType = (*AssetCode4)(nil)
 
 // AssetCode12 is an XDR Typedef defines as:
 //
-//   typedef opaque AssetCode12[12];
-//
+//	typedef opaque AssetCode12[12];
 type AssetCode12 [12]byte
 
 // XDRMaxSize implements the Sized interface for AssetCode12
@@ -1995,14 +1973,13 @@ var _ xdrType = (*AssetCode12)(nil)
 
 // AssetType is an XDR Enum defines as:
 //
-//   enum AssetType
-//    {
-//        ASSET_TYPE_NATIVE = 0,
-//        ASSET_TYPE_CREDIT_ALPHANUM4 = 1,
-//        ASSET_TYPE_CREDIT_ALPHANUM12 = 2,
-//        ASSET_TYPE_POOL_SHARE = 3
-//    };
-//
+//	enum AssetType
+//	 {
+//	     ASSET_TYPE_NATIVE = 0,
+//	     ASSET_TYPE_CREDIT_ALPHANUM4 = 1,
+//	     ASSET_TYPE_CREDIT_ALPHANUM12 = 2,
+//	     ASSET_TYPE_POOL_SHARE = 3
+//	 };
 type AssetType int32
 
 const (
@@ -2085,17 +2062,16 @@ var _ xdrType = (*AssetType)(nil)
 
 // AssetCode is an XDR Union defines as:
 //
-//   union AssetCode switch (AssetType type)
-//    {
-//    case ASSET_TYPE_CREDIT_ALPHANUM4:
-//        AssetCode4 assetCode4;
+//	union AssetCode switch (AssetType type)
+//	 {
+//	 case ASSET_TYPE_CREDIT_ALPHANUM4:
+//	     AssetCode4 assetCode4;
 //
-//    case ASSET_TYPE_CREDIT_ALPHANUM12:
-//        AssetCode12 assetCode12;
+//	 case ASSET_TYPE_CREDIT_ALPHANUM12:
+//	     AssetCode12 assetCode12;
 //
-//        // add other asset types here in the future
-//    };
-//
+//	     // add other asset types here in the future
+//	 };
 type AssetCode struct {
 	Type        AssetType
 	AssetCode4  *AssetCode4
@@ -2274,12 +2250,11 @@ var _ xdrType = (*AssetCode)(nil)
 
 // AlphaNum4 is an XDR Struct defines as:
 //
-//   struct AlphaNum4
-//    {
-//        AssetCode4 assetCode;
-//        AccountID issuer;
-//    };
-//
+//	struct AlphaNum4
+//	 {
+//	     AssetCode4 assetCode;
+//	     AccountID issuer;
+//	 };
 type AlphaNum4 struct {
 	AssetCode AssetCode4
 	Issuer    AccountId
@@ -2345,12 +2320,11 @@ var _ xdrType = (*AlphaNum4)(nil)
 
 // AlphaNum12 is an XDR Struct defines as:
 //
-//   struct AlphaNum12
-//    {
-//        AssetCode12 assetCode;
-//        AccountID issuer;
-//    };
-//
+//	struct AlphaNum12
+//	 {
+//	     AssetCode12 assetCode;
+//	     AccountID issuer;
+//	 };
 type AlphaNum12 struct {
 	AssetCode AssetCode12
 	Issuer    AccountId
@@ -2416,20 +2390,19 @@ var _ xdrType = (*AlphaNum12)(nil)
 
 // Asset is an XDR Union defines as:
 //
-//   union Asset switch (AssetType type)
-//    {
-//    case ASSET_TYPE_NATIVE: // Not credit
-//        void;
+//	union Asset switch (AssetType type)
+//	 {
+//	 case ASSET_TYPE_NATIVE: // Not credit
+//	     void;
 //
-//    case ASSET_TYPE_CREDIT_ALPHANUM4:
-//        AlphaNum4 alphaNum4;
+//	 case ASSET_TYPE_CREDIT_ALPHANUM4:
+//	     AlphaNum4 alphaNum4;
 //
-//    case ASSET_TYPE_CREDIT_ALPHANUM12:
-//        AlphaNum12 alphaNum12;
+//	 case ASSET_TYPE_CREDIT_ALPHANUM12:
+//	     AlphaNum12 alphaNum12;
 //
-//        // add other asset types here in the future
-//    };
-//
+//	     // add other asset types here in the future
+//	 };
 type Asset struct {
 	Type       AssetType
 	AlphaNum4  *AlphaNum4
@@ -2618,12 +2591,11 @@ var _ xdrType = (*Asset)(nil)
 
 // Price is an XDR Struct defines as:
 //
-//   struct Price
-//    {
-//        int32 n; // numerator
-//        int32 d; // denominator
-//    };
-//
+//	struct Price
+//	 {
+//	     int32 n; // numerator
+//	     int32 d; // denominator
+//	 };
 type Price struct {
 	N Int32
 	D Int32
@@ -2689,12 +2661,11 @@ var _ xdrType = (*Price)(nil)
 
 // Liabilities is an XDR Struct defines as:
 //
-//   struct Liabilities
-//    {
-//        int64 buying;
-//        int64 selling;
-//    };
-//
+//	struct Liabilities
+//	 {
+//	     int64 buying;
+//	     int64 selling;
+//	 };
 type Liabilities struct {
 	Buying  Int64
 	Selling Int64
@@ -2760,14 +2731,13 @@ var _ xdrType = (*Liabilities)(nil)
 
 // ThresholdIndexes is an XDR Enum defines as:
 //
-//   enum ThresholdIndexes
-//    {
-//        THRESHOLD_MASTER_WEIGHT = 0,
-//        THRESHOLD_LOW = 1,
-//        THRESHOLD_MED = 2,
-//        THRESHOLD_HIGH = 3
-//    };
-//
+//	enum ThresholdIndexes
+//	 {
+//	     THRESHOLD_MASTER_WEIGHT = 0,
+//	     THRESHOLD_LOW = 1,
+//	     THRESHOLD_MED = 2,
+//	     THRESHOLD_HIGH = 3
+//	 };
 type ThresholdIndexes int32
 
 const (
@@ -2850,16 +2820,15 @@ var _ xdrType = (*ThresholdIndexes)(nil)
 
 // LedgerEntryType is an XDR Enum defines as:
 //
-//   enum LedgerEntryType
-//    {
-//        ACCOUNT = 0,
-//        TRUSTLINE = 1,
-//        OFFER = 2,
-//        DATA = 3,
-//        CLAIMABLE_BALANCE = 4,
-//        LIQUIDITY_POOL = 5
-//    };
-//
+//	enum LedgerEntryType
+//	 {
+//	     ACCOUNT = 0,
+//	     TRUSTLINE = 1,
+//	     OFFER = 2,
+//	     DATA = 3,
+//	     CLAIMABLE_BALANCE = 4,
+//	     LIQUIDITY_POOL = 5
+//	 };
 type LedgerEntryType int32
 
 const (
@@ -2946,12 +2915,11 @@ var _ xdrType = (*LedgerEntryType)(nil)
 
 // Signer is an XDR Struct defines as:
 //
-//   struct Signer
-//    {
-//        SignerKey key;
-//        uint32 weight; // really only need 1 byte
-//    };
-//
+//	struct Signer
+//	 {
+//	     SignerKey key;
+//	     uint32 weight; // really only need 1 byte
+//	 };
 type Signer struct {
 	Key    SignerKey
 	Weight Uint32
@@ -3017,24 +2985,23 @@ var _ xdrType = (*Signer)(nil)
 
 // AccountFlags is an XDR Enum defines as:
 //
-//   enum AccountFlags
-//    { // masks for each flag
+//	enum AccountFlags
+//	 { // masks for each flag
 //
-//        // Flags set on issuer accounts
-//        // TrustLines are created with authorized set to "false" requiring
-//        // the issuer to set it for each TrustLine
-//        AUTH_REQUIRED_FLAG = 0x1,
-//        // If set, the authorized flag in TrustLines can be cleared
-//        // otherwise, authorization cannot be revoked
-//        AUTH_REVOCABLE_FLAG = 0x2,
-//        // Once set, causes all AUTH_* flags to be read-only
-//        AUTH_IMMUTABLE_FLAG = 0x4,
-//        // Trustlines are created with clawback enabled set to "true",
-//        // and claimable balances created from those trustlines are created
-//        // with clawback enabled set to "true"
-//        AUTH_CLAWBACK_ENABLED_FLAG = 0x8
-//    };
-//
+//	     // Flags set on issuer accounts
+//	     // TrustLines are created with authorized set to "false" requiring
+//	     // the issuer to set it for each TrustLine
+//	     AUTH_REQUIRED_FLAG = 0x1,
+//	     // If set, the authorized flag in TrustLines can be cleared
+//	     // otherwise, authorization cannot be revoked
+//	     AUTH_REVOCABLE_FLAG = 0x2,
+//	     // Once set, causes all AUTH_* flags to be read-only
+//	     AUTH_IMMUTABLE_FLAG = 0x4,
+//	     // Trustlines are created with clawback enabled set to "true",
+//	     // and claimable balances created from those trustlines are created
+//	     // with clawback enabled set to "true"
+//	     AUTH_CLAWBACK_ENABLED_FLAG = 0x8
+//	 };
 type AccountFlags int32
 
 const (
@@ -3117,43 +3084,38 @@ var _ xdrType = (*AccountFlags)(nil)
 
 // MaskAccountFlags is an XDR Const defines as:
 //
-//   const MASK_ACCOUNT_FLAGS = 0x7;
-//
+//	const MASK_ACCOUNT_FLAGS = 0x7;
 const MaskAccountFlags = 0x7
 
 // MaskAccountFlagsV17 is an XDR Const defines as:
 //
-//   const MASK_ACCOUNT_FLAGS_V17 = 0xF;
-//
+//	const MASK_ACCOUNT_FLAGS_V17 = 0xF;
 const MaskAccountFlagsV17 = 0xF
 
 // MaxSigners is an XDR Const defines as:
 //
-//   const MAX_SIGNERS = 20;
-//
+//	const MAX_SIGNERS = 20;
 const MaxSigners = 20
 
 // SponsorshipDescriptor is an XDR Typedef defines as:
 //
-//   typedef AccountID* SponsorshipDescriptor;
-//
+//	typedef AccountID* SponsorshipDescriptor;
 type SponsorshipDescriptor = *AccountId
 
 // AccountEntryExtensionV3 is an XDR Struct defines as:
 //
-//   struct AccountEntryExtensionV3
-//    {
-//        // We can use this to add more fields, or because it is first, to
-//        // change AccountEntryExtensionV3 into a union.
-//        ExtensionPoint ext;
+//	struct AccountEntryExtensionV3
+//	 {
+//	     // We can use this to add more fields, or because it is first, to
+//	     // change AccountEntryExtensionV3 into a union.
+//	     ExtensionPoint ext;
 //
-//        // Ledger number at which `seqNum` took on its present value.
-//        uint32 seqLedger;
+//	     // Ledger number at which `seqNum` took on its present value.
+//	     uint32 seqLedger;
 //
-//        // Time at which `seqNum` took on its present value.
-//        TimePoint seqTime;
-//    };
-//
+//	     // Time at which `seqNum` took on its present value.
+//	     TimePoint seqTime;
+//	 };
 type AccountEntryExtensionV3 struct {
 	Ext       ExtensionPoint
 	SeqLedger Uint32
@@ -3228,14 +3190,13 @@ var _ xdrType = (*AccountEntryExtensionV3)(nil)
 
 // AccountEntryExtensionV2Ext is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        case 3:
-//            AccountEntryExtensionV3 v3;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     case 3:
+//	         AccountEntryExtensionV3 v3;
+//	     }
 type AccountEntryExtensionV2Ext struct {
 	V  int32
 	V3 *AccountEntryExtensionV3
@@ -3376,22 +3337,21 @@ var _ xdrType = (*AccountEntryExtensionV2Ext)(nil)
 
 // AccountEntryExtensionV2 is an XDR Struct defines as:
 //
-//   struct AccountEntryExtensionV2
-//    {
-//        uint32 numSponsored;
-//        uint32 numSponsoring;
-//        SponsorshipDescriptor signerSponsoringIDs<MAX_SIGNERS>;
+//	struct AccountEntryExtensionV2
+//	 {
+//	     uint32 numSponsored;
+//	     uint32 numSponsoring;
+//	     SponsorshipDescriptor signerSponsoringIDs<MAX_SIGNERS>;
 //
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        case 3:
-//            AccountEntryExtensionV3 v3;
-//        }
-//        ext;
-//    };
-//
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     case 3:
+//	         AccountEntryExtensionV3 v3;
+//	     }
+//	     ext;
+//	 };
 type AccountEntryExtensionV2 struct {
 	NumSponsored        Uint32
 	NumSponsoring       Uint32
@@ -3510,14 +3470,13 @@ var _ xdrType = (*AccountEntryExtensionV2)(nil)
 
 // AccountEntryExtensionV1Ext is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        case 2:
-//            AccountEntryExtensionV2 v2;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     case 2:
+//	         AccountEntryExtensionV2 v2;
+//	     }
 type AccountEntryExtensionV1Ext struct {
 	V  int32
 	V2 *AccountEntryExtensionV2
@@ -3658,20 +3617,19 @@ var _ xdrType = (*AccountEntryExtensionV1Ext)(nil)
 
 // AccountEntryExtensionV1 is an XDR Struct defines as:
 //
-//   struct AccountEntryExtensionV1
-//    {
-//        Liabilities liabilities;
+//	struct AccountEntryExtensionV1
+//	 {
+//	     Liabilities liabilities;
 //
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        case 2:
-//            AccountEntryExtensionV2 v2;
-//        }
-//        ext;
-//    };
-//
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     case 2:
+//	         AccountEntryExtensionV2 v2;
+//	     }
+//	     ext;
+//	 };
 type AccountEntryExtensionV1 struct {
 	Liabilities Liabilities
 	Ext         AccountEntryExtensionV1Ext
@@ -3737,14 +3695,13 @@ var _ xdrType = (*AccountEntryExtensionV1)(nil)
 
 // AccountEntryExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        case 1:
-//            AccountEntryExtensionV1 v1;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     case 1:
+//	         AccountEntryExtensionV1 v1;
+//	     }
 type AccountEntryExt struct {
 	V  int32
 	V1 *AccountEntryExtensionV1
@@ -3885,35 +3842,34 @@ var _ xdrType = (*AccountEntryExt)(nil)
 
 // AccountEntry is an XDR Struct defines as:
 //
-//   struct AccountEntry
-//    {
-//        AccountID accountID;      // master public key for this account
-//        int64 balance;            // in stroops
-//        SequenceNumber seqNum;    // last sequence number used for this account
-//        uint32 numSubEntries;     // number of sub-entries this account has
-//                                  // drives the reserve
-//        AccountID* inflationDest; // Account to vote for during inflation
-//        uint32 flags;             // see AccountFlags
+//	struct AccountEntry
+//	 {
+//	     AccountID accountID;      // master public key for this account
+//	     int64 balance;            // in stroops
+//	     SequenceNumber seqNum;    // last sequence number used for this account
+//	     uint32 numSubEntries;     // number of sub-entries this account has
+//	                               // drives the reserve
+//	     AccountID* inflationDest; // Account to vote for during inflation
+//	     uint32 flags;             // see AccountFlags
 //
-//        string32 homeDomain; // can be used for reverse federation and memo lookup
+//	     string32 homeDomain; // can be used for reverse federation and memo lookup
 //
-//        // fields used for signatures
-//        // thresholds stores unsigned bytes: [weight of master|low|medium|high]
-//        Thresholds thresholds;
+//	     // fields used for signatures
+//	     // thresholds stores unsigned bytes: [weight of master|low|medium|high]
+//	     Thresholds thresholds;
 //
-//        Signer signers<MAX_SIGNERS>; // possible signers for this account
+//	     Signer signers<MAX_SIGNERS>; // possible signers for this account
 //
-//        // reserved for future use
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        case 1:
-//            AccountEntryExtensionV1 v1;
-//        }
-//        ext;
-//    };
-//
+//	     // reserved for future use
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     case 1:
+//	         AccountEntryExtensionV1 v1;
+//	     }
+//	     ext;
+//	 };
 type AccountEntry struct {
 	AccountId     AccountId
 	Balance       Int64
@@ -4086,18 +4042,17 @@ var _ xdrType = (*AccountEntry)(nil)
 
 // TrustLineFlags is an XDR Enum defines as:
 //
-//   enum TrustLineFlags
-//    {
-//        // issuer has authorized account to perform transactions with its credit
-//        AUTHORIZED_FLAG = 1,
-//        // issuer has authorized account to maintain and reduce liabilities for its
-//        // credit
-//        AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2,
-//        // issuer has specified that it may clawback its credit, and that claimable
-//        // balances created with its credit may also be clawed back
-//        TRUSTLINE_CLAWBACK_ENABLED_FLAG = 4
-//    };
-//
+//	enum TrustLineFlags
+//	 {
+//	     // issuer has authorized account to perform transactions with its credit
+//	     AUTHORIZED_FLAG = 1,
+//	     // issuer has authorized account to maintain and reduce liabilities for its
+//	     // credit
+//	     AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2,
+//	     // issuer has specified that it may clawback its credit, and that claimable
+//	     // balances created with its credit may also be clawed back
+//	     TRUSTLINE_CLAWBACK_ENABLED_FLAG = 4
+//	 };
 type TrustLineFlags int32
 
 const (
@@ -4178,29 +4133,25 @@ var _ xdrType = (*TrustLineFlags)(nil)
 
 // MaskTrustlineFlags is an XDR Const defines as:
 //
-//   const MASK_TRUSTLINE_FLAGS = 1;
-//
+//	const MASK_TRUSTLINE_FLAGS = 1;
 const MaskTrustlineFlags = 1
 
 // MaskTrustlineFlagsV13 is an XDR Const defines as:
 //
-//   const MASK_TRUSTLINE_FLAGS_V13 = 3;
-//
+//	const MASK_TRUSTLINE_FLAGS_V13 = 3;
 const MaskTrustlineFlagsV13 = 3
 
 // MaskTrustlineFlagsV17 is an XDR Const defines as:
 //
-//   const MASK_TRUSTLINE_FLAGS_V17 = 7;
-//
+//	const MASK_TRUSTLINE_FLAGS_V17 = 7;
 const MaskTrustlineFlagsV17 = 7
 
 // LiquidityPoolType is an XDR Enum defines as:
 //
-//   enum LiquidityPoolType
-//    {
-//        LIQUIDITY_POOL_CONSTANT_PRODUCT = 0
-//    };
-//
+//	enum LiquidityPoolType
+//	 {
+//	     LIQUIDITY_POOL_CONSTANT_PRODUCT = 0
+//	 };
 type LiquidityPoolType int32
 
 const (
@@ -4277,23 +4228,22 @@ var _ xdrType = (*LiquidityPoolType)(nil)
 
 // TrustLineAsset is an XDR Union defines as:
 //
-//   union TrustLineAsset switch (AssetType type)
-//    {
-//    case ASSET_TYPE_NATIVE: // Not credit
-//        void;
+//	union TrustLineAsset switch (AssetType type)
+//	 {
+//	 case ASSET_TYPE_NATIVE: // Not credit
+//	     void;
 //
-//    case ASSET_TYPE_CREDIT_ALPHANUM4:
-//        AlphaNum4 alphaNum4;
+//	 case ASSET_TYPE_CREDIT_ALPHANUM4:
+//	     AlphaNum4 alphaNum4;
 //
-//    case ASSET_TYPE_CREDIT_ALPHANUM12:
-//        AlphaNum12 alphaNum12;
+//	 case ASSET_TYPE_CREDIT_ALPHANUM12:
+//	     AlphaNum12 alphaNum12;
 //
-//    case ASSET_TYPE_POOL_SHARE:
-//        PoolID liquidityPoolID;
+//	 case ASSET_TYPE_POOL_SHARE:
+//	     PoolID liquidityPoolID;
 //
-//        // add other asset types here in the future
-//    };
-//
+//	     // add other asset types here in the future
+//	 };
 type TrustLineAsset struct {
 	Type            AssetType
 	AlphaNum4       *AlphaNum4
@@ -4530,12 +4480,11 @@ var _ xdrType = (*TrustLineAsset)(nil)
 
 // TrustLineEntryExtensionV2Ext is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type TrustLineEntryExtensionV2Ext struct {
 	V int32
 }
@@ -4628,18 +4577,17 @@ var _ xdrType = (*TrustLineEntryExtensionV2Ext)(nil)
 
 // TrustLineEntryExtensionV2 is an XDR Struct defines as:
 //
-//   struct TrustLineEntryExtensionV2
-//    {
-//        int32 liquidityPoolUseCount;
+//	struct TrustLineEntryExtensionV2
+//	 {
+//	     int32 liquidityPoolUseCount;
 //
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
-//    };
-//
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
+//	 };
 type TrustLineEntryExtensionV2 struct {
 	LiquidityPoolUseCount Int32
 	Ext                   TrustLineEntryExtensionV2Ext
@@ -4705,14 +4653,13 @@ var _ xdrType = (*TrustLineEntryExtensionV2)(nil)
 
 // TrustLineEntryV1Ext is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//                {
-//                case 0:
-//                    void;
-//                case 2:
-//                    TrustLineEntryExtensionV2 v2;
-//                }
-//
+//	union switch (int v)
+//	             {
+//	             case 0:
+//	                 void;
+//	             case 2:
+//	                 TrustLineEntryExtensionV2 v2;
+//	             }
 type TrustLineEntryV1Ext struct {
 	V  int32
 	V2 *TrustLineEntryExtensionV2
@@ -4853,20 +4800,19 @@ var _ xdrType = (*TrustLineEntryV1Ext)(nil)
 
 // TrustLineEntryV1 is an XDR NestedStruct defines as:
 //
-//   struct
-//            {
-//                Liabilities liabilities;
+//	struct
+//	         {
+//	             Liabilities liabilities;
 //
-//                union switch (int v)
-//                {
-//                case 0:
-//                    void;
-//                case 2:
-//                    TrustLineEntryExtensionV2 v2;
-//                }
-//                ext;
-//            }
-//
+//	             union switch (int v)
+//	             {
+//	             case 0:
+//	                 void;
+//	             case 2:
+//	                 TrustLineEntryExtensionV2 v2;
+//	             }
+//	             ext;
+//	         }
 type TrustLineEntryV1 struct {
 	Liabilities Liabilities
 	Ext         TrustLineEntryV1Ext
@@ -4932,26 +4878,25 @@ var _ xdrType = (*TrustLineEntryV1)(nil)
 
 // TrustLineEntryExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        case 1:
-//            struct
-//            {
-//                Liabilities liabilities;
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     case 1:
+//	         struct
+//	         {
+//	             Liabilities liabilities;
 //
-//                union switch (int v)
-//                {
-//                case 0:
-//                    void;
-//                case 2:
-//                    TrustLineEntryExtensionV2 v2;
-//                }
-//                ext;
-//            } v1;
-//        }
-//
+//	             union switch (int v)
+//	             {
+//	             case 0:
+//	                 void;
+//	             case 2:
+//	                 TrustLineEntryExtensionV2 v2;
+//	             }
+//	             ext;
+//	         } v1;
+//	     }
 type TrustLineEntryExt struct {
 	V  int32
 	V1 *TrustLineEntryV1
@@ -5092,39 +5037,38 @@ var _ xdrType = (*TrustLineEntryExt)(nil)
 
 // TrustLineEntry is an XDR Struct defines as:
 //
-//   struct TrustLineEntry
-//    {
-//        AccountID accountID;  // account this trustline belongs to
-//        TrustLineAsset asset; // type of asset (with issuer)
-//        int64 balance;        // how much of this asset the user has.
-//                              // Asset defines the unit for this;
+//	struct TrustLineEntry
+//	 {
+//	     AccountID accountID;  // account this trustline belongs to
+//	     TrustLineAsset asset; // type of asset (with issuer)
+//	     int64 balance;        // how much of this asset the user has.
+//	                           // Asset defines the unit for this;
 //
-//        int64 limit;  // balance cannot be above this
-//        uint32 flags; // see TrustLineFlags
+//	     int64 limit;  // balance cannot be above this
+//	     uint32 flags; // see TrustLineFlags
 //
-//        // reserved for future use
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        case 1:
-//            struct
-//            {
-//                Liabilities liabilities;
+//	     // reserved for future use
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     case 1:
+//	         struct
+//	         {
+//	             Liabilities liabilities;
 //
-//                union switch (int v)
-//                {
-//                case 0:
-//                    void;
-//                case 2:
-//                    TrustLineEntryExtensionV2 v2;
-//                }
-//                ext;
-//            } v1;
-//        }
-//        ext;
-//    };
-//
+//	             union switch (int v)
+//	             {
+//	             case 0:
+//	                 void;
+//	             case 2:
+//	                 TrustLineEntryExtensionV2 v2;
+//	             }
+//	             ext;
+//	         } v1;
+//	     }
+//	     ext;
+//	 };
 type TrustLineEntry struct {
 	AccountId AccountId
 	Asset     TrustLineAsset
@@ -5226,13 +5170,12 @@ var _ xdrType = (*TrustLineEntry)(nil)
 
 // OfferEntryFlags is an XDR Enum defines as:
 //
-//   enum OfferEntryFlags
-//    {
-//        // an offer with this flag will not act on and take a reverse offer of equal
-//        // price
-//        PASSIVE_FLAG = 1
-//    };
-//
+//	enum OfferEntryFlags
+//	 {
+//	     // an offer with this flag will not act on and take a reverse offer of equal
+//	     // price
+//	     PASSIVE_FLAG = 1
+//	 };
 type OfferEntryFlags int32
 
 const (
@@ -5309,18 +5252,16 @@ var _ xdrType = (*OfferEntryFlags)(nil)
 
 // MaskOfferentryFlags is an XDR Const defines as:
 //
-//   const MASK_OFFERENTRY_FLAGS = 1;
-//
+//	const MASK_OFFERENTRY_FLAGS = 1;
 const MaskOfferentryFlags = 1
 
 // OfferEntryExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type OfferEntryExt struct {
 	V int32
 }
@@ -5413,31 +5354,30 @@ var _ xdrType = (*OfferEntryExt)(nil)
 
 // OfferEntry is an XDR Struct defines as:
 //
-//   struct OfferEntry
-//    {
-//        AccountID sellerID;
-//        int64 offerID;
-//        Asset selling; // A
-//        Asset buying;  // B
-//        int64 amount;  // amount of A
+//	struct OfferEntry
+//	 {
+//	     AccountID sellerID;
+//	     int64 offerID;
+//	     Asset selling; // A
+//	     Asset buying;  // B
+//	     int64 amount;  // amount of A
 //
-//        /* price for this offer:
-//            price of A in terms of B
-//            price=AmountB/AmountA=priceNumerator/priceDenominator
-//            price is after fees
-//        */
-//        Price price;
-//        uint32 flags; // see OfferEntryFlags
+//	     /* price for this offer:
+//	         price of A in terms of B
+//	         price=AmountB/AmountA=priceNumerator/priceDenominator
+//	         price is after fees
+//	     */
+//	     Price price;
+//	     uint32 flags; // see OfferEntryFlags
 //
-//        // reserved for future use
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
-//    };
-//
+//	     // reserved for future use
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
+//	 };
 type OfferEntry struct {
 	SellerId AccountId
 	OfferId  Int64
@@ -5557,12 +5497,11 @@ var _ xdrType = (*OfferEntry)(nil)
 
 // DataEntryExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type DataEntryExt struct {
 	V int32
 }
@@ -5655,21 +5594,20 @@ var _ xdrType = (*DataEntryExt)(nil)
 
 // DataEntry is an XDR Struct defines as:
 //
-//   struct DataEntry
-//    {
-//        AccountID accountID; // account this data belongs to
-//        string64 dataName;
-//        DataValue dataValue;
+//	struct DataEntry
+//	 {
+//	     AccountID accountID; // account this data belongs to
+//	     string64 dataName;
+//	     DataValue dataValue;
 //
-//        // reserved for future use
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
-//    };
-//
+//	     // reserved for future use
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
+//	 };
 type DataEntry struct {
 	AccountId AccountId
 	DataName  String64
@@ -5753,16 +5691,15 @@ var _ xdrType = (*DataEntry)(nil)
 
 // ClaimPredicateType is an XDR Enum defines as:
 //
-//   enum ClaimPredicateType
-//    {
-//        CLAIM_PREDICATE_UNCONDITIONAL = 0,
-//        CLAIM_PREDICATE_AND = 1,
-//        CLAIM_PREDICATE_OR = 2,
-//        CLAIM_PREDICATE_NOT = 3,
-//        CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME = 4,
-//        CLAIM_PREDICATE_BEFORE_RELATIVE_TIME = 5
-//    };
-//
+//	enum ClaimPredicateType
+//	 {
+//	     CLAIM_PREDICATE_UNCONDITIONAL = 0,
+//	     CLAIM_PREDICATE_AND = 1,
+//	     CLAIM_PREDICATE_OR = 2,
+//	     CLAIM_PREDICATE_NOT = 3,
+//	     CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME = 4,
+//	     CLAIM_PREDICATE_BEFORE_RELATIVE_TIME = 5
+//	 };
 type ClaimPredicateType int32
 
 const (
@@ -5849,23 +5786,22 @@ var _ xdrType = (*ClaimPredicateType)(nil)
 
 // ClaimPredicate is an XDR Union defines as:
 //
-//   union ClaimPredicate switch (ClaimPredicateType type)
-//    {
-//    case CLAIM_PREDICATE_UNCONDITIONAL:
-//        void;
-//    case CLAIM_PREDICATE_AND:
-//        ClaimPredicate andPredicates<2>;
-//    case CLAIM_PREDICATE_OR:
-//        ClaimPredicate orPredicates<2>;
-//    case CLAIM_PREDICATE_NOT:
-//        ClaimPredicate* notPredicate;
-//    case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
-//        int64 absBefore; // Predicate will be true if closeTime < absBefore
-//    case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
-//        int64 relBefore; // Seconds since closeTime of the ledger in which the
-//                         // ClaimableBalanceEntry was created
-//    };
-//
+//	union ClaimPredicate switch (ClaimPredicateType type)
+//	 {
+//	 case CLAIM_PREDICATE_UNCONDITIONAL:
+//	     void;
+//	 case CLAIM_PREDICATE_AND:
+//	     ClaimPredicate andPredicates<2>;
+//	 case CLAIM_PREDICATE_OR:
+//	     ClaimPredicate orPredicates<2>;
+//	 case CLAIM_PREDICATE_NOT:
+//	     ClaimPredicate* notPredicate;
+//	 case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
+//	     int64 absBefore; // Predicate will be true if closeTime < absBefore
+//	 case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
+//	     int64 relBefore; // Seconds since closeTime of the ledger in which the
+//	                      // ClaimableBalanceEntry was created
+//	 };
 type ClaimPredicate struct {
 	Type          ClaimPredicateType
 	AndPredicates *[]ClaimPredicate `xdrmaxsize:"2"`
@@ -6253,11 +6189,10 @@ var _ xdrType = (*ClaimPredicate)(nil)
 
 // ClaimantType is an XDR Enum defines as:
 //
-//   enum ClaimantType
-//    {
-//        CLAIMANT_TYPE_V0 = 0
-//    };
-//
+//	enum ClaimantType
+//	 {
+//	     CLAIMANT_TYPE_V0 = 0
+//	 };
 type ClaimantType int32
 
 const (
@@ -6334,12 +6269,11 @@ var _ xdrType = (*ClaimantType)(nil)
 
 // ClaimantV0 is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            AccountID destination;    // The account that can use this condition
-//            ClaimPredicate predicate; // Claimable if predicate is true
-//        }
-//
+//	struct
+//	     {
+//	         AccountID destination;    // The account that can use this condition
+//	         ClaimPredicate predicate; // Claimable if predicate is true
+//	     }
 type ClaimantV0 struct {
 	Destination AccountId
 	Predicate   ClaimPredicate
@@ -6405,16 +6339,15 @@ var _ xdrType = (*ClaimantV0)(nil)
 
 // Claimant is an XDR Union defines as:
 //
-//   union Claimant switch (ClaimantType type)
-//    {
-//    case CLAIMANT_TYPE_V0:
-//        struct
-//        {
-//            AccountID destination;    // The account that can use this condition
-//            ClaimPredicate predicate; // Claimable if predicate is true
-//        } v0;
-//    };
-//
+//	union Claimant switch (ClaimantType type)
+//	 {
+//	 case CLAIMANT_TYPE_V0:
+//	     struct
+//	     {
+//	         AccountID destination;    // The account that can use this condition
+//	         ClaimPredicate predicate; // Claimable if predicate is true
+//	     } v0;
+//	 };
 type Claimant struct {
 	Type ClaimantType
 	V0   *ClaimantV0
@@ -6545,11 +6478,10 @@ var _ xdrType = (*Claimant)(nil)
 
 // ClaimableBalanceIdType is an XDR Enum defines as:
 //
-//   enum ClaimableBalanceIDType
-//    {
-//        CLAIMABLE_BALANCE_ID_TYPE_V0 = 0
-//    };
-//
+//	enum ClaimableBalanceIDType
+//	 {
+//	     CLAIMABLE_BALANCE_ID_TYPE_V0 = 0
+//	 };
 type ClaimableBalanceIdType int32
 
 const (
@@ -6626,12 +6558,11 @@ var _ xdrType = (*ClaimableBalanceIdType)(nil)
 
 // ClaimableBalanceId is an XDR Union defines as:
 //
-//   union ClaimableBalanceID switch (ClaimableBalanceIDType type)
-//    {
-//    case CLAIMABLE_BALANCE_ID_TYPE_V0:
-//        Hash v0;
-//    };
-//
+//	union ClaimableBalanceID switch (ClaimableBalanceIDType type)
+//	 {
+//	 case CLAIMABLE_BALANCE_ID_TYPE_V0:
+//	     Hash v0;
+//	 };
 type ClaimableBalanceId struct {
 	Type ClaimableBalanceIdType
 	V0   *Hash
@@ -6762,13 +6693,12 @@ var _ xdrType = (*ClaimableBalanceId)(nil)
 
 // ClaimableBalanceFlags is an XDR Enum defines as:
 //
-//   enum ClaimableBalanceFlags
-//    {
-//        // If set, the issuer account of the asset held by the claimable balance may
-//        // clawback the claimable balance
-//        CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG = 0x1
-//    };
-//
+//	enum ClaimableBalanceFlags
+//	 {
+//	     // If set, the issuer account of the asset held by the claimable balance may
+//	     // clawback the claimable balance
+//	     CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG = 0x1
+//	 };
 type ClaimableBalanceFlags int32
 
 const (
@@ -6845,18 +6775,16 @@ var _ xdrType = (*ClaimableBalanceFlags)(nil)
 
 // MaskClaimableBalanceFlags is an XDR Const defines as:
 //
-//   const MASK_CLAIMABLE_BALANCE_FLAGS = 0x1;
-//
+//	const MASK_CLAIMABLE_BALANCE_FLAGS = 0x1;
 const MaskClaimableBalanceFlags = 0x1
 
 // ClaimableBalanceEntryExtensionV1Ext is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type ClaimableBalanceEntryExtensionV1Ext struct {
 	V int32
 }
@@ -6949,18 +6877,17 @@ var _ xdrType = (*ClaimableBalanceEntryExtensionV1Ext)(nil)
 
 // ClaimableBalanceEntryExtensionV1 is an XDR Struct defines as:
 //
-//   struct ClaimableBalanceEntryExtensionV1
-//    {
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
+//	struct ClaimableBalanceEntryExtensionV1
+//	 {
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
 //
-//        uint32 flags; // see ClaimableBalanceFlags
-//    };
-//
+//	     uint32 flags; // see ClaimableBalanceFlags
+//	 };
 type ClaimableBalanceEntryExtensionV1 struct {
 	Ext   ClaimableBalanceEntryExtensionV1Ext
 	Flags Uint32
@@ -7026,14 +6953,13 @@ var _ xdrType = (*ClaimableBalanceEntryExtensionV1)(nil)
 
 // ClaimableBalanceEntryExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        case 1:
-//            ClaimableBalanceEntryExtensionV1 v1;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     case 1:
+//	         ClaimableBalanceEntryExtensionV1 v1;
+//	     }
 type ClaimableBalanceEntryExt struct {
 	V  int32
 	V1 *ClaimableBalanceEntryExtensionV1
@@ -7174,31 +7100,30 @@ var _ xdrType = (*ClaimableBalanceEntryExt)(nil)
 
 // ClaimableBalanceEntry is an XDR Struct defines as:
 //
-//   struct ClaimableBalanceEntry
-//    {
-//        // Unique identifier for this ClaimableBalanceEntry
-//        ClaimableBalanceID balanceID;
+//	struct ClaimableBalanceEntry
+//	 {
+//	     // Unique identifier for this ClaimableBalanceEntry
+//	     ClaimableBalanceID balanceID;
 //
-//        // List of claimants with associated predicate
-//        Claimant claimants<10>;
+//	     // List of claimants with associated predicate
+//	     Claimant claimants<10>;
 //
-//        // Any asset including native
-//        Asset asset;
+//	     // Any asset including native
+//	     Asset asset;
 //
-//        // Amount of asset
-//        int64 amount;
+//	     // Amount of asset
+//	     int64 amount;
 //
-//        // reserved for future use
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        case 1:
-//            ClaimableBalanceEntryExtensionV1 v1;
-//        }
-//        ext;
-//    };
-//
+//	     // reserved for future use
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     case 1:
+//	         ClaimableBalanceEntryExtensionV1 v1;
+//	     }
+//	     ext;
+//	 };
 type ClaimableBalanceEntry struct {
 	BalanceId ClaimableBalanceId
 	Claimants []Claimant `xdrmaxsize:"10"`
@@ -7311,13 +7236,12 @@ var _ xdrType = (*ClaimableBalanceEntry)(nil)
 
 // LiquidityPoolConstantProductParameters is an XDR Struct defines as:
 //
-//   struct LiquidityPoolConstantProductParameters
-//    {
-//        Asset assetA; // assetA < assetB
-//        Asset assetB;
-//        int32 fee; // Fee is in basis points, so the actual rate is (fee/100)%
-//    };
-//
+//	struct LiquidityPoolConstantProductParameters
+//	 {
+//	     Asset assetA; // assetA < assetB
+//	     Asset assetB;
+//	     int32 fee; // Fee is in basis points, so the actual rate is (fee/100)%
+//	 };
 type LiquidityPoolConstantProductParameters struct {
 	AssetA Asset
 	AssetB Asset
@@ -7392,17 +7316,16 @@ var _ xdrType = (*LiquidityPoolConstantProductParameters)(nil)
 
 // LiquidityPoolEntryConstantProduct is an XDR NestedStruct defines as:
 //
-//   struct
-//            {
-//                LiquidityPoolConstantProductParameters params;
+//	struct
+//	         {
+//	             LiquidityPoolConstantProductParameters params;
 //
-//                int64 reserveA;        // amount of A in the pool
-//                int64 reserveB;        // amount of B in the pool
-//                int64 totalPoolShares; // total number of pool shares issued
-//                int64 poolSharesTrustLineCount; // number of trust lines for the
-//                                                // associated pool shares
-//            }
-//
+//	             int64 reserveA;        // amount of A in the pool
+//	             int64 reserveB;        // amount of B in the pool
+//	             int64 totalPoolShares; // total number of pool shares issued
+//	             int64 poolSharesTrustLineCount; // number of trust lines for the
+//	                                             // associated pool shares
+//	         }
 type LiquidityPoolEntryConstantProduct struct {
 	Params                   LiquidityPoolConstantProductParameters
 	ReserveA                 Int64
@@ -7495,21 +7418,20 @@ var _ xdrType = (*LiquidityPoolEntryConstantProduct)(nil)
 
 // LiquidityPoolEntryBody is an XDR NestedUnion defines as:
 //
-//   union switch (LiquidityPoolType type)
-//        {
-//        case LIQUIDITY_POOL_CONSTANT_PRODUCT:
-//            struct
-//            {
-//                LiquidityPoolConstantProductParameters params;
+//	union switch (LiquidityPoolType type)
+//	     {
+//	     case LIQUIDITY_POOL_CONSTANT_PRODUCT:
+//	         struct
+//	         {
+//	             LiquidityPoolConstantProductParameters params;
 //
-//                int64 reserveA;        // amount of A in the pool
-//                int64 reserveB;        // amount of B in the pool
-//                int64 totalPoolShares; // total number of pool shares issued
-//                int64 poolSharesTrustLineCount; // number of trust lines for the
-//                                                // associated pool shares
-//            } constantProduct;
-//        }
-//
+//	             int64 reserveA;        // amount of A in the pool
+//	             int64 reserveB;        // amount of B in the pool
+//	             int64 totalPoolShares; // total number of pool shares issued
+//	             int64 poolSharesTrustLineCount; // number of trust lines for the
+//	                                             // associated pool shares
+//	         } constantProduct;
+//	     }
 type LiquidityPoolEntryBody struct {
 	Type            LiquidityPoolType
 	ConstantProduct *LiquidityPoolEntryConstantProduct
@@ -7640,27 +7562,26 @@ var _ xdrType = (*LiquidityPoolEntryBody)(nil)
 
 // LiquidityPoolEntry is an XDR Struct defines as:
 //
-//   struct LiquidityPoolEntry
-//    {
-//        PoolID liquidityPoolID;
+//	struct LiquidityPoolEntry
+//	 {
+//	     PoolID liquidityPoolID;
 //
-//        union switch (LiquidityPoolType type)
-//        {
-//        case LIQUIDITY_POOL_CONSTANT_PRODUCT:
-//            struct
-//            {
-//                LiquidityPoolConstantProductParameters params;
+//	     union switch (LiquidityPoolType type)
+//	     {
+//	     case LIQUIDITY_POOL_CONSTANT_PRODUCT:
+//	         struct
+//	         {
+//	             LiquidityPoolConstantProductParameters params;
 //
-//                int64 reserveA;        // amount of A in the pool
-//                int64 reserveB;        // amount of B in the pool
-//                int64 totalPoolShares; // total number of pool shares issued
-//                int64 poolSharesTrustLineCount; // number of trust lines for the
-//                                                // associated pool shares
-//            } constantProduct;
-//        }
-//        body;
-//    };
-//
+//	             int64 reserveA;        // amount of A in the pool
+//	             int64 reserveB;        // amount of B in the pool
+//	             int64 totalPoolShares; // total number of pool shares issued
+//	             int64 poolSharesTrustLineCount; // number of trust lines for the
+//	                                             // associated pool shares
+//	         } constantProduct;
+//	     }
+//	     body;
+//	 };
 type LiquidityPoolEntry struct {
 	LiquidityPoolId PoolId
 	Body            LiquidityPoolEntryBody
@@ -7726,12 +7647,11 @@ var _ xdrType = (*LiquidityPoolEntry)(nil)
 
 // LedgerEntryExtensionV1Ext is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type LedgerEntryExtensionV1Ext struct {
 	V int32
 }
@@ -7824,18 +7744,17 @@ var _ xdrType = (*LedgerEntryExtensionV1Ext)(nil)
 
 // LedgerEntryExtensionV1 is an XDR Struct defines as:
 //
-//   struct LedgerEntryExtensionV1
-//    {
-//        SponsorshipDescriptor sponsoringID;
+//	struct LedgerEntryExtensionV1
+//	 {
+//	     SponsorshipDescriptor sponsoringID;
 //
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
-//    };
-//
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
+//	 };
 type LedgerEntryExtensionV1 struct {
 	SponsoringId SponsorshipDescriptor
 	Ext          LedgerEntryExtensionV1Ext
@@ -7916,22 +7835,21 @@ var _ xdrType = (*LedgerEntryExtensionV1)(nil)
 
 // LedgerEntryData is an XDR NestedUnion defines as:
 //
-//   union switch (LedgerEntryType type)
-//        {
-//        case ACCOUNT:
-//            AccountEntry account;
-//        case TRUSTLINE:
-//            TrustLineEntry trustLine;
-//        case OFFER:
-//            OfferEntry offer;
-//        case DATA:
-//            DataEntry data;
-//        case CLAIMABLE_BALANCE:
-//            ClaimableBalanceEntry claimableBalance;
-//        case LIQUIDITY_POOL:
-//            LiquidityPoolEntry liquidityPool;
-//        }
-//
+//	union switch (LedgerEntryType type)
+//	     {
+//	     case ACCOUNT:
+//	         AccountEntry account;
+//	     case TRUSTLINE:
+//	         TrustLineEntry trustLine;
+//	     case OFFER:
+//	         OfferEntry offer;
+//	     case DATA:
+//	         DataEntry data;
+//	     case CLAIMABLE_BALANCE:
+//	         ClaimableBalanceEntry claimableBalance;
+//	     case LIQUIDITY_POOL:
+//	         LiquidityPoolEntry liquidityPool;
+//	     }
 type LedgerEntryData struct {
 	Type             LedgerEntryType
 	Account          *AccountEntry
@@ -8302,14 +8220,13 @@ var _ xdrType = (*LedgerEntryData)(nil)
 
 // LedgerEntryExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        case 1:
-//            LedgerEntryExtensionV1 v1;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     case 1:
+//	         LedgerEntryExtensionV1 v1;
+//	     }
 type LedgerEntryExt struct {
 	V  int32
 	V1 *LedgerEntryExtensionV1
@@ -8450,38 +8367,37 @@ var _ xdrType = (*LedgerEntryExt)(nil)
 
 // LedgerEntry is an XDR Struct defines as:
 //
-//   struct LedgerEntry
-//    {
-//        uint32 lastModifiedLedgerSeq; // ledger the LedgerEntry was last changed
+//	struct LedgerEntry
+//	 {
+//	     uint32 lastModifiedLedgerSeq; // ledger the LedgerEntry was last changed
 //
-//        union switch (LedgerEntryType type)
-//        {
-//        case ACCOUNT:
-//            AccountEntry account;
-//        case TRUSTLINE:
-//            TrustLineEntry trustLine;
-//        case OFFER:
-//            OfferEntry offer;
-//        case DATA:
-//            DataEntry data;
-//        case CLAIMABLE_BALANCE:
-//            ClaimableBalanceEntry claimableBalance;
-//        case LIQUIDITY_POOL:
-//            LiquidityPoolEntry liquidityPool;
-//        }
-//        data;
+//	     union switch (LedgerEntryType type)
+//	     {
+//	     case ACCOUNT:
+//	         AccountEntry account;
+//	     case TRUSTLINE:
+//	         TrustLineEntry trustLine;
+//	     case OFFER:
+//	         OfferEntry offer;
+//	     case DATA:
+//	         DataEntry data;
+//	     case CLAIMABLE_BALANCE:
+//	         ClaimableBalanceEntry claimableBalance;
+//	     case LIQUIDITY_POOL:
+//	         LiquidityPoolEntry liquidityPool;
+//	     }
+//	     data;
 //
-//        // reserved for future use
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        case 1:
-//            LedgerEntryExtensionV1 v1;
-//        }
-//        ext;
-//    };
-//
+//	     // reserved for future use
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     case 1:
+//	         LedgerEntryExtensionV1 v1;
+//	     }
+//	     ext;
+//	 };
 type LedgerEntry struct {
 	LastModifiedLedgerSeq Uint32
 	Data                  LedgerEntryData
@@ -8556,11 +8472,10 @@ var _ xdrType = (*LedgerEntry)(nil)
 
 // LedgerKeyAccount is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            AccountID accountID;
-//        }
-//
+//	struct
+//	     {
+//	         AccountID accountID;
+//	     }
 type LedgerKeyAccount struct {
 	AccountId AccountId
 }
@@ -8617,12 +8532,11 @@ var _ xdrType = (*LedgerKeyAccount)(nil)
 
 // LedgerKeyTrustLine is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            AccountID accountID;
-//            TrustLineAsset asset;
-//        }
-//
+//	struct
+//	     {
+//	         AccountID accountID;
+//	         TrustLineAsset asset;
+//	     }
 type LedgerKeyTrustLine struct {
 	AccountId AccountId
 	Asset     TrustLineAsset
@@ -8688,12 +8602,11 @@ var _ xdrType = (*LedgerKeyTrustLine)(nil)
 
 // LedgerKeyOffer is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            AccountID sellerID;
-//            int64 offerID;
-//        }
-//
+//	struct
+//	     {
+//	         AccountID sellerID;
+//	         int64 offerID;
+//	     }
 type LedgerKeyOffer struct {
 	SellerId AccountId
 	OfferId  Int64
@@ -8759,12 +8672,11 @@ var _ xdrType = (*LedgerKeyOffer)(nil)
 
 // LedgerKeyData is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            AccountID accountID;
-//            string64 dataName;
-//        }
-//
+//	struct
+//	     {
+//	         AccountID accountID;
+//	         string64 dataName;
+//	     }
 type LedgerKeyData struct {
 	AccountId AccountId
 	DataName  String64
@@ -8830,11 +8742,10 @@ var _ xdrType = (*LedgerKeyData)(nil)
 
 // LedgerKeyClaimableBalance is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            ClaimableBalanceID balanceID;
-//        }
-//
+//	struct
+//	     {
+//	         ClaimableBalanceID balanceID;
+//	     }
 type LedgerKeyClaimableBalance struct {
 	BalanceId ClaimableBalanceId
 }
@@ -8891,11 +8802,10 @@ var _ xdrType = (*LedgerKeyClaimableBalance)(nil)
 
 // LedgerKeyLiquidityPool is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            PoolID liquidityPoolID;
-//        }
-//
+//	struct
+//	     {
+//	         PoolID liquidityPoolID;
+//	     }
 type LedgerKeyLiquidityPool struct {
 	LiquidityPoolId PoolId
 }
@@ -8952,48 +8862,47 @@ var _ xdrType = (*LedgerKeyLiquidityPool)(nil)
 
 // LedgerKey is an XDR Union defines as:
 //
-//   union LedgerKey switch (LedgerEntryType type)
-//    {
-//    case ACCOUNT:
-//        struct
-//        {
-//            AccountID accountID;
-//        } account;
+//	union LedgerKey switch (LedgerEntryType type)
+//	 {
+//	 case ACCOUNT:
+//	     struct
+//	     {
+//	         AccountID accountID;
+//	     } account;
 //
-//    case TRUSTLINE:
-//        struct
-//        {
-//            AccountID accountID;
-//            TrustLineAsset asset;
-//        } trustLine;
+//	 case TRUSTLINE:
+//	     struct
+//	     {
+//	         AccountID accountID;
+//	         TrustLineAsset asset;
+//	     } trustLine;
 //
-//    case OFFER:
-//        struct
-//        {
-//            AccountID sellerID;
-//            int64 offerID;
-//        } offer;
+//	 case OFFER:
+//	     struct
+//	     {
+//	         AccountID sellerID;
+//	         int64 offerID;
+//	     } offer;
 //
-//    case DATA:
-//        struct
-//        {
-//            AccountID accountID;
-//            string64 dataName;
-//        } data;
+//	 case DATA:
+//	     struct
+//	     {
+//	         AccountID accountID;
+//	         string64 dataName;
+//	     } data;
 //
-//    case CLAIMABLE_BALANCE:
-//        struct
-//        {
-//            ClaimableBalanceID balanceID;
-//        } claimableBalance;
+//	 case CLAIMABLE_BALANCE:
+//	     struct
+//	     {
+//	         ClaimableBalanceID balanceID;
+//	     } claimableBalance;
 //
-//    case LIQUIDITY_POOL:
-//        struct
-//        {
-//            PoolID liquidityPoolID;
-//        } liquidityPool;
-//    };
-//
+//	 case LIQUIDITY_POOL:
+//	     struct
+//	     {
+//	         PoolID liquidityPoolID;
+//	     } liquidityPool;
+//	 };
 type LedgerKey struct {
 	Type             LedgerEntryType
 	Account          *LedgerKeyAccount
@@ -9364,18 +9273,17 @@ var _ xdrType = (*LedgerKey)(nil)
 
 // EnvelopeType is an XDR Enum defines as:
 //
-//   enum EnvelopeType
-//    {
-//        ENVELOPE_TYPE_TX_V0 = 0,
-//        ENVELOPE_TYPE_SCP = 1,
-//        ENVELOPE_TYPE_TX = 2,
-//        ENVELOPE_TYPE_AUTH = 3,
-//        ENVELOPE_TYPE_SCPVALUE = 4,
-//        ENVELOPE_TYPE_TX_FEE_BUMP = 5,
-//        ENVELOPE_TYPE_OP_ID = 6,
-//        ENVELOPE_TYPE_POOL_REVOKE_OP_ID = 7
-//    };
-//
+//	enum EnvelopeType
+//	 {
+//	     ENVELOPE_TYPE_TX_V0 = 0,
+//	     ENVELOPE_TYPE_SCP = 1,
+//	     ENVELOPE_TYPE_TX = 2,
+//	     ENVELOPE_TYPE_AUTH = 3,
+//	     ENVELOPE_TYPE_SCPVALUE = 4,
+//	     ENVELOPE_TYPE_TX_FEE_BUMP = 5,
+//	     ENVELOPE_TYPE_OP_ID = 6,
+//	     ENVELOPE_TYPE_POOL_REVOKE_OP_ID = 7
+//	 };
 type EnvelopeType int32
 
 const (
@@ -9466,8 +9374,7 @@ var _ xdrType = (*EnvelopeType)(nil)
 
 // UpgradeType is an XDR Typedef defines as:
 //
-//   typedef opaque UpgradeType<128>;
-//
+//	typedef opaque UpgradeType<128>;
 type UpgradeType []byte
 
 // XDRMaxSize implements the Sized interface for UpgradeType
@@ -9527,12 +9434,11 @@ var _ xdrType = (*UpgradeType)(nil)
 
 // StellarValueType is an XDR Enum defines as:
 //
-//   enum StellarValueType
-//    {
-//        STELLAR_VALUE_BASIC = 0,
-//        STELLAR_VALUE_SIGNED = 1
-//    };
-//
+//	enum StellarValueType
+//	 {
+//	     STELLAR_VALUE_BASIC = 0,
+//	     STELLAR_VALUE_SIGNED = 1
+//	 };
 type StellarValueType int32
 
 const (
@@ -9611,12 +9517,11 @@ var _ xdrType = (*StellarValueType)(nil)
 
 // LedgerCloseValueSignature is an XDR Struct defines as:
 //
-//   struct LedgerCloseValueSignature
-//    {
-//        NodeID nodeID;       // which node introduced the value
-//        Signature signature; // nodeID's signature
-//    };
-//
+//	struct LedgerCloseValueSignature
+//	 {
+//	     NodeID nodeID;       // which node introduced the value
+//	     Signature signature; // nodeID's signature
+//	 };
 type LedgerCloseValueSignature struct {
 	NodeId    NodeId
 	Signature Signature
@@ -9682,14 +9587,13 @@ var _ xdrType = (*LedgerCloseValueSignature)(nil)
 
 // StellarValueExt is an XDR NestedUnion defines as:
 //
-//   union switch (StellarValueType v)
-//        {
-//        case STELLAR_VALUE_BASIC:
-//            void;
-//        case STELLAR_VALUE_SIGNED:
-//            LedgerCloseValueSignature lcValueSignature;
-//        }
-//
+//	union switch (StellarValueType v)
+//	     {
+//	     case STELLAR_VALUE_BASIC:
+//	         void;
+//	     case STELLAR_VALUE_SIGNED:
+//	         LedgerCloseValueSignature lcValueSignature;
+//	     }
 type StellarValueExt struct {
 	V                StellarValueType
 	LcValueSignature *LedgerCloseValueSignature
@@ -9830,29 +9734,28 @@ var _ xdrType = (*StellarValueExt)(nil)
 
 // StellarValue is an XDR Struct defines as:
 //
-//   struct StellarValue
-//    {
-//        Hash txSetHash;      // transaction set to apply to previous ledger
-//        TimePoint closeTime; // network close time
+//	struct StellarValue
+//	 {
+//	     Hash txSetHash;      // transaction set to apply to previous ledger
+//	     TimePoint closeTime; // network close time
 //
-//        // upgrades to apply to the previous ledger (usually empty)
-//        // this is a vector of encoded 'LedgerUpgrade' so that nodes can drop
-//        // unknown steps during consensus if needed.
-//        // see notes below on 'LedgerUpgrade' for more detail
-//        // max size is dictated by number of upgrade types (+ room for future)
-//        UpgradeType upgrades<6>;
+//	     // upgrades to apply to the previous ledger (usually empty)
+//	     // this is a vector of encoded 'LedgerUpgrade' so that nodes can drop
+//	     // unknown steps during consensus if needed.
+//	     // see notes below on 'LedgerUpgrade' for more detail
+//	     // max size is dictated by number of upgrade types (+ room for future)
+//	     UpgradeType upgrades<6>;
 //
-//        // reserved for future use
-//        union switch (StellarValueType v)
-//        {
-//        case STELLAR_VALUE_BASIC:
-//            void;
-//        case STELLAR_VALUE_SIGNED:
-//            LedgerCloseValueSignature lcValueSignature;
-//        }
-//        ext;
-//    };
-//
+//	     // reserved for future use
+//	     union switch (StellarValueType v)
+//	     {
+//	     case STELLAR_VALUE_BASIC:
+//	         void;
+//	     case STELLAR_VALUE_SIGNED:
+//	         LedgerCloseValueSignature lcValueSignature;
+//	     }
+//	     ext;
+//	 };
 type StellarValue struct {
 	TxSetHash Hash
 	CloseTime TimePoint
@@ -9956,19 +9859,17 @@ var _ xdrType = (*StellarValue)(nil)
 
 // MaskLedgerHeaderFlags is an XDR Const defines as:
 //
-//   const MASK_LEDGER_HEADER_FLAGS = 0x7;
-//
+//	const MASK_LEDGER_HEADER_FLAGS = 0x7;
 const MaskLedgerHeaderFlags = 0x7
 
 // LedgerHeaderFlags is an XDR Enum defines as:
 //
-//   enum LedgerHeaderFlags
-//    {
-//        DISABLE_LIQUIDITY_POOL_TRADING_FLAG = 0x1,
-//        DISABLE_LIQUIDITY_POOL_DEPOSIT_FLAG = 0x2,
-//        DISABLE_LIQUIDITY_POOL_WITHDRAWAL_FLAG = 0x4
-//    };
-//
+//	enum LedgerHeaderFlags
+//	 {
+//	     DISABLE_LIQUIDITY_POOL_TRADING_FLAG = 0x1,
+//	     DISABLE_LIQUIDITY_POOL_DEPOSIT_FLAG = 0x2,
+//	     DISABLE_LIQUIDITY_POOL_WITHDRAWAL_FLAG = 0x4
+//	 };
 type LedgerHeaderFlags int32
 
 const (
@@ -10049,12 +9950,11 @@ var _ xdrType = (*LedgerHeaderFlags)(nil)
 
 // LedgerHeaderExtensionV1Ext is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type LedgerHeaderExtensionV1Ext struct {
 	V int32
 }
@@ -10147,18 +10047,17 @@ var _ xdrType = (*LedgerHeaderExtensionV1Ext)(nil)
 
 // LedgerHeaderExtensionV1 is an XDR Struct defines as:
 //
-//   struct LedgerHeaderExtensionV1
-//    {
-//        uint32 flags; // LedgerHeaderFlags
+//	struct LedgerHeaderExtensionV1
+//	 {
+//	     uint32 flags; // LedgerHeaderFlags
 //
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
-//    };
-//
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
+//	 };
 type LedgerHeaderExtensionV1 struct {
 	Flags Uint32
 	Ext   LedgerHeaderExtensionV1Ext
@@ -10224,14 +10123,13 @@ var _ xdrType = (*LedgerHeaderExtensionV1)(nil)
 
 // LedgerHeaderExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        case 1:
-//            LedgerHeaderExtensionV1 v1;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     case 1:
+//	         LedgerHeaderExtensionV1 v1;
+//	     }
 type LedgerHeaderExt struct {
 	V  int32
 	V1 *LedgerHeaderExtensionV1
@@ -10372,46 +10270,45 @@ var _ xdrType = (*LedgerHeaderExt)(nil)
 
 // LedgerHeader is an XDR Struct defines as:
 //
-//   struct LedgerHeader
-//    {
-//        uint32 ledgerVersion;    // the protocol version of the ledger
-//        Hash previousLedgerHash; // hash of the previous ledger header
-//        StellarValue scpValue;   // what consensus agreed to
-//        Hash txSetResultHash;    // the TransactionResultSet that led to this ledger
-//        Hash bucketListHash;     // hash of the ledger state
+//	struct LedgerHeader
+//	 {
+//	     uint32 ledgerVersion;    // the protocol version of the ledger
+//	     Hash previousLedgerHash; // hash of the previous ledger header
+//	     StellarValue scpValue;   // what consensus agreed to
+//	     Hash txSetResultHash;    // the TransactionResultSet that led to this ledger
+//	     Hash bucketListHash;     // hash of the ledger state
 //
-//        uint32 ledgerSeq; // sequence number of this ledger
+//	     uint32 ledgerSeq; // sequence number of this ledger
 //
-//        int64 totalCoins; // total number of stroops in existence.
-//                          // 10,000,000 stroops in 1 XLM
+//	     int64 totalCoins; // total number of stroops in existence.
+//	                       // 10,000,000 stroops in 1 XLM
 //
-//        int64 feePool;       // fees burned since last inflation run
-//        uint32 inflationSeq; // inflation sequence number
+//	     int64 feePool;       // fees burned since last inflation run
+//	     uint32 inflationSeq; // inflation sequence number
 //
-//        uint64 idPool; // last used global ID, used for generating objects
+//	     uint64 idPool; // last used global ID, used for generating objects
 //
-//        uint32 baseFee;     // base fee per operation in stroops
-//        uint32 baseReserve; // account base reserve in stroops
+//	     uint32 baseFee;     // base fee per operation in stroops
+//	     uint32 baseReserve; // account base reserve in stroops
 //
-//        uint32 maxTxSetSize; // maximum size a transaction set can be
+//	     uint32 maxTxSetSize; // maximum size a transaction set can be
 //
-//        Hash skipList[4]; // hashes of ledgers in the past. allows you to jump back
-//                          // in time without walking the chain back ledger by ledger
-//                          // each slot contains the oldest ledger that is mod of
-//                          // either 50  5000  50000 or 500000 depending on index
-//                          // skipList[0] mod(50), skipList[1] mod(5000), etc
+//	     Hash skipList[4]; // hashes of ledgers in the past. allows you to jump back
+//	                       // in time without walking the chain back ledger by ledger
+//	                       // each slot contains the oldest ledger that is mod of
+//	                       // either 50  5000  50000 or 500000 depending on index
+//	                       // skipList[0] mod(50), skipList[1] mod(5000), etc
 //
-//        // reserved for future use
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        case 1:
-//            LedgerHeaderExtensionV1 v1;
-//        }
-//        ext;
-//    };
-//
+//	     // reserved for future use
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     case 1:
+//	         LedgerHeaderExtensionV1 v1;
+//	     }
+//	     ext;
+//	 };
 type LedgerHeader struct {
 	LedgerVersion      Uint32
 	PreviousLedgerHash Hash
@@ -10598,15 +10495,14 @@ var _ xdrType = (*LedgerHeader)(nil)
 
 // LedgerUpgradeType is an XDR Enum defines as:
 //
-//   enum LedgerUpgradeType
-//    {
-//        LEDGER_UPGRADE_VERSION = 1,
-//        LEDGER_UPGRADE_BASE_FEE = 2,
-//        LEDGER_UPGRADE_MAX_TX_SET_SIZE = 3,
-//        LEDGER_UPGRADE_BASE_RESERVE = 4,
-//        LEDGER_UPGRADE_FLAGS = 5
-//    };
-//
+//	enum LedgerUpgradeType
+//	 {
+//	     LEDGER_UPGRADE_VERSION = 1,
+//	     LEDGER_UPGRADE_BASE_FEE = 2,
+//	     LEDGER_UPGRADE_MAX_TX_SET_SIZE = 3,
+//	     LEDGER_UPGRADE_BASE_RESERVE = 4,
+//	     LEDGER_UPGRADE_FLAGS = 5
+//	 };
 type LedgerUpgradeType int32
 
 const (
@@ -10691,20 +10587,19 @@ var _ xdrType = (*LedgerUpgradeType)(nil)
 
 // LedgerUpgrade is an XDR Union defines as:
 //
-//   union LedgerUpgrade switch (LedgerUpgradeType type)
-//    {
-//    case LEDGER_UPGRADE_VERSION:
-//        uint32 newLedgerVersion; // update ledgerVersion
-//    case LEDGER_UPGRADE_BASE_FEE:
-//        uint32 newBaseFee; // update baseFee
-//    case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
-//        uint32 newMaxTxSetSize; // update maxTxSetSize
-//    case LEDGER_UPGRADE_BASE_RESERVE:
-//        uint32 newBaseReserve; // update baseReserve
-//    case LEDGER_UPGRADE_FLAGS:
-//        uint32 newFlags; // update flags
-//    };
-//
+//	union LedgerUpgrade switch (LedgerUpgradeType type)
+//	 {
+//	 case LEDGER_UPGRADE_VERSION:
+//	     uint32 newLedgerVersion; // update ledgerVersion
+//	 case LEDGER_UPGRADE_BASE_FEE:
+//	     uint32 newBaseFee; // update baseFee
+//	 case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
+//	     uint32 newMaxTxSetSize; // update maxTxSetSize
+//	 case LEDGER_UPGRADE_BASE_RESERVE:
+//	     uint32 newBaseReserve; // update baseReserve
+//	 case LEDGER_UPGRADE_FLAGS:
+//	     uint32 newFlags; // update flags
+//	 };
 type LedgerUpgrade struct {
 	Type             LedgerUpgradeType
 	NewLedgerVersion *Uint32
@@ -11027,16 +10922,15 @@ var _ xdrType = (*LedgerUpgrade)(nil)
 
 // BucketEntryType is an XDR Enum defines as:
 //
-//   enum BucketEntryType
-//    {
-//        METAENTRY =
-//            -1, // At-and-after protocol 11: bucket metadata, should come first.
-//        LIVEENTRY = 0, // Before protocol 11: created-or-updated;
-//                       // At-and-after protocol 11: only updated.
-//        DEADENTRY = 1,
-//        INITENTRY = 2 // At-and-after protocol 11: only created.
-//    };
-//
+//	enum BucketEntryType
+//	 {
+//	     METAENTRY =
+//	         -1, // At-and-after protocol 11: bucket metadata, should come first.
+//	     LIVEENTRY = 0, // Before protocol 11: created-or-updated;
+//	                    // At-and-after protocol 11: only updated.
+//	     DEADENTRY = 1,
+//	     INITENTRY = 2 // At-and-after protocol 11: only created.
+//	 };
 type BucketEntryType int32
 
 const (
@@ -11119,12 +11013,11 @@ var _ xdrType = (*BucketEntryType)(nil)
 
 // BucketMetadataExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type BucketMetadataExt struct {
 	V int32
 }
@@ -11217,20 +11110,19 @@ var _ xdrType = (*BucketMetadataExt)(nil)
 
 // BucketMetadata is an XDR Struct defines as:
 //
-//   struct BucketMetadata
-//    {
-//        // Indicates the protocol version used to create / merge this bucket.
-//        uint32 ledgerVersion;
+//	struct BucketMetadata
+//	 {
+//	     // Indicates the protocol version used to create / merge this bucket.
+//	     uint32 ledgerVersion;
 //
-//        // reserved for future use
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
-//    };
-//
+//	     // reserved for future use
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
+//	 };
 type BucketMetadata struct {
 	LedgerVersion Uint32
 	Ext           BucketMetadataExt
@@ -11296,18 +11188,17 @@ var _ xdrType = (*BucketMetadata)(nil)
 
 // BucketEntry is an XDR Union defines as:
 //
-//   union BucketEntry switch (BucketEntryType type)
-//    {
-//    case LIVEENTRY:
-//    case INITENTRY:
-//        LedgerEntry liveEntry;
+//	union BucketEntry switch (BucketEntryType type)
+//	 {
+//	 case LIVEENTRY:
+//	 case INITENTRY:
+//	     LedgerEntry liveEntry;
 //
-//    case DEADENTRY:
-//        LedgerKey deadEntry;
-//    case METAENTRY:
-//        BucketMetadata metaEntry;
-//    };
-//
+//	 case DEADENTRY:
+//	     LedgerKey deadEntry;
+//	 case METAENTRY:
+//	     BucketMetadata metaEntry;
+//	 };
 type BucketEntry struct {
 	Type      BucketEntryType
 	LiveEntry *LedgerEntry
@@ -11556,12 +11447,11 @@ var _ xdrType = (*BucketEntry)(nil)
 
 // TransactionSet is an XDR Struct defines as:
 //
-//   struct TransactionSet
-//    {
-//        Hash previousLedgerHash;
-//        TransactionEnvelope txs<>;
-//    };
-//
+//	struct TransactionSet
+//	 {
+//	     Hash previousLedgerHash;
+//	     TransactionEnvelope txs<>;
+//	 };
 type TransactionSet struct {
 	PreviousLedgerHash Hash
 	Txs                []TransactionEnvelope
@@ -11644,12 +11534,11 @@ var _ xdrType = (*TransactionSet)(nil)
 
 // TransactionResultPair is an XDR Struct defines as:
 //
-//   struct TransactionResultPair
-//    {
-//        Hash transactionHash;
-//        TransactionResult result; // result for the transaction
-//    };
-//
+//	struct TransactionResultPair
+//	 {
+//	     Hash transactionHash;
+//	     TransactionResult result; // result for the transaction
+//	 };
 type TransactionResultPair struct {
 	TransactionHash Hash
 	Result          TransactionResult
@@ -11715,11 +11604,10 @@ var _ xdrType = (*TransactionResultPair)(nil)
 
 // TransactionResultSet is an XDR Struct defines as:
 //
-//   struct TransactionResultSet
-//    {
-//        TransactionResultPair results<>;
-//    };
-//
+//	struct TransactionResultSet
+//	 {
+//	     TransactionResultPair results<>;
+//	 };
 type TransactionResultSet struct {
 	Results []TransactionResultPair
 }
@@ -11793,12 +11681,11 @@ var _ xdrType = (*TransactionResultSet)(nil)
 
 // TransactionHistoryEntryExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type TransactionHistoryEntryExt struct {
 	V int32
 }
@@ -11891,20 +11778,19 @@ var _ xdrType = (*TransactionHistoryEntryExt)(nil)
 
 // TransactionHistoryEntry is an XDR Struct defines as:
 //
-//   struct TransactionHistoryEntry
-//    {
-//        uint32 ledgerSeq;
-//        TransactionSet txSet;
+//	struct TransactionHistoryEntry
+//	 {
+//	     uint32 ledgerSeq;
+//	     TransactionSet txSet;
 //
-//        // reserved for future use
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
-//    };
-//
+//	     // reserved for future use
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
+//	 };
 type TransactionHistoryEntry struct {
 	LedgerSeq Uint32
 	TxSet     TransactionSet
@@ -11979,12 +11865,11 @@ var _ xdrType = (*TransactionHistoryEntry)(nil)
 
 // TransactionHistoryResultEntryExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type TransactionHistoryResultEntryExt struct {
 	V int32
 }
@@ -12077,20 +11962,19 @@ var _ xdrType = (*TransactionHistoryResultEntryExt)(nil)
 
 // TransactionHistoryResultEntry is an XDR Struct defines as:
 //
-//   struct TransactionHistoryResultEntry
-//    {
-//        uint32 ledgerSeq;
-//        TransactionResultSet txResultSet;
+//	struct TransactionHistoryResultEntry
+//	 {
+//	     uint32 ledgerSeq;
+//	     TransactionResultSet txResultSet;
 //
-//        // reserved for future use
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
-//    };
-//
+//	     // reserved for future use
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
+//	 };
 type TransactionHistoryResultEntry struct {
 	LedgerSeq   Uint32
 	TxResultSet TransactionResultSet
@@ -12165,12 +12049,11 @@ var _ xdrType = (*TransactionHistoryResultEntry)(nil)
 
 // LedgerHeaderHistoryEntryExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type LedgerHeaderHistoryEntryExt struct {
 	V int32
 }
@@ -12263,20 +12146,19 @@ var _ xdrType = (*LedgerHeaderHistoryEntryExt)(nil)
 
 // LedgerHeaderHistoryEntry is an XDR Struct defines as:
 //
-//   struct LedgerHeaderHistoryEntry
-//    {
-//        Hash hash;
-//        LedgerHeader header;
+//	struct LedgerHeaderHistoryEntry
+//	 {
+//	     Hash hash;
+//	     LedgerHeader header;
 //
-//        // reserved for future use
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
-//    };
-//
+//	     // reserved for future use
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
+//	 };
 type LedgerHeaderHistoryEntry struct {
 	Hash   Hash
 	Header LedgerHeader
@@ -12351,12 +12233,11 @@ var _ xdrType = (*LedgerHeaderHistoryEntry)(nil)
 
 // LedgerScpMessages is an XDR Struct defines as:
 //
-//   struct LedgerSCPMessages
-//    {
-//        uint32 ledgerSeq;
-//        SCPEnvelope messages<>;
-//    };
-//
+//	struct LedgerSCPMessages
+//	 {
+//	     uint32 ledgerSeq;
+//	     SCPEnvelope messages<>;
+//	 };
 type LedgerScpMessages struct {
 	LedgerSeq Uint32
 	Messages  []ScpEnvelope
@@ -12439,12 +12320,11 @@ var _ xdrType = (*LedgerScpMessages)(nil)
 
 // ScpHistoryEntryV0 is an XDR Struct defines as:
 //
-//   struct SCPHistoryEntryV0
-//    {
-//        SCPQuorumSet quorumSets<>; // additional quorum sets used by ledgerMessages
-//        LedgerSCPMessages ledgerMessages;
-//    };
-//
+//	struct SCPHistoryEntryV0
+//	 {
+//	     SCPQuorumSet quorumSets<>; // additional quorum sets used by ledgerMessages
+//	     LedgerSCPMessages ledgerMessages;
+//	 };
 type ScpHistoryEntryV0 struct {
 	QuorumSets     []ScpQuorumSet
 	LedgerMessages LedgerScpMessages
@@ -12527,12 +12407,11 @@ var _ xdrType = (*ScpHistoryEntryV0)(nil)
 
 // ScpHistoryEntry is an XDR Union defines as:
 //
-//   union SCPHistoryEntry switch (int v)
-//    {
-//    case 0:
-//        SCPHistoryEntryV0 v0;
-//    };
-//
+//	union SCPHistoryEntry switch (int v)
+//	 {
+//	 case 0:
+//	     SCPHistoryEntryV0 v0;
+//	 };
 type ScpHistoryEntry struct {
 	V  int32
 	V0 *ScpHistoryEntryV0
@@ -12663,14 +12542,13 @@ var _ xdrType = (*ScpHistoryEntry)(nil)
 
 // LedgerEntryChangeType is an XDR Enum defines as:
 //
-//   enum LedgerEntryChangeType
-//    {
-//        LEDGER_ENTRY_CREATED = 0, // entry was added to the ledger
-//        LEDGER_ENTRY_UPDATED = 1, // entry was modified in the ledger
-//        LEDGER_ENTRY_REMOVED = 2, // entry was removed from the ledger
-//        LEDGER_ENTRY_STATE = 3    // value of the entry
-//    };
-//
+//	enum LedgerEntryChangeType
+//	 {
+//	     LEDGER_ENTRY_CREATED = 0, // entry was added to the ledger
+//	     LEDGER_ENTRY_UPDATED = 1, // entry was modified in the ledger
+//	     LEDGER_ENTRY_REMOVED = 2, // entry was removed from the ledger
+//	     LEDGER_ENTRY_STATE = 3    // value of the entry
+//	 };
 type LedgerEntryChangeType int32
 
 const (
@@ -12753,18 +12631,17 @@ var _ xdrType = (*LedgerEntryChangeType)(nil)
 
 // LedgerEntryChange is an XDR Union defines as:
 //
-//   union LedgerEntryChange switch (LedgerEntryChangeType type)
-//    {
-//    case LEDGER_ENTRY_CREATED:
-//        LedgerEntry created;
-//    case LEDGER_ENTRY_UPDATED:
-//        LedgerEntry updated;
-//    case LEDGER_ENTRY_REMOVED:
-//        LedgerKey removed;
-//    case LEDGER_ENTRY_STATE:
-//        LedgerEntry state;
-//    };
-//
+//	union LedgerEntryChange switch (LedgerEntryChangeType type)
+//	 {
+//	 case LEDGER_ENTRY_CREATED:
+//	     LedgerEntry created;
+//	 case LEDGER_ENTRY_UPDATED:
+//	     LedgerEntry updated;
+//	 case LEDGER_ENTRY_REMOVED:
+//	     LedgerKey removed;
+//	 case LEDGER_ENTRY_STATE:
+//	     LedgerEntry state;
+//	 };
 type LedgerEntryChange struct {
 	Type    LedgerEntryChangeType
 	Created *LedgerEntry
@@ -13039,8 +12916,7 @@ var _ xdrType = (*LedgerEntryChange)(nil)
 
 // LedgerEntryChanges is an XDR Typedef defines as:
 //
-//   typedef LedgerEntryChange LedgerEntryChanges<>;
-//
+//	typedef LedgerEntryChange LedgerEntryChanges<>;
 type LedgerEntryChanges []LedgerEntryChange
 
 // EncodeTo encodes this value using the Encoder.
@@ -13112,11 +12988,10 @@ var _ xdrType = (*LedgerEntryChanges)(nil)
 
 // OperationMeta is an XDR Struct defines as:
 //
-//   struct OperationMeta
-//    {
-//        LedgerEntryChanges changes;
-//    };
-//
+//	struct OperationMeta
+//	 {
+//	     LedgerEntryChanges changes;
+//	 };
 type OperationMeta struct {
 	Changes LedgerEntryChanges
 }
@@ -13173,12 +13048,11 @@ var _ xdrType = (*OperationMeta)(nil)
 
 // TransactionMetaV1 is an XDR Struct defines as:
 //
-//   struct TransactionMetaV1
-//    {
-//        LedgerEntryChanges txChanges; // tx level changes if any
-//        OperationMeta operations<>;   // meta for each operation
-//    };
-//
+//	struct TransactionMetaV1
+//	 {
+//	     LedgerEntryChanges txChanges; // tx level changes if any
+//	     OperationMeta operations<>;   // meta for each operation
+//	 };
 type TransactionMetaV1 struct {
 	TxChanges  LedgerEntryChanges
 	Operations []OperationMeta
@@ -13261,15 +13135,14 @@ var _ xdrType = (*TransactionMetaV1)(nil)
 
 // TransactionMetaV2 is an XDR Struct defines as:
 //
-//   struct TransactionMetaV2
-//    {
-//        LedgerEntryChanges txChangesBefore; // tx level changes before operations
-//                                            // are applied if any
-//        OperationMeta operations<>;         // meta for each operation
-//        LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
-//                                            // applied if any
-//    };
-//
+//	struct TransactionMetaV2
+//	 {
+//	     LedgerEntryChanges txChangesBefore; // tx level changes before operations
+//	                                         // are applied if any
+//	     OperationMeta operations<>;         // meta for each operation
+//	     LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
+//	                                         // applied if any
+//	 };
 type TransactionMetaV2 struct {
 	TxChangesBefore LedgerEntryChanges
 	Operations      []OperationMeta
@@ -13361,16 +13234,15 @@ var _ xdrType = (*TransactionMetaV2)(nil)
 
 // TransactionMeta is an XDR Union defines as:
 //
-//   union TransactionMeta switch (int v)
-//    {
-//    case 0:
-//        OperationMeta operations<>;
-//    case 1:
-//        TransactionMetaV1 v1;
-//    case 2:
-//        TransactionMetaV2 v2;
-//    };
-//
+//	union TransactionMeta switch (int v)
+//	 {
+//	 case 0:
+//	     OperationMeta operations<>;
+//	 case 1:
+//	     TransactionMetaV1 v1;
+//	 case 2:
+//	     TransactionMetaV2 v2;
+//	 };
 type TransactionMeta struct {
 	V          int32
 	Operations *[]OperationMeta
@@ -13614,13 +13486,12 @@ var _ xdrType = (*TransactionMeta)(nil)
 
 // TransactionResultMeta is an XDR Struct defines as:
 //
-//   struct TransactionResultMeta
-//    {
-//        TransactionResultPair result;
-//        LedgerEntryChanges feeProcessing;
-//        TransactionMeta txApplyProcessing;
-//    };
-//
+//	struct TransactionResultMeta
+//	 {
+//	     TransactionResultPair result;
+//	     LedgerEntryChanges feeProcessing;
+//	     TransactionMeta txApplyProcessing;
+//	 };
 type TransactionResultMeta struct {
 	Result            TransactionResultPair
 	FeeProcessing     LedgerEntryChanges
@@ -13695,12 +13566,11 @@ var _ xdrType = (*TransactionResultMeta)(nil)
 
 // UpgradeEntryMeta is an XDR Struct defines as:
 //
-//   struct UpgradeEntryMeta
-//    {
-//        LedgerUpgrade upgrade;
-//        LedgerEntryChanges changes;
-//    };
-//
+//	struct UpgradeEntryMeta
+//	 {
+//	     LedgerUpgrade upgrade;
+//	     LedgerEntryChanges changes;
+//	 };
 type UpgradeEntryMeta struct {
 	Upgrade LedgerUpgrade
 	Changes LedgerEntryChanges
@@ -13766,24 +13636,23 @@ var _ xdrType = (*UpgradeEntryMeta)(nil)
 
 // LedgerCloseMetaV0 is an XDR Struct defines as:
 //
-//   struct LedgerCloseMetaV0
-//    {
-//        LedgerHeaderHistoryEntry ledgerHeader;
-//        // NB: txSet is sorted in "Hash order"
-//        TransactionSet txSet;
+//	struct LedgerCloseMetaV0
+//	 {
+//	     LedgerHeaderHistoryEntry ledgerHeader;
+//	     // NB: txSet is sorted in "Hash order"
+//	     TransactionSet txSet;
 //
-//        // NB: transactions are sorted in apply order here
-//        // fees for all transactions are processed first
-//        // followed by applying transactions
-//        TransactionResultMeta txProcessing<>;
+//	     // NB: transactions are sorted in apply order here
+//	     // fees for all transactions are processed first
+//	     // followed by applying transactions
+//	     TransactionResultMeta txProcessing<>;
 //
-//        // upgrades are applied last
-//        UpgradeEntryMeta upgradesProcessing<>;
+//	     // upgrades are applied last
+//	     UpgradeEntryMeta upgradesProcessing<>;
 //
-//        // other misc information attached to the ledger close
-//        SCPHistoryEntry scpInfo<>;
-//    };
-//
+//	     // other misc information attached to the ledger close
+//	     SCPHistoryEntry scpInfo<>;
+//	 };
 type LedgerCloseMetaV0 struct {
 	LedgerHeader       LedgerHeaderHistoryEntry
 	TxSet              TransactionSet
@@ -13925,12 +13794,11 @@ var _ xdrType = (*LedgerCloseMetaV0)(nil)
 
 // LedgerCloseMeta is an XDR Union defines as:
 //
-//   union LedgerCloseMeta switch (int v)
-//    {
-//    case 0:
-//        LedgerCloseMetaV0 v0;
-//    };
-//
+//	union LedgerCloseMeta switch (int v)
+//	 {
+//	 case 0:
+//	     LedgerCloseMetaV0 v0;
+//	 };
 type LedgerCloseMeta struct {
 	V  int32
 	V0 *LedgerCloseMetaV0
@@ -14061,15 +13929,14 @@ var _ xdrType = (*LedgerCloseMeta)(nil)
 
 // ErrorCode is an XDR Enum defines as:
 //
-//   enum ErrorCode
-//    {
-//        ERR_MISC = 0, // Unspecific error
-//        ERR_DATA = 1, // Malformed data
-//        ERR_CONF = 2, // Misconfiguration error
-//        ERR_AUTH = 3, // Authentication failure
-//        ERR_LOAD = 4  // System overloaded
-//    };
-//
+//	enum ErrorCode
+//	 {
+//	     ERR_MISC = 0, // Unspecific error
+//	     ERR_DATA = 1, // Malformed data
+//	     ERR_CONF = 2, // Misconfiguration error
+//	     ERR_AUTH = 3, // Authentication failure
+//	     ERR_LOAD = 4  // System overloaded
+//	 };
 type ErrorCode int32
 
 const (
@@ -14154,12 +14021,11 @@ var _ xdrType = (*ErrorCode)(nil)
 
 // Error is an XDR Struct defines as:
 //
-//   struct Error
-//    {
-//        ErrorCode code;
-//        string msg<100>;
-//    };
-//
+//	struct Error
+//	 {
+//	     ErrorCode code;
+//	     string msg<100>;
+//	 };
 type Error struct {
 	Code ErrorCode
 	Msg  string `xdrmaxsize:"100"`
@@ -14225,11 +14091,10 @@ var _ xdrType = (*Error)(nil)
 
 // SendMore is an XDR Struct defines as:
 //
-//   struct SendMore
-//    {
-//        uint32 numMessages;
-//    };
-//
+//	struct SendMore
+//	 {
+//	     uint32 numMessages;
+//	 };
 type SendMore struct {
 	NumMessages Uint32
 }
@@ -14286,13 +14151,12 @@ var _ xdrType = (*SendMore)(nil)
 
 // AuthCert is an XDR Struct defines as:
 //
-//   struct AuthCert
-//    {
-//        Curve25519Public pubkey;
-//        uint64 expiration;
-//        Signature sig;
-//    };
-//
+//	struct AuthCert
+//	 {
+//	     Curve25519Public pubkey;
+//	     uint64 expiration;
+//	     Signature sig;
+//	 };
 type AuthCert struct {
 	Pubkey     Curve25519Public
 	Expiration Uint64
@@ -14367,19 +14231,18 @@ var _ xdrType = (*AuthCert)(nil)
 
 // Hello is an XDR Struct defines as:
 //
-//   struct Hello
-//    {
-//        uint32 ledgerVersion;
-//        uint32 overlayVersion;
-//        uint32 overlayMinVersion;
-//        Hash networkID;
-//        string versionStr<100>;
-//        int listeningPort;
-//        NodeID peerID;
-//        AuthCert cert;
-//        uint256 nonce;
-//    };
-//
+//	struct Hello
+//	 {
+//	     uint32 ledgerVersion;
+//	     uint32 overlayVersion;
+//	     uint32 overlayMinVersion;
+//	     Hash networkID;
+//	     string versionStr<100>;
+//	     int listeningPort;
+//	     NodeID peerID;
+//	     AuthCert cert;
+//	     uint256 nonce;
+//	 };
 type Hello struct {
 	LedgerVersion     Uint32
 	OverlayVersion    Uint32
@@ -14508,13 +14371,12 @@ var _ xdrType = (*Hello)(nil)
 
 // Auth is an XDR Struct defines as:
 //
-//   struct Auth
-//    {
-//        // Empty message, just to confirm
-//        // establishment of MAC keys.
-//        int unused;
-//    };
-//
+//	struct Auth
+//	 {
+//	     // Empty message, just to confirm
+//	     // establishment of MAC keys.
+//	     int unused;
+//	 };
 type Auth struct {
 	Unused int32
 }
@@ -14571,12 +14433,11 @@ var _ xdrType = (*Auth)(nil)
 
 // IpAddrType is an XDR Enum defines as:
 //
-//   enum IPAddrType
-//    {
-//        IPv4 = 0,
-//        IPv6 = 1
-//    };
-//
+//	enum IPAddrType
+//	 {
+//	     IPv4 = 0,
+//	     IPv6 = 1
+//	 };
 type IpAddrType int32
 
 const (
@@ -14655,14 +14516,13 @@ var _ xdrType = (*IpAddrType)(nil)
 
 // PeerAddressIp is an XDR NestedUnion defines as:
 //
-//   union switch (IPAddrType type)
-//        {
-//        case IPv4:
-//            opaque ipv4[4];
-//        case IPv6:
-//            opaque ipv6[16];
-//        }
-//
+//	union switch (IPAddrType type)
+//	     {
+//	     case IPv4:
+//	         opaque ipv4[4];
+//	     case IPv6:
+//	         opaque ipv6[16];
+//	     }
 type PeerAddressIp struct {
 	Type IpAddrType
 	Ipv4 *[4]byte  `xdrmaxsize:"4"`
@@ -14841,20 +14701,19 @@ var _ xdrType = (*PeerAddressIp)(nil)
 
 // PeerAddress is an XDR Struct defines as:
 //
-//   struct PeerAddress
-//    {
-//        union switch (IPAddrType type)
-//        {
-//        case IPv4:
-//            opaque ipv4[4];
-//        case IPv6:
-//            opaque ipv6[16];
-//        }
-//        ip;
-//        uint32 port;
-//        uint32 numFailures;
-//    };
-//
+//	struct PeerAddress
+//	 {
+//	     union switch (IPAddrType type)
+//	     {
+//	     case IPv4:
+//	         opaque ipv4[4];
+//	     case IPv6:
+//	         opaque ipv6[16];
+//	     }
+//	     ip;
+//	     uint32 port;
+//	     uint32 numFailures;
+//	 };
 type PeerAddress struct {
 	Ip          PeerAddressIp
 	Port        Uint32
@@ -14929,35 +14788,34 @@ var _ xdrType = (*PeerAddress)(nil)
 
 // MessageType is an XDR Enum defines as:
 //
-//   enum MessageType
-//    {
-//        ERROR_MSG = 0,
-//        AUTH = 2,
-//        DONT_HAVE = 3,
+//	enum MessageType
+//	 {
+//	     ERROR_MSG = 0,
+//	     AUTH = 2,
+//	     DONT_HAVE = 3,
 //
-//        GET_PEERS = 4, // gets a list of peers this guy knows about
-//        PEERS = 5,
+//	     GET_PEERS = 4, // gets a list of peers this guy knows about
+//	     PEERS = 5,
 //
-//        GET_TX_SET = 6, // gets a particular txset by hash
-//        TX_SET = 7,
+//	     GET_TX_SET = 6, // gets a particular txset by hash
+//	     TX_SET = 7,
 //
-//        TRANSACTION = 8, // pass on a tx you have heard about
+//	     TRANSACTION = 8, // pass on a tx you have heard about
 //
-//        // SCP
-//        GET_SCP_QUORUMSET = 9,
-//        SCP_QUORUMSET = 10,
-//        SCP_MESSAGE = 11,
-//        GET_SCP_STATE = 12,
+//	     // SCP
+//	     GET_SCP_QUORUMSET = 9,
+//	     SCP_QUORUMSET = 10,
+//	     SCP_MESSAGE = 11,
+//	     GET_SCP_STATE = 12,
 //
-//        // new messages
-//        HELLO = 13,
+//	     // new messages
+//	     HELLO = 13,
 //
-//        SURVEY_REQUEST = 14,
-//        SURVEY_RESPONSE = 15,
+//	     SURVEY_REQUEST = 14,
+//	     SURVEY_RESPONSE = 15,
 //
-//        SEND_MORE = 16
-//    };
-//
+//	     SEND_MORE = 16
+//	 };
 type MessageType int32
 
 const (
@@ -15064,12 +14922,11 @@ var _ xdrType = (*MessageType)(nil)
 
 // DontHave is an XDR Struct defines as:
 //
-//   struct DontHave
-//    {
-//        MessageType type;
-//        uint256 reqHash;
-//    };
-//
+//	struct DontHave
+//	 {
+//	     MessageType type;
+//	     uint256 reqHash;
+//	 };
 type DontHave struct {
 	Type    MessageType
 	ReqHash Uint256
@@ -15135,11 +14992,10 @@ var _ xdrType = (*DontHave)(nil)
 
 // SurveyMessageCommandType is an XDR Enum defines as:
 //
-//   enum SurveyMessageCommandType
-//    {
-//        SURVEY_TOPOLOGY = 0
-//    };
-//
+//	enum SurveyMessageCommandType
+//	 {
+//	     SURVEY_TOPOLOGY = 0
+//	 };
 type SurveyMessageCommandType int32
 
 const (
@@ -15216,15 +15072,14 @@ var _ xdrType = (*SurveyMessageCommandType)(nil)
 
 // SurveyRequestMessage is an XDR Struct defines as:
 //
-//   struct SurveyRequestMessage
-//    {
-//        NodeID surveyorPeerID;
-//        NodeID surveyedPeerID;
-//        uint32 ledgerNum;
-//        Curve25519Public encryptionKey;
-//        SurveyMessageCommandType commandType;
-//    };
-//
+//	struct SurveyRequestMessage
+//	 {
+//	     NodeID surveyorPeerID;
+//	     NodeID surveyedPeerID;
+//	     uint32 ledgerNum;
+//	     Curve25519Public encryptionKey;
+//	     SurveyMessageCommandType commandType;
+//	 };
 type SurveyRequestMessage struct {
 	SurveyorPeerId NodeId
 	SurveyedPeerId NodeId
@@ -15317,12 +15172,11 @@ var _ xdrType = (*SurveyRequestMessage)(nil)
 
 // SignedSurveyRequestMessage is an XDR Struct defines as:
 //
-//   struct SignedSurveyRequestMessage
-//    {
-//        Signature requestSignature;
-//        SurveyRequestMessage request;
-//    };
-//
+//	struct SignedSurveyRequestMessage
+//	 {
+//	     Signature requestSignature;
+//	     SurveyRequestMessage request;
+//	 };
 type SignedSurveyRequestMessage struct {
 	RequestSignature Signature
 	Request          SurveyRequestMessage
@@ -15388,8 +15242,7 @@ var _ xdrType = (*SignedSurveyRequestMessage)(nil)
 
 // EncryptedBody is an XDR Typedef defines as:
 //
-//   typedef opaque EncryptedBody<64000>;
-//
+//	typedef opaque EncryptedBody<64000>;
 type EncryptedBody []byte
 
 // XDRMaxSize implements the Sized interface for EncryptedBody
@@ -15449,15 +15302,14 @@ var _ xdrType = (*EncryptedBody)(nil)
 
 // SurveyResponseMessage is an XDR Struct defines as:
 //
-//   struct SurveyResponseMessage
-//    {
-//        NodeID surveyorPeerID;
-//        NodeID surveyedPeerID;
-//        uint32 ledgerNum;
-//        SurveyMessageCommandType commandType;
-//        EncryptedBody encryptedBody;
-//    };
-//
+//	struct SurveyResponseMessage
+//	 {
+//	     NodeID surveyorPeerID;
+//	     NodeID surveyedPeerID;
+//	     uint32 ledgerNum;
+//	     SurveyMessageCommandType commandType;
+//	     EncryptedBody encryptedBody;
+//	 };
 type SurveyResponseMessage struct {
 	SurveyorPeerId NodeId
 	SurveyedPeerId NodeId
@@ -15550,12 +15402,11 @@ var _ xdrType = (*SurveyResponseMessage)(nil)
 
 // SignedSurveyResponseMessage is an XDR Struct defines as:
 //
-//   struct SignedSurveyResponseMessage
-//    {
-//        Signature responseSignature;
-//        SurveyResponseMessage response;
-//    };
-//
+//	struct SignedSurveyResponseMessage
+//	 {
+//	     Signature responseSignature;
+//	     SurveyResponseMessage response;
+//	 };
 type SignedSurveyResponseMessage struct {
 	ResponseSignature Signature
 	Response          SurveyResponseMessage
@@ -15621,27 +15472,26 @@ var _ xdrType = (*SignedSurveyResponseMessage)(nil)
 
 // PeerStats is an XDR Struct defines as:
 //
-//   struct PeerStats
-//    {
-//        NodeID id;
-//        string versionStr<100>;
-//        uint64 messagesRead;
-//        uint64 messagesWritten;
-//        uint64 bytesRead;
-//        uint64 bytesWritten;
-//        uint64 secondsConnected;
+//	struct PeerStats
+//	 {
+//	     NodeID id;
+//	     string versionStr<100>;
+//	     uint64 messagesRead;
+//	     uint64 messagesWritten;
+//	     uint64 bytesRead;
+//	     uint64 bytesWritten;
+//	     uint64 secondsConnected;
 //
-//        uint64 uniqueFloodBytesRecv;
-//        uint64 duplicateFloodBytesRecv;
-//        uint64 uniqueFetchBytesRecv;
-//        uint64 duplicateFetchBytesRecv;
+//	     uint64 uniqueFloodBytesRecv;
+//	     uint64 duplicateFloodBytesRecv;
+//	     uint64 uniqueFetchBytesRecv;
+//	     uint64 duplicateFetchBytesRecv;
 //
-//        uint64 uniqueFloodMessageRecv;
-//        uint64 duplicateFloodMessageRecv;
-//        uint64 uniqueFetchMessageRecv;
-//        uint64 duplicateFetchMessageRecv;
-//    };
-//
+//	     uint64 uniqueFloodMessageRecv;
+//	     uint64 duplicateFloodMessageRecv;
+//	     uint64 uniqueFetchMessageRecv;
+//	     uint64 duplicateFetchMessageRecv;
+//	 };
 type PeerStats struct {
 	Id                        NodeId
 	VersionStr                string `xdrmaxsize:"100"`
@@ -15824,8 +15674,7 @@ var _ xdrType = (*PeerStats)(nil)
 
 // PeerStatList is an XDR Typedef defines as:
 //
-//   typedef PeerStats PeerStatList<25>;
-//
+//	typedef PeerStats PeerStatList<25>;
 type PeerStatList []PeerStats
 
 // XDRMaxSize implements the Sized interface for PeerStatList
@@ -15905,15 +15754,14 @@ var _ xdrType = (*PeerStatList)(nil)
 
 // TopologyResponseBody is an XDR Struct defines as:
 //
-//   struct TopologyResponseBody
-//    {
-//        PeerStatList inboundPeers;
-//        PeerStatList outboundPeers;
+//	struct TopologyResponseBody
+//	 {
+//	     PeerStatList inboundPeers;
+//	     PeerStatList outboundPeers;
 //
-//        uint32 totalInboundPeerCount;
-//        uint32 totalOutboundPeerCount;
-//    };
-//
+//	     uint32 totalInboundPeerCount;
+//	     uint32 totalOutboundPeerCount;
+//	 };
 type TopologyResponseBody struct {
 	InboundPeers           PeerStatList
 	OutboundPeers          PeerStatList
@@ -15997,12 +15845,11 @@ var _ xdrType = (*TopologyResponseBody)(nil)
 
 // SurveyResponseBody is an XDR Union defines as:
 //
-//   union SurveyResponseBody switch (SurveyMessageCommandType type)
-//    {
-//    case SURVEY_TOPOLOGY:
-//        TopologyResponseBody topologyResponseBody;
-//    };
-//
+//	union SurveyResponseBody switch (SurveyMessageCommandType type)
+//	 {
+//	 case SURVEY_TOPOLOGY:
+//	     TopologyResponseBody topologyResponseBody;
+//	 };
 type SurveyResponseBody struct {
 	Type                 SurveyMessageCommandType
 	TopologyResponseBody *TopologyResponseBody
@@ -16133,48 +15980,47 @@ var _ xdrType = (*SurveyResponseBody)(nil)
 
 // StellarMessage is an XDR Union defines as:
 //
-//   union StellarMessage switch (MessageType type)
-//    {
-//    case ERROR_MSG:
-//        Error error;
-//    case HELLO:
-//        Hello hello;
-//    case AUTH:
-//        Auth auth;
-//    case DONT_HAVE:
-//        DontHave dontHave;
-//    case GET_PEERS:
-//        void;
-//    case PEERS:
-//        PeerAddress peers<100>;
+//	union StellarMessage switch (MessageType type)
+//	 {
+//	 case ERROR_MSG:
+//	     Error error;
+//	 case HELLO:
+//	     Hello hello;
+//	 case AUTH:
+//	     Auth auth;
+//	 case DONT_HAVE:
+//	     DontHave dontHave;
+//	 case GET_PEERS:
+//	     void;
+//	 case PEERS:
+//	     PeerAddress peers<100>;
 //
-//    case GET_TX_SET:
-//        uint256 txSetHash;
-//    case TX_SET:
-//        TransactionSet txSet;
+//	 case GET_TX_SET:
+//	     uint256 txSetHash;
+//	 case TX_SET:
+//	     TransactionSet txSet;
 //
-//    case TRANSACTION:
-//        TransactionEnvelope transaction;
+//	 case TRANSACTION:
+//	     TransactionEnvelope transaction;
 //
-//    case SURVEY_REQUEST:
-//        SignedSurveyRequestMessage signedSurveyRequestMessage;
+//	 case SURVEY_REQUEST:
+//	     SignedSurveyRequestMessage signedSurveyRequestMessage;
 //
-//    case SURVEY_RESPONSE:
-//        SignedSurveyResponseMessage signedSurveyResponseMessage;
+//	 case SURVEY_RESPONSE:
+//	     SignedSurveyResponseMessage signedSurveyResponseMessage;
 //
-//    // SCP
-//    case GET_SCP_QUORUMSET:
-//        uint256 qSetHash;
-//    case SCP_QUORUMSET:
-//        SCPQuorumSet qSet;
-//    case SCP_MESSAGE:
-//        SCPEnvelope envelope;
-//    case GET_SCP_STATE:
-//        uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
-//    case SEND_MORE:
-//        SendMore sendMoreMessage;
-//    };
-//
+//	 // SCP
+//	 case GET_SCP_QUORUMSET:
+//	     uint256 qSetHash;
+//	 case SCP_QUORUMSET:
+//	     SCPQuorumSet qSet;
+//	 case SCP_MESSAGE:
+//	     SCPEnvelope envelope;
+//	 case GET_SCP_STATE:
+//	     uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
+//	 case SEND_MORE:
+//	     SendMore sendMoreMessage;
+//	 };
 type StellarMessage struct {
 	Type                        MessageType
 	Error                       *Error
@@ -17007,13 +16853,12 @@ var _ xdrType = (*StellarMessage)(nil)
 
 // AuthenticatedMessageV0 is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            uint64 sequence;
-//            StellarMessage message;
-//            HmacSha256Mac mac;
-//        }
-//
+//	struct
+//	     {
+//	         uint64 sequence;
+//	         StellarMessage message;
+//	         HmacSha256Mac mac;
+//	     }
 type AuthenticatedMessageV0 struct {
 	Sequence Uint64
 	Message  StellarMessage
@@ -17088,17 +16933,16 @@ var _ xdrType = (*AuthenticatedMessageV0)(nil)
 
 // AuthenticatedMessage is an XDR Union defines as:
 //
-//   union AuthenticatedMessage switch (uint32 v)
-//    {
-//    case 0:
-//        struct
-//        {
-//            uint64 sequence;
-//            StellarMessage message;
-//            HmacSha256Mac mac;
-//        } v0;
-//    };
-//
+//	union AuthenticatedMessage switch (uint32 v)
+//	 {
+//	 case 0:
+//	     struct
+//	     {
+//	         uint64 sequence;
+//	         StellarMessage message;
+//	         HmacSha256Mac mac;
+//	     } v0;
+//	 };
 type AuthenticatedMessage struct {
 	V  Uint32
 	V0 *AuthenticatedMessageV0
@@ -17229,12 +17073,11 @@ var _ xdrType = (*AuthenticatedMessage)(nil)
 
 // LiquidityPoolParameters is an XDR Union defines as:
 //
-//   union LiquidityPoolParameters switch (LiquidityPoolType type)
-//    {
-//    case LIQUIDITY_POOL_CONSTANT_PRODUCT:
-//        LiquidityPoolConstantProductParameters constantProduct;
-//    };
-//
+//	union LiquidityPoolParameters switch (LiquidityPoolType type)
+//	 {
+//	 case LIQUIDITY_POOL_CONSTANT_PRODUCT:
+//	     LiquidityPoolConstantProductParameters constantProduct;
+//	 };
 type LiquidityPoolParameters struct {
 	Type            LiquidityPoolType
 	ConstantProduct *LiquidityPoolConstantProductParameters
@@ -17365,12 +17208,11 @@ var _ xdrType = (*LiquidityPoolParameters)(nil)
 
 // MuxedAccountMed25519 is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            uint64 id;
-//            uint256 ed25519;
-//        }
-//
+//	struct
+//	     {
+//	         uint64 id;
+//	         uint256 ed25519;
+//	     }
 type MuxedAccountMed25519 struct {
 	Id      Uint64
 	Ed25519 Uint256
@@ -17436,18 +17278,17 @@ var _ xdrType = (*MuxedAccountMed25519)(nil)
 
 // MuxedAccount is an XDR Union defines as:
 //
-//   union MuxedAccount switch (CryptoKeyType type)
-//    {
-//    case KEY_TYPE_ED25519:
-//        uint256 ed25519;
-//    case KEY_TYPE_MUXED_ED25519:
-//        struct
-//        {
-//            uint64 id;
-//            uint256 ed25519;
-//        } med25519;
-//    };
-//
+//	union MuxedAccount switch (CryptoKeyType type)
+//	 {
+//	 case KEY_TYPE_ED25519:
+//	     uint256 ed25519;
+//	 case KEY_TYPE_MUXED_ED25519:
+//	     struct
+//	     {
+//	         uint64 id;
+//	         uint256 ed25519;
+//	     } med25519;
+//	 };
 type MuxedAccount struct {
 	Type     CryptoKeyType
 	Ed25519  *Uint256
@@ -17626,12 +17467,11 @@ var _ xdrType = (*MuxedAccount)(nil)
 
 // DecoratedSignature is an XDR Struct defines as:
 //
-//   struct DecoratedSignature
-//    {
-//        SignatureHint hint;  // last 4 bytes of the public key, used as a hint
-//        Signature signature; // actual signature
-//    };
-//
+//	struct DecoratedSignature
+//	 {
+//	     SignatureHint hint;  // last 4 bytes of the public key, used as a hint
+//	     Signature signature; // actual signature
+//	 };
 type DecoratedSignature struct {
 	Hint      SignatureHint
 	Signature Signature
@@ -17697,34 +17537,33 @@ var _ xdrType = (*DecoratedSignature)(nil)
 
 // OperationType is an XDR Enum defines as:
 //
-//   enum OperationType
-//    {
-//        CREATE_ACCOUNT = 0,
-//        PAYMENT = 1,
-//        PATH_PAYMENT_STRICT_RECEIVE = 2,
-//        MANAGE_SELL_OFFER = 3,
-//        CREATE_PASSIVE_SELL_OFFER = 4,
-//        SET_OPTIONS = 5,
-//        CHANGE_TRUST = 6,
-//        ALLOW_TRUST = 7,
-//        ACCOUNT_MERGE = 8,
-//        INFLATION = 9,
-//        MANAGE_DATA = 10,
-//        BUMP_SEQUENCE = 11,
-//        MANAGE_BUY_OFFER = 12,
-//        PATH_PAYMENT_STRICT_SEND = 13,
-//        CREATE_CLAIMABLE_BALANCE = 14,
-//        CLAIM_CLAIMABLE_BALANCE = 15,
-//        BEGIN_SPONSORING_FUTURE_RESERVES = 16,
-//        END_SPONSORING_FUTURE_RESERVES = 17,
-//        REVOKE_SPONSORSHIP = 18,
-//        CLAWBACK = 19,
-//        CLAWBACK_CLAIMABLE_BALANCE = 20,
-//        SET_TRUST_LINE_FLAGS = 21,
-//        LIQUIDITY_POOL_DEPOSIT = 22,
-//        LIQUIDITY_POOL_WITHDRAW = 23
-//    };
-//
+//	enum OperationType
+//	 {
+//	     CREATE_ACCOUNT = 0,
+//	     PAYMENT = 1,
+//	     PATH_PAYMENT_STRICT_RECEIVE = 2,
+//	     MANAGE_SELL_OFFER = 3,
+//	     CREATE_PASSIVE_SELL_OFFER = 4,
+//	     SET_OPTIONS = 5,
+//	     CHANGE_TRUST = 6,
+//	     ALLOW_TRUST = 7,
+//	     ACCOUNT_MERGE = 8,
+//	     INFLATION = 9,
+//	     MANAGE_DATA = 10,
+//	     BUMP_SEQUENCE = 11,
+//	     MANAGE_BUY_OFFER = 12,
+//	     PATH_PAYMENT_STRICT_SEND = 13,
+//	     CREATE_CLAIMABLE_BALANCE = 14,
+//	     CLAIM_CLAIMABLE_BALANCE = 15,
+//	     BEGIN_SPONSORING_FUTURE_RESERVES = 16,
+//	     END_SPONSORING_FUTURE_RESERVES = 17,
+//	     REVOKE_SPONSORSHIP = 18,
+//	     CLAWBACK = 19,
+//	     CLAWBACK_CLAIMABLE_BALANCE = 20,
+//	     SET_TRUST_LINE_FLAGS = 21,
+//	     LIQUIDITY_POOL_DEPOSIT = 22,
+//	     LIQUIDITY_POOL_WITHDRAW = 23
+//	 };
 type OperationType int32
 
 const (
@@ -17847,12 +17686,11 @@ var _ xdrType = (*OperationType)(nil)
 
 // CreateAccountOp is an XDR Struct defines as:
 //
-//   struct CreateAccountOp
-//    {
-//        AccountID destination; // account to create
-//        int64 startingBalance; // amount they end up with
-//    };
-//
+//	struct CreateAccountOp
+//	 {
+//	     AccountID destination; // account to create
+//	     int64 startingBalance; // amount they end up with
+//	 };
 type CreateAccountOp struct {
 	Destination     AccountId
 	StartingBalance Int64
@@ -17918,13 +17756,12 @@ var _ xdrType = (*CreateAccountOp)(nil)
 
 // PaymentOp is an XDR Struct defines as:
 //
-//   struct PaymentOp
-//    {
-//        MuxedAccount destination; // recipient of the payment
-//        Asset asset;              // what they end up with
-//        int64 amount;             // amount they end up with
-//    };
-//
+//	struct PaymentOp
+//	 {
+//	     MuxedAccount destination; // recipient of the payment
+//	     Asset asset;              // what they end up with
+//	     int64 amount;             // amount they end up with
+//	 };
 type PaymentOp struct {
 	Destination MuxedAccount
 	Asset       Asset
@@ -17999,20 +17836,19 @@ var _ xdrType = (*PaymentOp)(nil)
 
 // PathPaymentStrictReceiveOp is an XDR Struct defines as:
 //
-//   struct PathPaymentStrictReceiveOp
-//    {
-//        Asset sendAsset; // asset we pay with
-//        int64 sendMax;   // the maximum amount of sendAsset to
-//                         // send (excluding fees).
-//                         // The operation will fail if can't be met
+//	struct PathPaymentStrictReceiveOp
+//	 {
+//	     Asset sendAsset; // asset we pay with
+//	     int64 sendMax;   // the maximum amount of sendAsset to
+//	                      // send (excluding fees).
+//	                      // The operation will fail if can't be met
 //
-//        MuxedAccount destination; // recipient of the payment
-//        Asset destAsset;          // what they end up with
-//        int64 destAmount;         // amount they end up with
+//	     MuxedAccount destination; // recipient of the payment
+//	     Asset destAsset;          // what they end up with
+//	     int64 destAmount;         // amount they end up with
 //
-//        Asset path<5>; // additional hops it must go through to get there
-//    };
-//
+//	     Asset path<5>; // additional hops it must go through to get there
+//	 };
 type PathPaymentStrictReceiveOp struct {
 	SendAsset   Asset
 	SendMax     Int64
@@ -18134,20 +17970,19 @@ var _ xdrType = (*PathPaymentStrictReceiveOp)(nil)
 
 // PathPaymentStrictSendOp is an XDR Struct defines as:
 //
-//   struct PathPaymentStrictSendOp
-//    {
-//        Asset sendAsset;  // asset we pay with
-//        int64 sendAmount; // amount of sendAsset to send (excluding fees)
+//	struct PathPaymentStrictSendOp
+//	 {
+//	     Asset sendAsset;  // asset we pay with
+//	     int64 sendAmount; // amount of sendAsset to send (excluding fees)
 //
-//        MuxedAccount destination; // recipient of the payment
-//        Asset destAsset;          // what they end up with
-//        int64 destMin;            // the minimum amount of dest asset to
-//                                  // be received
-//                                  // The operation will fail if it can't be met
+//	     MuxedAccount destination; // recipient of the payment
+//	     Asset destAsset;          // what they end up with
+//	     int64 destMin;            // the minimum amount of dest asset to
+//	                               // be received
+//	                               // The operation will fail if it can't be met
 //
-//        Asset path<5>; // additional hops it must go through to get there
-//    };
-//
+//	     Asset path<5>; // additional hops it must go through to get there
+//	 };
 type PathPaymentStrictSendOp struct {
 	SendAsset   Asset
 	SendAmount  Int64
@@ -18269,17 +18104,16 @@ var _ xdrType = (*PathPaymentStrictSendOp)(nil)
 
 // ManageSellOfferOp is an XDR Struct defines as:
 //
-//   struct ManageSellOfferOp
-//    {
-//        Asset selling;
-//        Asset buying;
-//        int64 amount; // amount being sold. if set to 0, delete the offer
-//        Price price;  // price of thing being sold in terms of what you are buying
+//	struct ManageSellOfferOp
+//	 {
+//	     Asset selling;
+//	     Asset buying;
+//	     int64 amount; // amount being sold. if set to 0, delete the offer
+//	     Price price;  // price of thing being sold in terms of what you are buying
 //
-//        // 0=create a new offer, otherwise edit an existing offer
-//        int64 offerID;
-//    };
-//
+//	     // 0=create a new offer, otherwise edit an existing offer
+//	     int64 offerID;
+//	 };
 type ManageSellOfferOp struct {
 	Selling Asset
 	Buying  Asset
@@ -18372,18 +18206,17 @@ var _ xdrType = (*ManageSellOfferOp)(nil)
 
 // ManageBuyOfferOp is an XDR Struct defines as:
 //
-//   struct ManageBuyOfferOp
-//    {
-//        Asset selling;
-//        Asset buying;
-//        int64 buyAmount; // amount being bought. if set to 0, delete the offer
-//        Price price;     // price of thing being bought in terms of what you are
-//                         // selling
+//	struct ManageBuyOfferOp
+//	 {
+//	     Asset selling;
+//	     Asset buying;
+//	     int64 buyAmount; // amount being bought. if set to 0, delete the offer
+//	     Price price;     // price of thing being bought in terms of what you are
+//	                      // selling
 //
-//        // 0=create a new offer, otherwise edit an existing offer
-//        int64 offerID;
-//    };
-//
+//	     // 0=create a new offer, otherwise edit an existing offer
+//	     int64 offerID;
+//	 };
 type ManageBuyOfferOp struct {
 	Selling   Asset
 	Buying    Asset
@@ -18476,14 +18309,13 @@ var _ xdrType = (*ManageBuyOfferOp)(nil)
 
 // CreatePassiveSellOfferOp is an XDR Struct defines as:
 //
-//   struct CreatePassiveSellOfferOp
-//    {
-//        Asset selling; // A
-//        Asset buying;  // B
-//        int64 amount;  // amount taker gets
-//        Price price;   // cost of A in terms of B
-//    };
-//
+//	struct CreatePassiveSellOfferOp
+//	 {
+//	     Asset selling; // A
+//	     Asset buying;  // B
+//	     int64 amount;  // amount taker gets
+//	     Price price;   // cost of A in terms of B
+//	 };
 type CreatePassiveSellOfferOp struct {
 	Selling Asset
 	Buying  Asset
@@ -18567,26 +18399,25 @@ var _ xdrType = (*CreatePassiveSellOfferOp)(nil)
 
 // SetOptionsOp is an XDR Struct defines as:
 //
-//   struct SetOptionsOp
-//    {
-//        AccountID* inflationDest; // sets the inflation destination
+//	struct SetOptionsOp
+//	 {
+//	     AccountID* inflationDest; // sets the inflation destination
 //
-//        uint32* clearFlags; // which flags to clear
-//        uint32* setFlags;   // which flags to set
+//	     uint32* clearFlags; // which flags to clear
+//	     uint32* setFlags;   // which flags to set
 //
-//        // account threshold manipulation
-//        uint32* masterWeight; // weight of the master account
-//        uint32* lowThreshold;
-//        uint32* medThreshold;
-//        uint32* highThreshold;
+//	     // account threshold manipulation
+//	     uint32* masterWeight; // weight of the master account
+//	     uint32* lowThreshold;
+//	     uint32* medThreshold;
+//	     uint32* highThreshold;
 //
-//        string32* homeDomain; // sets the home domain
+//	     string32* homeDomain; // sets the home domain
 //
-//        // Add, update or remove a signer for the account
-//        // signer is deleted if the weight is 0
-//        Signer* signer;
-//    };
-//
+//	     // Add, update or remove a signer for the account
+//	     // signer is deleted if the weight is 0
+//	     Signer* signer;
+//	 };
 type SetOptionsOp struct {
 	InflationDest *AccountId
 	ClearFlags    *Uint32
@@ -18842,23 +18673,22 @@ var _ xdrType = (*SetOptionsOp)(nil)
 
 // ChangeTrustAsset is an XDR Union defines as:
 //
-//   union ChangeTrustAsset switch (AssetType type)
-//    {
-//    case ASSET_TYPE_NATIVE: // Not credit
-//        void;
+//	union ChangeTrustAsset switch (AssetType type)
+//	 {
+//	 case ASSET_TYPE_NATIVE: // Not credit
+//	     void;
 //
-//    case ASSET_TYPE_CREDIT_ALPHANUM4:
-//        AlphaNum4 alphaNum4;
+//	 case ASSET_TYPE_CREDIT_ALPHANUM4:
+//	     AlphaNum4 alphaNum4;
 //
-//    case ASSET_TYPE_CREDIT_ALPHANUM12:
-//        AlphaNum12 alphaNum12;
+//	 case ASSET_TYPE_CREDIT_ALPHANUM12:
+//	     AlphaNum12 alphaNum12;
 //
-//    case ASSET_TYPE_POOL_SHARE:
-//        LiquidityPoolParameters liquidityPool;
+//	 case ASSET_TYPE_POOL_SHARE:
+//	     LiquidityPoolParameters liquidityPool;
 //
-//        // add other asset types here in the future
-//    };
-//
+//	     // add other asset types here in the future
+//	 };
 type ChangeTrustAsset struct {
 	Type          AssetType
 	AlphaNum4     *AlphaNum4
@@ -19095,14 +18925,13 @@ var _ xdrType = (*ChangeTrustAsset)(nil)
 
 // ChangeTrustOp is an XDR Struct defines as:
 //
-//   struct ChangeTrustOp
-//    {
-//        ChangeTrustAsset line;
+//	struct ChangeTrustOp
+//	 {
+//	     ChangeTrustAsset line;
 //
-//        // if limit is set to 0, deletes the trust line
-//        int64 limit;
-//    };
-//
+//	     // if limit is set to 0, deletes the trust line
+//	     int64 limit;
+//	 };
 type ChangeTrustOp struct {
 	Line  ChangeTrustAsset
 	Limit Int64
@@ -19168,15 +18997,14 @@ var _ xdrType = (*ChangeTrustOp)(nil)
 
 // AllowTrustOp is an XDR Struct defines as:
 //
-//   struct AllowTrustOp
-//    {
-//        AccountID trustor;
-//        AssetCode asset;
+//	struct AllowTrustOp
+//	 {
+//	     AccountID trustor;
+//	     AssetCode asset;
 //
-//        // One of 0, AUTHORIZED_FLAG, or AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG
-//        uint32 authorize;
-//    };
-//
+//	     // One of 0, AUTHORIZED_FLAG, or AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG
+//	     uint32 authorize;
+//	 };
 type AllowTrustOp struct {
 	Trustor   AccountId
 	Asset     AssetCode
@@ -19251,12 +19079,11 @@ var _ xdrType = (*AllowTrustOp)(nil)
 
 // ManageDataOp is an XDR Struct defines as:
 //
-//   struct ManageDataOp
-//    {
-//        string64 dataName;
-//        DataValue* dataValue; // set to null to clear
-//    };
-//
+//	struct ManageDataOp
+//	 {
+//	     string64 dataName;
+//	     DataValue* dataValue; // set to null to clear
+//	 };
 type ManageDataOp struct {
 	DataName  String64
 	DataValue *DataValue
@@ -19337,11 +19164,10 @@ var _ xdrType = (*ManageDataOp)(nil)
 
 // BumpSequenceOp is an XDR Struct defines as:
 //
-//   struct BumpSequenceOp
-//    {
-//        SequenceNumber bumpTo;
-//    };
-//
+//	struct BumpSequenceOp
+//	 {
+//	     SequenceNumber bumpTo;
+//	 };
 type BumpSequenceOp struct {
 	BumpTo SequenceNumber
 }
@@ -19398,13 +19224,12 @@ var _ xdrType = (*BumpSequenceOp)(nil)
 
 // CreateClaimableBalanceOp is an XDR Struct defines as:
 //
-//   struct CreateClaimableBalanceOp
-//    {
-//        Asset asset;
-//        int64 amount;
-//        Claimant claimants<10>;
-//    };
-//
+//	struct CreateClaimableBalanceOp
+//	 {
+//	     Asset asset;
+//	     int64 amount;
+//	     Claimant claimants<10>;
+//	 };
 type CreateClaimableBalanceOp struct {
 	Asset     Asset
 	Amount    Int64
@@ -19499,11 +19324,10 @@ var _ xdrType = (*CreateClaimableBalanceOp)(nil)
 
 // ClaimClaimableBalanceOp is an XDR Struct defines as:
 //
-//   struct ClaimClaimableBalanceOp
-//    {
-//        ClaimableBalanceID balanceID;
-//    };
-//
+//	struct ClaimClaimableBalanceOp
+//	 {
+//	     ClaimableBalanceID balanceID;
+//	 };
 type ClaimClaimableBalanceOp struct {
 	BalanceId ClaimableBalanceId
 }
@@ -19560,11 +19384,10 @@ var _ xdrType = (*ClaimClaimableBalanceOp)(nil)
 
 // BeginSponsoringFutureReservesOp is an XDR Struct defines as:
 //
-//   struct BeginSponsoringFutureReservesOp
-//    {
-//        AccountID sponsoredID;
-//    };
-//
+//	struct BeginSponsoringFutureReservesOp
+//	 {
+//	     AccountID sponsoredID;
+//	 };
 type BeginSponsoringFutureReservesOp struct {
 	SponsoredId AccountId
 }
@@ -19621,12 +19444,11 @@ var _ xdrType = (*BeginSponsoringFutureReservesOp)(nil)
 
 // RevokeSponsorshipType is an XDR Enum defines as:
 //
-//   enum RevokeSponsorshipType
-//    {
-//        REVOKE_SPONSORSHIP_LEDGER_ENTRY = 0,
-//        REVOKE_SPONSORSHIP_SIGNER = 1
-//    };
-//
+//	enum RevokeSponsorshipType
+//	 {
+//	     REVOKE_SPONSORSHIP_LEDGER_ENTRY = 0,
+//	     REVOKE_SPONSORSHIP_SIGNER = 1
+//	 };
 type RevokeSponsorshipType int32
 
 const (
@@ -19705,12 +19527,11 @@ var _ xdrType = (*RevokeSponsorshipType)(nil)
 
 // RevokeSponsorshipOpSigner is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            AccountID accountID;
-//            SignerKey signerKey;
-//        }
-//
+//	struct
+//	     {
+//	         AccountID accountID;
+//	         SignerKey signerKey;
+//	     }
 type RevokeSponsorshipOpSigner struct {
 	AccountId AccountId
 	SignerKey SignerKey
@@ -19776,18 +19597,17 @@ var _ xdrType = (*RevokeSponsorshipOpSigner)(nil)
 
 // RevokeSponsorshipOp is an XDR Union defines as:
 //
-//   union RevokeSponsorshipOp switch (RevokeSponsorshipType type)
-//    {
-//    case REVOKE_SPONSORSHIP_LEDGER_ENTRY:
-//        LedgerKey ledgerKey;
-//    case REVOKE_SPONSORSHIP_SIGNER:
-//        struct
-//        {
-//            AccountID accountID;
-//            SignerKey signerKey;
-//        } signer;
-//    };
-//
+//	union RevokeSponsorshipOp switch (RevokeSponsorshipType type)
+//	 {
+//	 case REVOKE_SPONSORSHIP_LEDGER_ENTRY:
+//	     LedgerKey ledgerKey;
+//	 case REVOKE_SPONSORSHIP_SIGNER:
+//	     struct
+//	     {
+//	         AccountID accountID;
+//	         SignerKey signerKey;
+//	     } signer;
+//	 };
 type RevokeSponsorshipOp struct {
 	Type      RevokeSponsorshipType
 	LedgerKey *LedgerKey
@@ -19966,13 +19786,12 @@ var _ xdrType = (*RevokeSponsorshipOp)(nil)
 
 // ClawbackOp is an XDR Struct defines as:
 //
-//   struct ClawbackOp
-//    {
-//        Asset asset;
-//        MuxedAccount from;
-//        int64 amount;
-//    };
-//
+//	struct ClawbackOp
+//	 {
+//	     Asset asset;
+//	     MuxedAccount from;
+//	     int64 amount;
+//	 };
 type ClawbackOp struct {
 	Asset  Asset
 	From   MuxedAccount
@@ -20047,11 +19866,10 @@ var _ xdrType = (*ClawbackOp)(nil)
 
 // ClawbackClaimableBalanceOp is an XDR Struct defines as:
 //
-//   struct ClawbackClaimableBalanceOp
-//    {
-//        ClaimableBalanceID balanceID;
-//    };
-//
+//	struct ClawbackClaimableBalanceOp
+//	 {
+//	     ClaimableBalanceID balanceID;
+//	 };
 type ClawbackClaimableBalanceOp struct {
 	BalanceId ClaimableBalanceId
 }
@@ -20108,15 +19926,14 @@ var _ xdrType = (*ClawbackClaimableBalanceOp)(nil)
 
 // SetTrustLineFlagsOp is an XDR Struct defines as:
 //
-//   struct SetTrustLineFlagsOp
-//    {
-//        AccountID trustor;
-//        Asset asset;
+//	struct SetTrustLineFlagsOp
+//	 {
+//	     AccountID trustor;
+//	     Asset asset;
 //
-//        uint32 clearFlags; // which flags to clear
-//        uint32 setFlags;   // which flags to set
-//    };
-//
+//	     uint32 clearFlags; // which flags to clear
+//	     uint32 setFlags;   // which flags to set
+//	 };
 type SetTrustLineFlagsOp struct {
 	Trustor    AccountId
 	Asset      Asset
@@ -20200,21 +20017,19 @@ var _ xdrType = (*SetTrustLineFlagsOp)(nil)
 
 // LiquidityPoolFeeV18 is an XDR Const defines as:
 //
-//   const LIQUIDITY_POOL_FEE_V18 = 30;
-//
+//	const LIQUIDITY_POOL_FEE_V18 = 30;
 const LiquidityPoolFeeV18 = 30
 
 // LiquidityPoolDepositOp is an XDR Struct defines as:
 //
-//   struct LiquidityPoolDepositOp
-//    {
-//        PoolID liquidityPoolID;
-//        int64 maxAmountA; // maximum amount of first asset to deposit
-//        int64 maxAmountB; // maximum amount of second asset to deposit
-//        Price minPrice;   // minimum depositA/depositB
-//        Price maxPrice;   // maximum depositA/depositB
-//    };
-//
+//	struct LiquidityPoolDepositOp
+//	 {
+//	     PoolID liquidityPoolID;
+//	     int64 maxAmountA; // maximum amount of first asset to deposit
+//	     int64 maxAmountB; // maximum amount of second asset to deposit
+//	     Price minPrice;   // minimum depositA/depositB
+//	     Price maxPrice;   // maximum depositA/depositB
+//	 };
 type LiquidityPoolDepositOp struct {
 	LiquidityPoolId PoolId
 	MaxAmountA      Int64
@@ -20307,14 +20122,13 @@ var _ xdrType = (*LiquidityPoolDepositOp)(nil)
 
 // LiquidityPoolWithdrawOp is an XDR Struct defines as:
 //
-//   struct LiquidityPoolWithdrawOp
-//    {
-//        PoolID liquidityPoolID;
-//        int64 amount;     // amount of pool shares to withdraw
-//        int64 minAmountA; // minimum amount of first asset to withdraw
-//        int64 minAmountB; // minimum amount of second asset to withdraw
-//    };
-//
+//	struct LiquidityPoolWithdrawOp
+//	 {
+//	     PoolID liquidityPoolID;
+//	     int64 amount;     // amount of pool shares to withdraw
+//	     int64 minAmountA; // minimum amount of first asset to withdraw
+//	     int64 minAmountB; // minimum amount of second asset to withdraw
+//	 };
 type LiquidityPoolWithdrawOp struct {
 	LiquidityPoolId PoolId
 	Amount          Int64
@@ -20398,58 +20212,57 @@ var _ xdrType = (*LiquidityPoolWithdrawOp)(nil)
 
 // OperationBody is an XDR NestedUnion defines as:
 //
-//   union switch (OperationType type)
-//        {
-//        case CREATE_ACCOUNT:
-//            CreateAccountOp createAccountOp;
-//        case PAYMENT:
-//            PaymentOp paymentOp;
-//        case PATH_PAYMENT_STRICT_RECEIVE:
-//            PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
-//        case MANAGE_SELL_OFFER:
-//            ManageSellOfferOp manageSellOfferOp;
-//        case CREATE_PASSIVE_SELL_OFFER:
-//            CreatePassiveSellOfferOp createPassiveSellOfferOp;
-//        case SET_OPTIONS:
-//            SetOptionsOp setOptionsOp;
-//        case CHANGE_TRUST:
-//            ChangeTrustOp changeTrustOp;
-//        case ALLOW_TRUST:
-//            AllowTrustOp allowTrustOp;
-//        case ACCOUNT_MERGE:
-//            MuxedAccount destination;
-//        case INFLATION:
-//            void;
-//        case MANAGE_DATA:
-//            ManageDataOp manageDataOp;
-//        case BUMP_SEQUENCE:
-//            BumpSequenceOp bumpSequenceOp;
-//        case MANAGE_BUY_OFFER:
-//            ManageBuyOfferOp manageBuyOfferOp;
-//        case PATH_PAYMENT_STRICT_SEND:
-//            PathPaymentStrictSendOp pathPaymentStrictSendOp;
-//        case CREATE_CLAIMABLE_BALANCE:
-//            CreateClaimableBalanceOp createClaimableBalanceOp;
-//        case CLAIM_CLAIMABLE_BALANCE:
-//            ClaimClaimableBalanceOp claimClaimableBalanceOp;
-//        case BEGIN_SPONSORING_FUTURE_RESERVES:
-//            BeginSponsoringFutureReservesOp beginSponsoringFutureReservesOp;
-//        case END_SPONSORING_FUTURE_RESERVES:
-//            void;
-//        case REVOKE_SPONSORSHIP:
-//            RevokeSponsorshipOp revokeSponsorshipOp;
-//        case CLAWBACK:
-//            ClawbackOp clawbackOp;
-//        case CLAWBACK_CLAIMABLE_BALANCE:
-//            ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
-//        case SET_TRUST_LINE_FLAGS:
-//            SetTrustLineFlagsOp setTrustLineFlagsOp;
-//        case LIQUIDITY_POOL_DEPOSIT:
-//            LiquidityPoolDepositOp liquidityPoolDepositOp;
-//        case LIQUIDITY_POOL_WITHDRAW:
-//            LiquidityPoolWithdrawOp liquidityPoolWithdrawOp;
-//        }
-//
+//	union switch (OperationType type)
+//	     {
+//	     case CREATE_ACCOUNT:
+//	         CreateAccountOp createAccountOp;
+//	     case PAYMENT:
+//	         PaymentOp paymentOp;
+//	     case PATH_PAYMENT_STRICT_RECEIVE:
+//	         PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
+//	     case MANAGE_SELL_OFFER:
+//	         ManageSellOfferOp manageSellOfferOp;
+//	     case CREATE_PASSIVE_SELL_OFFER:
+//	         CreatePassiveSellOfferOp createPassiveSellOfferOp;
+//	     case SET_OPTIONS:
+//	         SetOptionsOp setOptionsOp;
+//	     case CHANGE_TRUST:
+//	         ChangeTrustOp changeTrustOp;
+//	     case ALLOW_TRUST:
+//	         AllowTrustOp allowTrustOp;
+//	     case ACCOUNT_MERGE:
+//	         MuxedAccount destination;
+//	     case INFLATION:
+//	         void;
+//	     case MANAGE_DATA:
+//	         ManageDataOp manageDataOp;
+//	     case BUMP_SEQUENCE:
+//	         BumpSequenceOp bumpSequenceOp;
+//	     case MANAGE_BUY_OFFER:
+//	         ManageBuyOfferOp manageBuyOfferOp;
+//	     case PATH_PAYMENT_STRICT_SEND:
+//	         PathPaymentStrictSendOp pathPaymentStrictSendOp;
+//	     case CREATE_CLAIMABLE_BALANCE:
+//	         CreateClaimableBalanceOp createClaimableBalanceOp;
+//	     case CLAIM_CLAIMABLE_BALANCE:
+//	         ClaimClaimableBalanceOp claimClaimableBalanceOp;
+//	     case BEGIN_SPONSORING_FUTURE_RESERVES:
+//	         BeginSponsoringFutureReservesOp beginSponsoringFutureReservesOp;
+//	     case END_SPONSORING_FUTURE_RESERVES:
+//	         void;
+//	     case REVOKE_SPONSORSHIP:
+//	         RevokeSponsorshipOp revokeSponsorshipOp;
+//	     case CLAWBACK:
+//	         ClawbackOp clawbackOp;
+//	     case CLAWBACK_CLAIMABLE_BALANCE:
+//	         ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
+//	     case SET_TRUST_LINE_FLAGS:
+//	         SetTrustLineFlagsOp setTrustLineFlagsOp;
+//	     case LIQUIDITY_POOL_DEPOSIT:
+//	         LiquidityPoolDepositOp liquidityPoolDepositOp;
+//	     case LIQUIDITY_POOL_WITHDRAW:
+//	         LiquidityPoolWithdrawOp liquidityPoolWithdrawOp;
+//	     }
 type OperationBody struct {
 	Type                            OperationType
 	CreateAccountOp                 *CreateAccountOp
@@ -21608,67 +21421,66 @@ var _ xdrType = (*OperationBody)(nil)
 
 // Operation is an XDR Struct defines as:
 //
-//   struct Operation
-//    {
-//        // sourceAccount is the account used to run the operation
-//        // if not set, the runtime defaults to "sourceAccount" specified at
-//        // the transaction level
-//        MuxedAccount* sourceAccount;
+//	struct Operation
+//	 {
+//	     // sourceAccount is the account used to run the operation
+//	     // if not set, the runtime defaults to "sourceAccount" specified at
+//	     // the transaction level
+//	     MuxedAccount* sourceAccount;
 //
-//        union switch (OperationType type)
-//        {
-//        case CREATE_ACCOUNT:
-//            CreateAccountOp createAccountOp;
-//        case PAYMENT:
-//            PaymentOp paymentOp;
-//        case PATH_PAYMENT_STRICT_RECEIVE:
-//            PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
-//        case MANAGE_SELL_OFFER:
-//            ManageSellOfferOp manageSellOfferOp;
-//        case CREATE_PASSIVE_SELL_OFFER:
-//            CreatePassiveSellOfferOp createPassiveSellOfferOp;
-//        case SET_OPTIONS:
-//            SetOptionsOp setOptionsOp;
-//        case CHANGE_TRUST:
-//            ChangeTrustOp changeTrustOp;
-//        case ALLOW_TRUST:
-//            AllowTrustOp allowTrustOp;
-//        case ACCOUNT_MERGE:
-//            MuxedAccount destination;
-//        case INFLATION:
-//            void;
-//        case MANAGE_DATA:
-//            ManageDataOp manageDataOp;
-//        case BUMP_SEQUENCE:
-//            BumpSequenceOp bumpSequenceOp;
-//        case MANAGE_BUY_OFFER:
-//            ManageBuyOfferOp manageBuyOfferOp;
-//        case PATH_PAYMENT_STRICT_SEND:
-//            PathPaymentStrictSendOp pathPaymentStrictSendOp;
-//        case CREATE_CLAIMABLE_BALANCE:
-//            CreateClaimableBalanceOp createClaimableBalanceOp;
-//        case CLAIM_CLAIMABLE_BALANCE:
-//            ClaimClaimableBalanceOp claimClaimableBalanceOp;
-//        case BEGIN_SPONSORING_FUTURE_RESERVES:
-//            BeginSponsoringFutureReservesOp beginSponsoringFutureReservesOp;
-//        case END_SPONSORING_FUTURE_RESERVES:
-//            void;
-//        case REVOKE_SPONSORSHIP:
-//            RevokeSponsorshipOp revokeSponsorshipOp;
-//        case CLAWBACK:
-//            ClawbackOp clawbackOp;
-//        case CLAWBACK_CLAIMABLE_BALANCE:
-//            ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
-//        case SET_TRUST_LINE_FLAGS:
-//            SetTrustLineFlagsOp setTrustLineFlagsOp;
-//        case LIQUIDITY_POOL_DEPOSIT:
-//            LiquidityPoolDepositOp liquidityPoolDepositOp;
-//        case LIQUIDITY_POOL_WITHDRAW:
-//            LiquidityPoolWithdrawOp liquidityPoolWithdrawOp;
-//        }
-//        body;
-//    };
-//
+//	     union switch (OperationType type)
+//	     {
+//	     case CREATE_ACCOUNT:
+//	         CreateAccountOp createAccountOp;
+//	     case PAYMENT:
+//	         PaymentOp paymentOp;
+//	     case PATH_PAYMENT_STRICT_RECEIVE:
+//	         PathPaymentStrictReceiveOp pathPaymentStrictReceiveOp;
+//	     case MANAGE_SELL_OFFER:
+//	         ManageSellOfferOp manageSellOfferOp;
+//	     case CREATE_PASSIVE_SELL_OFFER:
+//	         CreatePassiveSellOfferOp createPassiveSellOfferOp;
+//	     case SET_OPTIONS:
+//	         SetOptionsOp setOptionsOp;
+//	     case CHANGE_TRUST:
+//	         ChangeTrustOp changeTrustOp;
+//	     case ALLOW_TRUST:
+//	         AllowTrustOp allowTrustOp;
+//	     case ACCOUNT_MERGE:
+//	         MuxedAccount destination;
+//	     case INFLATION:
+//	         void;
+//	     case MANAGE_DATA:
+//	         ManageDataOp manageDataOp;
+//	     case BUMP_SEQUENCE:
+//	         BumpSequenceOp bumpSequenceOp;
+//	     case MANAGE_BUY_OFFER:
+//	         ManageBuyOfferOp manageBuyOfferOp;
+//	     case PATH_PAYMENT_STRICT_SEND:
+//	         PathPaymentStrictSendOp pathPaymentStrictSendOp;
+//	     case CREATE_CLAIMABLE_BALANCE:
+//	         CreateClaimableBalanceOp createClaimableBalanceOp;
+//	     case CLAIM_CLAIMABLE_BALANCE:
+//	         ClaimClaimableBalanceOp claimClaimableBalanceOp;
+//	     case BEGIN_SPONSORING_FUTURE_RESERVES:
+//	         BeginSponsoringFutureReservesOp beginSponsoringFutureReservesOp;
+//	     case END_SPONSORING_FUTURE_RESERVES:
+//	         void;
+//	     case REVOKE_SPONSORSHIP:
+//	         RevokeSponsorshipOp revokeSponsorshipOp;
+//	     case CLAWBACK:
+//	         ClawbackOp clawbackOp;
+//	     case CLAWBACK_CLAIMABLE_BALANCE:
+//	         ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
+//	     case SET_TRUST_LINE_FLAGS:
+//	         SetTrustLineFlagsOp setTrustLineFlagsOp;
+//	     case LIQUIDITY_POOL_DEPOSIT:
+//	         LiquidityPoolDepositOp liquidityPoolDepositOp;
+//	     case LIQUIDITY_POOL_WITHDRAW:
+//	         LiquidityPoolWithdrawOp liquidityPoolWithdrawOp;
+//	     }
+//	     body;
+//	 };
 type Operation struct {
 	SourceAccount *MuxedAccount
 	Body          OperationBody
@@ -21749,13 +21561,12 @@ var _ xdrType = (*Operation)(nil)
 
 // HashIdPreimageOperationId is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            AccountID sourceAccount;
-//            SequenceNumber seqNum;
-//            uint32 opNum;
-//        }
-//
+//	struct
+//	     {
+//	         AccountID sourceAccount;
+//	         SequenceNumber seqNum;
+//	         uint32 opNum;
+//	     }
 type HashIdPreimageOperationId struct {
 	SourceAccount AccountId
 	SeqNum        SequenceNumber
@@ -21830,15 +21641,14 @@ var _ xdrType = (*HashIdPreimageOperationId)(nil)
 
 // HashIdPreimageRevokeId is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            AccountID sourceAccount;
-//            SequenceNumber seqNum;
-//            uint32 opNum;
-//            PoolID liquidityPoolID;
-//            Asset asset;
-//        }
-//
+//	struct
+//	     {
+//	         AccountID sourceAccount;
+//	         SequenceNumber seqNum;
+//	         uint32 opNum;
+//	         PoolID liquidityPoolID;
+//	         Asset asset;
+//	     }
 type HashIdPreimageRevokeId struct {
 	SourceAccount   AccountId
 	SeqNum          SequenceNumber
@@ -21931,26 +21741,25 @@ var _ xdrType = (*HashIdPreimageRevokeId)(nil)
 
 // HashIdPreimage is an XDR Union defines as:
 //
-//   union HashIDPreimage switch (EnvelopeType type)
-//    {
-//    case ENVELOPE_TYPE_OP_ID:
-//        struct
-//        {
-//            AccountID sourceAccount;
-//            SequenceNumber seqNum;
-//            uint32 opNum;
-//        } operationID;
-//    case ENVELOPE_TYPE_POOL_REVOKE_OP_ID:
-//        struct
-//        {
-//            AccountID sourceAccount;
-//            SequenceNumber seqNum;
-//            uint32 opNum;
-//            PoolID liquidityPoolID;
-//            Asset asset;
-//        } revokeID;
-//    };
-//
+//	union HashIDPreimage switch (EnvelopeType type)
+//	 {
+//	 case ENVELOPE_TYPE_OP_ID:
+//	     struct
+//	     {
+//	         AccountID sourceAccount;
+//	         SequenceNumber seqNum;
+//	         uint32 opNum;
+//	     } operationID;
+//	 case ENVELOPE_TYPE_POOL_REVOKE_OP_ID:
+//	     struct
+//	     {
+//	         AccountID sourceAccount;
+//	         SequenceNumber seqNum;
+//	         uint32 opNum;
+//	         PoolID liquidityPoolID;
+//	         Asset asset;
+//	     } revokeID;
+//	 };
 type HashIdPreimage struct {
 	Type        EnvelopeType
 	OperationId *HashIdPreimageOperationId
@@ -22129,15 +21938,14 @@ var _ xdrType = (*HashIdPreimage)(nil)
 
 // MemoType is an XDR Enum defines as:
 //
-//   enum MemoType
-//    {
-//        MEMO_NONE = 0,
-//        MEMO_TEXT = 1,
-//        MEMO_ID = 2,
-//        MEMO_HASH = 3,
-//        MEMO_RETURN = 4
-//    };
-//
+//	enum MemoType
+//	 {
+//	     MEMO_NONE = 0,
+//	     MEMO_TEXT = 1,
+//	     MEMO_ID = 2,
+//	     MEMO_HASH = 3,
+//	     MEMO_RETURN = 4
+//	 };
 type MemoType int32
 
 const (
@@ -22222,20 +22030,19 @@ var _ xdrType = (*MemoType)(nil)
 
 // Memo is an XDR Union defines as:
 //
-//   union Memo switch (MemoType type)
-//    {
-//    case MEMO_NONE:
-//        void;
-//    case MEMO_TEXT:
-//        string text<28>;
-//    case MEMO_ID:
-//        uint64 id;
-//    case MEMO_HASH:
-//        Hash hash; // the hash of what to pull from the content server
-//    case MEMO_RETURN:
-//        Hash retHash; // the hash of the tx you are rejecting
-//    };
-//
+//	union Memo switch (MemoType type)
+//	 {
+//	 case MEMO_NONE:
+//	     void;
+//	 case MEMO_TEXT:
+//	     string text<28>;
+//	 case MEMO_ID:
+//	     uint64 id;
+//	 case MEMO_HASH:
+//	     Hash hash; // the hash of what to pull from the content server
+//	 case MEMO_RETURN:
+//	     Hash retHash; // the hash of the tx you are rejecting
+//	 };
 type Memo struct {
 	Type    MemoType
 	Text    *string `xdrmaxsize:"28"`
@@ -22520,12 +22327,11 @@ var _ xdrType = (*Memo)(nil)
 
 // TimeBounds is an XDR Struct defines as:
 //
-//   struct TimeBounds
-//    {
-//        TimePoint minTime;
-//        TimePoint maxTime; // 0 here means no maxTime
-//    };
-//
+//	struct TimeBounds
+//	 {
+//	     TimePoint minTime;
+//	     TimePoint maxTime; // 0 here means no maxTime
+//	 };
 type TimeBounds struct {
 	MinTime TimePoint
 	MaxTime TimePoint
@@ -22591,12 +22397,11 @@ var _ xdrType = (*TimeBounds)(nil)
 
 // LedgerBounds is an XDR Struct defines as:
 //
-//   struct LedgerBounds
-//    {
-//        uint32 minLedger;
-//        uint32 maxLedger; // 0 here means no maxLedger
-//    };
-//
+//	struct LedgerBounds
+//	 {
+//	     uint32 minLedger;
+//	     uint32 maxLedger; // 0 here means no maxLedger
+//	 };
 type LedgerBounds struct {
 	MinLedger Uint32
 	MaxLedger Uint32
@@ -22662,39 +22467,38 @@ var _ xdrType = (*LedgerBounds)(nil)
 
 // PreconditionsV2 is an XDR Struct defines as:
 //
-//   struct PreconditionsV2
-//    {
-//        TimeBounds* timeBounds;
+//	struct PreconditionsV2
+//	 {
+//	     TimeBounds* timeBounds;
 //
-//        // Transaction only valid for ledger numbers n such that
-//        // minLedger <= n < maxLedger (if maxLedger == 0, then
-//        // only minLedger is checked)
-//        LedgerBounds* ledgerBounds;
+//	     // Transaction only valid for ledger numbers n such that
+//	     // minLedger <= n < maxLedger (if maxLedger == 0, then
+//	     // only minLedger is checked)
+//	     LedgerBounds* ledgerBounds;
 //
-//        // If NULL, only valid when sourceAccount's sequence number
-//        // is seqNum - 1.  Otherwise, valid when sourceAccount's
-//        // sequence number n satisfies minSeqNum <= n < tx.seqNum.
-//        // Note that after execution the account's sequence number
-//        // is always raised to tx.seqNum, and a transaction is not
-//        // valid if tx.seqNum is too high to ensure replay protection.
-//        SequenceNumber* minSeqNum;
+//	     // If NULL, only valid when sourceAccount's sequence number
+//	     // is seqNum - 1.  Otherwise, valid when sourceAccount's
+//	     // sequence number n satisfies minSeqNum <= n < tx.seqNum.
+//	     // Note that after execution the account's sequence number
+//	     // is always raised to tx.seqNum, and a transaction is not
+//	     // valid if tx.seqNum is too high to ensure replay protection.
+//	     SequenceNumber* minSeqNum;
 //
-//        // For the transaction to be valid, the current ledger time must
-//        // be at least minSeqAge greater than sourceAccount's seqTime.
-//        Duration minSeqAge;
+//	     // For the transaction to be valid, the current ledger time must
+//	     // be at least minSeqAge greater than sourceAccount's seqTime.
+//	     Duration minSeqAge;
 //
-//        // For the transaction to be valid, the current ledger number
-//        // must be at least minSeqLedgerGap greater than sourceAccount's
-//        // seqLedger.
-//        uint32 minSeqLedgerGap;
+//	     // For the transaction to be valid, the current ledger number
+//	     // must be at least minSeqLedgerGap greater than sourceAccount's
+//	     // seqLedger.
+//	     uint32 minSeqLedgerGap;
 //
-//        // For the transaction to be valid, there must be a signature
-//        // corresponding to every Signer in this array, even if the
-//        // signature is not otherwise required by the sourceAccount or
-//        // operations.
-//        SignerKey extraSigners<2>;
-//    };
-//
+//	     // For the transaction to be valid, there must be a signature
+//	     // corresponding to every Signer in this array, even if the
+//	     // signature is not otherwise required by the sourceAccount or
+//	     // operations.
+//	     SignerKey extraSigners<2>;
+//	 };
 type PreconditionsV2 struct {
 	TimeBounds      *TimeBounds
 	LedgerBounds    *LedgerBounds
@@ -22859,13 +22663,12 @@ var _ xdrType = (*PreconditionsV2)(nil)
 
 // PreconditionType is an XDR Enum defines as:
 //
-//   enum PreconditionType
-//    {
-//        PRECOND_NONE = 0,
-//        PRECOND_TIME = 1,
-//        PRECOND_V2 = 2
-//    };
-//
+//	enum PreconditionType
+//	 {
+//	     PRECOND_NONE = 0,
+//	     PRECOND_TIME = 1,
+//	     PRECOND_V2 = 2
+//	 };
 type PreconditionType int32
 
 const (
@@ -22946,16 +22749,15 @@ var _ xdrType = (*PreconditionType)(nil)
 
 // Preconditions is an XDR Union defines as:
 //
-//   union Preconditions switch (PreconditionType type)
-//    {
-//    case PRECOND_NONE:
-//        void;
-//    case PRECOND_TIME:
-//        TimeBounds timeBounds;
-//    case PRECOND_V2:
-//        PreconditionsV2 v2;
-//    };
-//
+//	union Preconditions switch (PreconditionType type)
+//	 {
+//	 case PRECOND_NONE:
+//	     void;
+//	 case PRECOND_TIME:
+//	     TimeBounds timeBounds;
+//	 case PRECOND_V2:
+//	     PreconditionsV2 v2;
+//	 };
 type Preconditions struct {
 	Type       PreconditionType
 	TimeBounds *TimeBounds
@@ -23144,18 +22946,16 @@ var _ xdrType = (*Preconditions)(nil)
 
 // MaxOpsPerTx is an XDR Const defines as:
 //
-//   const MAX_OPS_PER_TX = 100;
-//
+//	const MAX_OPS_PER_TX = 100;
 const MaxOpsPerTx = 100
 
 // TransactionV0Ext is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type TransactionV0Ext struct {
 	V int32
 }
@@ -23248,22 +23048,21 @@ var _ xdrType = (*TransactionV0Ext)(nil)
 
 // TransactionV0 is an XDR Struct defines as:
 //
-//   struct TransactionV0
-//    {
-//        uint256 sourceAccountEd25519;
-//        uint32 fee;
-//        SequenceNumber seqNum;
-//        TimeBounds* timeBounds;
-//        Memo memo;
-//        Operation operations<MAX_OPS_PER_TX>;
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
-//    };
-//
+//	struct TransactionV0
+//	 {
+//	     uint256 sourceAccountEd25519;
+//	     uint32 fee;
+//	     SequenceNumber seqNum;
+//	     TimeBounds* timeBounds;
+//	     Memo memo;
+//	     Operation operations<MAX_OPS_PER_TX>;
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
+//	 };
 type TransactionV0 struct {
 	SourceAccountEd25519 Uint256
 	Fee                  Uint32
@@ -23409,14 +23208,13 @@ var _ xdrType = (*TransactionV0)(nil)
 
 // TransactionV0Envelope is an XDR Struct defines as:
 //
-//   struct TransactionV0Envelope
-//    {
-//        TransactionV0 tx;
-//        /* Each decorated signature is a signature over the SHA256 hash of
-//         * a TransactionSignaturePayload */
-//        DecoratedSignature signatures<20>;
-//    };
-//
+//	struct TransactionV0Envelope
+//	 {
+//	     TransactionV0 tx;
+//	     /* Each decorated signature is a signature over the SHA256 hash of
+//	      * a TransactionSignaturePayload */
+//	     DecoratedSignature signatures<20>;
+//	 };
 type TransactionV0Envelope struct {
 	Tx         TransactionV0
 	Signatures []DecoratedSignature `xdrmaxsize:"20"`
@@ -23502,12 +23300,11 @@ var _ xdrType = (*TransactionV0Envelope)(nil)
 
 // TransactionExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type TransactionExt struct {
 	V int32
 }
@@ -23600,33 +23397,32 @@ var _ xdrType = (*TransactionExt)(nil)
 
 // Transaction is an XDR Struct defines as:
 //
-//   struct Transaction
-//    {
-//        // account used to run the transaction
-//        MuxedAccount sourceAccount;
+//	struct Transaction
+//	 {
+//	     // account used to run the transaction
+//	     MuxedAccount sourceAccount;
 //
-//        // the fee the sourceAccount will pay
-//        uint32 fee;
+//	     // the fee the sourceAccount will pay
+//	     uint32 fee;
 //
-//        // sequence number to consume in the account
-//        SequenceNumber seqNum;
+//	     // sequence number to consume in the account
+//	     SequenceNumber seqNum;
 //
-//        // validity conditions
-//        Preconditions cond;
+//	     // validity conditions
+//	     Preconditions cond;
 //
-//        Memo memo;
+//	     Memo memo;
 //
-//        Operation operations<MAX_OPS_PER_TX>;
+//	     Operation operations<MAX_OPS_PER_TX>;
 //
-//        // reserved for future use
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
-//    };
-//
+//	     // reserved for future use
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
+//	 };
 type Transaction struct {
 	SourceAccount MuxedAccount
 	Fee           Uint32
@@ -23757,14 +23553,13 @@ var _ xdrType = (*Transaction)(nil)
 
 // TransactionV1Envelope is an XDR Struct defines as:
 //
-//   struct TransactionV1Envelope
-//    {
-//        Transaction tx;
-//        /* Each decorated signature is a signature over the SHA256 hash of
-//         * a TransactionSignaturePayload */
-//        DecoratedSignature signatures<20>;
-//    };
-//
+//	struct TransactionV1Envelope
+//	 {
+//	     Transaction tx;
+//	     /* Each decorated signature is a signature over the SHA256 hash of
+//	      * a TransactionSignaturePayload */
+//	     DecoratedSignature signatures<20>;
+//	 };
 type TransactionV1Envelope struct {
 	Tx         Transaction
 	Signatures []DecoratedSignature `xdrmaxsize:"20"`
@@ -23850,12 +23645,11 @@ var _ xdrType = (*TransactionV1Envelope)(nil)
 
 // FeeBumpTransactionInnerTx is an XDR NestedUnion defines as:
 //
-//   union switch (EnvelopeType type)
-//        {
-//        case ENVELOPE_TYPE_TX:
-//            TransactionV1Envelope v1;
-//        }
-//
+//	union switch (EnvelopeType type)
+//	     {
+//	     case ENVELOPE_TYPE_TX:
+//	         TransactionV1Envelope v1;
+//	     }
 type FeeBumpTransactionInnerTx struct {
 	Type EnvelopeType
 	V1   *TransactionV1Envelope
@@ -23986,12 +23780,11 @@ var _ xdrType = (*FeeBumpTransactionInnerTx)(nil)
 
 // FeeBumpTransactionExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type FeeBumpTransactionExt struct {
 	V int32
 }
@@ -24084,24 +23877,23 @@ var _ xdrType = (*FeeBumpTransactionExt)(nil)
 
 // FeeBumpTransaction is an XDR Struct defines as:
 //
-//   struct FeeBumpTransaction
-//    {
-//        MuxedAccount feeSource;
-//        int64 fee;
-//        union switch (EnvelopeType type)
-//        {
-//        case ENVELOPE_TYPE_TX:
-//            TransactionV1Envelope v1;
-//        }
-//        innerTx;
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
-//    };
-//
+//	struct FeeBumpTransaction
+//	 {
+//	     MuxedAccount feeSource;
+//	     int64 fee;
+//	     union switch (EnvelopeType type)
+//	     {
+//	     case ENVELOPE_TYPE_TX:
+//	         TransactionV1Envelope v1;
+//	     }
+//	     innerTx;
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
+//	 };
 type FeeBumpTransaction struct {
 	FeeSource MuxedAccount
 	Fee       Int64
@@ -24185,14 +23977,13 @@ var _ xdrType = (*FeeBumpTransaction)(nil)
 
 // FeeBumpTransactionEnvelope is an XDR Struct defines as:
 //
-//   struct FeeBumpTransactionEnvelope
-//    {
-//        FeeBumpTransaction tx;
-//        /* Each decorated signature is a signature over the SHA256 hash of
-//         * a TransactionSignaturePayload */
-//        DecoratedSignature signatures<20>;
-//    };
-//
+//	struct FeeBumpTransactionEnvelope
+//	 {
+//	     FeeBumpTransaction tx;
+//	     /* Each decorated signature is a signature over the SHA256 hash of
+//	      * a TransactionSignaturePayload */
+//	     DecoratedSignature signatures<20>;
+//	 };
 type FeeBumpTransactionEnvelope struct {
 	Tx         FeeBumpTransaction
 	Signatures []DecoratedSignature `xdrmaxsize:"20"`
@@ -24278,16 +24069,15 @@ var _ xdrType = (*FeeBumpTransactionEnvelope)(nil)
 
 // TransactionEnvelope is an XDR Union defines as:
 //
-//   union TransactionEnvelope switch (EnvelopeType type)
-//    {
-//    case ENVELOPE_TYPE_TX_V0:
-//        TransactionV0Envelope v0;
-//    case ENVELOPE_TYPE_TX:
-//        TransactionV1Envelope v1;
-//    case ENVELOPE_TYPE_TX_FEE_BUMP:
-//        FeeBumpTransactionEnvelope feeBump;
-//    };
-//
+//	union TransactionEnvelope switch (EnvelopeType type)
+//	 {
+//	 case ENVELOPE_TYPE_TX_V0:
+//	     TransactionV0Envelope v0;
+//	 case ENVELOPE_TYPE_TX:
+//	     TransactionV1Envelope v1;
+//	 case ENVELOPE_TYPE_TX_FEE_BUMP:
+//	     FeeBumpTransactionEnvelope feeBump;
+//	 };
 type TransactionEnvelope struct {
 	Type    EnvelopeType
 	V0      *TransactionV0Envelope
@@ -24514,15 +24304,14 @@ var _ xdrType = (*TransactionEnvelope)(nil)
 
 // TransactionSignaturePayloadTaggedTransaction is an XDR NestedUnion defines as:
 //
-//   union switch (EnvelopeType type)
-//        {
-//        // Backwards Compatibility: Use ENVELOPE_TYPE_TX to sign ENVELOPE_TYPE_TX_V0
-//        case ENVELOPE_TYPE_TX:
-//            Transaction tx;
-//        case ENVELOPE_TYPE_TX_FEE_BUMP:
-//            FeeBumpTransaction feeBump;
-//        }
-//
+//	union switch (EnvelopeType type)
+//	     {
+//	     // Backwards Compatibility: Use ENVELOPE_TYPE_TX to sign ENVELOPE_TYPE_TX_V0
+//	     case ENVELOPE_TYPE_TX:
+//	         Transaction tx;
+//	     case ENVELOPE_TYPE_TX_FEE_BUMP:
+//	         FeeBumpTransaction feeBump;
+//	     }
 type TransactionSignaturePayloadTaggedTransaction struct {
 	Type    EnvelopeType
 	Tx      *Transaction
@@ -24701,20 +24490,19 @@ var _ xdrType = (*TransactionSignaturePayloadTaggedTransaction)(nil)
 
 // TransactionSignaturePayload is an XDR Struct defines as:
 //
-//   struct TransactionSignaturePayload
-//    {
-//        Hash networkId;
-//        union switch (EnvelopeType type)
-//        {
-//        // Backwards Compatibility: Use ENVELOPE_TYPE_TX to sign ENVELOPE_TYPE_TX_V0
-//        case ENVELOPE_TYPE_TX:
-//            Transaction tx;
-//        case ENVELOPE_TYPE_TX_FEE_BUMP:
-//            FeeBumpTransaction feeBump;
-//        }
-//        taggedTransaction;
-//    };
-//
+//	struct TransactionSignaturePayload
+//	 {
+//	     Hash networkId;
+//	     union switch (EnvelopeType type)
+//	     {
+//	     // Backwards Compatibility: Use ENVELOPE_TYPE_TX to sign ENVELOPE_TYPE_TX_V0
+//	     case ENVELOPE_TYPE_TX:
+//	         Transaction tx;
+//	     case ENVELOPE_TYPE_TX_FEE_BUMP:
+//	         FeeBumpTransaction feeBump;
+//	     }
+//	     taggedTransaction;
+//	 };
 type TransactionSignaturePayload struct {
 	NetworkId         Hash
 	TaggedTransaction TransactionSignaturePayloadTaggedTransaction
@@ -24780,13 +24568,12 @@ var _ xdrType = (*TransactionSignaturePayload)(nil)
 
 // ClaimAtomType is an XDR Enum defines as:
 //
-//   enum ClaimAtomType
-//    {
-//        CLAIM_ATOM_TYPE_V0 = 0,
-//        CLAIM_ATOM_TYPE_ORDER_BOOK = 1,
-//        CLAIM_ATOM_TYPE_LIQUIDITY_POOL = 2
-//    };
-//
+//	enum ClaimAtomType
+//	 {
+//	     CLAIM_ATOM_TYPE_V0 = 0,
+//	     CLAIM_ATOM_TYPE_ORDER_BOOK = 1,
+//	     CLAIM_ATOM_TYPE_LIQUIDITY_POOL = 2
+//	 };
 type ClaimAtomType int32
 
 const (
@@ -24867,21 +24654,20 @@ var _ xdrType = (*ClaimAtomType)(nil)
 
 // ClaimOfferAtomV0 is an XDR Struct defines as:
 //
-//   struct ClaimOfferAtomV0
-//    {
-//        // emitted to identify the offer
-//        uint256 sellerEd25519; // Account that owns the offer
-//        int64 offerID;
+//	struct ClaimOfferAtomV0
+//	 {
+//	     // emitted to identify the offer
+//	     uint256 sellerEd25519; // Account that owns the offer
+//	     int64 offerID;
 //
-//        // amount and asset taken from the owner
-//        Asset assetSold;
-//        int64 amountSold;
+//	     // amount and asset taken from the owner
+//	     Asset assetSold;
+//	     int64 amountSold;
 //
-//        // amount and asset sent to the owner
-//        Asset assetBought;
-//        int64 amountBought;
-//    };
-//
+//	     // amount and asset sent to the owner
+//	     Asset assetBought;
+//	     int64 amountBought;
+//	 };
 type ClaimOfferAtomV0 struct {
 	SellerEd25519 Uint256
 	OfferId       Int64
@@ -24983,21 +24769,20 @@ var _ xdrType = (*ClaimOfferAtomV0)(nil)
 
 // ClaimOfferAtom is an XDR Struct defines as:
 //
-//   struct ClaimOfferAtom
-//    {
-//        // emitted to identify the offer
-//        AccountID sellerID; // Account that owns the offer
-//        int64 offerID;
+//	struct ClaimOfferAtom
+//	 {
+//	     // emitted to identify the offer
+//	     AccountID sellerID; // Account that owns the offer
+//	     int64 offerID;
 //
-//        // amount and asset taken from the owner
-//        Asset assetSold;
-//        int64 amountSold;
+//	     // amount and asset taken from the owner
+//	     Asset assetSold;
+//	     int64 amountSold;
 //
-//        // amount and asset sent to the owner
-//        Asset assetBought;
-//        int64 amountBought;
-//    };
-//
+//	     // amount and asset sent to the owner
+//	     Asset assetBought;
+//	     int64 amountBought;
+//	 };
 type ClaimOfferAtom struct {
 	SellerId     AccountId
 	OfferId      Int64
@@ -25099,19 +24884,18 @@ var _ xdrType = (*ClaimOfferAtom)(nil)
 
 // ClaimLiquidityAtom is an XDR Struct defines as:
 //
-//   struct ClaimLiquidityAtom
-//    {
-//        PoolID liquidityPoolID;
+//	struct ClaimLiquidityAtom
+//	 {
+//	     PoolID liquidityPoolID;
 //
-//        // amount and asset taken from the pool
-//        Asset assetSold;
-//        int64 amountSold;
+//	     // amount and asset taken from the pool
+//	     Asset assetSold;
+//	     int64 amountSold;
 //
-//        // amount and asset sent to the pool
-//        Asset assetBought;
-//        int64 amountBought;
-//    };
-//
+//	     // amount and asset sent to the pool
+//	     Asset assetBought;
+//	     int64 amountBought;
+//	 };
 type ClaimLiquidityAtom struct {
 	LiquidityPoolId PoolId
 	AssetSold       Asset
@@ -25204,16 +24988,15 @@ var _ xdrType = (*ClaimLiquidityAtom)(nil)
 
 // ClaimAtom is an XDR Union defines as:
 //
-//   union ClaimAtom switch (ClaimAtomType type)
-//    {
-//    case CLAIM_ATOM_TYPE_V0:
-//        ClaimOfferAtomV0 v0;
-//    case CLAIM_ATOM_TYPE_ORDER_BOOK:
-//        ClaimOfferAtom orderBook;
-//    case CLAIM_ATOM_TYPE_LIQUIDITY_POOL:
-//        ClaimLiquidityAtom liquidityPool;
-//    };
-//
+//	union ClaimAtom switch (ClaimAtomType type)
+//	 {
+//	 case CLAIM_ATOM_TYPE_V0:
+//	     ClaimOfferAtomV0 v0;
+//	 case CLAIM_ATOM_TYPE_ORDER_BOOK:
+//	     ClaimOfferAtom orderBook;
+//	 case CLAIM_ATOM_TYPE_LIQUIDITY_POOL:
+//	     ClaimLiquidityAtom liquidityPool;
+//	 };
 type ClaimAtom struct {
 	Type          ClaimAtomType
 	V0            *ClaimOfferAtomV0
@@ -25440,19 +25223,18 @@ var _ xdrType = (*ClaimAtom)(nil)
 
 // CreateAccountResultCode is an XDR Enum defines as:
 //
-//   enum CreateAccountResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        CREATE_ACCOUNT_SUCCESS = 0, // account was created
+//	enum CreateAccountResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     CREATE_ACCOUNT_SUCCESS = 0, // account was created
 //
-//        // codes considered as "failure" for the operation
-//        CREATE_ACCOUNT_MALFORMED = -1,   // invalid destination
-//        CREATE_ACCOUNT_UNDERFUNDED = -2, // not enough funds in source account
-//        CREATE_ACCOUNT_LOW_RESERVE =
-//            -3, // would create an account below the min reserve
-//        CREATE_ACCOUNT_ALREADY_EXIST = -4 // account already exists
-//    };
-//
+//	     // codes considered as "failure" for the operation
+//	     CREATE_ACCOUNT_MALFORMED = -1,   // invalid destination
+//	     CREATE_ACCOUNT_UNDERFUNDED = -2, // not enough funds in source account
+//	     CREATE_ACCOUNT_LOW_RESERVE =
+//	         -3, // would create an account below the min reserve
+//	     CREATE_ACCOUNT_ALREADY_EXIST = -4 // account already exists
+//	 };
 type CreateAccountResultCode int32
 
 const (
@@ -25537,17 +25319,16 @@ var _ xdrType = (*CreateAccountResultCode)(nil)
 
 // CreateAccountResult is an XDR Union defines as:
 //
-//   union CreateAccountResult switch (CreateAccountResultCode code)
-//    {
-//    case CREATE_ACCOUNT_SUCCESS:
-//        void;
-//    case CREATE_ACCOUNT_MALFORMED:
-//    case CREATE_ACCOUNT_UNDERFUNDED:
-//    case CREATE_ACCOUNT_LOW_RESERVE:
-//    case CREATE_ACCOUNT_ALREADY_EXIST:
-//        void;
-//    };
-//
+//	union CreateAccountResult switch (CreateAccountResultCode code)
+//	 {
+//	 case CREATE_ACCOUNT_SUCCESS:
+//	     void;
+//	 case CREATE_ACCOUNT_MALFORMED:
+//	 case CREATE_ACCOUNT_UNDERFUNDED:
+//	 case CREATE_ACCOUNT_LOW_RESERVE:
+//	 case CREATE_ACCOUNT_ALREADY_EXIST:
+//	     void;
+//	 };
 type CreateAccountResult struct {
 	Code CreateAccountResultCode
 }
@@ -25680,23 +25461,22 @@ var _ xdrType = (*CreateAccountResult)(nil)
 
 // PaymentResultCode is an XDR Enum defines as:
 //
-//   enum PaymentResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        PAYMENT_SUCCESS = 0, // payment successfully completed
+//	enum PaymentResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     PAYMENT_SUCCESS = 0, // payment successfully completed
 //
-//        // codes considered as "failure" for the operation
-//        PAYMENT_MALFORMED = -1,          // bad input
-//        PAYMENT_UNDERFUNDED = -2,        // not enough funds in source account
-//        PAYMENT_SRC_NO_TRUST = -3,       // no trust line on source account
-//        PAYMENT_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
-//        PAYMENT_NO_DESTINATION = -5,     // destination account does not exist
-//        PAYMENT_NO_TRUST = -6,       // destination missing a trust line for asset
-//        PAYMENT_NOT_AUTHORIZED = -7, // destination not authorized to hold asset
-//        PAYMENT_LINE_FULL = -8,      // destination would go above their limit
-//        PAYMENT_NO_ISSUER = -9       // missing issuer on asset
-//    };
-//
+//	     // codes considered as "failure" for the operation
+//	     PAYMENT_MALFORMED = -1,          // bad input
+//	     PAYMENT_UNDERFUNDED = -2,        // not enough funds in source account
+//	     PAYMENT_SRC_NO_TRUST = -3,       // no trust line on source account
+//	     PAYMENT_SRC_NOT_AUTHORIZED = -4, // source not authorized to transfer
+//	     PAYMENT_NO_DESTINATION = -5,     // destination account does not exist
+//	     PAYMENT_NO_TRUST = -6,       // destination missing a trust line for asset
+//	     PAYMENT_NOT_AUTHORIZED = -7, // destination not authorized to hold asset
+//	     PAYMENT_LINE_FULL = -8,      // destination would go above their limit
+//	     PAYMENT_NO_ISSUER = -9       // missing issuer on asset
+//	 };
 type PaymentResultCode int32
 
 const (
@@ -25791,22 +25571,21 @@ var _ xdrType = (*PaymentResultCode)(nil)
 
 // PaymentResult is an XDR Union defines as:
 //
-//   union PaymentResult switch (PaymentResultCode code)
-//    {
-//    case PAYMENT_SUCCESS:
-//        void;
-//    case PAYMENT_MALFORMED:
-//    case PAYMENT_UNDERFUNDED:
-//    case PAYMENT_SRC_NO_TRUST:
-//    case PAYMENT_SRC_NOT_AUTHORIZED:
-//    case PAYMENT_NO_DESTINATION:
-//    case PAYMENT_NO_TRUST:
-//    case PAYMENT_NOT_AUTHORIZED:
-//    case PAYMENT_LINE_FULL:
-//    case PAYMENT_NO_ISSUER:
-//        void;
-//    };
-//
+//	union PaymentResult switch (PaymentResultCode code)
+//	 {
+//	 case PAYMENT_SUCCESS:
+//	     void;
+//	 case PAYMENT_MALFORMED:
+//	 case PAYMENT_UNDERFUNDED:
+//	 case PAYMENT_SRC_NO_TRUST:
+//	 case PAYMENT_SRC_NOT_AUTHORIZED:
+//	 case PAYMENT_NO_DESTINATION:
+//	 case PAYMENT_NO_TRUST:
+//	 case PAYMENT_NOT_AUTHORIZED:
+//	 case PAYMENT_LINE_FULL:
+//	 case PAYMENT_NO_ISSUER:
+//	     void;
+//	 };
 type PaymentResult struct {
 	Code PaymentResultCode
 }
@@ -25989,35 +25768,34 @@ var _ xdrType = (*PaymentResult)(nil)
 
 // PathPaymentStrictReceiveResultCode is an XDR Enum defines as:
 //
-//   enum PathPaymentStrictReceiveResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        PATH_PAYMENT_STRICT_RECEIVE_SUCCESS = 0, // success
+//	enum PathPaymentStrictReceiveResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     PATH_PAYMENT_STRICT_RECEIVE_SUCCESS = 0, // success
 //
-//        // codes considered as "failure" for the operation
-//        PATH_PAYMENT_STRICT_RECEIVE_MALFORMED = -1, // bad input
-//        PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED =
-//            -2, // not enough funds in source account
-//        PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST =
-//            -3, // no trust line on source account
-//        PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED =
-//            -4, // source not authorized to transfer
-//        PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION =
-//            -5, // destination account does not exist
-//        PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST =
-//            -6, // dest missing a trust line for asset
-//        PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED =
-//            -7, // dest not authorized to hold asset
-//        PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL =
-//            -8, // dest would go above their limit
-//        PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER = -9, // missing issuer on one asset
-//        PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS =
-//            -10, // not enough offers to satisfy path
-//        PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF =
-//            -11, // would cross one of its own offers
-//        PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX = -12 // could not satisfy sendmax
-//    };
-//
+//	     // codes considered as "failure" for the operation
+//	     PATH_PAYMENT_STRICT_RECEIVE_MALFORMED = -1, // bad input
+//	     PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED =
+//	         -2, // not enough funds in source account
+//	     PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST =
+//	         -3, // no trust line on source account
+//	     PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED =
+//	         -4, // source not authorized to transfer
+//	     PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION =
+//	         -5, // destination account does not exist
+//	     PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST =
+//	         -6, // dest missing a trust line for asset
+//	     PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED =
+//	         -7, // dest not authorized to hold asset
+//	     PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL =
+//	         -8, // dest would go above their limit
+//	     PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER = -9, // missing issuer on one asset
+//	     PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS =
+//	         -10, // not enough offers to satisfy path
+//	     PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF =
+//	         -11, // would cross one of its own offers
+//	     PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX = -12 // could not satisfy sendmax
+//	 };
 type PathPaymentStrictReceiveResultCode int32
 
 const (
@@ -26118,13 +25896,12 @@ var _ xdrType = (*PathPaymentStrictReceiveResultCode)(nil)
 
 // SimplePaymentResult is an XDR Struct defines as:
 //
-//   struct SimplePaymentResult
-//    {
-//        AccountID destination;
-//        Asset asset;
-//        int64 amount;
-//    };
-//
+//	struct SimplePaymentResult
+//	 {
+//	     AccountID destination;
+//	     Asset asset;
+//	     int64 amount;
+//	 };
 type SimplePaymentResult struct {
 	Destination AccountId
 	Asset       Asset
@@ -26199,12 +25976,11 @@ var _ xdrType = (*SimplePaymentResult)(nil)
 
 // PathPaymentStrictReceiveResultSuccess is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            ClaimAtom offers<>;
-//            SimplePaymentResult last;
-//        }
-//
+//	struct
+//	     {
+//	         ClaimAtom offers<>;
+//	         SimplePaymentResult last;
+//	     }
 type PathPaymentStrictReceiveResultSuccess struct {
 	Offers []ClaimAtom
 	Last   SimplePaymentResult
@@ -26287,32 +26063,31 @@ var _ xdrType = (*PathPaymentStrictReceiveResultSuccess)(nil)
 
 // PathPaymentStrictReceiveResult is an XDR Union defines as:
 //
-//   union PathPaymentStrictReceiveResult switch (
-//        PathPaymentStrictReceiveResultCode code)
-//    {
-//    case PATH_PAYMENT_STRICT_RECEIVE_SUCCESS:
-//        struct
-//        {
-//            ClaimAtom offers<>;
-//            SimplePaymentResult last;
-//        } success;
-//    case PATH_PAYMENT_STRICT_RECEIVE_MALFORMED:
-//    case PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED:
-//    case PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST:
-//    case PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED:
-//    case PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION:
-//    case PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST:
-//    case PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED:
-//    case PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL:
-//        void;
-//    case PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER:
-//        Asset noIssuer; // the asset that caused the error
-//    case PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS:
-//    case PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF:
-//    case PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX:
-//        void;
-//    };
-//
+//	union PathPaymentStrictReceiveResult switch (
+//	     PathPaymentStrictReceiveResultCode code)
+//	 {
+//	 case PATH_PAYMENT_STRICT_RECEIVE_SUCCESS:
+//	     struct
+//	     {
+//	         ClaimAtom offers<>;
+//	         SimplePaymentResult last;
+//	     } success;
+//	 case PATH_PAYMENT_STRICT_RECEIVE_MALFORMED:
+//	 case PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED:
+//	 case PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST:
+//	 case PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED:
+//	 case PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION:
+//	 case PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST:
+//	 case PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED:
+//	 case PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL:
+//	     void;
+//	 case PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER:
+//	     Asset noIssuer; // the asset that caused the error
+//	 case PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS:
+//	 case PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF:
+//	 case PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX:
+//	     void;
+//	 };
 type PathPaymentStrictReceiveResult struct {
 	Code     PathPaymentStrictReceiveResultCode
 	Success  *PathPaymentStrictReceiveResultSuccess
@@ -26601,34 +26376,33 @@ var _ xdrType = (*PathPaymentStrictReceiveResult)(nil)
 
 // PathPaymentStrictSendResultCode is an XDR Enum defines as:
 //
-//   enum PathPaymentStrictSendResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        PATH_PAYMENT_STRICT_SEND_SUCCESS = 0, // success
+//	enum PathPaymentStrictSendResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     PATH_PAYMENT_STRICT_SEND_SUCCESS = 0, // success
 //
-//        // codes considered as "failure" for the operation
-//        PATH_PAYMENT_STRICT_SEND_MALFORMED = -1, // bad input
-//        PATH_PAYMENT_STRICT_SEND_UNDERFUNDED =
-//            -2, // not enough funds in source account
-//        PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST =
-//            -3, // no trust line on source account
-//        PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED =
-//            -4, // source not authorized to transfer
-//        PATH_PAYMENT_STRICT_SEND_NO_DESTINATION =
-//            -5, // destination account does not exist
-//        PATH_PAYMENT_STRICT_SEND_NO_TRUST =
-//            -6, // dest missing a trust line for asset
-//        PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED =
-//            -7, // dest not authorized to hold asset
-//        PATH_PAYMENT_STRICT_SEND_LINE_FULL = -8, // dest would go above their limit
-//        PATH_PAYMENT_STRICT_SEND_NO_ISSUER = -9, // missing issuer on one asset
-//        PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS =
-//            -10, // not enough offers to satisfy path
-//        PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF =
-//            -11, // would cross one of its own offers
-//        PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN = -12 // could not satisfy destMin
-//    };
-//
+//	     // codes considered as "failure" for the operation
+//	     PATH_PAYMENT_STRICT_SEND_MALFORMED = -1, // bad input
+//	     PATH_PAYMENT_STRICT_SEND_UNDERFUNDED =
+//	         -2, // not enough funds in source account
+//	     PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST =
+//	         -3, // no trust line on source account
+//	     PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED =
+//	         -4, // source not authorized to transfer
+//	     PATH_PAYMENT_STRICT_SEND_NO_DESTINATION =
+//	         -5, // destination account does not exist
+//	     PATH_PAYMENT_STRICT_SEND_NO_TRUST =
+//	         -6, // dest missing a trust line for asset
+//	     PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED =
+//	         -7, // dest not authorized to hold asset
+//	     PATH_PAYMENT_STRICT_SEND_LINE_FULL = -8, // dest would go above their limit
+//	     PATH_PAYMENT_STRICT_SEND_NO_ISSUER = -9, // missing issuer on one asset
+//	     PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS =
+//	         -10, // not enough offers to satisfy path
+//	     PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF =
+//	         -11, // would cross one of its own offers
+//	     PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN = -12 // could not satisfy destMin
+//	 };
 type PathPaymentStrictSendResultCode int32
 
 const (
@@ -26729,12 +26503,11 @@ var _ xdrType = (*PathPaymentStrictSendResultCode)(nil)
 
 // PathPaymentStrictSendResultSuccess is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            ClaimAtom offers<>;
-//            SimplePaymentResult last;
-//        }
-//
+//	struct
+//	     {
+//	         ClaimAtom offers<>;
+//	         SimplePaymentResult last;
+//	     }
 type PathPaymentStrictSendResultSuccess struct {
 	Offers []ClaimAtom
 	Last   SimplePaymentResult
@@ -26817,31 +26590,30 @@ var _ xdrType = (*PathPaymentStrictSendResultSuccess)(nil)
 
 // PathPaymentStrictSendResult is an XDR Union defines as:
 //
-//   union PathPaymentStrictSendResult switch (PathPaymentStrictSendResultCode code)
-//    {
-//    case PATH_PAYMENT_STRICT_SEND_SUCCESS:
-//        struct
-//        {
-//            ClaimAtom offers<>;
-//            SimplePaymentResult last;
-//        } success;
-//    case PATH_PAYMENT_STRICT_SEND_MALFORMED:
-//    case PATH_PAYMENT_STRICT_SEND_UNDERFUNDED:
-//    case PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST:
-//    case PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED:
-//    case PATH_PAYMENT_STRICT_SEND_NO_DESTINATION:
-//    case PATH_PAYMENT_STRICT_SEND_NO_TRUST:
-//    case PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED:
-//    case PATH_PAYMENT_STRICT_SEND_LINE_FULL:
-//        void;
-//    case PATH_PAYMENT_STRICT_SEND_NO_ISSUER:
-//        Asset noIssuer; // the asset that caused the error
-//    case PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS:
-//    case PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF:
-//    case PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN:
-//        void;
-//    };
-//
+//	union PathPaymentStrictSendResult switch (PathPaymentStrictSendResultCode code)
+//	 {
+//	 case PATH_PAYMENT_STRICT_SEND_SUCCESS:
+//	     struct
+//	     {
+//	         ClaimAtom offers<>;
+//	         SimplePaymentResult last;
+//	     } success;
+//	 case PATH_PAYMENT_STRICT_SEND_MALFORMED:
+//	 case PATH_PAYMENT_STRICT_SEND_UNDERFUNDED:
+//	 case PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST:
+//	 case PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED:
+//	 case PATH_PAYMENT_STRICT_SEND_NO_DESTINATION:
+//	 case PATH_PAYMENT_STRICT_SEND_NO_TRUST:
+//	 case PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED:
+//	 case PATH_PAYMENT_STRICT_SEND_LINE_FULL:
+//	     void;
+//	 case PATH_PAYMENT_STRICT_SEND_NO_ISSUER:
+//	     Asset noIssuer; // the asset that caused the error
+//	 case PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS:
+//	 case PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF:
+//	 case PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN:
+//	     void;
+//	 };
 type PathPaymentStrictSendResult struct {
 	Code     PathPaymentStrictSendResultCode
 	Success  *PathPaymentStrictSendResultSuccess
@@ -27130,33 +26902,32 @@ var _ xdrType = (*PathPaymentStrictSendResult)(nil)
 
 // ManageSellOfferResultCode is an XDR Enum defines as:
 //
-//   enum ManageSellOfferResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        MANAGE_SELL_OFFER_SUCCESS = 0,
+//	enum ManageSellOfferResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     MANAGE_SELL_OFFER_SUCCESS = 0,
 //
-//        // codes considered as "failure" for the operation
-//        MANAGE_SELL_OFFER_MALFORMED = -1, // generated offer would be invalid
-//        MANAGE_SELL_OFFER_SELL_NO_TRUST =
-//            -2,                              // no trust line for what we're selling
-//        MANAGE_SELL_OFFER_BUY_NO_TRUST = -3, // no trust line for what we're buying
-//        MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
-//        MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
-//        MANAGE_SELL_OFFER_LINE_FULL = -6, // can't receive more of what it's buying
-//        MANAGE_SELL_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
-//        MANAGE_SELL_OFFER_CROSS_SELF =
-//            -8, // would cross an offer from the same user
-//        MANAGE_SELL_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
-//        MANAGE_SELL_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
+//	     // codes considered as "failure" for the operation
+//	     MANAGE_SELL_OFFER_MALFORMED = -1, // generated offer would be invalid
+//	     MANAGE_SELL_OFFER_SELL_NO_TRUST =
+//	         -2,                              // no trust line for what we're selling
+//	     MANAGE_SELL_OFFER_BUY_NO_TRUST = -3, // no trust line for what we're buying
+//	     MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
+//	     MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
+//	     MANAGE_SELL_OFFER_LINE_FULL = -6, // can't receive more of what it's buying
+//	     MANAGE_SELL_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
+//	     MANAGE_SELL_OFFER_CROSS_SELF =
+//	         -8, // would cross an offer from the same user
+//	     MANAGE_SELL_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
+//	     MANAGE_SELL_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
 //
-//        // update errors
-//        MANAGE_SELL_OFFER_NOT_FOUND =
-//            -11, // offerID does not match an existing offer
+//	     // update errors
+//	     MANAGE_SELL_OFFER_NOT_FOUND =
+//	         -11, // offerID does not match an existing offer
 //
-//        MANAGE_SELL_OFFER_LOW_RESERVE =
-//            -12 // not enough funds to create a new Offer
-//    };
-//
+//	     MANAGE_SELL_OFFER_LOW_RESERVE =
+//	         -12 // not enough funds to create a new Offer
+//	 };
 type ManageSellOfferResultCode int32
 
 const (
@@ -27257,13 +27028,12 @@ var _ xdrType = (*ManageSellOfferResultCode)(nil)
 
 // ManageOfferEffect is an XDR Enum defines as:
 //
-//   enum ManageOfferEffect
-//    {
-//        MANAGE_OFFER_CREATED = 0,
-//        MANAGE_OFFER_UPDATED = 1,
-//        MANAGE_OFFER_DELETED = 2
-//    };
-//
+//	enum ManageOfferEffect
+//	 {
+//	     MANAGE_OFFER_CREATED = 0,
+//	     MANAGE_OFFER_UPDATED = 1,
+//	     MANAGE_OFFER_DELETED = 2
+//	 };
 type ManageOfferEffect int32
 
 const (
@@ -27344,15 +27114,14 @@ var _ xdrType = (*ManageOfferEffect)(nil)
 
 // ManageOfferSuccessResultOffer is an XDR NestedUnion defines as:
 //
-//   union switch (ManageOfferEffect effect)
-//        {
-//        case MANAGE_OFFER_CREATED:
-//        case MANAGE_OFFER_UPDATED:
-//            OfferEntry offer;
-//        case MANAGE_OFFER_DELETED:
-//            void;
-//        }
-//
+//	union switch (ManageOfferEffect effect)
+//	     {
+//	     case MANAGE_OFFER_CREATED:
+//	     case MANAGE_OFFER_UPDATED:
+//	         OfferEntry offer;
+//	     case MANAGE_OFFER_DELETED:
+//	         void;
+//	     }
 type ManageOfferSuccessResultOffer struct {
 	Effect ManageOfferEffect
 	Offer  *OfferEntry
@@ -27515,22 +27284,21 @@ var _ xdrType = (*ManageOfferSuccessResultOffer)(nil)
 
 // ManageOfferSuccessResult is an XDR Struct defines as:
 //
-//   struct ManageOfferSuccessResult
-//    {
-//        // offers that got claimed while creating this offer
-//        ClaimAtom offersClaimed<>;
+//	struct ManageOfferSuccessResult
+//	 {
+//	     // offers that got claimed while creating this offer
+//	     ClaimAtom offersClaimed<>;
 //
-//        union switch (ManageOfferEffect effect)
-//        {
-//        case MANAGE_OFFER_CREATED:
-//        case MANAGE_OFFER_UPDATED:
-//            OfferEntry offer;
-//        case MANAGE_OFFER_DELETED:
-//            void;
-//        }
-//        offer;
-//    };
-//
+//	     union switch (ManageOfferEffect effect)
+//	     {
+//	     case MANAGE_OFFER_CREATED:
+//	     case MANAGE_OFFER_UPDATED:
+//	         OfferEntry offer;
+//	     case MANAGE_OFFER_DELETED:
+//	         void;
+//	     }
+//	     offer;
+//	 };
 type ManageOfferSuccessResult struct {
 	OffersClaimed []ClaimAtom
 	Offer         ManageOfferSuccessResultOffer
@@ -27613,25 +27381,24 @@ var _ xdrType = (*ManageOfferSuccessResult)(nil)
 
 // ManageSellOfferResult is an XDR Union defines as:
 //
-//   union ManageSellOfferResult switch (ManageSellOfferResultCode code)
-//    {
-//    case MANAGE_SELL_OFFER_SUCCESS:
-//        ManageOfferSuccessResult success;
-//    case MANAGE_SELL_OFFER_MALFORMED:
-//    case MANAGE_SELL_OFFER_SELL_NO_TRUST:
-//    case MANAGE_SELL_OFFER_BUY_NO_TRUST:
-//    case MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED:
-//    case MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED:
-//    case MANAGE_SELL_OFFER_LINE_FULL:
-//    case MANAGE_SELL_OFFER_UNDERFUNDED:
-//    case MANAGE_SELL_OFFER_CROSS_SELF:
-//    case MANAGE_SELL_OFFER_SELL_NO_ISSUER:
-//    case MANAGE_SELL_OFFER_BUY_NO_ISSUER:
-//    case MANAGE_SELL_OFFER_NOT_FOUND:
-//    case MANAGE_SELL_OFFER_LOW_RESERVE:
-//        void;
-//    };
-//
+//	union ManageSellOfferResult switch (ManageSellOfferResultCode code)
+//	 {
+//	 case MANAGE_SELL_OFFER_SUCCESS:
+//	     ManageOfferSuccessResult success;
+//	 case MANAGE_SELL_OFFER_MALFORMED:
+//	 case MANAGE_SELL_OFFER_SELL_NO_TRUST:
+//	 case MANAGE_SELL_OFFER_BUY_NO_TRUST:
+//	 case MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED:
+//	 case MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED:
+//	 case MANAGE_SELL_OFFER_LINE_FULL:
+//	 case MANAGE_SELL_OFFER_UNDERFUNDED:
+//	 case MANAGE_SELL_OFFER_CROSS_SELF:
+//	 case MANAGE_SELL_OFFER_SELL_NO_ISSUER:
+//	 case MANAGE_SELL_OFFER_BUY_NO_ISSUER:
+//	 case MANAGE_SELL_OFFER_NOT_FOUND:
+//	 case MANAGE_SELL_OFFER_LOW_RESERVE:
+//	     void;
+//	 };
 type ManageSellOfferResult struct {
 	Code    ManageSellOfferResultCode
 	Success *ManageOfferSuccessResult
@@ -27882,30 +27649,29 @@ var _ xdrType = (*ManageSellOfferResult)(nil)
 
 // ManageBuyOfferResultCode is an XDR Enum defines as:
 //
-//   enum ManageBuyOfferResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        MANAGE_BUY_OFFER_SUCCESS = 0,
+//	enum ManageBuyOfferResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     MANAGE_BUY_OFFER_SUCCESS = 0,
 //
-//        // codes considered as "failure" for the operation
-//        MANAGE_BUY_OFFER_MALFORMED = -1,     // generated offer would be invalid
-//        MANAGE_BUY_OFFER_SELL_NO_TRUST = -2, // no trust line for what we're selling
-//        MANAGE_BUY_OFFER_BUY_NO_TRUST = -3,  // no trust line for what we're buying
-//        MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
-//        MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
-//        MANAGE_BUY_OFFER_LINE_FULL = -6,   // can't receive more of what it's buying
-//        MANAGE_BUY_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
-//        MANAGE_BUY_OFFER_CROSS_SELF = -8, // would cross an offer from the same user
-//        MANAGE_BUY_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
-//        MANAGE_BUY_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
+//	     // codes considered as "failure" for the operation
+//	     MANAGE_BUY_OFFER_MALFORMED = -1,     // generated offer would be invalid
+//	     MANAGE_BUY_OFFER_SELL_NO_TRUST = -2, // no trust line for what we're selling
+//	     MANAGE_BUY_OFFER_BUY_NO_TRUST = -3,  // no trust line for what we're buying
+//	     MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
+//	     MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
+//	     MANAGE_BUY_OFFER_LINE_FULL = -6,   // can't receive more of what it's buying
+//	     MANAGE_BUY_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
+//	     MANAGE_BUY_OFFER_CROSS_SELF = -8, // would cross an offer from the same user
+//	     MANAGE_BUY_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
+//	     MANAGE_BUY_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
 //
-//        // update errors
-//        MANAGE_BUY_OFFER_NOT_FOUND =
-//            -11, // offerID does not match an existing offer
+//	     // update errors
+//	     MANAGE_BUY_OFFER_NOT_FOUND =
+//	         -11, // offerID does not match an existing offer
 //
-//        MANAGE_BUY_OFFER_LOW_RESERVE = -12 // not enough funds to create a new Offer
-//    };
-//
+//	     MANAGE_BUY_OFFER_LOW_RESERVE = -12 // not enough funds to create a new Offer
+//	 };
 type ManageBuyOfferResultCode int32
 
 const (
@@ -28006,25 +27772,24 @@ var _ xdrType = (*ManageBuyOfferResultCode)(nil)
 
 // ManageBuyOfferResult is an XDR Union defines as:
 //
-//   union ManageBuyOfferResult switch (ManageBuyOfferResultCode code)
-//    {
-//    case MANAGE_BUY_OFFER_SUCCESS:
-//        ManageOfferSuccessResult success;
-//    case MANAGE_BUY_OFFER_MALFORMED:
-//    case MANAGE_BUY_OFFER_SELL_NO_TRUST:
-//    case MANAGE_BUY_OFFER_BUY_NO_TRUST:
-//    case MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED:
-//    case MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED:
-//    case MANAGE_BUY_OFFER_LINE_FULL:
-//    case MANAGE_BUY_OFFER_UNDERFUNDED:
-//    case MANAGE_BUY_OFFER_CROSS_SELF:
-//    case MANAGE_BUY_OFFER_SELL_NO_ISSUER:
-//    case MANAGE_BUY_OFFER_BUY_NO_ISSUER:
-//    case MANAGE_BUY_OFFER_NOT_FOUND:
-//    case MANAGE_BUY_OFFER_LOW_RESERVE:
-//        void;
-//    };
-//
+//	union ManageBuyOfferResult switch (ManageBuyOfferResultCode code)
+//	 {
+//	 case MANAGE_BUY_OFFER_SUCCESS:
+//	     ManageOfferSuccessResult success;
+//	 case MANAGE_BUY_OFFER_MALFORMED:
+//	 case MANAGE_BUY_OFFER_SELL_NO_TRUST:
+//	 case MANAGE_BUY_OFFER_BUY_NO_TRUST:
+//	 case MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED:
+//	 case MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED:
+//	 case MANAGE_BUY_OFFER_LINE_FULL:
+//	 case MANAGE_BUY_OFFER_UNDERFUNDED:
+//	 case MANAGE_BUY_OFFER_CROSS_SELF:
+//	 case MANAGE_BUY_OFFER_SELL_NO_ISSUER:
+//	 case MANAGE_BUY_OFFER_BUY_NO_ISSUER:
+//	 case MANAGE_BUY_OFFER_NOT_FOUND:
+//	 case MANAGE_BUY_OFFER_LOW_RESERVE:
+//	     void;
+//	 };
 type ManageBuyOfferResult struct {
 	Code    ManageBuyOfferResultCode
 	Success *ManageOfferSuccessResult
@@ -28275,24 +28040,23 @@ var _ xdrType = (*ManageBuyOfferResult)(nil)
 
 // SetOptionsResultCode is an XDR Enum defines as:
 //
-//   enum SetOptionsResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        SET_OPTIONS_SUCCESS = 0,
-//        // codes considered as "failure" for the operation
-//        SET_OPTIONS_LOW_RESERVE = -1,      // not enough funds to add a signer
-//        SET_OPTIONS_TOO_MANY_SIGNERS = -2, // max number of signers already reached
-//        SET_OPTIONS_BAD_FLAGS = -3,        // invalid combination of clear/set flags
-//        SET_OPTIONS_INVALID_INFLATION = -4,      // inflation account does not exist
-//        SET_OPTIONS_CANT_CHANGE = -5,            // can no longer change this option
-//        SET_OPTIONS_UNKNOWN_FLAG = -6,           // can't set an unknown flag
-//        SET_OPTIONS_THRESHOLD_OUT_OF_RANGE = -7, // bad value for weight/threshold
-//        SET_OPTIONS_BAD_SIGNER = -8,             // signer cannot be masterkey
-//        SET_OPTIONS_INVALID_HOME_DOMAIN = -9,    // malformed home domain
-//        SET_OPTIONS_AUTH_REVOCABLE_REQUIRED =
-//            -10 // auth revocable is required for clawback
-//    };
-//
+//	enum SetOptionsResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     SET_OPTIONS_SUCCESS = 0,
+//	     // codes considered as "failure" for the operation
+//	     SET_OPTIONS_LOW_RESERVE = -1,      // not enough funds to add a signer
+//	     SET_OPTIONS_TOO_MANY_SIGNERS = -2, // max number of signers already reached
+//	     SET_OPTIONS_BAD_FLAGS = -3,        // invalid combination of clear/set flags
+//	     SET_OPTIONS_INVALID_INFLATION = -4,      // inflation account does not exist
+//	     SET_OPTIONS_CANT_CHANGE = -5,            // can no longer change this option
+//	     SET_OPTIONS_UNKNOWN_FLAG = -6,           // can't set an unknown flag
+//	     SET_OPTIONS_THRESHOLD_OUT_OF_RANGE = -7, // bad value for weight/threshold
+//	     SET_OPTIONS_BAD_SIGNER = -8,             // signer cannot be masterkey
+//	     SET_OPTIONS_INVALID_HOME_DOMAIN = -9,    // malformed home domain
+//	     SET_OPTIONS_AUTH_REVOCABLE_REQUIRED =
+//	         -10 // auth revocable is required for clawback
+//	 };
 type SetOptionsResultCode int32
 
 const (
@@ -28389,23 +28153,22 @@ var _ xdrType = (*SetOptionsResultCode)(nil)
 
 // SetOptionsResult is an XDR Union defines as:
 //
-//   union SetOptionsResult switch (SetOptionsResultCode code)
-//    {
-//    case SET_OPTIONS_SUCCESS:
-//        void;
-//    case SET_OPTIONS_LOW_RESERVE:
-//    case SET_OPTIONS_TOO_MANY_SIGNERS:
-//    case SET_OPTIONS_BAD_FLAGS:
-//    case SET_OPTIONS_INVALID_INFLATION:
-//    case SET_OPTIONS_CANT_CHANGE:
-//    case SET_OPTIONS_UNKNOWN_FLAG:
-//    case SET_OPTIONS_THRESHOLD_OUT_OF_RANGE:
-//    case SET_OPTIONS_BAD_SIGNER:
-//    case SET_OPTIONS_INVALID_HOME_DOMAIN:
-//    case SET_OPTIONS_AUTH_REVOCABLE_REQUIRED:
-//        void;
-//    };
-//
+//	union SetOptionsResult switch (SetOptionsResultCode code)
+//	 {
+//	 case SET_OPTIONS_SUCCESS:
+//	     void;
+//	 case SET_OPTIONS_LOW_RESERVE:
+//	 case SET_OPTIONS_TOO_MANY_SIGNERS:
+//	 case SET_OPTIONS_BAD_FLAGS:
+//	 case SET_OPTIONS_INVALID_INFLATION:
+//	 case SET_OPTIONS_CANT_CHANGE:
+//	 case SET_OPTIONS_UNKNOWN_FLAG:
+//	 case SET_OPTIONS_THRESHOLD_OUT_OF_RANGE:
+//	 case SET_OPTIONS_BAD_SIGNER:
+//	 case SET_OPTIONS_INVALID_HOME_DOMAIN:
+//	 case SET_OPTIONS_AUTH_REVOCABLE_REQUIRED:
+//	     void;
+//	 };
 type SetOptionsResult struct {
 	Code SetOptionsResultCode
 }
@@ -28598,25 +28361,24 @@ var _ xdrType = (*SetOptionsResult)(nil)
 
 // ChangeTrustResultCode is an XDR Enum defines as:
 //
-//   enum ChangeTrustResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        CHANGE_TRUST_SUCCESS = 0,
-//        // codes considered as "failure" for the operation
-//        CHANGE_TRUST_MALFORMED = -1,     // bad input
-//        CHANGE_TRUST_NO_ISSUER = -2,     // could not find issuer
-//        CHANGE_TRUST_INVALID_LIMIT = -3, // cannot drop limit below balance
-//                                         // cannot create with a limit of 0
-//        CHANGE_TRUST_LOW_RESERVE =
-//            -4, // not enough funds to create a new trust line,
-//        CHANGE_TRUST_SELF_NOT_ALLOWED = -5,   // trusting self is not allowed
-//        CHANGE_TRUST_TRUST_LINE_MISSING = -6, // Asset trustline is missing for pool
-//        CHANGE_TRUST_CANNOT_DELETE =
-//            -7, // Asset trustline is still referenced in a pool
-//        CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES =
-//            -8 // Asset trustline is deauthorized
-//    };
-//
+//	enum ChangeTrustResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     CHANGE_TRUST_SUCCESS = 0,
+//	     // codes considered as "failure" for the operation
+//	     CHANGE_TRUST_MALFORMED = -1,     // bad input
+//	     CHANGE_TRUST_NO_ISSUER = -2,     // could not find issuer
+//	     CHANGE_TRUST_INVALID_LIMIT = -3, // cannot drop limit below balance
+//	                                      // cannot create with a limit of 0
+//	     CHANGE_TRUST_LOW_RESERVE =
+//	         -4, // not enough funds to create a new trust line,
+//	     CHANGE_TRUST_SELF_NOT_ALLOWED = -5,   // trusting self is not allowed
+//	     CHANGE_TRUST_TRUST_LINE_MISSING = -6, // Asset trustline is missing for pool
+//	     CHANGE_TRUST_CANNOT_DELETE =
+//	         -7, // Asset trustline is still referenced in a pool
+//	     CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES =
+//	         -8 // Asset trustline is deauthorized
+//	 };
 type ChangeTrustResultCode int32
 
 const (
@@ -28709,21 +28471,20 @@ var _ xdrType = (*ChangeTrustResultCode)(nil)
 
 // ChangeTrustResult is an XDR Union defines as:
 //
-//   union ChangeTrustResult switch (ChangeTrustResultCode code)
-//    {
-//    case CHANGE_TRUST_SUCCESS:
-//        void;
-//    case CHANGE_TRUST_MALFORMED:
-//    case CHANGE_TRUST_NO_ISSUER:
-//    case CHANGE_TRUST_INVALID_LIMIT:
-//    case CHANGE_TRUST_LOW_RESERVE:
-//    case CHANGE_TRUST_SELF_NOT_ALLOWED:
-//    case CHANGE_TRUST_TRUST_LINE_MISSING:
-//    case CHANGE_TRUST_CANNOT_DELETE:
-//    case CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES:
-//        void;
-//    };
-//
+//	union ChangeTrustResult switch (ChangeTrustResultCode code)
+//	 {
+//	 case CHANGE_TRUST_SUCCESS:
+//	     void;
+//	 case CHANGE_TRUST_MALFORMED:
+//	 case CHANGE_TRUST_NO_ISSUER:
+//	 case CHANGE_TRUST_INVALID_LIMIT:
+//	 case CHANGE_TRUST_LOW_RESERVE:
+//	 case CHANGE_TRUST_SELF_NOT_ALLOWED:
+//	 case CHANGE_TRUST_TRUST_LINE_MISSING:
+//	 case CHANGE_TRUST_CANNOT_DELETE:
+//	 case CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES:
+//	     void;
+//	 };
 type ChangeTrustResult struct {
 	Code ChangeTrustResultCode
 }
@@ -28896,21 +28657,20 @@ var _ xdrType = (*ChangeTrustResult)(nil)
 
 // AllowTrustResultCode is an XDR Enum defines as:
 //
-//   enum AllowTrustResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        ALLOW_TRUST_SUCCESS = 0,
-//        // codes considered as "failure" for the operation
-//        ALLOW_TRUST_MALFORMED = -1,     // asset is not ASSET_TYPE_ALPHANUM
-//        ALLOW_TRUST_NO_TRUST_LINE = -2, // trustor does not have a trustline
-//                                        // source account does not require trust
-//        ALLOW_TRUST_TRUST_NOT_REQUIRED = -3,
-//        ALLOW_TRUST_CANT_REVOKE = -4,      // source account can't revoke trust,
-//        ALLOW_TRUST_SELF_NOT_ALLOWED = -5, // trusting self is not allowed
-//        ALLOW_TRUST_LOW_RESERVE = -6       // claimable balances can't be created
-//                                           // on revoke due to low reserves
-//    };
-//
+//	enum AllowTrustResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     ALLOW_TRUST_SUCCESS = 0,
+//	     // codes considered as "failure" for the operation
+//	     ALLOW_TRUST_MALFORMED = -1,     // asset is not ASSET_TYPE_ALPHANUM
+//	     ALLOW_TRUST_NO_TRUST_LINE = -2, // trustor does not have a trustline
+//	                                     // source account does not require trust
+//	     ALLOW_TRUST_TRUST_NOT_REQUIRED = -3,
+//	     ALLOW_TRUST_CANT_REVOKE = -4,      // source account can't revoke trust,
+//	     ALLOW_TRUST_SELF_NOT_ALLOWED = -5, // trusting self is not allowed
+//	     ALLOW_TRUST_LOW_RESERVE = -6       // claimable balances can't be created
+//	                                        // on revoke due to low reserves
+//	 };
 type AllowTrustResultCode int32
 
 const (
@@ -28999,19 +28759,18 @@ var _ xdrType = (*AllowTrustResultCode)(nil)
 
 // AllowTrustResult is an XDR Union defines as:
 //
-//   union AllowTrustResult switch (AllowTrustResultCode code)
-//    {
-//    case ALLOW_TRUST_SUCCESS:
-//        void;
-//    case ALLOW_TRUST_MALFORMED:
-//    case ALLOW_TRUST_NO_TRUST_LINE:
-//    case ALLOW_TRUST_TRUST_NOT_REQUIRED:
-//    case ALLOW_TRUST_CANT_REVOKE:
-//    case ALLOW_TRUST_SELF_NOT_ALLOWED:
-//    case ALLOW_TRUST_LOW_RESERVE:
-//        void;
-//    };
-//
+//	union AllowTrustResult switch (AllowTrustResultCode code)
+//	 {
+//	 case ALLOW_TRUST_SUCCESS:
+//	     void;
+//	 case ALLOW_TRUST_MALFORMED:
+//	 case ALLOW_TRUST_NO_TRUST_LINE:
+//	 case ALLOW_TRUST_TRUST_NOT_REQUIRED:
+//	 case ALLOW_TRUST_CANT_REVOKE:
+//	 case ALLOW_TRUST_SELF_NOT_ALLOWED:
+//	 case ALLOW_TRUST_LOW_RESERVE:
+//	     void;
+//	 };
 type AllowTrustResult struct {
 	Code AllowTrustResultCode
 }
@@ -29164,21 +28923,20 @@ var _ xdrType = (*AllowTrustResult)(nil)
 
 // AccountMergeResultCode is an XDR Enum defines as:
 //
-//   enum AccountMergeResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        ACCOUNT_MERGE_SUCCESS = 0,
-//        // codes considered as "failure" for the operation
-//        ACCOUNT_MERGE_MALFORMED = -1,       // can't merge onto itself
-//        ACCOUNT_MERGE_NO_ACCOUNT = -2,      // destination does not exist
-//        ACCOUNT_MERGE_IMMUTABLE_SET = -3,   // source account has AUTH_IMMUTABLE set
-//        ACCOUNT_MERGE_HAS_SUB_ENTRIES = -4, // account has trust lines/offers
-//        ACCOUNT_MERGE_SEQNUM_TOO_FAR = -5,  // sequence number is over max allowed
-//        ACCOUNT_MERGE_DEST_FULL = -6,       // can't add source balance to
-//                                            // destination balance
-//        ACCOUNT_MERGE_IS_SPONSOR = -7       // can't merge account that is a sponsor
-//    };
-//
+//	enum AccountMergeResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     ACCOUNT_MERGE_SUCCESS = 0,
+//	     // codes considered as "failure" for the operation
+//	     ACCOUNT_MERGE_MALFORMED = -1,       // can't merge onto itself
+//	     ACCOUNT_MERGE_NO_ACCOUNT = -2,      // destination does not exist
+//	     ACCOUNT_MERGE_IMMUTABLE_SET = -3,   // source account has AUTH_IMMUTABLE set
+//	     ACCOUNT_MERGE_HAS_SUB_ENTRIES = -4, // account has trust lines/offers
+//	     ACCOUNT_MERGE_SEQNUM_TOO_FAR = -5,  // sequence number is over max allowed
+//	     ACCOUNT_MERGE_DEST_FULL = -6,       // can't add source balance to
+//	                                         // destination balance
+//	     ACCOUNT_MERGE_IS_SPONSOR = -7       // can't merge account that is a sponsor
+//	 };
 type AccountMergeResultCode int32
 
 const (
@@ -29269,20 +29027,19 @@ var _ xdrType = (*AccountMergeResultCode)(nil)
 
 // AccountMergeResult is an XDR Union defines as:
 //
-//   union AccountMergeResult switch (AccountMergeResultCode code)
-//    {
-//    case ACCOUNT_MERGE_SUCCESS:
-//        int64 sourceAccountBalance; // how much got transferred from source account
-//    case ACCOUNT_MERGE_MALFORMED:
-//    case ACCOUNT_MERGE_NO_ACCOUNT:
-//    case ACCOUNT_MERGE_IMMUTABLE_SET:
-//    case ACCOUNT_MERGE_HAS_SUB_ENTRIES:
-//    case ACCOUNT_MERGE_SEQNUM_TOO_FAR:
-//    case ACCOUNT_MERGE_DEST_FULL:
-//    case ACCOUNT_MERGE_IS_SPONSOR:
-//        void;
-//    };
-//
+//	union AccountMergeResult switch (AccountMergeResultCode code)
+//	 {
+//	 case ACCOUNT_MERGE_SUCCESS:
+//	     int64 sourceAccountBalance; // how much got transferred from source account
+//	 case ACCOUNT_MERGE_MALFORMED:
+//	 case ACCOUNT_MERGE_NO_ACCOUNT:
+//	 case ACCOUNT_MERGE_IMMUTABLE_SET:
+//	 case ACCOUNT_MERGE_HAS_SUB_ENTRIES:
+//	 case ACCOUNT_MERGE_SEQNUM_TOO_FAR:
+//	 case ACCOUNT_MERGE_DEST_FULL:
+//	 case ACCOUNT_MERGE_IS_SPONSOR:
+//	     void;
+//	 };
 type AccountMergeResult struct {
 	Code                 AccountMergeResultCode
 	SourceAccountBalance *Int64
@@ -29483,14 +29240,13 @@ var _ xdrType = (*AccountMergeResult)(nil)
 
 // InflationResultCode is an XDR Enum defines as:
 //
-//   enum InflationResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        INFLATION_SUCCESS = 0,
-//        // codes considered as "failure" for the operation
-//        INFLATION_NOT_TIME = -1
-//    };
-//
+//	enum InflationResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     INFLATION_SUCCESS = 0,
+//	     // codes considered as "failure" for the operation
+//	     INFLATION_NOT_TIME = -1
+//	 };
 type InflationResultCode int32
 
 const (
@@ -29569,12 +29325,11 @@ var _ xdrType = (*InflationResultCode)(nil)
 
 // InflationPayout is an XDR Struct defines as:
 //
-//   struct InflationPayout // or use PaymentResultAtom to limit types?
-//    {
-//        AccountID destination;
-//        int64 amount;
-//    };
-//
+//	struct InflationPayout // or use PaymentResultAtom to limit types?
+//	 {
+//	     AccountID destination;
+//	     int64 amount;
+//	 };
 type InflationPayout struct {
 	Destination AccountId
 	Amount      Int64
@@ -29640,14 +29395,13 @@ var _ xdrType = (*InflationPayout)(nil)
 
 // InflationResult is an XDR Union defines as:
 //
-//   union InflationResult switch (InflationResultCode code)
-//    {
-//    case INFLATION_SUCCESS:
-//        InflationPayout payouts<>;
-//    case INFLATION_NOT_TIME:
-//        void;
-//    };
-//
+//	union InflationResult switch (InflationResultCode code)
+//	 {
+//	 case INFLATION_SUCCESS:
+//	     InflationPayout payouts<>;
+//	 case INFLATION_NOT_TIME:
+//	     void;
+//	 };
 type InflationResult struct {
 	Code    InflationResultCode
 	Payouts *[]InflationPayout
@@ -29805,19 +29559,18 @@ var _ xdrType = (*InflationResult)(nil)
 
 // ManageDataResultCode is an XDR Enum defines as:
 //
-//   enum ManageDataResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        MANAGE_DATA_SUCCESS = 0,
-//        // codes considered as "failure" for the operation
-//        MANAGE_DATA_NOT_SUPPORTED_YET =
-//            -1, // The network hasn't moved to this protocol change yet
-//        MANAGE_DATA_NAME_NOT_FOUND =
-//            -2, // Trying to remove a Data Entry that isn't there
-//        MANAGE_DATA_LOW_RESERVE = -3, // not enough funds to create a new Data Entry
-//        MANAGE_DATA_INVALID_NAME = -4 // Name not a valid string
-//    };
-//
+//	enum ManageDataResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     MANAGE_DATA_SUCCESS = 0,
+//	     // codes considered as "failure" for the operation
+//	     MANAGE_DATA_NOT_SUPPORTED_YET =
+//	         -1, // The network hasn't moved to this protocol change yet
+//	     MANAGE_DATA_NAME_NOT_FOUND =
+//	         -2, // Trying to remove a Data Entry that isn't there
+//	     MANAGE_DATA_LOW_RESERVE = -3, // not enough funds to create a new Data Entry
+//	     MANAGE_DATA_INVALID_NAME = -4 // Name not a valid string
+//	 };
 type ManageDataResultCode int32
 
 const (
@@ -29902,17 +29655,16 @@ var _ xdrType = (*ManageDataResultCode)(nil)
 
 // ManageDataResult is an XDR Union defines as:
 //
-//   union ManageDataResult switch (ManageDataResultCode code)
-//    {
-//    case MANAGE_DATA_SUCCESS:
-//        void;
-//    case MANAGE_DATA_NOT_SUPPORTED_YET:
-//    case MANAGE_DATA_NAME_NOT_FOUND:
-//    case MANAGE_DATA_LOW_RESERVE:
-//    case MANAGE_DATA_INVALID_NAME:
-//        void;
-//    };
-//
+//	union ManageDataResult switch (ManageDataResultCode code)
+//	 {
+//	 case MANAGE_DATA_SUCCESS:
+//	     void;
+//	 case MANAGE_DATA_NOT_SUPPORTED_YET:
+//	 case MANAGE_DATA_NAME_NOT_FOUND:
+//	 case MANAGE_DATA_LOW_RESERVE:
+//	 case MANAGE_DATA_INVALID_NAME:
+//	     void;
+//	 };
 type ManageDataResult struct {
 	Code ManageDataResultCode
 }
@@ -30045,14 +29797,13 @@ var _ xdrType = (*ManageDataResult)(nil)
 
 // BumpSequenceResultCode is an XDR Enum defines as:
 //
-//   enum BumpSequenceResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        BUMP_SEQUENCE_SUCCESS = 0,
-//        // codes considered as "failure" for the operation
-//        BUMP_SEQUENCE_BAD_SEQ = -1 // `bumpTo` is not within bounds
-//    };
-//
+//	enum BumpSequenceResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     BUMP_SEQUENCE_SUCCESS = 0,
+//	     // codes considered as "failure" for the operation
+//	     BUMP_SEQUENCE_BAD_SEQ = -1 // `bumpTo` is not within bounds
+//	 };
 type BumpSequenceResultCode int32
 
 const (
@@ -30131,14 +29882,13 @@ var _ xdrType = (*BumpSequenceResultCode)(nil)
 
 // BumpSequenceResult is an XDR Union defines as:
 //
-//   union BumpSequenceResult switch (BumpSequenceResultCode code)
-//    {
-//    case BUMP_SEQUENCE_SUCCESS:
-//        void;
-//    case BUMP_SEQUENCE_BAD_SEQ:
-//        void;
-//    };
-//
+//	union BumpSequenceResult switch (BumpSequenceResultCode code)
+//	 {
+//	 case BUMP_SEQUENCE_SUCCESS:
+//	     void;
+//	 case BUMP_SEQUENCE_BAD_SEQ:
+//	     void;
+//	 };
 type BumpSequenceResult struct {
 	Code BumpSequenceResultCode
 }
@@ -30241,16 +29991,15 @@ var _ xdrType = (*BumpSequenceResult)(nil)
 
 // CreateClaimableBalanceResultCode is an XDR Enum defines as:
 //
-//   enum CreateClaimableBalanceResultCode
-//    {
-//        CREATE_CLAIMABLE_BALANCE_SUCCESS = 0,
-//        CREATE_CLAIMABLE_BALANCE_MALFORMED = -1,
-//        CREATE_CLAIMABLE_BALANCE_LOW_RESERVE = -2,
-//        CREATE_CLAIMABLE_BALANCE_NO_TRUST = -3,
-//        CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -4,
-//        CREATE_CLAIMABLE_BALANCE_UNDERFUNDED = -5
-//    };
-//
+//	enum CreateClaimableBalanceResultCode
+//	 {
+//	     CREATE_CLAIMABLE_BALANCE_SUCCESS = 0,
+//	     CREATE_CLAIMABLE_BALANCE_MALFORMED = -1,
+//	     CREATE_CLAIMABLE_BALANCE_LOW_RESERVE = -2,
+//	     CREATE_CLAIMABLE_BALANCE_NO_TRUST = -3,
+//	     CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -4,
+//	     CREATE_CLAIMABLE_BALANCE_UNDERFUNDED = -5
+//	 };
 type CreateClaimableBalanceResultCode int32
 
 const (
@@ -30337,19 +30086,18 @@ var _ xdrType = (*CreateClaimableBalanceResultCode)(nil)
 
 // CreateClaimableBalanceResult is an XDR Union defines as:
 //
-//   union CreateClaimableBalanceResult switch (
-//        CreateClaimableBalanceResultCode code)
-//    {
-//    case CREATE_CLAIMABLE_BALANCE_SUCCESS:
-//        ClaimableBalanceID balanceID;
-//    case CREATE_CLAIMABLE_BALANCE_MALFORMED:
-//    case CREATE_CLAIMABLE_BALANCE_LOW_RESERVE:
-//    case CREATE_CLAIMABLE_BALANCE_NO_TRUST:
-//    case CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED:
-//    case CREATE_CLAIMABLE_BALANCE_UNDERFUNDED:
-//        void;
-//    };
-//
+//	union CreateClaimableBalanceResult switch (
+//	     CreateClaimableBalanceResultCode code)
+//	 {
+//	 case CREATE_CLAIMABLE_BALANCE_SUCCESS:
+//	     ClaimableBalanceID balanceID;
+//	 case CREATE_CLAIMABLE_BALANCE_MALFORMED:
+//	 case CREATE_CLAIMABLE_BALANCE_LOW_RESERVE:
+//	 case CREATE_CLAIMABLE_BALANCE_NO_TRUST:
+//	 case CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED:
+//	 case CREATE_CLAIMABLE_BALANCE_UNDERFUNDED:
+//	     void;
+//	 };
 type CreateClaimableBalanceResult struct {
 	Code      CreateClaimableBalanceResultCode
 	BalanceId *ClaimableBalanceId
@@ -30530,16 +30278,15 @@ var _ xdrType = (*CreateClaimableBalanceResult)(nil)
 
 // ClaimClaimableBalanceResultCode is an XDR Enum defines as:
 //
-//   enum ClaimClaimableBalanceResultCode
-//    {
-//        CLAIM_CLAIMABLE_BALANCE_SUCCESS = 0,
-//        CLAIM_CLAIMABLE_BALANCE_DOES_NOT_EXIST = -1,
-//        CLAIM_CLAIMABLE_BALANCE_CANNOT_CLAIM = -2,
-//        CLAIM_CLAIMABLE_BALANCE_LINE_FULL = -3,
-//        CLAIM_CLAIMABLE_BALANCE_NO_TRUST = -4,
-//        CLAIM_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -5
-//    };
-//
+//	enum ClaimClaimableBalanceResultCode
+//	 {
+//	     CLAIM_CLAIMABLE_BALANCE_SUCCESS = 0,
+//	     CLAIM_CLAIMABLE_BALANCE_DOES_NOT_EXIST = -1,
+//	     CLAIM_CLAIMABLE_BALANCE_CANNOT_CLAIM = -2,
+//	     CLAIM_CLAIMABLE_BALANCE_LINE_FULL = -3,
+//	     CLAIM_CLAIMABLE_BALANCE_NO_TRUST = -4,
+//	     CLAIM_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -5
+//	 };
 type ClaimClaimableBalanceResultCode int32
 
 const (
@@ -30626,18 +30373,17 @@ var _ xdrType = (*ClaimClaimableBalanceResultCode)(nil)
 
 // ClaimClaimableBalanceResult is an XDR Union defines as:
 //
-//   union ClaimClaimableBalanceResult switch (ClaimClaimableBalanceResultCode code)
-//    {
-//    case CLAIM_CLAIMABLE_BALANCE_SUCCESS:
-//        void;
-//    case CLAIM_CLAIMABLE_BALANCE_DOES_NOT_EXIST:
-//    case CLAIM_CLAIMABLE_BALANCE_CANNOT_CLAIM:
-//    case CLAIM_CLAIMABLE_BALANCE_LINE_FULL:
-//    case CLAIM_CLAIMABLE_BALANCE_NO_TRUST:
-//    case CLAIM_CLAIMABLE_BALANCE_NOT_AUTHORIZED:
-//        void;
-//    };
-//
+//	union ClaimClaimableBalanceResult switch (ClaimClaimableBalanceResultCode code)
+//	 {
+//	 case CLAIM_CLAIMABLE_BALANCE_SUCCESS:
+//	     void;
+//	 case CLAIM_CLAIMABLE_BALANCE_DOES_NOT_EXIST:
+//	 case CLAIM_CLAIMABLE_BALANCE_CANNOT_CLAIM:
+//	 case CLAIM_CLAIMABLE_BALANCE_LINE_FULL:
+//	 case CLAIM_CLAIMABLE_BALANCE_NO_TRUST:
+//	 case CLAIM_CLAIMABLE_BALANCE_NOT_AUTHORIZED:
+//	     void;
+//	 };
 type ClaimClaimableBalanceResult struct {
 	Code ClaimClaimableBalanceResultCode
 }
@@ -30780,17 +30526,16 @@ var _ xdrType = (*ClaimClaimableBalanceResult)(nil)
 
 // BeginSponsoringFutureReservesResultCode is an XDR Enum defines as:
 //
-//   enum BeginSponsoringFutureReservesResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        BEGIN_SPONSORING_FUTURE_RESERVES_SUCCESS = 0,
+//	enum BeginSponsoringFutureReservesResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     BEGIN_SPONSORING_FUTURE_RESERVES_SUCCESS = 0,
 //
-//        // codes considered as "failure" for the operation
-//        BEGIN_SPONSORING_FUTURE_RESERVES_MALFORMED = -1,
-//        BEGIN_SPONSORING_FUTURE_RESERVES_ALREADY_SPONSORED = -2,
-//        BEGIN_SPONSORING_FUTURE_RESERVES_RECURSIVE = -3
-//    };
-//
+//	     // codes considered as "failure" for the operation
+//	     BEGIN_SPONSORING_FUTURE_RESERVES_MALFORMED = -1,
+//	     BEGIN_SPONSORING_FUTURE_RESERVES_ALREADY_SPONSORED = -2,
+//	     BEGIN_SPONSORING_FUTURE_RESERVES_RECURSIVE = -3
+//	 };
 type BeginSponsoringFutureReservesResultCode int32
 
 const (
@@ -30873,17 +30618,16 @@ var _ xdrType = (*BeginSponsoringFutureReservesResultCode)(nil)
 
 // BeginSponsoringFutureReservesResult is an XDR Union defines as:
 //
-//   union BeginSponsoringFutureReservesResult switch (
-//        BeginSponsoringFutureReservesResultCode code)
-//    {
-//    case BEGIN_SPONSORING_FUTURE_RESERVES_SUCCESS:
-//        void;
-//    case BEGIN_SPONSORING_FUTURE_RESERVES_MALFORMED:
-//    case BEGIN_SPONSORING_FUTURE_RESERVES_ALREADY_SPONSORED:
-//    case BEGIN_SPONSORING_FUTURE_RESERVES_RECURSIVE:
-//        void;
-//    };
-//
+//	union BeginSponsoringFutureReservesResult switch (
+//	     BeginSponsoringFutureReservesResultCode code)
+//	 {
+//	 case BEGIN_SPONSORING_FUTURE_RESERVES_SUCCESS:
+//	     void;
+//	 case BEGIN_SPONSORING_FUTURE_RESERVES_MALFORMED:
+//	 case BEGIN_SPONSORING_FUTURE_RESERVES_ALREADY_SPONSORED:
+//	 case BEGIN_SPONSORING_FUTURE_RESERVES_RECURSIVE:
+//	     void;
+//	 };
 type BeginSponsoringFutureReservesResult struct {
 	Code BeginSponsoringFutureReservesResultCode
 }
@@ -31006,15 +30750,14 @@ var _ xdrType = (*BeginSponsoringFutureReservesResult)(nil)
 
 // EndSponsoringFutureReservesResultCode is an XDR Enum defines as:
 //
-//   enum EndSponsoringFutureReservesResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        END_SPONSORING_FUTURE_RESERVES_SUCCESS = 0,
+//	enum EndSponsoringFutureReservesResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     END_SPONSORING_FUTURE_RESERVES_SUCCESS = 0,
 //
-//        // codes considered as "failure" for the operation
-//        END_SPONSORING_FUTURE_RESERVES_NOT_SPONSORED = -1
-//    };
-//
+//	     // codes considered as "failure" for the operation
+//	     END_SPONSORING_FUTURE_RESERVES_NOT_SPONSORED = -1
+//	 };
 type EndSponsoringFutureReservesResultCode int32
 
 const (
@@ -31093,15 +30836,14 @@ var _ xdrType = (*EndSponsoringFutureReservesResultCode)(nil)
 
 // EndSponsoringFutureReservesResult is an XDR Union defines as:
 //
-//   union EndSponsoringFutureReservesResult switch (
-//        EndSponsoringFutureReservesResultCode code)
-//    {
-//    case END_SPONSORING_FUTURE_RESERVES_SUCCESS:
-//        void;
-//    case END_SPONSORING_FUTURE_RESERVES_NOT_SPONSORED:
-//        void;
-//    };
-//
+//	union EndSponsoringFutureReservesResult switch (
+//	     EndSponsoringFutureReservesResultCode code)
+//	 {
+//	 case END_SPONSORING_FUTURE_RESERVES_SUCCESS:
+//	     void;
+//	 case END_SPONSORING_FUTURE_RESERVES_NOT_SPONSORED:
+//	     void;
+//	 };
 type EndSponsoringFutureReservesResult struct {
 	Code EndSponsoringFutureReservesResultCode
 }
@@ -31204,19 +30946,18 @@ var _ xdrType = (*EndSponsoringFutureReservesResult)(nil)
 
 // RevokeSponsorshipResultCode is an XDR Enum defines as:
 //
-//   enum RevokeSponsorshipResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        REVOKE_SPONSORSHIP_SUCCESS = 0,
+//	enum RevokeSponsorshipResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     REVOKE_SPONSORSHIP_SUCCESS = 0,
 //
-//        // codes considered as "failure" for the operation
-//        REVOKE_SPONSORSHIP_DOES_NOT_EXIST = -1,
-//        REVOKE_SPONSORSHIP_NOT_SPONSOR = -2,
-//        REVOKE_SPONSORSHIP_LOW_RESERVE = -3,
-//        REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE = -4,
-//        REVOKE_SPONSORSHIP_MALFORMED = -5
-//    };
-//
+//	     // codes considered as "failure" for the operation
+//	     REVOKE_SPONSORSHIP_DOES_NOT_EXIST = -1,
+//	     REVOKE_SPONSORSHIP_NOT_SPONSOR = -2,
+//	     REVOKE_SPONSORSHIP_LOW_RESERVE = -3,
+//	     REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE = -4,
+//	     REVOKE_SPONSORSHIP_MALFORMED = -5
+//	 };
 type RevokeSponsorshipResultCode int32
 
 const (
@@ -31303,18 +31044,17 @@ var _ xdrType = (*RevokeSponsorshipResultCode)(nil)
 
 // RevokeSponsorshipResult is an XDR Union defines as:
 //
-//   union RevokeSponsorshipResult switch (RevokeSponsorshipResultCode code)
-//    {
-//    case REVOKE_SPONSORSHIP_SUCCESS:
-//        void;
-//    case REVOKE_SPONSORSHIP_DOES_NOT_EXIST:
-//    case REVOKE_SPONSORSHIP_NOT_SPONSOR:
-//    case REVOKE_SPONSORSHIP_LOW_RESERVE:
-//    case REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE:
-//    case REVOKE_SPONSORSHIP_MALFORMED:
-//        void;
-//    };
-//
+//	union RevokeSponsorshipResult switch (RevokeSponsorshipResultCode code)
+//	 {
+//	 case REVOKE_SPONSORSHIP_SUCCESS:
+//	     void;
+//	 case REVOKE_SPONSORSHIP_DOES_NOT_EXIST:
+//	 case REVOKE_SPONSORSHIP_NOT_SPONSOR:
+//	 case REVOKE_SPONSORSHIP_LOW_RESERVE:
+//	 case REVOKE_SPONSORSHIP_ONLY_TRANSFERABLE:
+//	 case REVOKE_SPONSORSHIP_MALFORMED:
+//	     void;
+//	 };
 type RevokeSponsorshipResult struct {
 	Code RevokeSponsorshipResultCode
 }
@@ -31457,18 +31197,17 @@ var _ xdrType = (*RevokeSponsorshipResult)(nil)
 
 // ClawbackResultCode is an XDR Enum defines as:
 //
-//   enum ClawbackResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        CLAWBACK_SUCCESS = 0,
+//	enum ClawbackResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     CLAWBACK_SUCCESS = 0,
 //
-//        // codes considered as "failure" for the operation
-//        CLAWBACK_MALFORMED = -1,
-//        CLAWBACK_NOT_CLAWBACK_ENABLED = -2,
-//        CLAWBACK_NO_TRUST = -3,
-//        CLAWBACK_UNDERFUNDED = -4
-//    };
-//
+//	     // codes considered as "failure" for the operation
+//	     CLAWBACK_MALFORMED = -1,
+//	     CLAWBACK_NOT_CLAWBACK_ENABLED = -2,
+//	     CLAWBACK_NO_TRUST = -3,
+//	     CLAWBACK_UNDERFUNDED = -4
+//	 };
 type ClawbackResultCode int32
 
 const (
@@ -31553,17 +31292,16 @@ var _ xdrType = (*ClawbackResultCode)(nil)
 
 // ClawbackResult is an XDR Union defines as:
 //
-//   union ClawbackResult switch (ClawbackResultCode code)
-//    {
-//    case CLAWBACK_SUCCESS:
-//        void;
-//    case CLAWBACK_MALFORMED:
-//    case CLAWBACK_NOT_CLAWBACK_ENABLED:
-//    case CLAWBACK_NO_TRUST:
-//    case CLAWBACK_UNDERFUNDED:
-//        void;
-//    };
-//
+//	union ClawbackResult switch (ClawbackResultCode code)
+//	 {
+//	 case CLAWBACK_SUCCESS:
+//	     void;
+//	 case CLAWBACK_MALFORMED:
+//	 case CLAWBACK_NOT_CLAWBACK_ENABLED:
+//	 case CLAWBACK_NO_TRUST:
+//	 case CLAWBACK_UNDERFUNDED:
+//	     void;
+//	 };
 type ClawbackResult struct {
 	Code ClawbackResultCode
 }
@@ -31696,17 +31434,16 @@ var _ xdrType = (*ClawbackResult)(nil)
 
 // ClawbackClaimableBalanceResultCode is an XDR Enum defines as:
 //
-//   enum ClawbackClaimableBalanceResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        CLAWBACK_CLAIMABLE_BALANCE_SUCCESS = 0,
+//	enum ClawbackClaimableBalanceResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     CLAWBACK_CLAIMABLE_BALANCE_SUCCESS = 0,
 //
-//        // codes considered as "failure" for the operation
-//        CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST = -1,
-//        CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER = -2,
-//        CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED = -3
-//    };
-//
+//	     // codes considered as "failure" for the operation
+//	     CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST = -1,
+//	     CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER = -2,
+//	     CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED = -3
+//	 };
 type ClawbackClaimableBalanceResultCode int32
 
 const (
@@ -31789,17 +31526,16 @@ var _ xdrType = (*ClawbackClaimableBalanceResultCode)(nil)
 
 // ClawbackClaimableBalanceResult is an XDR Union defines as:
 //
-//   union ClawbackClaimableBalanceResult switch (
-//        ClawbackClaimableBalanceResultCode code)
-//    {
-//    case CLAWBACK_CLAIMABLE_BALANCE_SUCCESS:
-//        void;
-//    case CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST:
-//    case CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER:
-//    case CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED:
-//        void;
-//    };
-//
+//	union ClawbackClaimableBalanceResult switch (
+//	     ClawbackClaimableBalanceResultCode code)
+//	 {
+//	 case CLAWBACK_CLAIMABLE_BALANCE_SUCCESS:
+//	     void;
+//	 case CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST:
+//	 case CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER:
+//	 case CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED:
+//	     void;
+//	 };
 type ClawbackClaimableBalanceResult struct {
 	Code ClawbackClaimableBalanceResultCode
 }
@@ -31922,20 +31658,19 @@ var _ xdrType = (*ClawbackClaimableBalanceResult)(nil)
 
 // SetTrustLineFlagsResultCode is an XDR Enum defines as:
 //
-//   enum SetTrustLineFlagsResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        SET_TRUST_LINE_FLAGS_SUCCESS = 0,
+//	enum SetTrustLineFlagsResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     SET_TRUST_LINE_FLAGS_SUCCESS = 0,
 //
-//        // codes considered as "failure" for the operation
-//        SET_TRUST_LINE_FLAGS_MALFORMED = -1,
-//        SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
-//        SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3,
-//        SET_TRUST_LINE_FLAGS_INVALID_STATE = -4,
-//        SET_TRUST_LINE_FLAGS_LOW_RESERVE = -5 // claimable balances can't be created
-//                                              // on revoke due to low reserves
-//    };
-//
+//	     // codes considered as "failure" for the operation
+//	     SET_TRUST_LINE_FLAGS_MALFORMED = -1,
+//	     SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
+//	     SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3,
+//	     SET_TRUST_LINE_FLAGS_INVALID_STATE = -4,
+//	     SET_TRUST_LINE_FLAGS_LOW_RESERVE = -5 // claimable balances can't be created
+//	                                           // on revoke due to low reserves
+//	 };
 type SetTrustLineFlagsResultCode int32
 
 const (
@@ -32022,18 +31757,17 @@ var _ xdrType = (*SetTrustLineFlagsResultCode)(nil)
 
 // SetTrustLineFlagsResult is an XDR Union defines as:
 //
-//   union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
-//    {
-//    case SET_TRUST_LINE_FLAGS_SUCCESS:
-//        void;
-//    case SET_TRUST_LINE_FLAGS_MALFORMED:
-//    case SET_TRUST_LINE_FLAGS_NO_TRUST_LINE:
-//    case SET_TRUST_LINE_FLAGS_CANT_REVOKE:
-//    case SET_TRUST_LINE_FLAGS_INVALID_STATE:
-//    case SET_TRUST_LINE_FLAGS_LOW_RESERVE:
-//        void;
-//    };
-//
+//	union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
+//	 {
+//	 case SET_TRUST_LINE_FLAGS_SUCCESS:
+//	     void;
+//	 case SET_TRUST_LINE_FLAGS_MALFORMED:
+//	 case SET_TRUST_LINE_FLAGS_NO_TRUST_LINE:
+//	 case SET_TRUST_LINE_FLAGS_CANT_REVOKE:
+//	 case SET_TRUST_LINE_FLAGS_INVALID_STATE:
+//	 case SET_TRUST_LINE_FLAGS_LOW_RESERVE:
+//	     void;
+//	 };
 type SetTrustLineFlagsResult struct {
 	Code SetTrustLineFlagsResultCode
 }
@@ -32176,25 +31910,24 @@ var _ xdrType = (*SetTrustLineFlagsResult)(nil)
 
 // LiquidityPoolDepositResultCode is an XDR Enum defines as:
 //
-//   enum LiquidityPoolDepositResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        LIQUIDITY_POOL_DEPOSIT_SUCCESS = 0,
+//	enum LiquidityPoolDepositResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     LIQUIDITY_POOL_DEPOSIT_SUCCESS = 0,
 //
-//        // codes considered as "failure" for the operation
-//        LIQUIDITY_POOL_DEPOSIT_MALFORMED = -1,      // bad input
-//        LIQUIDITY_POOL_DEPOSIT_NO_TRUST = -2,       // no trust line for one of the
-//                                                    // assets
-//        LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED = -3, // not authorized for one of the
-//                                                    // assets
-//        LIQUIDITY_POOL_DEPOSIT_UNDERFUNDED = -4,    // not enough balance for one of
-//                                                    // the assets
-//        LIQUIDITY_POOL_DEPOSIT_LINE_FULL = -5,      // pool share trust line doesn't
-//                                                    // have sufficient limit
-//        LIQUIDITY_POOL_DEPOSIT_BAD_PRICE = -6,      // deposit price outside bounds
-//        LIQUIDITY_POOL_DEPOSIT_POOL_FULL = -7       // pool reserves are full
-//    };
-//
+//	     // codes considered as "failure" for the operation
+//	     LIQUIDITY_POOL_DEPOSIT_MALFORMED = -1,      // bad input
+//	     LIQUIDITY_POOL_DEPOSIT_NO_TRUST = -2,       // no trust line for one of the
+//	                                                 // assets
+//	     LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED = -3, // not authorized for one of the
+//	                                                 // assets
+//	     LIQUIDITY_POOL_DEPOSIT_UNDERFUNDED = -4,    // not enough balance for one of
+//	                                                 // the assets
+//	     LIQUIDITY_POOL_DEPOSIT_LINE_FULL = -5,      // pool share trust line doesn't
+//	                                                 // have sufficient limit
+//	     LIQUIDITY_POOL_DEPOSIT_BAD_PRICE = -6,      // deposit price outside bounds
+//	     LIQUIDITY_POOL_DEPOSIT_POOL_FULL = -7       // pool reserves are full
+//	 };
 type LiquidityPoolDepositResultCode int32
 
 const (
@@ -32285,20 +32018,19 @@ var _ xdrType = (*LiquidityPoolDepositResultCode)(nil)
 
 // LiquidityPoolDepositResult is an XDR Union defines as:
 //
-//   union LiquidityPoolDepositResult switch (LiquidityPoolDepositResultCode code)
-//    {
-//    case LIQUIDITY_POOL_DEPOSIT_SUCCESS:
-//        void;
-//    case LIQUIDITY_POOL_DEPOSIT_MALFORMED:
-//    case LIQUIDITY_POOL_DEPOSIT_NO_TRUST:
-//    case LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED:
-//    case LIQUIDITY_POOL_DEPOSIT_UNDERFUNDED:
-//    case LIQUIDITY_POOL_DEPOSIT_LINE_FULL:
-//    case LIQUIDITY_POOL_DEPOSIT_BAD_PRICE:
-//    case LIQUIDITY_POOL_DEPOSIT_POOL_FULL:
-//        void;
-//    };
-//
+//	union LiquidityPoolDepositResult switch (LiquidityPoolDepositResultCode code)
+//	 {
+//	 case LIQUIDITY_POOL_DEPOSIT_SUCCESS:
+//	     void;
+//	 case LIQUIDITY_POOL_DEPOSIT_MALFORMED:
+//	 case LIQUIDITY_POOL_DEPOSIT_NO_TRUST:
+//	 case LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED:
+//	 case LIQUIDITY_POOL_DEPOSIT_UNDERFUNDED:
+//	 case LIQUIDITY_POOL_DEPOSIT_LINE_FULL:
+//	 case LIQUIDITY_POOL_DEPOSIT_BAD_PRICE:
+//	 case LIQUIDITY_POOL_DEPOSIT_POOL_FULL:
+//	     void;
+//	 };
 type LiquidityPoolDepositResult struct {
 	Code LiquidityPoolDepositResultCode
 }
@@ -32461,22 +32193,21 @@ var _ xdrType = (*LiquidityPoolDepositResult)(nil)
 
 // LiquidityPoolWithdrawResultCode is an XDR Enum defines as:
 //
-//   enum LiquidityPoolWithdrawResultCode
-//    {
-//        // codes considered as "success" for the operation
-//        LIQUIDITY_POOL_WITHDRAW_SUCCESS = 0,
+//	enum LiquidityPoolWithdrawResultCode
+//	 {
+//	     // codes considered as "success" for the operation
+//	     LIQUIDITY_POOL_WITHDRAW_SUCCESS = 0,
 //
-//        // codes considered as "failure" for the operation
-//        LIQUIDITY_POOL_WITHDRAW_MALFORMED = -1,    // bad input
-//        LIQUIDITY_POOL_WITHDRAW_NO_TRUST = -2,     // no trust line for one of the
-//                                                   // assets
-//        LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED = -3,  // not enough balance of the
-//                                                   // pool share
-//        LIQUIDITY_POOL_WITHDRAW_LINE_FULL = -4,    // would go above limit for one
-//                                                   // of the assets
-//        LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM = -5 // didn't withdraw enough
-//    };
-//
+//	     // codes considered as "failure" for the operation
+//	     LIQUIDITY_POOL_WITHDRAW_MALFORMED = -1,    // bad input
+//	     LIQUIDITY_POOL_WITHDRAW_NO_TRUST = -2,     // no trust line for one of the
+//	                                                // assets
+//	     LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED = -3,  // not enough balance of the
+//	                                                // pool share
+//	     LIQUIDITY_POOL_WITHDRAW_LINE_FULL = -4,    // would go above limit for one
+//	                                                // of the assets
+//	     LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM = -5 // didn't withdraw enough
+//	 };
 type LiquidityPoolWithdrawResultCode int32
 
 const (
@@ -32563,18 +32294,17 @@ var _ xdrType = (*LiquidityPoolWithdrawResultCode)(nil)
 
 // LiquidityPoolWithdrawResult is an XDR Union defines as:
 //
-//   union LiquidityPoolWithdrawResult switch (LiquidityPoolWithdrawResultCode code)
-//    {
-//    case LIQUIDITY_POOL_WITHDRAW_SUCCESS:
-//        void;
-//    case LIQUIDITY_POOL_WITHDRAW_MALFORMED:
-//    case LIQUIDITY_POOL_WITHDRAW_NO_TRUST:
-//    case LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED:
-//    case LIQUIDITY_POOL_WITHDRAW_LINE_FULL:
-//    case LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM:
-//        void;
-//    };
-//
+//	union LiquidityPoolWithdrawResult switch (LiquidityPoolWithdrawResultCode code)
+//	 {
+//	 case LIQUIDITY_POOL_WITHDRAW_SUCCESS:
+//	     void;
+//	 case LIQUIDITY_POOL_WITHDRAW_MALFORMED:
+//	 case LIQUIDITY_POOL_WITHDRAW_NO_TRUST:
+//	 case LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED:
+//	 case LIQUIDITY_POOL_WITHDRAW_LINE_FULL:
+//	 case LIQUIDITY_POOL_WITHDRAW_UNDER_MINIMUM:
+//	     void;
+//	 };
 type LiquidityPoolWithdrawResult struct {
 	Code LiquidityPoolWithdrawResultCode
 }
@@ -32717,18 +32447,17 @@ var _ xdrType = (*LiquidityPoolWithdrawResult)(nil)
 
 // OperationResultCode is an XDR Enum defines as:
 //
-//   enum OperationResultCode
-//    {
-//        opINNER = 0, // inner object result is valid
+//	enum OperationResultCode
+//	 {
+//	     opINNER = 0, // inner object result is valid
 //
-//        opBAD_AUTH = -1,            // too few valid signatures / wrong network
-//        opNO_ACCOUNT = -2,          // source account was not found
-//        opNOT_SUPPORTED = -3,       // operation not supported at this time
-//        opTOO_MANY_SUBENTRIES = -4, // max number of subentries already reached
-//        opEXCEEDED_WORK_LIMIT = -5, // operation did too much work
-//        opTOO_MANY_SPONSORING = -6  // account is sponsoring too many entries
-//    };
-//
+//	     opBAD_AUTH = -1,            // too few valid signatures / wrong network
+//	     opNO_ACCOUNT = -2,          // source account was not found
+//	     opNOT_SUPPORTED = -3,       // operation not supported at this time
+//	     opTOO_MANY_SUBENTRIES = -4, // max number of subentries already reached
+//	     opEXCEEDED_WORK_LIMIT = -5, // operation did too much work
+//	     opTOO_MANY_SPONSORING = -6  // account is sponsoring too many entries
+//	 };
 type OperationResultCode int32
 
 const (
@@ -32817,58 +32546,57 @@ var _ xdrType = (*OperationResultCode)(nil)
 
 // OperationResultTr is an XDR NestedUnion defines as:
 //
-//   union switch (OperationType type)
-//        {
-//        case CREATE_ACCOUNT:
-//            CreateAccountResult createAccountResult;
-//        case PAYMENT:
-//            PaymentResult paymentResult;
-//        case PATH_PAYMENT_STRICT_RECEIVE:
-//            PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
-//        case MANAGE_SELL_OFFER:
-//            ManageSellOfferResult manageSellOfferResult;
-//        case CREATE_PASSIVE_SELL_OFFER:
-//            ManageSellOfferResult createPassiveSellOfferResult;
-//        case SET_OPTIONS:
-//            SetOptionsResult setOptionsResult;
-//        case CHANGE_TRUST:
-//            ChangeTrustResult changeTrustResult;
-//        case ALLOW_TRUST:
-//            AllowTrustResult allowTrustResult;
-//        case ACCOUNT_MERGE:
-//            AccountMergeResult accountMergeResult;
-//        case INFLATION:
-//            InflationResult inflationResult;
-//        case MANAGE_DATA:
-//            ManageDataResult manageDataResult;
-//        case BUMP_SEQUENCE:
-//            BumpSequenceResult bumpSeqResult;
-//        case MANAGE_BUY_OFFER:
-//            ManageBuyOfferResult manageBuyOfferResult;
-//        case PATH_PAYMENT_STRICT_SEND:
-//            PathPaymentStrictSendResult pathPaymentStrictSendResult;
-//        case CREATE_CLAIMABLE_BALANCE:
-//            CreateClaimableBalanceResult createClaimableBalanceResult;
-//        case CLAIM_CLAIMABLE_BALANCE:
-//            ClaimClaimableBalanceResult claimClaimableBalanceResult;
-//        case BEGIN_SPONSORING_FUTURE_RESERVES:
-//            BeginSponsoringFutureReservesResult beginSponsoringFutureReservesResult;
-//        case END_SPONSORING_FUTURE_RESERVES:
-//            EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
-//        case REVOKE_SPONSORSHIP:
-//            RevokeSponsorshipResult revokeSponsorshipResult;
-//        case CLAWBACK:
-//            ClawbackResult clawbackResult;
-//        case CLAWBACK_CLAIMABLE_BALANCE:
-//            ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
-//        case SET_TRUST_LINE_FLAGS:
-//            SetTrustLineFlagsResult setTrustLineFlagsResult;
-//        case LIQUIDITY_POOL_DEPOSIT:
-//            LiquidityPoolDepositResult liquidityPoolDepositResult;
-//        case LIQUIDITY_POOL_WITHDRAW:
-//            LiquidityPoolWithdrawResult liquidityPoolWithdrawResult;
-//        }
-//
+//	union switch (OperationType type)
+//	     {
+//	     case CREATE_ACCOUNT:
+//	         CreateAccountResult createAccountResult;
+//	     case PAYMENT:
+//	         PaymentResult paymentResult;
+//	     case PATH_PAYMENT_STRICT_RECEIVE:
+//	         PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
+//	     case MANAGE_SELL_OFFER:
+//	         ManageSellOfferResult manageSellOfferResult;
+//	     case CREATE_PASSIVE_SELL_OFFER:
+//	         ManageSellOfferResult createPassiveSellOfferResult;
+//	     case SET_OPTIONS:
+//	         SetOptionsResult setOptionsResult;
+//	     case CHANGE_TRUST:
+//	         ChangeTrustResult changeTrustResult;
+//	     case ALLOW_TRUST:
+//	         AllowTrustResult allowTrustResult;
+//	     case ACCOUNT_MERGE:
+//	         AccountMergeResult accountMergeResult;
+//	     case INFLATION:
+//	         InflationResult inflationResult;
+//	     case MANAGE_DATA:
+//	         ManageDataResult manageDataResult;
+//	     case BUMP_SEQUENCE:
+//	         BumpSequenceResult bumpSeqResult;
+//	     case MANAGE_BUY_OFFER:
+//	         ManageBuyOfferResult manageBuyOfferResult;
+//	     case PATH_PAYMENT_STRICT_SEND:
+//	         PathPaymentStrictSendResult pathPaymentStrictSendResult;
+//	     case CREATE_CLAIMABLE_BALANCE:
+//	         CreateClaimableBalanceResult createClaimableBalanceResult;
+//	     case CLAIM_CLAIMABLE_BALANCE:
+//	         ClaimClaimableBalanceResult claimClaimableBalanceResult;
+//	     case BEGIN_SPONSORING_FUTURE_RESERVES:
+//	         BeginSponsoringFutureReservesResult beginSponsoringFutureReservesResult;
+//	     case END_SPONSORING_FUTURE_RESERVES:
+//	         EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
+//	     case REVOKE_SPONSORSHIP:
+//	         RevokeSponsorshipResult revokeSponsorshipResult;
+//	     case CLAWBACK:
+//	         ClawbackResult clawbackResult;
+//	     case CLAWBACK_CLAIMABLE_BALANCE:
+//	         ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
+//	     case SET_TRUST_LINE_FLAGS:
+//	         SetTrustLineFlagsResult setTrustLineFlagsResult;
+//	     case LIQUIDITY_POOL_DEPOSIT:
+//	         LiquidityPoolDepositResult liquidityPoolDepositResult;
+//	     case LIQUIDITY_POOL_WITHDRAW:
+//	         LiquidityPoolWithdrawResult liquidityPoolWithdrawResult;
+//	     }
 type OperationResultTr struct {
 	Type                                OperationType
 	CreateAccountResult                 *CreateAccountResult
@@ -34103,70 +33831,69 @@ var _ xdrType = (*OperationResultTr)(nil)
 
 // OperationResult is an XDR Union defines as:
 //
-//   union OperationResult switch (OperationResultCode code)
-//    {
-//    case opINNER:
-//        union switch (OperationType type)
-//        {
-//        case CREATE_ACCOUNT:
-//            CreateAccountResult createAccountResult;
-//        case PAYMENT:
-//            PaymentResult paymentResult;
-//        case PATH_PAYMENT_STRICT_RECEIVE:
-//            PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
-//        case MANAGE_SELL_OFFER:
-//            ManageSellOfferResult manageSellOfferResult;
-//        case CREATE_PASSIVE_SELL_OFFER:
-//            ManageSellOfferResult createPassiveSellOfferResult;
-//        case SET_OPTIONS:
-//            SetOptionsResult setOptionsResult;
-//        case CHANGE_TRUST:
-//            ChangeTrustResult changeTrustResult;
-//        case ALLOW_TRUST:
-//            AllowTrustResult allowTrustResult;
-//        case ACCOUNT_MERGE:
-//            AccountMergeResult accountMergeResult;
-//        case INFLATION:
-//            InflationResult inflationResult;
-//        case MANAGE_DATA:
-//            ManageDataResult manageDataResult;
-//        case BUMP_SEQUENCE:
-//            BumpSequenceResult bumpSeqResult;
-//        case MANAGE_BUY_OFFER:
-//            ManageBuyOfferResult manageBuyOfferResult;
-//        case PATH_PAYMENT_STRICT_SEND:
-//            PathPaymentStrictSendResult pathPaymentStrictSendResult;
-//        case CREATE_CLAIMABLE_BALANCE:
-//            CreateClaimableBalanceResult createClaimableBalanceResult;
-//        case CLAIM_CLAIMABLE_BALANCE:
-//            ClaimClaimableBalanceResult claimClaimableBalanceResult;
-//        case BEGIN_SPONSORING_FUTURE_RESERVES:
-//            BeginSponsoringFutureReservesResult beginSponsoringFutureReservesResult;
-//        case END_SPONSORING_FUTURE_RESERVES:
-//            EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
-//        case REVOKE_SPONSORSHIP:
-//            RevokeSponsorshipResult revokeSponsorshipResult;
-//        case CLAWBACK:
-//            ClawbackResult clawbackResult;
-//        case CLAWBACK_CLAIMABLE_BALANCE:
-//            ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
-//        case SET_TRUST_LINE_FLAGS:
-//            SetTrustLineFlagsResult setTrustLineFlagsResult;
-//        case LIQUIDITY_POOL_DEPOSIT:
-//            LiquidityPoolDepositResult liquidityPoolDepositResult;
-//        case LIQUIDITY_POOL_WITHDRAW:
-//            LiquidityPoolWithdrawResult liquidityPoolWithdrawResult;
-//        }
-//        tr;
-//    case opBAD_AUTH:
-//    case opNO_ACCOUNT:
-//    case opNOT_SUPPORTED:
-//    case opTOO_MANY_SUBENTRIES:
-//    case opEXCEEDED_WORK_LIMIT:
-//    case opTOO_MANY_SPONSORING:
-//        void;
-//    };
-//
+//	union OperationResult switch (OperationResultCode code)
+//	 {
+//	 case opINNER:
+//	     union switch (OperationType type)
+//	     {
+//	     case CREATE_ACCOUNT:
+//	         CreateAccountResult createAccountResult;
+//	     case PAYMENT:
+//	         PaymentResult paymentResult;
+//	     case PATH_PAYMENT_STRICT_RECEIVE:
+//	         PathPaymentStrictReceiveResult pathPaymentStrictReceiveResult;
+//	     case MANAGE_SELL_OFFER:
+//	         ManageSellOfferResult manageSellOfferResult;
+//	     case CREATE_PASSIVE_SELL_OFFER:
+//	         ManageSellOfferResult createPassiveSellOfferResult;
+//	     case SET_OPTIONS:
+//	         SetOptionsResult setOptionsResult;
+//	     case CHANGE_TRUST:
+//	         ChangeTrustResult changeTrustResult;
+//	     case ALLOW_TRUST:
+//	         AllowTrustResult allowTrustResult;
+//	     case ACCOUNT_MERGE:
+//	         AccountMergeResult accountMergeResult;
+//	     case INFLATION:
+//	         InflationResult inflationResult;
+//	     case MANAGE_DATA:
+//	         ManageDataResult manageDataResult;
+//	     case BUMP_SEQUENCE:
+//	         BumpSequenceResult bumpSeqResult;
+//	     case MANAGE_BUY_OFFER:
+//	         ManageBuyOfferResult manageBuyOfferResult;
+//	     case PATH_PAYMENT_STRICT_SEND:
+//	         PathPaymentStrictSendResult pathPaymentStrictSendResult;
+//	     case CREATE_CLAIMABLE_BALANCE:
+//	         CreateClaimableBalanceResult createClaimableBalanceResult;
+//	     case CLAIM_CLAIMABLE_BALANCE:
+//	         ClaimClaimableBalanceResult claimClaimableBalanceResult;
+//	     case BEGIN_SPONSORING_FUTURE_RESERVES:
+//	         BeginSponsoringFutureReservesResult beginSponsoringFutureReservesResult;
+//	     case END_SPONSORING_FUTURE_RESERVES:
+//	         EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
+//	     case REVOKE_SPONSORSHIP:
+//	         RevokeSponsorshipResult revokeSponsorshipResult;
+//	     case CLAWBACK:
+//	         ClawbackResult clawbackResult;
+//	     case CLAWBACK_CLAIMABLE_BALANCE:
+//	         ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
+//	     case SET_TRUST_LINE_FLAGS:
+//	         SetTrustLineFlagsResult setTrustLineFlagsResult;
+//	     case LIQUIDITY_POOL_DEPOSIT:
+//	         LiquidityPoolDepositResult liquidityPoolDepositResult;
+//	     case LIQUIDITY_POOL_WITHDRAW:
+//	         LiquidityPoolWithdrawResult liquidityPoolWithdrawResult;
+//	     }
+//	     tr;
+//	 case opBAD_AUTH:
+//	 case opNO_ACCOUNT:
+//	 case opNOT_SUPPORTED:
+//	 case opTOO_MANY_SUBENTRIES:
+//	 case opEXCEEDED_WORK_LIMIT:
+//	 case opTOO_MANY_SPONSORING:
+//	     void;
+//	 };
 type OperationResult struct {
 	Code OperationResultCode
 	Tr   *OperationResultTr
@@ -34357,33 +34084,32 @@ var _ xdrType = (*OperationResult)(nil)
 
 // TransactionResultCode is an XDR Enum defines as:
 //
-//   enum TransactionResultCode
-//    {
-//        txFEE_BUMP_INNER_SUCCESS = 1, // fee bump inner transaction succeeded
-//        txSUCCESS = 0,                // all operations succeeded
+//	enum TransactionResultCode
+//	 {
+//	     txFEE_BUMP_INNER_SUCCESS = 1, // fee bump inner transaction succeeded
+//	     txSUCCESS = 0,                // all operations succeeded
 //
-//        txFAILED = -1, // one of the operations failed (none were applied)
+//	     txFAILED = -1, // one of the operations failed (none were applied)
 //
-//        txTOO_EARLY = -2,         // ledger closeTime before minTime
-//        txTOO_LATE = -3,          // ledger closeTime after maxTime
-//        txMISSING_OPERATION = -4, // no operation was specified
-//        txBAD_SEQ = -5,           // sequence number does not match source account
+//	     txTOO_EARLY = -2,         // ledger closeTime before minTime
+//	     txTOO_LATE = -3,          // ledger closeTime after maxTime
+//	     txMISSING_OPERATION = -4, // no operation was specified
+//	     txBAD_SEQ = -5,           // sequence number does not match source account
 //
-//        txBAD_AUTH = -6,             // too few valid signatures / wrong network
-//        txINSUFFICIENT_BALANCE = -7, // fee would bring account below reserve
-//        txNO_ACCOUNT = -8,           // source account not found
-//        txINSUFFICIENT_FEE = -9,     // fee is too small
-//        txBAD_AUTH_EXTRA = -10,      // unused signatures attached to transaction
-//        txINTERNAL_ERROR = -11,      // an unknown error occurred
+//	     txBAD_AUTH = -6,             // too few valid signatures / wrong network
+//	     txINSUFFICIENT_BALANCE = -7, // fee would bring account below reserve
+//	     txNO_ACCOUNT = -8,           // source account not found
+//	     txINSUFFICIENT_FEE = -9,     // fee is too small
+//	     txBAD_AUTH_EXTRA = -10,      // unused signatures attached to transaction
+//	     txINTERNAL_ERROR = -11,      // an unknown error occurred
 //
-//        txNOT_SUPPORTED = -12,         // transaction type not supported
-//        txFEE_BUMP_INNER_FAILED = -13, // fee bump inner transaction failed
-//        txBAD_SPONSORSHIP = -14,       // sponsorship not confirmed
-//        txBAD_MIN_SEQ_AGE_OR_GAP =
-//            -15, // minSeqAge or minSeqLedgerGap conditions not met
-//        txMALFORMED = -16 // precondition is invalid
-//    };
-//
+//	     txNOT_SUPPORTED = -12,         // transaction type not supported
+//	     txFEE_BUMP_INNER_FAILED = -13, // fee bump inner transaction failed
+//	     txBAD_SPONSORSHIP = -14,       // sponsorship not confirmed
+//	     txBAD_MIN_SEQ_AGE_OR_GAP =
+//	         -15, // minSeqAge or minSeqLedgerGap conditions not met
+//	     txMALFORMED = -16 // precondition is invalid
+//	 };
 type TransactionResultCode int32
 
 const (
@@ -34494,30 +34220,29 @@ var _ xdrType = (*TransactionResultCode)(nil)
 
 // InnerTransactionResultResult is an XDR NestedUnion defines as:
 //
-//   union switch (TransactionResultCode code)
-//        {
-//        // txFEE_BUMP_INNER_SUCCESS is not included
-//        case txSUCCESS:
-//        case txFAILED:
-//            OperationResult results<>;
-//        case txTOO_EARLY:
-//        case txTOO_LATE:
-//        case txMISSING_OPERATION:
-//        case txBAD_SEQ:
-//        case txBAD_AUTH:
-//        case txINSUFFICIENT_BALANCE:
-//        case txNO_ACCOUNT:
-//        case txINSUFFICIENT_FEE:
-//        case txBAD_AUTH_EXTRA:
-//        case txINTERNAL_ERROR:
-//        case txNOT_SUPPORTED:
-//        // txFEE_BUMP_INNER_FAILED is not included
-//        case txBAD_SPONSORSHIP:
-//        case txBAD_MIN_SEQ_AGE_OR_GAP:
-//        case txMALFORMED:
-//            void;
-//        }
-//
+//	union switch (TransactionResultCode code)
+//	     {
+//	     // txFEE_BUMP_INNER_SUCCESS is not included
+//	     case txSUCCESS:
+//	     case txFAILED:
+//	         OperationResult results<>;
+//	     case txTOO_EARLY:
+//	     case txTOO_LATE:
+//	     case txMISSING_OPERATION:
+//	     case txBAD_SEQ:
+//	     case txBAD_AUTH:
+//	     case txINSUFFICIENT_BALANCE:
+//	     case txNO_ACCOUNT:
+//	     case txINSUFFICIENT_FEE:
+//	     case txBAD_AUTH_EXTRA:
+//	     case txINTERNAL_ERROR:
+//	     case txNOT_SUPPORTED:
+//	     // txFEE_BUMP_INNER_FAILED is not included
+//	     case txBAD_SPONSORSHIP:
+//	     case txBAD_MIN_SEQ_AGE_OR_GAP:
+//	     case txMALFORMED:
+//	         void;
+//	     }
 type InnerTransactionResultResult struct {
 	Code    TransactionResultCode
 	Results *[]OperationResult
@@ -34844,12 +34569,11 @@ var _ xdrType = (*InnerTransactionResultResult)(nil)
 
 // InnerTransactionResultExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type InnerTransactionResultExt struct {
 	V int32
 }
@@ -34942,45 +34666,44 @@ var _ xdrType = (*InnerTransactionResultExt)(nil)
 
 // InnerTransactionResult is an XDR Struct defines as:
 //
-//   struct InnerTransactionResult
-//    {
-//        // Always 0. Here for binary compatibility.
-//        int64 feeCharged;
+//	struct InnerTransactionResult
+//	 {
+//	     // Always 0. Here for binary compatibility.
+//	     int64 feeCharged;
 //
-//        union switch (TransactionResultCode code)
-//        {
-//        // txFEE_BUMP_INNER_SUCCESS is not included
-//        case txSUCCESS:
-//        case txFAILED:
-//            OperationResult results<>;
-//        case txTOO_EARLY:
-//        case txTOO_LATE:
-//        case txMISSING_OPERATION:
-//        case txBAD_SEQ:
-//        case txBAD_AUTH:
-//        case txINSUFFICIENT_BALANCE:
-//        case txNO_ACCOUNT:
-//        case txINSUFFICIENT_FEE:
-//        case txBAD_AUTH_EXTRA:
-//        case txINTERNAL_ERROR:
-//        case txNOT_SUPPORTED:
-//        // txFEE_BUMP_INNER_FAILED is not included
-//        case txBAD_SPONSORSHIP:
-//        case txBAD_MIN_SEQ_AGE_OR_GAP:
-//        case txMALFORMED:
-//            void;
-//        }
-//        result;
+//	     union switch (TransactionResultCode code)
+//	     {
+//	     // txFEE_BUMP_INNER_SUCCESS is not included
+//	     case txSUCCESS:
+//	     case txFAILED:
+//	         OperationResult results<>;
+//	     case txTOO_EARLY:
+//	     case txTOO_LATE:
+//	     case txMISSING_OPERATION:
+//	     case txBAD_SEQ:
+//	     case txBAD_AUTH:
+//	     case txINSUFFICIENT_BALANCE:
+//	     case txNO_ACCOUNT:
+//	     case txINSUFFICIENT_FEE:
+//	     case txBAD_AUTH_EXTRA:
+//	     case txINTERNAL_ERROR:
+//	     case txNOT_SUPPORTED:
+//	     // txFEE_BUMP_INNER_FAILED is not included
+//	     case txBAD_SPONSORSHIP:
+//	     case txBAD_MIN_SEQ_AGE_OR_GAP:
+//	     case txMALFORMED:
+//	         void;
+//	     }
+//	     result;
 //
-//        // reserved for future use
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
-//    };
-//
+//	     // reserved for future use
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
+//	 };
 type InnerTransactionResult struct {
 	FeeCharged Int64
 	Result     InnerTransactionResultResult
@@ -35055,12 +34778,11 @@ var _ xdrType = (*InnerTransactionResult)(nil)
 
 // InnerTransactionResultPair is an XDR Struct defines as:
 //
-//   struct InnerTransactionResultPair
-//    {
-//        Hash transactionHash;          // hash of the inner transaction
-//        InnerTransactionResult result; // result for the inner transaction
-//    };
-//
+//	struct InnerTransactionResultPair
+//	 {
+//	     Hash transactionHash;          // hash of the inner transaction
+//	     InnerTransactionResult result; // result for the inner transaction
+//	 };
 type InnerTransactionResultPair struct {
 	TransactionHash Hash
 	Result          InnerTransactionResult
@@ -35126,32 +34848,31 @@ var _ xdrType = (*InnerTransactionResultPair)(nil)
 
 // TransactionResultResult is an XDR NestedUnion defines as:
 //
-//   union switch (TransactionResultCode code)
-//        {
-//        case txFEE_BUMP_INNER_SUCCESS:
-//        case txFEE_BUMP_INNER_FAILED:
-//            InnerTransactionResultPair innerResultPair;
-//        case txSUCCESS:
-//        case txFAILED:
-//            OperationResult results<>;
-//        case txTOO_EARLY:
-//        case txTOO_LATE:
-//        case txMISSING_OPERATION:
-//        case txBAD_SEQ:
-//        case txBAD_AUTH:
-//        case txINSUFFICIENT_BALANCE:
-//        case txNO_ACCOUNT:
-//        case txINSUFFICIENT_FEE:
-//        case txBAD_AUTH_EXTRA:
-//        case txINTERNAL_ERROR:
-//        case txNOT_SUPPORTED:
-//        // case txFEE_BUMP_INNER_FAILED: handled above
-//        case txBAD_SPONSORSHIP:
-//        case txBAD_MIN_SEQ_AGE_OR_GAP:
-//        case txMALFORMED:
-//            void;
-//        }
-//
+//	union switch (TransactionResultCode code)
+//	     {
+//	     case txFEE_BUMP_INNER_SUCCESS:
+//	     case txFEE_BUMP_INNER_FAILED:
+//	         InnerTransactionResultPair innerResultPair;
+//	     case txSUCCESS:
+//	     case txFAILED:
+//	         OperationResult results<>;
+//	     case txTOO_EARLY:
+//	     case txTOO_LATE:
+//	     case txMISSING_OPERATION:
+//	     case txBAD_SEQ:
+//	     case txBAD_AUTH:
+//	     case txINSUFFICIENT_BALANCE:
+//	     case txNO_ACCOUNT:
+//	     case txINSUFFICIENT_FEE:
+//	     case txBAD_AUTH_EXTRA:
+//	     case txINTERNAL_ERROR:
+//	     case txNOT_SUPPORTED:
+//	     // case txFEE_BUMP_INNER_FAILED: handled above
+//	     case txBAD_SPONSORSHIP:
+//	     case txBAD_MIN_SEQ_AGE_OR_GAP:
+//	     case txMALFORMED:
+//	         void;
+//	     }
 type TransactionResultResult struct {
 	Code            TransactionResultCode
 	InnerResultPair *InnerTransactionResultPair
@@ -35548,12 +35269,11 @@ var _ xdrType = (*TransactionResultResult)(nil)
 
 // TransactionResultExt is an XDR NestedUnion defines as:
 //
-//   union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//
+//	union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
 type TransactionResultExt struct {
 	V int32
 }
@@ -35646,46 +35366,45 @@ var _ xdrType = (*TransactionResultExt)(nil)
 
 // TransactionResult is an XDR Struct defines as:
 //
-//   struct TransactionResult
-//    {
-//        int64 feeCharged; // actual fee charged for the transaction
+//	struct TransactionResult
+//	 {
+//	     int64 feeCharged; // actual fee charged for the transaction
 //
-//        union switch (TransactionResultCode code)
-//        {
-//        case txFEE_BUMP_INNER_SUCCESS:
-//        case txFEE_BUMP_INNER_FAILED:
-//            InnerTransactionResultPair innerResultPair;
-//        case txSUCCESS:
-//        case txFAILED:
-//            OperationResult results<>;
-//        case txTOO_EARLY:
-//        case txTOO_LATE:
-//        case txMISSING_OPERATION:
-//        case txBAD_SEQ:
-//        case txBAD_AUTH:
-//        case txINSUFFICIENT_BALANCE:
-//        case txNO_ACCOUNT:
-//        case txINSUFFICIENT_FEE:
-//        case txBAD_AUTH_EXTRA:
-//        case txINTERNAL_ERROR:
-//        case txNOT_SUPPORTED:
-//        // case txFEE_BUMP_INNER_FAILED: handled above
-//        case txBAD_SPONSORSHIP:
-//        case txBAD_MIN_SEQ_AGE_OR_GAP:
-//        case txMALFORMED:
-//            void;
-//        }
-//        result;
+//	     union switch (TransactionResultCode code)
+//	     {
+//	     case txFEE_BUMP_INNER_SUCCESS:
+//	     case txFEE_BUMP_INNER_FAILED:
+//	         InnerTransactionResultPair innerResultPair;
+//	     case txSUCCESS:
+//	     case txFAILED:
+//	         OperationResult results<>;
+//	     case txTOO_EARLY:
+//	     case txTOO_LATE:
+//	     case txMISSING_OPERATION:
+//	     case txBAD_SEQ:
+//	     case txBAD_AUTH:
+//	     case txINSUFFICIENT_BALANCE:
+//	     case txNO_ACCOUNT:
+//	     case txINSUFFICIENT_FEE:
+//	     case txBAD_AUTH_EXTRA:
+//	     case txINTERNAL_ERROR:
+//	     case txNOT_SUPPORTED:
+//	     // case txFEE_BUMP_INNER_FAILED: handled above
+//	     case txBAD_SPONSORSHIP:
+//	     case txBAD_MIN_SEQ_AGE_OR_GAP:
+//	     case txMALFORMED:
+//	         void;
+//	     }
+//	     result;
 //
-//        // reserved for future use
-//        union switch (int v)
-//        {
-//        case 0:
-//            void;
-//        }
-//        ext;
-//    };
-//
+//	     // reserved for future use
+//	     union switch (int v)
+//	     {
+//	     case 0:
+//	         void;
+//	     }
+//	     ext;
+//	 };
 type TransactionResult struct {
 	FeeCharged Int64
 	Result     TransactionResultResult
@@ -35760,8 +35479,7 @@ var _ xdrType = (*TransactionResult)(nil)
 
 // Hash is an XDR Typedef defines as:
 //
-//   typedef opaque Hash[32];
-//
+//	typedef opaque Hash[32];
 type Hash [32]byte
 
 // XDRMaxSize implements the Sized interface for Hash
@@ -35821,8 +35539,7 @@ var _ xdrType = (*Hash)(nil)
 
 // Uint256 is an XDR Typedef defines as:
 //
-//   typedef opaque uint256[32];
-//
+//	typedef opaque uint256[32];
 type Uint256 [32]byte
 
 // XDRMaxSize implements the Sized interface for Uint256
@@ -35882,8 +35599,7 @@ var _ xdrType = (*Uint256)(nil)
 
 // Uint32 is an XDR Typedef defines as:
 //
-//   typedef unsigned int uint32;
-//
+//	typedef unsigned int uint32;
 type Uint32 uint32
 
 // EncodeTo encodes this value using the Encoder.
@@ -35940,8 +35656,7 @@ var _ xdrType = (*Uint32)(nil)
 
 // Int32 is an XDR Typedef defines as:
 //
-//   typedef int int32;
-//
+//	typedef int int32;
 type Int32 int32
 
 // EncodeTo encodes this value using the Encoder.
@@ -35998,8 +35713,7 @@ var _ xdrType = (*Int32)(nil)
 
 // Uint64 is an XDR Typedef defines as:
 //
-//   typedef unsigned hyper uint64;
-//
+//	typedef unsigned hyper uint64;
 type Uint64 uint64
 
 // EncodeTo encodes this value using the Encoder.
@@ -36056,8 +35770,7 @@ var _ xdrType = (*Uint64)(nil)
 
 // Int64 is an XDR Typedef defines as:
 //
-//   typedef hyper int64;
-//
+//	typedef hyper int64;
 type Int64 int64
 
 // EncodeTo encodes this value using the Encoder.
@@ -36114,12 +35827,11 @@ var _ xdrType = (*Int64)(nil)
 
 // ExtensionPoint is an XDR Union defines as:
 //
-//   union ExtensionPoint switch (int v)
-//    {
-//    case 0:
-//        void;
-//    };
-//
+//	union ExtensionPoint switch (int v)
+//	 {
+//	 case 0:
+//	     void;
+//	 };
 type ExtensionPoint struct {
 	V int32
 }
@@ -36212,17 +35924,16 @@ var _ xdrType = (*ExtensionPoint)(nil)
 
 // CryptoKeyType is an XDR Enum defines as:
 //
-//   enum CryptoKeyType
-//    {
-//        KEY_TYPE_ED25519 = 0,
-//        KEY_TYPE_PRE_AUTH_TX = 1,
-//        KEY_TYPE_HASH_X = 2,
-//        KEY_TYPE_ED25519_SIGNED_PAYLOAD = 3,
-//        // MUXED enum values for supported type are derived from the enum values
-//        // above by ORing them with 0x100
-//        KEY_TYPE_MUXED_ED25519 = 0x100
-//    };
-//
+//	enum CryptoKeyType
+//	 {
+//	     KEY_TYPE_ED25519 = 0,
+//	     KEY_TYPE_PRE_AUTH_TX = 1,
+//	     KEY_TYPE_HASH_X = 2,
+//	     KEY_TYPE_ED25519_SIGNED_PAYLOAD = 3,
+//	     // MUXED enum values for supported type are derived from the enum values
+//	     // above by ORing them with 0x100
+//	     KEY_TYPE_MUXED_ED25519 = 0x100
+//	 };
 type CryptoKeyType int32
 
 const (
@@ -36307,11 +36018,10 @@ var _ xdrType = (*CryptoKeyType)(nil)
 
 // PublicKeyType is an XDR Enum defines as:
 //
-//   enum PublicKeyType
-//    {
-//        PUBLIC_KEY_TYPE_ED25519 = KEY_TYPE_ED25519
-//    };
-//
+//	enum PublicKeyType
+//	 {
+//	     PUBLIC_KEY_TYPE_ED25519 = KEY_TYPE_ED25519
+//	 };
 type PublicKeyType int32
 
 const (
@@ -36388,14 +36098,13 @@ var _ xdrType = (*PublicKeyType)(nil)
 
 // SignerKeyType is an XDR Enum defines as:
 //
-//   enum SignerKeyType
-//    {
-//        SIGNER_KEY_TYPE_ED25519 = KEY_TYPE_ED25519,
-//        SIGNER_KEY_TYPE_PRE_AUTH_TX = KEY_TYPE_PRE_AUTH_TX,
-//        SIGNER_KEY_TYPE_HASH_X = KEY_TYPE_HASH_X,
-//        SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD = KEY_TYPE_ED25519_SIGNED_PAYLOAD
-//    };
-//
+//	enum SignerKeyType
+//	 {
+//	     SIGNER_KEY_TYPE_ED25519 = KEY_TYPE_ED25519,
+//	     SIGNER_KEY_TYPE_PRE_AUTH_TX = KEY_TYPE_PRE_AUTH_TX,
+//	     SIGNER_KEY_TYPE_HASH_X = KEY_TYPE_HASH_X,
+//	     SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD = KEY_TYPE_ED25519_SIGNED_PAYLOAD
+//	 };
 type SignerKeyType int32
 
 const (
@@ -36478,12 +36187,11 @@ var _ xdrType = (*SignerKeyType)(nil)
 
 // PublicKey is an XDR Union defines as:
 //
-//   union PublicKey switch (PublicKeyType type)
-//    {
-//    case PUBLIC_KEY_TYPE_ED25519:
-//        uint256 ed25519;
-//    };
-//
+//	union PublicKey switch (PublicKeyType type)
+//	 {
+//	 case PUBLIC_KEY_TYPE_ED25519:
+//	     uint256 ed25519;
+//	 };
 type PublicKey struct {
 	Type    PublicKeyType
 	Ed25519 *Uint256
@@ -36614,14 +36322,13 @@ var _ xdrType = (*PublicKey)(nil)
 
 // SignerKeyEd25519SignedPayload is an XDR NestedStruct defines as:
 //
-//   struct
-//        {
-//            /* Public key that must sign the payload. */
-//            uint256 ed25519;
-//            /* Payload to be raw signed by ed25519. */
-//            opaque payload<64>;
-//        }
-//
+//	struct
+//	     {
+//	         /* Public key that must sign the payload. */
+//	         uint256 ed25519;
+//	         /* Payload to be raw signed by ed25519. */
+//	         opaque payload<64>;
+//	     }
 type SignerKeyEd25519SignedPayload struct {
 	Ed25519 Uint256
 	Payload []byte `xdrmaxsize:"64"`
@@ -36687,26 +36394,25 @@ var _ xdrType = (*SignerKeyEd25519SignedPayload)(nil)
 
 // SignerKey is an XDR Union defines as:
 //
-//   union SignerKey switch (SignerKeyType type)
-//    {
-//    case SIGNER_KEY_TYPE_ED25519:
-//        uint256 ed25519;
-//    case SIGNER_KEY_TYPE_PRE_AUTH_TX:
-//        /* SHA-256 Hash of TransactionSignaturePayload structure */
-//        uint256 preAuthTx;
-//    case SIGNER_KEY_TYPE_HASH_X:
-//        /* Hash of random 256 bit preimage X */
-//        uint256 hashX;
-//    case SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD:
-//        struct
-//        {
-//            /* Public key that must sign the payload. */
-//            uint256 ed25519;
-//            /* Payload to be raw signed by ed25519. */
-//            opaque payload<64>;
-//        } ed25519SignedPayload;
-//    };
-//
+//	union SignerKey switch (SignerKeyType type)
+//	 {
+//	 case SIGNER_KEY_TYPE_ED25519:
+//	     uint256 ed25519;
+//	 case SIGNER_KEY_TYPE_PRE_AUTH_TX:
+//	     /* SHA-256 Hash of TransactionSignaturePayload structure */
+//	     uint256 preAuthTx;
+//	 case SIGNER_KEY_TYPE_HASH_X:
+//	     /* Hash of random 256 bit preimage X */
+//	     uint256 hashX;
+//	 case SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD:
+//	     struct
+//	     {
+//	         /* Public key that must sign the payload. */
+//	         uint256 ed25519;
+//	         /* Payload to be raw signed by ed25519. */
+//	         opaque payload<64>;
+//	     } ed25519SignedPayload;
+//	 };
 type SignerKey struct {
 	Type                 SignerKeyType
 	Ed25519              *Uint256
@@ -36981,8 +36687,7 @@ var _ xdrType = (*SignerKey)(nil)
 
 // Signature is an XDR Typedef defines as:
 //
-//   typedef opaque Signature<64>;
-//
+//	typedef opaque Signature<64>;
 type Signature []byte
 
 // XDRMaxSize implements the Sized interface for Signature
@@ -37042,8 +36747,7 @@ var _ xdrType = (*Signature)(nil)
 
 // SignatureHint is an XDR Typedef defines as:
 //
-//   typedef opaque SignatureHint[4];
-//
+//	typedef opaque SignatureHint[4];
 type SignatureHint [4]byte
 
 // XDRMaxSize implements the Sized interface for SignatureHint
@@ -37103,8 +36807,7 @@ var _ xdrType = (*SignatureHint)(nil)
 
 // NodeId is an XDR Typedef defines as:
 //
-//   typedef PublicKey NodeID;
-//
+//	typedef PublicKey NodeID;
 type NodeId PublicKey
 
 // SwitchFieldName returns the field name in which this union's
@@ -37190,11 +36893,10 @@ var _ xdrType = (*NodeId)(nil)
 
 // Curve25519Secret is an XDR Struct defines as:
 //
-//   struct Curve25519Secret
-//    {
-//        opaque key[32];
-//    };
-//
+//	struct Curve25519Secret
+//	 {
+//	     opaque key[32];
+//	 };
 type Curve25519Secret struct {
 	Key [32]byte `xdrmaxsize:"32"`
 }
@@ -37251,11 +36953,10 @@ var _ xdrType = (*Curve25519Secret)(nil)
 
 // Curve25519Public is an XDR Struct defines as:
 //
-//   struct Curve25519Public
-//    {
-//        opaque key[32];
-//    };
-//
+//	struct Curve25519Public
+//	 {
+//	     opaque key[32];
+//	 };
 type Curve25519Public struct {
 	Key [32]byte `xdrmaxsize:"32"`
 }
@@ -37312,11 +37013,10 @@ var _ xdrType = (*Curve25519Public)(nil)
 
 // HmacSha256Key is an XDR Struct defines as:
 //
-//   struct HmacSha256Key
-//    {
-//        opaque key[32];
-//    };
-//
+//	struct HmacSha256Key
+//	 {
+//	     opaque key[32];
+//	 };
 type HmacSha256Key struct {
 	Key [32]byte `xdrmaxsize:"32"`
 }
@@ -37373,11 +37073,10 @@ var _ xdrType = (*HmacSha256Key)(nil)
 
 // HmacSha256Mac is an XDR Struct defines as:
 //
-//   struct HmacSha256Mac
-//    {
-//        opaque mac[32];
-//    };
-//
+//	struct HmacSha256Mac
+//	 {
+//	     opaque mac[32];
+//	 };
 type HmacSha256Mac struct {
 	Mac [32]byte `xdrmaxsize:"32"`
 }


### PR DESCRIPTION
### What
[Go 1.19 is out](https://tip.golang.org/doc/go1.19), so we should support 1.18 and 1.19. 

### Why
We support the two latest stable Golang versions.

### Known limitations
n/a