### PR TITLE
exp/lighthorizon: Add JSON content type to responses.

### DIFF
--- a/exp/lighthorizon/actions/main.go
+++ b/exp/lighthorizon/actions/main.go
@@ -61,6 +61,8 @@ func sendPageResponse(w http.ResponseWriter, page hal.Page) {
 	if err != nil {
 		log.Error(err)
 		sendErrorResponse(w, http.StatusInternalServerError, "")
+	} else {
+		w.Header().Set("Content-Type", "application/openapi+yaml")
 	}
 }
 

--- a/exp/lighthorizon/actions/main.go
+++ b/exp/lighthorizon/actions/main.go
@@ -62,7 +62,7 @@ func sendPageResponse(w http.ResponseWriter, page hal.Page) {
 		log.Error(err)
 		sendErrorResponse(w, http.StatusInternalServerError, "")
 	} else {
-		w.Header().Set("Content-Type", "application/openapi+yaml")
+		w.Header().Set("Content-Type", "application/hal+json; charset=utf-8")
 	}
 }
 


### PR DESCRIPTION
### What
Adds JSON `Content-Type` header to responses to render correctly.

### Why
self-explanatory
