### PR TITLE
exp/lighthorizon/services: Fetch ledgers in parallel to them being processed.

### DIFF
--- a/exp/lighthorizon/actions/accounts.go
+++ b/exp/lighthorizon/actions/accounts.go
@@ -62,7 +62,8 @@ func NewTXByAccountHandler(lightHorizon services.LightHorizon) func(http.Respons
 		page.Init()
 		page.FullURL = r.URL
 
-		txns, err := lightHorizon.Transactions.GetTransactionsByAccount(ctx, paginate.Cursor, paginate.Limit, accountId)
+		txns, err := lightHorizon.Transactions.GetTransactionsByAccount(ctx,
+			paginate.Cursor, paginate.Limit, accountId)
 		if err != nil {
 			log.Error(err)
 			sendErrorResponse(w, http.StatusInternalServerError, err.Error())

--- a/exp/lighthorizon/services/cursor.go
+++ b/exp/lighthorizon/services/cursor.go
@@ -10,6 +10,7 @@ import (
 type CursorManager interface {
 	Begin(cursor int64) (int64, error)
 	Advance() (int64, error)
+	Skip(count int) (int64, error)
 }
 
 type AccountActivityCursorManager struct {
@@ -88,6 +89,17 @@ func (c *AccountActivityCursorManager) Advance() (int64, error) {
 	}
 
 	return c.lastCursor.ToInt64(), nil
+}
+
+func (c *AccountActivityCursorManager) Skip(count int) (cursor int64, err error) {
+	for i := 1; i <= count; i++ {
+		cursor, err = c.Advance()
+		if err != nil {
+			return
+		}
+	}
+
+	return
 }
 
 var _ CursorManager = (*AccountActivityCursorManager)(nil) // ensure conformity to the interface

--- a/exp/lighthorizon/services/cursor.go
+++ b/exp/lighthorizon/services/cursor.go
@@ -10,7 +10,7 @@ import (
 type CursorManager interface {
 	Begin(cursor int64) (int64, error)
 	Advance() (int64, error)
-	Skip(count int) (int64, error)
+	Skip(count uint) (int64, error)
 }
 
 type AccountActivityCursorManager struct {
@@ -91,15 +91,17 @@ func (c *AccountActivityCursorManager) Advance() (int64, error) {
 	return c.lastCursor.ToInt64(), nil
 }
 
-func (c *AccountActivityCursorManager) Skip(count int) (cursor int64, err error) {
-	for i := 1; i <= count; i++ {
+func (c *AccountActivityCursorManager) Skip(count uint) (int64, error) {
+	var err error
+	cursor := c.lastCursor.ToInt64()
+	for i := uint(1); i <= count; i++ {
 		cursor, err = c.Advance()
 		if err != nil {
-			return
+			return cursor, err
 		}
 	}
 
-	return
+	return cursor, nil
 }
 
 var _ CursorManager = (*AccountActivityCursorManager)(nil) // ensure conformity to the interface

--- a/exp/lighthorizon/services/main.go
+++ b/exp/lighthorizon/services/main.go
@@ -205,7 +205,8 @@ func incrementAverage(prevAverage *time.Duration, latest time.Duration, newCount
 // `downloadWorkerCount` of them in parallel.
 //
 // It's the caller's responsibility to ensure that all of the goroutines in the
-// returned group have completed.
+// returned group have completed. In contrast, this function closes the output
+// channel when all work has been submitted (or the context errors).
 //
 // FIXME: Should this be a part of archive.Archive?
 func downloadLedgers(

--- a/exp/lighthorizon/services/main_test.go
+++ b/exp/lighthorizon/services/main_test.go
@@ -117,10 +117,10 @@ func mockArchiveAndIndex(ctx context.Context, passphrase string) (archive.Archiv
 	expectedLedger3Tx2 := testLedgerTx(source, 2, 34)
 
 	mockArchive.
-		On("GetLedger", ctx, uint32(1586112)).Return(expectedLedger1, nil).
-		On("GetLedger", ctx, uint32(1586113)).Return(expectedLedger2, nil).
-		On("GetLedger", ctx, uint32(1586114)).Return(expectedLedger3, nil).
-		On("GetLedger", ctx, mock.Anything).Return(xdr.LedgerCloseMeta{}, nil)
+		On("GetLedger", mock.Anything, uint32(1586112)).Return(expectedLedger1, nil).
+		On("GetLedger", mock.Anything, uint32(1586113)).Return(expectedLedger2, nil).
+		On("GetLedger", mock.Anything, uint32(1586114)).Return(expectedLedger3, nil).
+		On("GetLedger", mock.Anything, mock.Anything).Return(xdr.LedgerCloseMeta{}, nil)
 
 	mockArchive.
 		On("NewLedgerTransactionReaderFromLedgerCloseMeta", passphrase, expectedLedger1).Return(mockReaderLedger1, nil).

--- a/historyarchive/range.go
+++ b/historyarchive/range.go
@@ -134,6 +134,10 @@ func (r Range) InRange(sequence uint32) bool {
 	return sequence >= r.Low && sequence <= r.High
 }
 
+func (r Range) Size() uint32 {
+	return 1 + (r.High - r.Low)
+}
+
 type byUint32 []uint32
 
 func (a byUint32) Len() int           { return len(a) }


### PR DESCRIPTION
### What
This modifies the ledger download+processing code to download subsets of the entire checkpoint range in parallel. Preliminary testing suggests that this can **massively** reduce request latency.

Before:

> "GET http://localhost:8080/accounts/GBBJPGXTNNYBQGAIGONBFB6P7SUNO75GJEQ4Y7FVGMB2GPS3DJQVXSEP/transactions?cursor=179115963198013441&limit=10 HTTP/1.1" from 127.0.0.1:38834 - 200 199360B in **55.8414775s**

After:

> "GET http://localhost:8080/accounts/GBBJPGXTNNYBQGAIGONBFB6P7SUNO75GJEQ4Y7FVGMB2GPS3DJQVXSEP/transactions?cursor=179115963198013441&limit=10 HTTP/1.1" from 127.0.0.1:54188 - 200 199360B in **16.043121887s**

(Note that the indices are local and no on-disk cache was used.)

### Why
We can reduce latency by doing ledger downloads in parallel to processing. See #4468.

### Known limitations
Obviously, neither of these represent acceptable levels of latency if we're talking about _parity_ with classic Horizon. However, it's still a massive improvement over the previous code if we decide that high latency is acceptable for deeply historical requests.