### PR TITLE
services/horizon: Add history_assets to lookup tables reap

### DIFF
--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -879,6 +879,24 @@ func (q Q) ReapLookupTables(ctx context.Context, offsets map[string]int64) (
 				objectField: "history_account_id",
 			},
 		},
+		"history_assets": {
+			{
+				name:        "history_trades",
+				objectField: "base_asset_id",
+			},
+			{
+				name:        "history_trades",
+				objectField: "counter_asset_id",
+			},
+			{
+				name:        "history_trades_60000",
+				objectField: "base_asset_id",
+			},
+			{
+				name:        "history_trades_60000",
+				objectField: "counter_asset_id",
+			},
+		},
 		"history_claimable_balances": {
 			{
 				name:        "history_operation_claimable_balances",

--- a/services/horizon/internal/db2/history/reap_test.go
+++ b/services/horizon/internal/db2/history/reap_test.go
@@ -22,6 +22,7 @@ func TestReapLookupTables(t *testing.T) {
 	var (
 		prevLedgers, curLedgers                     int
 		prevAccounts, curAccounts                   int
+		prevAssets, curAssets                       int
 		prevClaimableBalances, curClaimableBalances int
 		prevLiquidityPools, curLiquidityPools       int
 	)
@@ -31,6 +32,8 @@ func TestReapLookupTables(t *testing.T) {
 		err := db.GetRaw(tt.Ctx, &prevLedgers, `SELECT COUNT(*) FROM history_ledgers`)
 		tt.Require.NoError(err)
 		err = db.GetRaw(tt.Ctx, &prevAccounts, `SELECT COUNT(*) FROM history_accounts`)
+		tt.Require.NoError(err)
+		err = db.GetRaw(tt.Ctx, &prevAssets, `SELECT COUNT(*) FROM history_assets`)
 		tt.Require.NoError(err)
 		err = db.GetRaw(tt.Ctx, &prevClaimableBalances, `SELECT COUNT(*) FROM history_claimable_balances`)
 		tt.Require.NoError(err)
@@ -60,6 +63,8 @@ func TestReapLookupTables(t *testing.T) {
 		tt.Require.NoError(err)
 		err = db.GetRaw(tt.Ctx, &curAccounts, `SELECT COUNT(*) FROM history_accounts`)
 		tt.Require.NoError(err)
+		err = db.GetRaw(tt.Ctx, &curAssets, `SELECT COUNT(*) FROM history_assets`)
+		tt.Require.NoError(err)
 		err = db.GetRaw(tt.Ctx, &curClaimableBalances, `SELECT COUNT(*) FROM history_claimable_balances`)
 		tt.Require.NoError(err)
 		err = db.GetRaw(tt.Ctx, &curLiquidityPools, `SELECT COUNT(*) FROM history_liquidity_pools`)
@@ -73,6 +78,10 @@ func TestReapLookupTables(t *testing.T) {
 	tt.Assert.Equal(1, curAccounts, "curAccounts")
 	tt.Assert.Equal(int64(24), deletedCount["history_accounts"], `deletedCount["history_accounts"]`)
 
+	tt.Assert.Equal(7, prevAssets, "prevAssets")
+	tt.Assert.Equal(0, curAssets, "curAssets")
+	tt.Assert.Equal(int64(7), deletedCount["history_assets"], `deletedCount["history_assets"]`)
+
 	tt.Assert.Equal(1, prevClaimableBalances, "prevClaimableBalances")
 	tt.Assert.Equal(0, curClaimableBalances, "curClaimableBalances")
 	tt.Assert.Equal(int64(1), deletedCount["history_claimable_balances"], `deletedCount["history_claimable_balances"]`)
@@ -81,8 +90,9 @@ func TestReapLookupTables(t *testing.T) {
 	tt.Assert.Equal(0, curLiquidityPools, "curLiquidityPools")
 	tt.Assert.Equal(int64(1), deletedCount["history_liquidity_pools"], `deletedCount["history_liquidity_pools"]`)
 
-	tt.Assert.Len(newOffsets, 3)
+	tt.Assert.Len(newOffsets, 4)
 	tt.Assert.Equal(int64(0), newOffsets["history_accounts"])
+	tt.Assert.Equal(int64(0), newOffsets["history_assets"])
 	tt.Assert.Equal(int64(0), newOffsets["history_claimable_balances"])
 	tt.Assert.Equal(int64(0), newOffsets["history_liquidity_pools"])
 }

--- a/services/horizon/internal/db2/schema/60_add_asset_id_indexes.sql
+++ b/services/horizon/internal/db2/schema/60_add_asset_id_indexes.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+
+CREATE INDEX "htrd_by_counter_asset" ON history_trades USING btree (counter_asset_id);
+CREATE INDEX "htrd_agg_counter_asset" ON history_trades_60000 USING btree (counter_asset_id);
+
+-- +migrate Down
+
+DROP INDEX "htrd_by_counter_asset";
+DROP INDEX "htrd_agg_counter_asset";

--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -1507,11 +1507,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and

--- a/services/horizon/internal/db2/schema/bindata.go
+++ b/services/horizon/internal/db2/schema/bindata.go
@@ -1507,13 +1507,11 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Adds the last remaining table: `history_assets` to lookup table reaper.

Close #4396.

### Why

In https://github.com/stellar/go/pull/4518 the code responsible for reaping lookup tables was added but was missing one table: `history_assets` due to lack of proper indexes. This commit should remove all remaining data in lookup tables.

### Known limitations

[TODO or N/A]
