### PR TITLE
Incorporate generics into Light Horizon code

### DIFF
--- a/exp/lighthorizon/archive/ingest_archive.go
+++ b/exp/lighthorizon/archive/ingest_archive.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/ingest/ledgerbackend"
 	"github.com/stellar/go/metaarchive"
+	"github.com/stellar/go/support/collections/set"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/storage"
@@ -95,30 +96,26 @@ func (a ingestArchive) NewLedgerTransactionReaderFromLedgerCloseMeta(networkPass
 	return &ingestTransactionReaderAdaption{ingestReader}, nil
 }
 
-func (a ingestArchive) GetTransactionParticipants(transaction LedgerTransaction) (map[string]struct{}, error) {
-	participants, err := index.GetTransactionParticipants(a.ingestTx(transaction))
+func (a ingestArchive) GetTransactionParticipants(tx LedgerTransaction) (set.Set[string], error) {
+	participants, err := index.GetTransactionParticipants(a.ingestTx(tx))
 	if err != nil {
 		return nil, err
 	}
-	set := make(map[string]struct{})
-	exists := struct{}{}
-	for _, participant := range participants {
-		set[participant] = exists
-	}
-	return set, nil
+
+	s := set.NewSet[string](len(participants))
+	s.AddSlice(participants)
+	return s, nil
 }
 
-func (a ingestArchive) GetOperationParticipants(transaction LedgerTransaction, operation xdr.Operation, opIndex int) (map[string]struct{}, error) {
-	participants, err := index.GetOperationParticipants(a.ingestTx(transaction), operation, opIndex)
+func (a ingestArchive) GetOperationParticipants(tx LedgerTransaction, op xdr.Operation, opIndex int) (set.Set[string], error) {
+	participants, err := index.GetOperationParticipants(a.ingestTx(tx), op, opIndex)
 	if err != nil {
 		return nil, err
 	}
-	set := make(map[string]struct{})
-	exists := struct{}{}
-	for _, participant := range participants {
-		set[participant] = exists
-	}
-	return set, nil
+
+	s := set.NewSet[string](len(participants))
+	s.AddSlice(participants)
+	return s, nil
 }
 
 func (ingestArchive) ingestTx(transaction LedgerTransaction) ingest.LedgerTransaction {

--- a/exp/lighthorizon/archive/main.go
+++ b/exp/lighthorizon/archive/main.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"context"
 
+	"github.com/stellar/go/support/collections/set"
 	"github.com/stellar/go/xdr"
 )
 
@@ -49,10 +50,10 @@ type Archive interface {
 
 	// GetTransactionParticipants - takes a LedgerTransaction and returns a set of all
 	// participants(accounts) in the transaction. If there is any error, it will return nil and the error.
-	GetTransactionParticipants(transaction LedgerTransaction) (map[string]struct{}, error)
+	GetTransactionParticipants(tx LedgerTransaction) (set.Set[string], error)
 
 	// GetOperationParticipants - takes a LedgerTransaction, the Operation within the transaction, and
 	// the 0 based index of the operation within the transaction. It will return a set of all participants(accounts)
 	// in the operation. If there is any error, it will return nil and the error.
-	GetOperationParticipants(transaction LedgerTransaction, operation xdr.Operation, opIndex int) (map[string]struct{}, error)
+	GetOperationParticipants(tx LedgerTransaction, op xdr.Operation, opIndex int) (set.Set[string], error)
 }

--- a/exp/lighthorizon/archive/mock_archive.go
+++ b/exp/lighthorizon/archive/mock_archive.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"context"
 
+	"github.com/stellar/go/support/collections/set"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
 )
@@ -35,12 +36,12 @@ func (m *MockArchive) NewLedgerTransactionReaderFromLedgerCloseMeta(networkPassp
 	return args.Get(0).(LedgerTransactionReader), args.Error(1)
 }
 
-func (m *MockArchive) GetTransactionParticipants(transaction LedgerTransaction) (map[string]struct{}, error) {
-	args := m.Called(transaction)
-	return args.Get(0).(map[string]struct{}), args.Error(1)
+func (m *MockArchive) GetTransactionParticipants(tx LedgerTransaction) (set.Set[string], error) {
+	args := m.Called(tx)
+	return args.Get(0).(set.Set[string]), args.Error(1)
 }
 
-func (m *MockArchive) GetOperationParticipants(transaction LedgerTransaction, operation xdr.Operation, opIndex int) (map[string]struct{}, error) {
-	args := m.Called(transaction, operation, opIndex)
-	return args.Get(0).(map[string]struct{}), args.Error(1)
+func (m *MockArchive) GetOperationParticipants(tx LedgerTransaction, op xdr.Operation, opIndex int) (set.Set[string], error) {
+	args := m.Called(tx, op, opIndex)
+	return args.Get(0).(set.Set[string]), args.Error(1)
 }

--- a/exp/lighthorizon/index/backend/file.go
+++ b/exp/lighthorizon/index/backend/file.go
@@ -10,6 +10,7 @@ import (
 
 	types "github.com/stellar/go/exp/lighthorizon/index/types"
 
+	"github.com/stellar/go/support/collections/set"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
 )
@@ -157,7 +158,7 @@ func (s *FileBackend) ReadAccounts() ([]string, error) {
 		// Note that this will never be too large, but may be too small.
 		preallocationSize = int(info.Size()) / (gAddressSize + 1) // +1 for \n
 	}
-	accountMap := make(map[string]struct{}, preallocationSize)
+	accountMap := set.NewSet[string](preallocationSize)
 	accounts := make([]string, 0, preallocationSize)
 
 	reader := bufio.NewReaderSize(f, 100*gAddressSize) // reasonable buffer size
@@ -173,8 +174,8 @@ func (s *FileBackend) ReadAccounts() ([]string, error) {
 
 		// The account list is very unlikely to be unique (especially if it was made
 		// w/ parallel flushes), so let's ensure that that's the case.
-		if _, ok := accountMap[account]; !ok {
-			accountMap[account] = struct{}{}
+		if !accountMap.Contains(account) {
+			accountMap.Add(account)
 			accounts = append(accounts, account)
 		}
 	}

--- a/exp/lighthorizon/services/main_test.go
+++ b/exp/lighthorizon/services/main_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stellar/go/exp/lighthorizon/archive"
 	"github.com/stellar/go/exp/lighthorizon/index"
+	"github.com/stellar/go/support/collections/set"
 	"github.com/stellar/go/toid"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/mock"
@@ -128,12 +129,12 @@ func mockArchiveAndIndex(ctx context.Context, passphrase string) (archive.Archiv
 		On("NewLedgerTransactionReaderFromLedgerCloseMeta", passphrase, expectedLedger3).Return(mockReaderLedger3, nil).
 		On("NewLedgerTransactionReaderFromLedgerCloseMeta", passphrase, mock.Anything).Return(mockReaderLedgerTheRest, nil)
 
-	partialParticipants := make(map[string]struct{})
-	partialParticipants[source.Address()] = struct{}{}
+	partialParticipants := set.Set[string]{}
+	partialParticipants.Add(source.Address())
 
-	allParticipants := make(map[string]struct{})
-	allParticipants[source.Address()] = struct{}{}
-	allParticipants[source2.Address()] = struct{}{}
+	allParticipants := set.Set[string]{}
+	allParticipants.Add(source.Address())
+	allParticipants.Add(source2.Address())
 
 	mockArchive.
 		On("GetTransactionParticipants", expectedLedger1Tx1).Return(partialParticipants, nil).

--- a/support/collections/maps/map.go
+++ b/support/collections/maps/map.go
@@ -1,0 +1,17 @@
+package maps
+
+func Keys[T comparable, U any](m map[T]U) []T {
+	keys := make([]T, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func Values[T comparable, U any](m map[T]U) []U {
+	values := make([]U, 0, len(m))
+	for _, value := range m {
+		values = append(values, value)
+	}
+	return values
+}

--- a/support/collections/maps/map_test.go
+++ b/support/collections/maps/map_test.go
@@ -1,0 +1,22 @@
+package maps
+
+import (
+	"testing"
+
+	"github.com/stellar/go/support/collections/set"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanity(t *testing.T) {
+	m := map[int]float32{1: 10, 2: 20, 3: 30}
+	require.Equal(t, []int{1, 2, 3}, Keys(m))
+	require.Equal(t, []float32{10, 20, 30}, Values(m))
+
+	// compatibility with collections/set.Set
+	s := set.Set[float32]{}
+	s.Add(1)
+	s.Add(2)
+	s.Add(3)
+
+	require.Equal(t, []float32{1, 2, 3}, Keys(s))
+}

--- a/support/collections/maps/map_test.go
+++ b/support/collections/maps/map_test.go
@@ -9,8 +9,10 @@ import (
 
 func TestSanity(t *testing.T) {
 	m := map[int]float32{1: 10, 2: 20, 3: 30}
-	require.Equal(t, []int{1, 2, 3}, Keys(m))
-	require.Equal(t, []float32{10, 20, 30}, Values(m))
+	for k, v := range m {
+		require.Contains(t, Keys(m), k)
+		require.Contains(t, Values(m), v)
+	}
 
 	// compatibility with collections/set.Set
 	s := set.Set[float32]{}
@@ -18,5 +20,7 @@ func TestSanity(t *testing.T) {
 	s.Add(2)
 	s.Add(3)
 
-	require.Equal(t, []float32{1, 2, 3}, Keys(s))
+	for item := range s {
+		require.Contains(t, Keys(s), item)
+	}
 }

--- a/support/collections/set/set.go
+++ b/support/collections/set/set.go
@@ -10,6 +10,12 @@ func (set Set[T]) Add(item T) {
 	set[item] = struct{}{}
 }
 
+func (set Set[T]) AddSlice(items []T) {
+	for _, item := range items {
+		set[item] = struct{}{}
+	}
+}
+
 func (set Set[T]) Remove(item T) {
 	delete(set, item)
 }


### PR DESCRIPTION
### What
Incorporate `set.Set[T]` into the codebase and introduce a new `Keys` for `map`s.

### Why
Forcing users to use `map[string]struct{}` as a set structure in 2022 is absurd.

### Known limitations
None, generics are amazing.