### PR TITLE
exp/lighthorizon: Add a set of tools to aide in index inspection.

### DIFF
--- a/exp/lighthorizon/tools/cache.go
+++ b/exp/lighthorizon/tools/cache.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"github.com/stellar/go/metaarchive"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/storage"
@@ -20,9 +21,7 @@ const (
 	defaultCacheCount = (60 * 60 * 24) / 5 // ~24hrs worth of ledgers
 )
 
-func main() {
-	log.SetLevel(log.InfoLevel)
-
+func addCacheCommands(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "cache",
 		Long: "Manages the on-disk cache of ledgers.",
@@ -31,11 +30,11 @@ cache build --start 1234 --count 1000 s3://txmeta /tmp/example
 cache purge /tmp/example 1234 1300
 cache show /tmp/example`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// require a subcommand for now - eventually this will live under
-			// the lighthorizon command
+			// require a subcommand - this is just a "category"
 			return cmd.Help()
 		},
 	}
+
 	purge := &cobra.Command{
 		Use:  "purge [flags] path <start> <end>",
 		Long: "Purges individual ledgers (or ranges) from the cache, or the entire cache.",
@@ -119,7 +118,12 @@ purge /tmp/example 1000 1005    # purge a ledger range`,
 	build.Flags().Uint("count", defaultCacheCount, "number of ledgers to cache")
 
 	cmd.AddCommand(build, purge, show)
-	cmd.Execute()
+	if parent == nil {
+		return cmd
+	}
+
+	parent.AddCommand(cmd)
+	return parent
 }
 
 func BuildCache(ledgerSource, cacheDir string, start uint32, count uint, repair bool) error {

--- a/exp/lighthorizon/tools/explorer.go
+++ b/exp/lighthorizon/tools/explorer.go
@@ -61,7 +61,7 @@ index stats file:///tmp/indices`,
 
 			// We want to summarize as much as possible on a Ctrl+C event, so
 			// this handles that by setting up a context that gets cancelled on
-			// SIGINT.
+			// SIGINT. A second Ctrl+C will kill the process as usual.
 			//
 			// https://millhouse.dev/posts/graceful-shutdowns-in-golang-with-signal-notify-context
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGINT)

--- a/exp/lighthorizon/tools/explorer.go
+++ b/exp/lighthorizon/tools/explorer.go
@@ -124,9 +124,9 @@ index stats file:///tmp/indices`,
 		Long: "View the accounts in an index source or view the " +
 			"checkpoints specific account(s) are active in.",
 		Example: `view s3://indices
-view s3://indices GAXLQGKIUAIIUHAX4GJO3J7HFGLBCNF6ZCZSTLJE7EKO5IUHGLQLMXZO
+view s3:///indices GAXLQGKIUAIIUHAX4GJO3J7HFGLBCNF6ZCZSTLJE7EKO5IUHGLQLMXZO
 view file:///tmp/indices --limit=0 GAXLQGKIUAIIUHAX4GJO3J7HFGLBCNF6ZCZSTLJE7EKO5IUHGLQLMXZO
-view gcs://indices GAXLQGKIUAIIUHAX4GJO3J7HFGLBCNF6ZCZSTLJE7EKO5IUHGLQLMXZO,GBUUWQDVEEXBJCUF5UL24YGXKJIP5EMM7KFWIAR33KQRJR34GN6HEDPV,GBYETUYNBK2ZO5MSYBJKSLDEA2ZHIXLCFL3MMWU6RHFVAUBKEWQORYKS`,
+view gcs://indices --limit=10 GAXLQGKIUAIIUHAX4GJO3J7HFGLBCNF6ZCZSTLJE7EKO5IUHGLQLMXZO,GBUUWQDVEEXBJCUF5UL24YGXKJIP5EMM7KFWIAR33KQRJR34GN6HEDPV,GBYETUYNBK2ZO5MSYBJKSLDEA2ZHIXLCFL3MMWU6RHFVAUBKEWQORYKS`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 2 {
 				return cmd.Usage()
@@ -241,12 +241,14 @@ func getIndex(path, account, indexName string, limit uint) map[uint32][]string {
 func showAccounts(path string, limit uint) []string {
 	store, err := index.Connect(path)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Failed to connect to index store at %s: %v", path, err)
+		return nil
 	}
 
 	accounts, err := store.ReadAccounts()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Failed read accounts from index store at %s: %v", path, err)
+		return nil
 	}
 
 	if limit == 0 {

--- a/exp/lighthorizon/tools/explorer.go
+++ b/exp/lighthorizon/tools/explorer.go
@@ -9,7 +9,6 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 
 	"github.com/stellar/go/exp/lighthorizon/index"
 	"github.com/stellar/go/historyarchive"
@@ -234,6 +233,7 @@ func getIndex(path, account, indexName string, limit uint) map[uint32][]string {
 	log.Infof("Checkpoint range: [%d, %d]",
 		ordered.MinSlice(maps.Keys(activity)),
 		ordered.MaxSlice(maps.Keys(activity)))
+	log.Infof("All discovered indices: %s", strings.Join(indexNames, ", "))
 
 	return activity
 }
@@ -260,18 +260,4 @@ func showAccounts(path string, limit uint) []string {
 	}
 
 	return accounts
-}
-
-func slicesHaveSameElements(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	copyA, copyB := make([]string, len(a)), make([]string, len(b))
-	copy(copyA, a)
-	copy(copyB, b)
-	slices.Sort(copyA)
-	slices.Sort(copyB)
-
-	return slices.Equal(copyA, copyB)
 }

--- a/exp/lighthorizon/tools/explorer.go
+++ b/exp/lighthorizon/tools/explorer.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -50,6 +51,7 @@ index stats file:///tmp/indices`,
 			}
 
 			path := args[0]
