### PR TITLE
services/horizon: Skip integration tests when no changes

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -100,7 +100,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ./horizon
-        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('./services/horizon/internal/integration/**') }}
+        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('./services/horizon/**/*_test.go') }}
 
     - if: ${{ steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
       run: go test -race -timeout 25m -v ./services/horizon/internal/integration/...

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -94,13 +94,14 @@ jobs:
     - name: Build Horizon reproducible build
       run: |
         go build -v -trimpath -buildvcs=false ./services/horizon
+        touch empty
 
     - name: Save Horizon binary and integration tests source hash to cache
       id: horizon_binary_tests_hash
       uses: actions/cache@v3
       with:
-        path: ./horizon
-        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('./services/horizon/internal/integration/**') }}-${{ env.PROTOCOL_19_CORE_DOCKER_IMG }}-${{ env.PROTOCOL_18_CORE_DOCKER_IMG }}
+        path: ./empty
+        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('./clients/horizonclient/**') }}-${{ hashFiles('./protocols/horizon/**') }}-${{ hashFiles('./services/horizon/internal/integration/**') }}-${{ env.PROTOCOL_19_CORE_DOCKER_IMG }}-${{ env.PROTOCOL_18_CORE_DOCKER_IMG }}
 
     - if: ${{ steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
       run: go test -race -timeout 25m -v ./services/horizon/internal/integration/...

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -100,7 +100,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ./horizon
-        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('/usr/bin/stellar-core') }}-${{ hashFiles('./services/horizon/**/*_test.go') }}
+        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('./services/horizon/internal/integration/**') }}
 
     - if: ${{ steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
       run: go test -race -timeout 25m -v ./services/horizon/internal/integration/...

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -93,7 +93,7 @@ jobs:
 
     - name: Build Horizon reproducible build
       run: |
-        go build -v -buildvcs=false ./services/horizon
+        go build -v -trimpath -buildvcs=false ./services/horizon
 
     - name: Save Horizon binary and integration tests source hash to cache
       id: horizon_binary_tests_hash

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -100,7 +100,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ./horizon
-        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('./services/horizon/**/*_test.go') }}
+        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('/usr/bin/stellar-core') }}-${{ hashFiles('./services/horizon/**/*_test.go') }}
 
     - if: ${{ steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
       run: go test -race -timeout 25m -v ./services/horizon/internal/integration/...

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -101,7 +101,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ./empty
-        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('./clients/horizonclient/**') }}-${{ hashFiles('./protocols/horizon/**') }}-${{ hashFiles('./services/horizon/internal/integration/**') }}-${{ env.PROTOCOL_19_CORE_DOCKER_IMG }}-${{ env.PROTOCOL_18_CORE_DOCKER_IMG }}
+        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('./clients/horizonclient/**') }}-${{ hashFiles('./protocols/horizon/**') }}-${{ hashFiles('./txnbuild/**') }}-${{ hashFiles('./services/horizon/internal/integration/**') }}-${{ env.PROTOCOL_19_CORE_DOCKER_IMG }}-${{ env.PROTOCOL_18_CORE_DOCKER_IMG }}
 
     - if: ${{ steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
       run: go test -race -timeout 25m -v ./services/horizon/internal/integration/...

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -91,7 +91,19 @@ jobs:
       name: Setup Captive Core Remote Storage
       run: echo 'HORIZON_INTEGRATION_TESTS_CAPTIVE_CORE_USE_DB=true' >> $GITHUB_ENV
 
-    - run: go test -race -timeout 25m -v ./services/horizon/internal/integration/...
+    - name: Build Horizon reproducible build
+      run: |
+        go build -buildvcs=false ./services/horizon
+
+    - name: Save Horizon binary and integration tests source hash to cache
+      id: horizon_binary_tests_hash
+      uses: actions/cache@v3
+      with:
+        path: ./horizon
+        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('./services/horizon/internal/integration/...') }}
+
+    - if: ${{ steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
+      run: go test -race -timeout 25m -v ./services/horizon/internal/integration/...
 
   verify-range:
     name: Test (and push) verify-range image

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -100,7 +100,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ./horizon
-        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('./services/horizon/internal/integration/**') }}
+        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('./services/horizon/internal/integration/**') }}-${{ env.PROTOCOL_19_CORE_DOCKER_IMG }}-${{ env.PROTOCOL_18_CORE_DOCKER_IMG }}
 
     - if: ${{ steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
       run: go test -race -timeout 25m -v ./services/horizon/internal/integration/...

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -93,14 +93,14 @@ jobs:
 
     - name: Build Horizon reproducible build
       run: |
-        go build -buildvcs=false ./services/horizon
+        go build -v -buildvcs=false ./services/horizon
 
     - name: Save Horizon binary and integration tests source hash to cache
       id: horizon_binary_tests_hash
       uses: actions/cache@v3
       with:
         path: ./horizon
-        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('./services/horizon/internal/integration/...') }}
+        key: horizon-hash-${{ hashFiles('./horizon') }}-${{ hashFiles('./services/horizon/internal/integration/**') }}
 
     - if: ${{ steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
       run: go test -race -timeout 25m -v ./services/horizon/internal/integration/...


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Skip integration test if they have already passed for the `[hash of horizon binary, hash of horizon integration tests files, p19 core docker image name, p18 core docker image name]` set. The solution leverages `actions/cache@v3` action to store the hash between workflow runs.

### Why

Integration tests usually take more than 25 minutes and will take more if more tests are added in the future. Very often PR in `stellar/go` are not connected to Horizon or change docs. In such case there is no reason to run integration tests.

### Known limitations

I added extended `integration` job just before tests are executed and I use:
```yaml
if: ${{ steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
````
condition in the last run which starts integration tests. This means all of the steps before that like downloading and installing Stellar-Core are executed. The reason for this is that it's impossible to stop Github actions workflow at any job with success result. The run must either fail or all consecutive runs must contain `if` case.
