### PR TITLE
exp/lighthorizon/build: bump go version to 18 on lighthorizon docker images, they need it now

### DIFF
--- a/exp/lighthorizon/build/index-batch/Dockerfile
+++ b/exp/lighthorizon/build/index-batch/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS builder
+FROM golang:1.18 AS builder
 
 WORKDIR /go/src/github.com/stellar/go
 COPY . ./

--- a/exp/lighthorizon/build/index-single/Dockerfile
+++ b/exp/lighthorizon/build/index-single/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS builder
+FROM golang:1.18 AS builder
 
 WORKDIR /go/src/github.com/stellar/go
 COPY . ./

--- a/exp/lighthorizon/build/web/Dockerfile
+++ b/exp/lighthorizon/build/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS builder
+FROM golang:1.18 AS builder
 
 WORKDIR /go/src/github.com/stellar/go
 COPY . ./


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

bump go version on the lighthorizon dockers to 18

### Why

some of app code is now using go 18 aspects.

### Known limitations


