### PR TITLE
exp/lighthorizon/services: Move service-specific stuff to its own file.

### DIFF
--- a/exp/lighthorizon/services/main.go
+++ b/exp/lighthorizon/services/main.go
@@ -3,13 +3,11 @@ package services
 import (
 	"context"
 	"io"
-	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stellar/go/exp/lighthorizon/archive"
-	"github.com/stellar/go/exp/lighthorizon/common"
 	"github.com/stellar/go/exp/lighthorizon/index"
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/xdr"
@@ -72,141 +70,10 @@ type Config struct {
 	Metrics    Metrics
 }
 
-type TransactionsService struct {
-	TransactionRepository
-	Config Config
-}
-
-type OperationsService struct {
-	OperationsRepository
-	Config Config
-}
-
-type OperationsRepository interface {
-	GetOperationsByAccount(ctx context.Context, cursor int64, limit uint64, accountId string) ([]common.Operation, error)
-}
-
-type TransactionRepository interface {
-	GetTransactionsByAccount(ctx context.Context, cursor int64, limit uint64, accountId string) ([]common.Transaction, error)
-}
-
 // searchCallback is a generic way for any endpoint to process a transaction and
 // its corresponding ledger. It should return whether or not we should stop
 // processing (e.g. when a limit is reached) and any error that occurred.
 type searchCallback func(archive.LedgerTransaction, *xdr.LedgerHeader) (finished bool, err error)
-
-func operationsResponseAgeSeconds(ops []common.Operation) float64 {
-	if len(ops) == 0 {
-		return -1
-	}
-
-	oldest := ops[0].LedgerHeader.ScpValue.CloseTime
-	for i := 1; i < len(ops); i++ {
-		if closeTime := ops[i].LedgerHeader.ScpValue.CloseTime; closeTime < oldest {
-			oldest = closeTime
-		}
-	}
-
-	lastCloseTime := time.Unix(int64(oldest), 0).UTC()
-	now := time.Now().UTC()
-	if now.Before(lastCloseTime) {
-		log.Errorf("current time %v is before oldest operation close time %v", now, lastCloseTime)
-		return -1
-	}
-	return now.Sub(lastCloseTime).Seconds()
-}
-
-func (os *OperationsService) GetOperationsByAccount(ctx context.Context,
-	cursor int64, limit uint64,
-	accountId string,
-) ([]common.Operation, error) {
-	ops := []common.Operation{}
-
-	opsCallback := func(tx archive.LedgerTransaction, ledgerHeader *xdr.LedgerHeader) (bool, error) {
-		for operationOrder, op := range tx.Envelope.Operations() {
-			opParticipants, err := os.Config.Archive.GetOperationParticipants(tx, op, operationOrder)
-			if err != nil {
-				return false, err
-			}
-
-			if _, foundInOp := opParticipants[accountId]; foundInOp {
-				ops = append(ops, common.Operation{
-					TransactionEnvelope: &tx.Envelope,
-					TransactionResult:   &tx.Result.Result,
-					LedgerHeader:        ledgerHeader,
-					TxIndex:             int32(tx.Index),
-					OpIndex:             int32(operationOrder),
-				})
-
-				if uint64(len(ops)) == limit {
-					return true, nil
-				}
-			}
-		}
-
-		return false, nil
-	}
-
-	err := searchAccountTransactions(ctx, cursor, accountId, os.Config, opsCallback)
-	if age := operationsResponseAgeSeconds(ops); age >= 0 {
-		os.Config.Metrics.ResponseAgeHistogram.With(prometheus.Labels{
-			"request":    "GetOperationsByAccount",
-			"successful": strconv.FormatBool(err == nil),
-		}).Observe(age)
-	}
-
-	return ops, err
-}
-
-func transactionsResponseAgeSeconds(txs []common.Transaction) float64 {
-	if len(txs) == 0 {
-		return -1
-	}
-
-	oldest := txs[0].LedgerHeader.ScpValue.CloseTime
-	for i := 1; i < len(txs); i++ {
-		if closeTime := txs[i].LedgerHeader.ScpValue.CloseTime; closeTime < oldest {
-			oldest = closeTime
-		}
-	}
-
-	lastCloseTime := time.Unix(int64(oldest), 0).UTC()
-	now := time.Now().UTC()
-	if now.Before(lastCloseTime) {
-		log.Errorf("current time %v is before oldest transaction close time %v", now, lastCloseTime)
-		return -1
-	}
-	return now.Sub(lastCloseTime).Seconds()
-}
-
-func (ts *TransactionsService) GetTransactionsByAccount(ctx context.Context,
-	cursor int64, limit uint64,
-	accountId string,
-) ([]common.Transaction, error) {
-	txs := []common.Transaction{}
-
-	txsCallback := func(tx archive.LedgerTransaction, ledgerHeader *xdr.LedgerHeader) (bool, error) {
-		txs = append(txs, common.Transaction{
-			TransactionEnvelope: &tx.Envelope,
-			TransactionResult:   &tx.Result.Result,
-			LedgerHeader:        ledgerHeader,
-			TxIndex:             int32(tx.Index),
-			NetworkPassphrase:   ts.Config.Passphrase,
-		})
-
-		return uint64(len(txs)) == limit, nil
-	}
-
-	err := searchAccountTransactions(ctx, cursor, accountId, ts.Config, txsCallback)
-	if age := transactionsResponseAgeSeconds(txs); age >= 0 {
-		ts.Config.Metrics.ResponseAgeHistogram.With(prometheus.Labels{
-			"request":    "GetTransactionsByAccount",
-			"successful": strconv.FormatBool(err == nil),
-		}).Observe(age)
-	}
-
-	return txs, err
-}
 
 func searchAccountTransactions(ctx context.Context,
 	cursor int64,

--- a/exp/lighthorizon/services/operations.go
+++ b/exp/lighthorizon/services/operations.go
@@ -12,21 +12,16 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-type OperationsService struct {
-	OperationsRepository
-	Config Config
-}
-
 type OperationsRepository interface {
 	GetOperationsByAccount(ctx context.Context,
 		cursor int64, limit uint64,
 		accountId string,
 	) ([]common.Operation, error)
+}
 
-	GetPaymentsByAccount(ctx context.Context,
-		cursor int64, limit uint64,
-		accountId string,
-	) ([]common.Operation, error)
+type OperationsService struct {
+	OperationsRepository
+	Config Config
 }
 
 func (os *OperationsService) GetOperationsByAccount(ctx context.Context,
@@ -91,3 +86,5 @@ func operationsResponseAgeSeconds(ops []common.Operation) float64 {
 	}
 	return now.Sub(lastCloseTime).Seconds()
 }
+
+var _ OperationsRepository = (*OperationsService)(nil) // ensure conformity to the interface

--- a/exp/lighthorizon/services/operations.go
+++ b/exp/lighthorizon/services/operations.go
@@ -1,0 +1,93 @@
+package services
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go/exp/lighthorizon/archive"
+	"github.com/stellar/go/exp/lighthorizon/common"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/go/xdr"
+)
+
+type OperationsService struct {
+	OperationsRepository
+	Config Config
+}
+
+type OperationsRepository interface {
+	GetOperationsByAccount(ctx context.Context,
+		cursor int64, limit uint64,
+		accountId string,
+	) ([]common.Operation, error)
+
+	GetPaymentsByAccount(ctx context.Context,
+		cursor int64, limit uint64,
+		accountId string,
+	) ([]common.Operation, error)
+}
+
+func (os *OperationsService) GetOperationsByAccount(ctx context.Context,
+	cursor int64, limit uint64,
+	accountId string,
+) ([]common.Operation, error) {
+	ops := []common.Operation{}
+
+	opsCallback := func(tx archive.LedgerTransaction, ledgerHeader *xdr.LedgerHeader) (bool, error) {
+		for operationOrder, op := range tx.Envelope.Operations() {
+			opParticipants, err := os.Config.Archive.GetOperationParticipants(tx, op, operationOrder)
+			if err != nil {
+				return false, err
+			}
+
+			if _, foundInOp := opParticipants[accountId]; foundInOp {
+				ops = append(ops, common.Operation{
+					TransactionEnvelope: &tx.Envelope,
+					TransactionResult:   &tx.Result.Result,
+					LedgerHeader:        ledgerHeader,
+					TxIndex:             int32(tx.Index),
+					OpIndex:             int32(operationOrder),
+				})
+
+				if uint64(len(ops)) == limit {
+					return true, nil
+				}
+			}
+		}
+
+		return false, nil
+	}
+
+	err := searchAccountTransactions(ctx, cursor, accountId, os.Config, opsCallback)
+	if age := operationsResponseAgeSeconds(ops); age >= 0 {
+		os.Config.Metrics.ResponseAgeHistogram.With(prometheus.Labels{
+			"request":    "GetOperationsByAccount",
+			"successful": strconv.FormatBool(err == nil),
+		}).Observe(age)
+	}
+
+	return ops, err
+}
+
+func operationsResponseAgeSeconds(ops []common.Operation) float64 {
+	if len(ops) == 0 {
+		return -1
+	}
+
+	oldest := ops[0].LedgerHeader.ScpValue.CloseTime
+	for i := 1; i < len(ops); i++ {
+		if closeTime := ops[i].LedgerHeader.ScpValue.CloseTime; closeTime < oldest {
+			oldest = closeTime
+		}
+	}
+
+	lastCloseTime := time.Unix(int64(oldest), 0).UTC()
+	now := time.Now().UTC()
+	if now.Before(lastCloseTime) {
+		log.Errorf("current time %v is before oldest operation close time %v", now, lastCloseTime)
+		return -1
+	}
+	return now.Sub(lastCloseTime).Seconds()
+}

--- a/exp/lighthorizon/services/transactions.go
+++ b/exp/lighthorizon/services/transactions.go
@@ -1,0 +1,75 @@
+package services
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go/exp/lighthorizon/archive"
+	"github.com/stellar/go/exp/lighthorizon/common"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/go/xdr"
+)
+
+type TransactionsService struct {
+	TransactionRepository
+	Config Config
+}
+
+type TransactionRepository interface {
+	GetTransactionsByAccount(ctx context.Context,
+		cursor int64, limit uint64,
+		accountId string,
+	) ([]common.Transaction, error)
+}
+
+func (ts *TransactionsService) GetTransactionsByAccount(ctx context.Context,
+	cursor int64, limit uint64,
+	accountId string,
+) ([]common.Transaction, error) {
+	txs := []common.Transaction{}
+
+	txsCallback := func(tx archive.LedgerTransaction, ledgerHeader *xdr.LedgerHeader) (bool, error) {
+		txs = append(txs, common.Transaction{
+			TransactionEnvelope: &tx.Envelope,
+			TransactionResult:   &tx.Result.Result,
+			LedgerHeader:        ledgerHeader,
+			TxIndex:             int32(tx.Index),
+			NetworkPassphrase:   ts.Config.Passphrase,
+		})
+
+		return uint64(len(txs)) == limit, nil
+	}
+
+	err := searchAccountTransactions(ctx, cursor, accountId, ts.Config, txsCallback)
+	if age := transactionsResponseAgeSeconds(txs); age >= 0 {
+		ts.Config.Metrics.ResponseAgeHistogram.With(prometheus.Labels{
+			"request":    "GetTransactionsByAccount",
+			"successful": strconv.FormatBool(err == nil),
+		}).Observe(age)
+	}
+
+	return txs, err
+}
+
+func transactionsResponseAgeSeconds(txs []common.Transaction) float64 {
+	if len(txs) == 0 {
+		return -1
+	}
+
+	oldest := txs[0].LedgerHeader.ScpValue.CloseTime
+	for i := 1; i < len(txs); i++ {
+		if closeTime := txs[i].LedgerHeader.ScpValue.CloseTime; closeTime < oldest {
+			oldest = closeTime
+		}
+	}
+
+	lastCloseTime := time.Unix(int64(oldest), 0).UTC()
+	now := time.Now().UTC()
+	if now.Before(lastCloseTime) {
+		log.Errorf("current time %v is before oldest transaction close time %v", now, lastCloseTime)
+		return -1
+	}
+	return now.Sub(lastCloseTime).Seconds()
+}

--- a/exp/lighthorizon/services/transactions.go
+++ b/exp/lighthorizon/services/transactions.go
@@ -73,3 +73,5 @@ func transactionsResponseAgeSeconds(txs []common.Transaction) float64 {
 	}
 	return now.Sub(lastCloseTime).Seconds()
 }
+
+var _ TransactionRepository = (*TransactionsService)(nil) // ensure conformity to the interface


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
This moves transaction-related stuff to `./services/transactions.go` and operation-related stuff to `./services/operations.go`.

### Why
Better readability via code grouping.