+			start := time.Now()
 			log.Infof("Analyzing indices at %s", path)
 
 			allCheckpoints := set.Set[uint32]{}
@@ -61,20 +63,15 @@ index stats file:///tmp/indices`,
 			// this handles that by setting up a context that gets cancelled on
 			// SIGINT.
 			//
-			// https://pace.dev/blog/2020/02/17/repond-to-ctrl-c-interrupt-signals-gracefully-with-context-in-golang-by-mat-ryer.html
-			c := make(chan os.Signal, 1)
-			signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			// https://millhouse.dev/posts/graceful-shutdowns-in-golang-with-signal-notify-context
+			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
+			defer stop()
 			go func() {
-				select {
-				case <-c:
-					cancel()
-				case <-ctx.Done():
-				}
-
-				<-c
-				os.Exit(1)
+				<-ctx.Done()
+				stop()
+				log.WithField("error", ctx.Err()).
+					Warn("Received interrupt, shutting down gracefully & summarizing findings...")
+				log.Warn("Press Ctrl+C again to abort.")
 			}()
 
 			mostActiveAccountChk := 0
@@ -96,13 +93,12 @@ index stats file:///tmp/indices`,
 				}
 			}
 
-			log.WithField("error", ctx.Err()).
-				Info("Done analyzing indices, summarizing...")
-
 			ledgerCount := len(allCheckpoints) * int(checkpointMgr.GetCheckpointFrequency())
 
+			log.Info("Done analyzing indices, summarizing...")
 			log.Infof("")
 			log.Infof("=== Final Summary ===")
+			log.Infof("Analysis took %s.", time.Since(start))
 			log.Infof("Path:     %s", path)
 			log.Infof("Accounts: %d", len(accounts))
 			log.Infof("Smallest checkpoint: %d", ordered.MinSlice(allCheckpoints.Slice()))

--- a/exp/lighthorizon/tools/explorer.go
+++ b/exp/lighthorizon/tools/explorer.go
@@ -78,6 +78,8 @@ index stats file:///tmp/indices`,
 				os.Exit(1)
 			}()
 
+			mostActiveAccountChk := 0
+			mostActiveAccount := ""
 			for _, account := range accounts {
 				if ctx.Err() != nil {
 					break
@@ -87,6 +89,11 @@ index stats file:///tmp/indices`,
 				allCheckpoints.AddSlice(maps.Keys(activity))
 				for _, names := range activity {
 					allIndexNames.AddSlice(names)
+				}
+
+				if len(activity) > mostActiveAccountChk {
+					mostActiveAccount = account
+					mostActiveAccountChk = len(activity)
 				}
 			}
 
@@ -105,6 +112,8 @@ index stats file:///tmp/indices`,
 				len(allCheckpoints), ledgerCount,
 				float64(ledgerCount)/(float64(60*60*24)/6.0) /* approx. ledgers per day */)
 			log.Infof("Index names: %s", strings.Join(allIndexNames.Slice(), ", "))
