### PR TITLE
services/horizon: Fix check_release_hash in Golang 1.18+

### DIFF
--- a/services/horizon/internal/scripts/check_release_hash/Dockerfile
+++ b/services/horizon/internal/scripts/check_release_hash/Dockerfile
@@ -1,5 +1,5 @@
 # Change to Go version used in CI or rebuild with --build-arg.
-ARG GO_IMAGE=golang:1.18
+ARG GO_IMAGE=golang:1.19
 FROM $GO_IMAGE
 
 WORKDIR /go/src/github.com/stellar/go

--- a/services/horizon/internal/scripts/check_release_hash/check.sh
+++ b/services/horizon/internal/scripts/check_release_hash/check.sh
@@ -20,6 +20,14 @@ unzip $TAG-windows-amd64.zip
 
 cd -
 
+# Since Go 1.18 vcs (git) info is added to the binary. One of the values is:
+# vcs.modified which determines if git working dir is clean. We need to
+# specifically add the files below to .gitignore to make git ignore them.
+touch ~/.gitignore
+echo -e "check.sh\n" >> ~/.gitignore
+echo -e "released/\n" >> ~/.gitignore
+git config --global core.excludesFile '~/.gitignore'
+
 git pull origin --tags
 git checkout $TAG
 # -keep: artifact directories are not removed after packaging


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Ensure the git working dir in `check_release_hash` image is clean.

### Why

Starting from the Go 1.18 [release notes](https://tip.golang.org/doc/go1.18):
> The go command now embeds version control information in binaries. It includes the currently checked-out revision, commit time, and a flag indicating whether edited or untracked files are present. Version control information is embedded if the go command is invoked in a directory within a Git, Mercurial, Fossil, or Bazaar repository, and the main package and its containing main module are in the same repository. This information may be omitted using the flag -buildvcs=false.

Go binaries now embed git state information in `vcs` map. One of the fields: `vcs.modified` is set to `true` if working dir is not clear, `false` otherwise. This can break builds reproducibility if Horizon is built in a dirty dir.

### Known limitations

[TODO or N/A]
