### PR TITLE
exp/lighthorizon/index/cmd: Fix index single watch, slow down the retry on not-found ledgers 

### DIFF
--- a/exp/lighthorizon/index/builder.go
+++ b/exp/lighthorizon/index/builder.go
@@ -294,13 +294,13 @@ func (builder *IndexBuilder) Watch(ctx context.Context) error {
 		//
 		// [1]: https://stellarfoundation.slack.com/archives/C02B04RMK/p1654903342555669
 
-		// We sleep with linear backoff starting with 3s. Ledgers get posted
+		// We sleep with linear backoff starting with 6s. Ledgers get posted
 		// every 5-7s on average, but to be extra careful, let's give it a full
 		// minute before we give up entirely.
 		timedCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 		defer cancel()
 
-		sleepTime := (3 * time.Second)
+		sleepTime := (6 * time.Second)
 	outer:
 		for {
 			time.Sleep(sleepTime)

--- a/exp/lighthorizon/index/builder.go
+++ b/exp/lighthorizon/index/builder.go
@@ -294,16 +294,16 @@ func (builder *IndexBuilder) Watch(ctx context.Context) error {
 		//
 		// [1]: https://stellarfoundation.slack.com/archives/C02B04RMK/p1654903342555669
 
-		// We sleep with linear backoff starting with 1s. Ledgers get posted
+		// We sleep with linear backoff starting with 3s. Ledgers get posted
 		// every 5-7s on average, but to be extra careful, let's give it a full
 		// minute before we give up entirely.
 		timedCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 		defer cancel()
 
-		sleepTime := time.Second
-
+		sleepTime := (3 * time.Second)
 	outer:
 		for {
+			time.Sleep(sleepTime)
 			select {
 			case <-timedCtx.Done():
 				return errors.Wrap(timedCtx.Err(), "awaiting next ledger failed")
@@ -318,8 +318,7 @@ func (builder *IndexBuilder) Watch(ctx context.Context) error {
 				}
 
 				if os.IsNotExist(buildErr) {
-					time.Sleep(sleepTime)
-					sleepTime += 2
+					sleepTime += (time.Second * 2)
 					continue
 				}
 

--- a/support/storage/http.go
+++ b/support/storage/http.go
@@ -30,7 +30,7 @@ func checkResp(r *http.Response) error {
 	if r.StatusCode >= 200 && r.StatusCode < 400 {
 		return nil
 	} else {
-		return fmt.Errorf("Bad HTTP response '%s' for %s '%s'",
+		return fmt.Errorf("bad HTTP response '%s' for %s '%s'",
 			r.Status, r.Request.Method, r.Request.URL.String())
 	}
 }

--- a/support/storage/s3.go
+++ b/support/storage/s3.go
@@ -263,5 +263,7 @@ func (b *S3Storage) s3HttpProxy() s3HttpProxy {
 	if b.s3Http != nil {
 		return b.s3Http
 	}
-	return &defaultS3HttpProxy{}
+	return &defaultS3HttpProxy{
+		S3Storage: b,
+	}
 }

--- a/support/storage/s3.go
+++ b/support/storage/s3.go
@@ -5,16 +5,39 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"os"
 	"path"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/stellar/go/support/errors"
 )
+
+type s3HttpProxy interface {
+	Send(*s3.GetObjectInput) (io.ReadCloser, error)
+}
+
+type defaultS3HttpProxy struct {
+	*S3Storage
+}
+
+func (proxy *defaultS3HttpProxy) Send(params *s3.GetObjectInput) (io.ReadCloser, error) {
+	req, resp := proxy.svc.GetObjectRequest(params)
+	if proxy.unsignedRequests {
+		req.Handlers.Sign.Clear() // makes this request unsigned
+	}
+	req.SetContext(proxy.ctx)
+	logReq(req.HTTPRequest)
+	err := req.Send()
+	logResp(req.HTTPResponse)
+
+	return resp.Body, err
+}
 
 type S3Storage struct {
 	ctx              context.Context
@@ -23,6 +46,7 @@ type S3Storage struct {
 	prefix           string
 	unsignedRequests bool
 	writeACLrule     string
+	s3Http           s3HttpProxy
 }
 
 func NewS3Storage(
@@ -67,19 +91,16 @@ func (b *S3Storage) GetFile(pth string) (io.ReadCloser, error) {
 		Key:    aws.String(key),
 	}
 
-	req, resp := b.svc.GetObjectRequest(params)
-	if b.unsignedRequests {
-		req.Handlers.Sign.Clear() // makes this request unsigned
-	}
-	req.SetContext(b.ctx)
-	logReq(req.HTTPRequest)
-	err := req.Send()
-	logResp(req.HTTPResponse)
+	resp, err := b.s3HttpProxy().Send(params)
+
 	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == s3.ErrCodeNoSuchKey {
+			return nil, os.ErrNotExist
+		}
 		return nil, err
 	}
 
-	return resp.Body, nil
+	return resp, nil
 }
 
 func (b *S3Storage) Head(pth string) (*http.Response, error) {
@@ -236,4 +257,11 @@ func (b *S3Storage) CanListFiles() bool {
 
 func (b *S3Storage) Close() error {
 	return nil
+}
+
+func (b *S3Storage) s3HttpProxy() s3HttpProxy {
+	if b.s3Http != nil {
+		return b.s3Http
+	}
+	return &defaultS3HttpProxy{}
 }

--- a/support/storage/s3_test.go
+++ b/support/storage/s3_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -88,4 +89,26 @@ func TestGetFileNotFound(t *testing.T) {
 	_, err := s3Storage.GetFile("path")
 
 	assert.Equal(t, err, os.ErrNotExist)
+}
+
+func TestGetFileFound(t *testing.T) {
+	mockS3 := &MockS3{}
+	mockS3HttpProxy := &MockS3HttpProxy{}
+	testCloser := io.NopCloser(strings.NewReader(""))
+
+	mockS3HttpProxy.On("Send", mock.Anything).Return(testCloser, nil)
+
+	s3Storage := S3Storage{
+		ctx:              context.Background(),
+		svc:              mockS3,
+		bucket:           "bucket",
+		prefix:           "prefix",
+		unsignedRequests: false,
+		writeACLrule:     "",
+		s3Http:           mockS3HttpProxy,
+	}
+
+	closer, err := s3Storage.GetFile("path")
+	assert.Nil(t, err)
+	assert.Equal(t, closer, testCloser)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Noticed the index single cmd with `watch` was err'ing on getting latest ledger from txmeta source, and then exiting execution, the s3 'not found' was not being converted to the expected os `ErrNotFound` to allow it to re-attempt after backoff, instead it treated it as severe err instead.

### Why

the single `watch` needs to continue iteration attempts to get latest ledger tx meta, not trigger the entire single process to exit.

Closes https://github.com/stellar/go/issues/4583

### Known limitations


