### PR TITLE
all: Add a generic 'complete' job for PR pass criteria flexibility.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
 
 jobs:
+  go-complete:
+    if: always()
+    needs: [check, build, test]
+    runs-on: ubuntu-latest
+    steps:
+    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      run: exit 1
 
   check:
     strategy:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  go-complete:
+  complete:
     if: always()
     needs: [check, build, test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What
This adds a `go-complete` (prefixed in case we want to add e.g. a `horizon-complete` in the future) job that encompasses all of the Go-related checks into one job.

### Why
It makes it easier to control which jobs are "required" for a PR to be merged. Additional context from @leighmcculloch is [here](https://github.com/stellar/terraform/pull/892#discussion_r942737090).

### Known limitations
n/a
