### PR TITLE
services/horizon: Remove unstable apt repo from verify-range

### DIFF
--- a/services/horizon/docker/verify-range/dependencies
+++ b/services/horizon/docker/verify-range/dependencies
@@ -7,7 +7,7 @@ apt-get clean
 
 wget -qO - https://apt.stellar.org/SDF.asc | apt-key add -
 echo "deb https://apt.stellar.org $(lsb_release -cs) stable" | sudo tee -a /etc/apt/sources.list.d/SDF.list
-echo "deb https://apt.stellar.org $(lsb_release -cs) unstable" | sudo tee -a /etc/apt/sources.list.d/SDF-unstable.list
+# echo "deb https://apt.stellar.org $(lsb_release -cs) unstable" | sudo tee -a /etc/apt/sources.list.d/SDF-unstable.list
 apt-get update
 apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Temporarily remove unstable apt repo from verify-range.

### Why

The latest build of `stellar-core` in unstable throws:
```
default: Got an exception: bad value of v in _ext_t
```
when running catchup command on specific ledger ranges [1].

[1] https://github.com/stellar/go/runs/7728721193?check_suite_focus=true

### Known limitations

[TODO or N/A]