+			log.Infof("Most active account: %s (%d checkpoints)",
+				mostActiveAccount, mostActiveAccountChk)
 
 			return nil
 		},
@@ -222,6 +231,9 @@ func getIndex(path, account, indexName string, limit uint) map[uint32][]string {
 
 	log.Infof("Summary: %d active checkpoints, %d possible active ledgers",
 		len(activity), len(activity)*int(freq))
+	log.Infof("Checkpoint range: [%d, %d]",
+		ordered.MinSlice(maps.Keys(activity)),
+		ordered.MaxSlice(maps.Keys(activity)))
 
 	return activity
 }

--- a/exp/lighthorizon/tools/explorer.go
+++ b/exp/lighthorizon/tools/explorer.go
@@ -63,7 +63,7 @@ index stats file:///tmp/indices`,
 			// SIGINT.
 			//
 			// https://pace.dev/blog/2020/02/17/repond-to-ctrl-c-interrupt-signals-gracefully-with-context-in-golang-by-mat-ryer.html
-			c := make(chan os.Signal)
+			c := make(chan os.Signal, 1)
 			signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/exp/lighthorizon/tools/explorer.go
+++ b/exp/lighthorizon/tools/explorer.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
+
+	"github.com/stellar/go/exp/lighthorizon/index"
+	"github.com/stellar/go/historyarchive"
+	"github.com/stellar/go/strkey"
+	"github.com/stellar/go/support/collections/maps"
+	"github.com/stellar/go/support/collections/set"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/go/support/ordered"
+)
+
+var (
+	checkpointMgr = historyarchive.NewCheckpointManager(0)
+)
+
+func addIndexCommands(parent *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "index",
+		Long: "Lets you view details about an index source.",
+		Example: `
+index view file:///tmp/indices
+index view file:///tmp/indices GAGJZWQ5QT34VK3U6W6YKRYFIK6YSAXQC6BHIIYLG6X3CE5QW2KAYNJR
+index stats file:///tmp/indices`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// require a subcommand - this is just a "category"
+			return cmd.Help()
+		},
+	}
+
+	stats := &cobra.Command{
+		Use: "stats <index path>",
+		Long: "Summarize the statistics (like the # of active checkpoints " +
+			"or accounts). Note that this is a very read-heavy operation and " +
+			"will incur download bandwidth costs if reading from remote, " +
+			"billable sources.",
+		Example: `stats s3://indices`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return cmd.Usage()
+			}
+
+			path := args[0]
+			log.Infof("Analyzing indices at %s", path)
+
+			allCheckpoints := set.Set[uint32]{}
+			allIndexNames := set.Set[string]{}
+			accounts := showAccounts(path, 0)
+			log.Infof("Analyzing indices for %d accounts.", len(accounts))
+
+			// We want to summarize as much as possible on a Ctrl+C event, so
+			// this handles that by setting up a context that gets cancelled on
+			// SIGINT.
+			//
+			// https://pace.dev/blog/2020/02/17/repond-to-ctrl-c-interrupt-signals-gracefully-with-context-in-golang-by-mat-ryer.html
+			c := make(chan os.Signal)
+			signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go func() {
+				select {
+				case <-c:
+					cancel()
+				case <-ctx.Done():
+				}
+
+				<-c
+				os.Exit(1)
+			}()
+
+			for _, account := range accounts {
+				if ctx.Err() != nil {
+					break
+				}
+
+				activity := getIndex(path, account, "", 0)
+				allCheckpoints.AddSlice(maps.Keys(activity))
+				for _, names := range activity {
+					allIndexNames.AddSlice(names)
+				}
+			}
+
+			log.WithField("error", ctx.Err()).
+				Info("Done analyzing indices, summarizing...")
+
+			ledgerCount := len(allCheckpoints) * int(checkpointMgr.GetCheckpointFrequency())
+
+			log.Infof("")
+			log.Infof("=== Final Summary ===")
+			log.Infof("Path:     %s", path)
+			log.Infof("Accounts: %d", len(accounts))
+			log.Infof("Smallest checkpoint: %d", ordered.MinSlice(allCheckpoints.Slice()))
+			log.Infof("Largest  checkpoint: %d", ordered.MaxSlice(allCheckpoints.Slice()))
+			log.Infof("Checkpoint count:    %d (%d possible ledgers, ~%0.2f days)",
+				len(allCheckpoints), ledgerCount,
+				float64(ledgerCount)/(float64(60*60*24)/6.0) /* approx. ledgers per day */)
+			log.Infof("Index names: %s", strings.Join(allIndexNames.Slice(), ", "))
+
+			return nil
+		},
+	}
+
+	view := &cobra.Command{
+		Use: "view <index path> [accounts?]",
+		Long: "View the accounts in an index source or view the " +
+			"checkpoints specific account(s) are active in.",
+		Example: `view s3://indices
+view s3://indices GAXLQGKIUAIIUHAX4GJO3J7HFGLBCNF6ZCZSTLJE7EKO5IUHGLQLMXZO
+view file:///tmp/indices --limit=0 GAXLQGKIUAIIUHAX4GJO3J7HFGLBCNF6ZCZSTLJE7EKO5IUHGLQLMXZO
+view gcs://indices GAXLQGKIUAIIUHAX4GJO3J7HFGLBCNF6ZCZSTLJE7EKO5IUHGLQLMXZO,GBUUWQDVEEXBJCUF5UL24YGXKJIP5EMM7KFWIAR33KQRJR34GN6HEDPV,GBYETUYNBK2ZO5MSYBJKSLDEA2ZHIXLCFL3MMWU6RHFVAUBKEWQORYKS`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 2 {
+				return cmd.Usage()
+			}
+
+			path := args[0]
+			log.Infof("Analyzing indices at %s", path)
+
+			accounts := []string{}
+			if len(args) == 2 {
+				accounts = strings.Split(args[1], ",")
+			}
+
+			limit, err := cmd.Flags().GetUint("limit")
+			if err != nil {
+				return cmd.Usage()
+			}
+
+			if len(accounts) > 0 {
+				indexName, err := cmd.Flags().GetString("index-name")
+				if err != nil {
+					return cmd.Usage()
+				}
+
+				for _, account := range accounts {
+					if !strkey.IsValidEd25519PublicKey(account) &&
+						!strkey.IsValidMuxedAccountEd25519PublicKey(account) {
+						log.Errorf("Invalid account ID: '%s'", account)
+						continue
+					}
+
+					getIndex(path, account, indexName, limit)
+				}
+			} else {
+				showAccounts(path, limit)
+			}
+
+			return nil
+		},
+	}
+
+	view.Flags().Uint("limit", 10, "a maximum number of accounts or checkpoints to show")
+	view.Flags().String("index-name", "", "filter for a particular index")
+	cmd.AddCommand(stats, view)
+
+	if parent == nil {
+		return cmd
+	}
+	parent.AddCommand(cmd)
+	return parent
+}
+
+func getIndex(path, account, indexName string, limit uint) map[uint32][]string {
+	freq := checkpointMgr.GetCheckpointFrequency()
+
+	store, err := index.Connect(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	indices, err := store.Read(account)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// It's better to summarize activity and then group it by index rather than
+	// just show activity in each index, because there's likely a ton of overlap
+	// across indices.
+	activity := map[uint32][]string{}
+	indexNames := []string{}
+
+	for name, idx := range indices {
+		log.Infof("Index found: '%s'", name)
+		if indexName != "" && name != indexName {
+			continue
+		}
+
+		indexNames = append(indexNames, name)
+
+		checkpoint, err := idx.NextActiveBit(0)
+		for err != io.EOF {
+			activity[checkpoint] = append(activity[checkpoint], name)
+			checkpoint, err = idx.NextActiveBit(checkpoint + 1)
+
+			if limit > 0 && limit <= uint(len(activity)) {
+				break
+			}
+		}
+	}
+
+	log.WithField("account", account).WithField("limit", limit).
+		Infof("Activity for account:")
+
+	for checkpoint, names := range activity {
+		first := (checkpoint - 1) * freq
+		last := first + freq
+
+		nameStr := strings.Join(names, ", ")
+		log.WithField("indices", nameStr).
+			Infof("  - checkpoint %d, ledgers [%d, %d)", checkpoint, first, last)
+	}
+
+	log.Infof("Summary: %d active checkpoints, %d possible active ledgers",
+		len(activity), len(activity)*int(freq))
+
+	return activity
+}
+
+func showAccounts(path string, limit uint) []string {
+	store, err := index.Connect(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	accounts, err := store.ReadAccounts()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if limit == 0 {
+		limit = uint(len(accounts))
+	}
+
+	for i := uint(0); i < limit; i++ {
+		log.Info(accounts[i])
+	}
+
+	return accounts
+}
+
+func slicesHaveSameElements(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	copyA, copyB := make([]string, len(a)), make([]string, len(b))
+	copy(copyA, a)
+	copy(copyB, b)
+	slices.Sort(copyA)
+	slices.Sort(copyB)
+
+	return slices.Equal(copyA, copyB)
+}

--- a/exp/lighthorizon/tools/main.go
+++ b/exp/lighthorizon/tools/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/stellar/go/support/log"
+)
+
+func main() {
+	log.SetLevel(log.InfoLevel)
+
+	cmd := &cobra.Command{
+		Use:     "tools",
+		Long:    "Please specify a subcommand to use this toolset.",
+		Example: "",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// require a subcommand - this is just a "category"
+			return cmd.Help()
+		},
+	}
+
+	cmd = addCacheCommands(cmd)
+	cmd = addIndexCommands(cmd)
+	cmd.Execute()
+}

