### PR TITLE
exp/lighhorizon: Make indexing s3 bucket configurable

### DIFF
--- a/exp/lighthorizon/index/builder.go
+++ b/exp/lighthorizon/index/builder.go
@@ -34,7 +34,7 @@ func BuildIndices(
 	L := log.Ctx(ctx).WithField("service", "builder")
 
 	indexStore, err := ConnectWithConfig(StoreConfig{
-		Url:     targetUrl,
+		URL:     targetUrl,
 		Workers: uint32(workerCount),
 		Log:     L.WithField("subservice", "index"),
 	})

--- a/exp/lighthorizon/index/store.go
+++ b/exp/lighthorizon/index/store.go
@@ -38,7 +38,7 @@ type Store interface {
 
 type StoreConfig struct {
 	// init time config
-	Url     string
+	URL     string
 	Workers uint32
 
 	// runtime config

--- a/exp/lighthorizon/main.go
+++ b/exp/lighthorizon/main.go
@@ -34,7 +34,7 @@ if left empty, uses a temporary directory`)
 
 	registry := prometheus.NewRegistry()
 	indexStore, err := index.ConnectWithConfig(index.StoreConfig{
-		Url:     *indexesUrl,
+		URL:     *indexesUrl,
 		Log:     L.WithField("subservice", "index"),
 		Metrics: registry,
 	})

--- a/exp/lighthorizon/services/cursor_test.go
+++ b/exp/lighthorizon/services/cursor_test.go
@@ -21,10 +21,13 @@ func TestAccountTransactionCursorManager(t *testing.T) {
 	accountId := keypair.MustRandom().Address()
 
 	// Create an index and fill it with some checkpoint details.
-	store, err := index.NewFileStore(index.StoreConfig{
-		Url:     "file://" + t.TempDir(),
-		Workers: 4,
-	})
+	tmp := t.TempDir()
+	store, err := index.NewFileStore(tmp,
+		index.StoreConfig{
+			URL:     "file://" + tmp,
+			Workers: 4,
+		},
+	)
 	require.NoError(t, err)
 
 	for _, checkpoint := range []uint32{1, 5, 10} {


### PR DESCRIPTION
Closes #4504 

Also, 

* Renames Url to URL
* stops the abuse of `StoreConfig.URL` which I don't think should be overwritten 