### PR TITLE
exp/lighthorizon: *Correctly* set `Content-Type`, plus JSONify errors

### DIFF
--- a/exp/lighthorizon/actions/main.go
+++ b/exp/lighthorizon/actions/main.go
@@ -3,7 +3,6 @@ package actions
 import (
 	"embed"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -71,8 +70,22 @@ func sendErrorResponse(w http.ResponseWriter, errorCode int, errorMsg string) {
 	}
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(errorCode)
-	w.Write([]byte(fmt.Sprintf("{'error': '%s', 'status': %d}", errorMsg, errorCode)))
+
+	// TODO: Use Horizon's existing Problem
+	errBlob := struct {
+		Message string `json:"error"`
+		Status  int    `json:"status"`
+	}{
+		Message: errorMsg,
+		Status:  errorCode,
+	}
+
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(errBlob); err != nil {
+		log.Error(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func requestUnaryParam(r *http.Request, paramName string) (string, error) {

--- a/exp/lighthorizon/actions/main.go
+++ b/exp/lighthorizon/actions/main.go
@@ -55,23 +55,24 @@ type pagination struct {
 }
 
 func sendPageResponse(w http.ResponseWriter, page hal.Page) {
+	w.Header().Set("Content-Type", "application/hal+json; charset=utf-8")
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
 	err := encoder.Encode(page)
 	if err != nil {
 		log.Error(err)
 		sendErrorResponse(w, http.StatusInternalServerError, "")
-	} else {
-		w.Header().Set("Content-Type", "application/hal+json; charset=utf-8")
 	}
 }
 
 func sendErrorResponse(w http.ResponseWriter, errorCode int, errorMsg string) {
-	if errorMsg != "" {
-		http.Error(w, fmt.Sprintf("Error: %s", errorMsg), errorCode)
-	} else {
-		http.Error(w, string(serverError), errorCode)
+	if errorMsg == "" {
+		errorMsg = string(serverError)
 	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(errorCode)
+	w.Write([]byte(fmt.Sprintf("{'error': '%s', 'status': %d}", errorMsg, errorCode)))
 }
 
 func requestUnaryParam(r *http.Request, paramName string) (string, error) {


### PR DESCRIPTION
### What
This sets the content-type at the right time and also makes error messages proper JSON.

### Why
The headers can't be set after `Write()` is called on `w`.