--- a/support/collections/set/set.go
+++ b/support/collections/set/set.go
@@ -24,3 +24,11 @@ func (set Set[T]) Contains(item T) bool {
 	_, ok := set[item]
 	return ok
 }
+
+func (set Set[T]) Slice() []T {
+	slice := make([]T, 0, len(set))
+	for key := range set {
+		slice = append(slice, key)
+	}
+	return slice
+}

--- a/support/ordered/math.go
+++ b/support/ordered/math.go
@@ -19,3 +19,29 @@ func Max[T constraints.Ordered](a, b T) T {
 	}
 	return b
 }
+
+// MinSlice returns the smallest element in a slice-like container.
+func MinSlice[T constraints.Ordered](slice []T) T {
+	var smallest T
+
+	for i := 0; i < len(slice); i++ {
+		if i == 0 || slice[i] < smallest {
+			smallest = slice[i]
+		}
+	}
+
+	return smallest
+}
+
+// MaxSlice returns the largest element in a slice-like container.
+func MaxSlice[T constraints.Ordered](slice []T) T {
+	var largest T
+
+	for i := 0; i < len(slice); i++ {
+		if i == 0 || slice[i] > largest  {
+			largest  = slice[i]
+		}
+	}
+
+	return largest
+}

--- a/support/ordered/math.go
+++ b/support/ordered/math.go
@@ -38,8 +38,8 @@ func MaxSlice[T constraints.Ordered](slice []T) T {
 	var largest T
 
 	for i := 0; i < len(slice); i++ {
-		if i == 0 || slice[i] > largest  {
-			largest  = slice[i]
+		if i == 0 || slice[i] > largest {
+			largest = slice[i]
 		}
 	}
 


### PR DESCRIPTION
### What
This extends the `tools` toolkit (which previously only let you inspect the web server ledger cache) to add helpful tools to inspect indexes. It includes the following tools: when given an index location, you can

 * view what accounts are indexed there
 * view what checkpoints particular accounts are active at
 * view statistics about the index such as:
   - the # of accounts indexed, 
   - the range (smallest, largest) of indexed checkpoints
   - the total # of active checkpoints (thus giving you a ledger range covered by the index)
   - the index names

### Why
This is particularly useful until we extend the index format to store some of this stuff internally, so that we can learn about long-running processes (like the map-reduce index builder) and how much progress they've made.

For example, I used this toolset to learn that there was ~1mo of indexed data on S3 for the demo.

### Known limitations
n/a

### Examples

Command: `./tools index view file://$HOME/workspace/indices --limit 5`
Output:

```
INFO[2022-08-29T15:47:15.823-07:00] Analyzing indices at file:///home/george/workspace/indices  pid=241771
INFO[2022-08-29T15:47:15.836-07:00] GCJ7F2CINZQ2WWXTS2X3BOY4UUAM4X7Q4PSKCQPI6URA56AQAUND724S  pid=241771
INFO[2022-08-29T15:47:15.836-07:00] GCMY3A5MTQKSFQYMJWTNVVMSJ3GRW567UVPIP4TYZGJ2O5YGCLIPVUQ7  pid=241771
INFO[2022-08-29T15:47:15.836-07:00] GA2HILXX64DMVBRJCRRXYUFNB5DKT5UOTSIY7RCHTDVKLHL2IARY7U52  pid=241771
INFO[2022-08-29T15:47:15.836-07:00] GAQVDLMFY4M64PHLB3U4Q6QLESTJWTMUVBVJA4H5DIFFPHMPSZAYGBI6  pid=241771
INFO[2022-08-29T15:47:15.836-07:00] GC2TQLMT3YJCC24VCYM6ZP46WWPXE22IVP4DEPNFHEQDJ3MZ7QTNFD2C  pid=241771
```

-------

Command:

```bash
./tools index view file://$HOME/workspace/indices \
    GCJ7F2CINZQ2WWXTS2X3BOY4UUAM4X7Q4PSKCQPI6URA56AQAUND724S,GCMY3A5MTQKSFQYMJWTNVVMSJ3GRW567UVPIP4TYZGJ2O5YGCLIPVUQ7
```

```
INFO[2022-08-29T17:06:01.406-07:00] Analyzing indices at file:///home/george/workspace/indices  pid=287475
INFO[2022-08-29T17:06:01.408-07:00] Index found: 'all/all'                        pid=287475
INFO[2022-08-29T17:06:01.408-07:00] Index found: 'all/payments'                   pid=287475
INFO[2022-08-29T17:06:01.408-07:00] Index found: 'successful/all'                 pid=287475
INFO[2022-08-29T17:06:01.409-07:00] Index found: 'successful/payments'            pid=287475
INFO[2022-08-29T17:06:01.409-07:00] Activity for account:                         account=GCJ7F2CINZQ2WWXTS2X3BOY4UUAM4X7Q4PSKCQPI6URA56AQAUND724S limit=10 pid=287475
INFO[2022-08-29T17:06:01.409-07:00]   - checkpoint 22039, ledgers [1410432, 1410496)  indices="all/all, all/payments, successful/all, successful/payments" pid=287475
INFO[2022-08-29T17:06:01.409-07:00] Summary: 1 active checkpoints, 64 possible active ledgers  pid=287475
INFO[2022-08-29T17:06:01.409-07:00] Checkpoint range: [22039, 22039]              pid=287475
INFO[2022-08-29T17:06:01.411-07:00] Index found: 'all/all'                        pid=287475
INFO[2022-08-29T17:06:01.411-07:00] Index found: 'all/payments'                   pid=287475
INFO[2022-08-29T17:06:01.411-07:00] Index found: 'successful/all'                 pid=287475
INFO[2022-08-29T17:06:01.411-07:00] Index found: 'successful/payments'            pid=287475
INFO[2022-08-29T17:06:01.411-07:00] Activity for account:                         account=GCMY3A5MTQKSFQYMJWTNVVMSJ3GRW567UVPIP4TYZGJ2O5YGCLIPVUQ7 limit=10 pid=287475
INFO[2022-08-29T17:06:01.411-07:00]   - checkpoint 22034, ledgers [1410112, 1410176)  indices="all/all, all/payments, successful/all, successful/payments" pid=287475
INFO[2022-08-29T17:06:01.411-07:00] Summary: 1 active checkpoints, 64 possible active ledgers  pid=287475
INFO[2022-08-29T17:06:01.411-07:00] Checkpoint range: [22034, 22034]              pid=287475
```

---------

Command: `./tools index stats file://$HOME/workspace/indices `
Output:

```
[... lots of output like the previous command abridged ...]
INFO[2022-08-29T15:49:21.939-07:00] === Final Summary ===                         pid=242344
INFO[2022-08-29T15:49:21.939-07:00] Path:     file:///home/george/workspace/indices  pid=242344
INFO[2022-08-29T15:49:21.939-07:00] Accounts: 24563                               pid=242344
INFO[2022-08-29T15:49:21.940-07:00] Smallest checkpoint: 22032                    pid=242344
INFO[2022-08-29T15:49:21.940-07:00] Largest  checkpoint: 22992                    pid=242344
INFO[2022-08-29T15:49:21.940-07:00] Checkpoint count:    961 (61504 possible ledgers, ~4.27 days)  pid=242344
INFO[2022-08-29T15:49:21.940-07:00] Index names: successful/payments, all/all, all/payments, successful/all  pid=242344
INFO[2022-08-29T15:49:22.122-07:00] Most active account: GCFJN22UG6IZHXKDVAJWAVEQ3NERGCRCURR2FHARNRBNLYFEQZGML4PW (961 checkpoints)  pid=287361
```