### PR TITLE
clients/horizonclient: fix theoretical bug in currentServerTime

### DIFF
--- a/clients/horizonclient/internal.go
+++ b/clients/horizonclient/internal.go
@@ -140,9 +140,9 @@ func setCurrentServerTime(host string, serverDate []string, clock *clock.Clock) 
 // currentServerTime returns the current server time for a given horizon server
 func currentServerTime(host string, currentTimeUTC int64) int64 {
 	serverTimeMapMutex.Lock()
-	st := ServerTimeMap[host]
+	st, has := ServerTimeMap[host]
 	serverTimeMapMutex.Unlock()
-	if &st == nil {
+	if !has {
 		return 0
 	}
 

--- a/clients/horizonclient/internal_test.go
+++ b/clients/horizonclient/internal_test.go
@@ -7,28 +7,40 @@ import (
 )
 
 func TestCurrentServerTime(t *testing.T) {
-	currentTime := currentServerTime("non-existing-host-name", 60)
+	t.Run("non-existing-host-name", func(t *testing.T) {
+		currentTime := currentServerTime("non-existing-host-name", 60)
+		defer func() {
+			serverTimeMapMutex.Lock()
+			ServerTimeMap["TestCurrentServerTime-server-behind"] = ServerTimeRecord{ServerTime: 27, LocalTimeRecorded: 23}
+			serverTimeMapMutex.Unlock()
+		}()
 
-	require.Zerof(t, currentTime, "server time for non-existing time is expected to be zero, but was %d instead", currentTime)
+		require.Zerof(t, currentTime, "server time for non-existing time is expected to be zero, but was %d instead", currentTime)
+	})
 
-	serverTimeMapMutex.Lock()
-	ServerTimeMap["TestCurrentServerTime-server-behind"] = ServerTimeRecord{ServerTime: 27, LocalTimeRecorded: 23}
-	serverTimeMapMutex.Unlock()
+	t.Run("server-behind", func(t *testing.T) {
+		currentTime := currentServerTime("TestCurrentServerTime-server-behind", 500)
+		defer func() {
+			serverTimeMapMutex.Lock()
+			delete(ServerTimeMap, "TestCurrentServerTime-server-behind")
+			serverTimeMapMutex.Unlock()
+		}()
 
-	currentTime = currentServerTime("TestCurrentServerTime-server-behind", 500)
+		require.Zerof(t, currentTime, "server time is too old and the method should have returned 0; instead, %d was returned", currentTime)
+	})
 
-	require.Zerof(t, currentTime, "server time is too old and the method should have returned 0; instead, %d was returned", currentTime)
+	t.Run("normal", func(t *testing.T) {
+		serverTimeMapMutex.Lock()
+		ServerTimeMap["TestCurrentServerTime-server"] = ServerTimeRecord{ServerTime: 27, LocalTimeRecorded: 23}
+		serverTimeMapMutex.Unlock()
 
-	serverTimeMapMutex.Lock()
-	delete(ServerTimeMap, "TestCurrentServerTime-server-behind")
-	ServerTimeMap["TestCurrentServerTime-server"] = ServerTimeRecord{ServerTime: 27, LocalTimeRecorded: 23}
-	serverTimeMapMutex.Unlock()
+		defer func() {
+			serverTimeMapMutex.Lock()
+			delete(ServerTimeMap, "TestCurrentServerTime-server")
+			serverTimeMapMutex.Unlock()
+		}()
 
-	currentTime = currentServerTime("TestCurrentServerTime-server", 37)
-
-	require.Equalf(t, currentTime, int64(41), "currentServerTime should have returned %d, but returned %d instead", 41, currentTime)
-
-	serverTimeMapMutex.Lock()
-	delete(ServerTimeMap, "TestCurrentServerTime-server")
-	serverTimeMapMutex.Unlock()
+		currentTime := currentServerTime("TestCurrentServerTime-server", 37)
+		require.Equalf(t, currentTime, int64(41), "currentServerTime should have returned %d, but returned %d instead", 41, currentTime)
+	})
 }

--- a/clients/horizonclient/internal_test.go
+++ b/clients/horizonclient/internal_test.go
@@ -1,0 +1,34 @@
+package horizonclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCurrentServerTime(t *testing.T) {
+	currentTime := currentServerTime("non-existing-host-name", 60)
+
+	require.Zerof(t, currentTime, "server time for non-existing time is expected to be zero, but was %d instead", currentTime)
+
+	serverTimeMapMutex.Lock()
+	ServerTimeMap["TestCurrentServerTime-server-behind"] = ServerTimeRecord{ServerTime: 27, LocalTimeRecorded: 23}
+	serverTimeMapMutex.Unlock()
+
+	currentTime = currentServerTime("TestCurrentServerTime-server-behind", 500)
+
+	require.Zerof(t, currentTime, "server time is too old and the method should have returned 0; instead, %d was returned", currentTime)
+
+	serverTimeMapMutex.Lock()
+	delete(ServerTimeMap, "TestCurrentServerTime-server-behind")
+	ServerTimeMap["TestCurrentServerTime-server"] = ServerTimeRecord{ServerTime: 27, LocalTimeRecorded: 23}
+	serverTimeMapMutex.Unlock()
+
+	currentTime = currentServerTime("TestCurrentServerTime-server", 37)
+
+	require.Equalf(t, currentTime, int64(41), "currentServerTime should have returned %d, but returned %d instead", 41, currentTime)
+
+	serverTimeMapMutex.Lock()
+	delete(ServerTimeMap, "TestCurrentServerTime-server")
+	serverTimeMapMutex.Unlock()
+}

--- a/clients/horizonclient/internal_test.go
+++ b/clients/horizonclient/internal_test.go
@@ -9,16 +9,14 @@ import (
 func TestCurrentServerTime(t *testing.T) {
 	t.Run("non-existing-host-name", func(t *testing.T) {
 		currentTime := currentServerTime("non-existing-host-name", 60)
-		defer func() {
-			serverTimeMapMutex.Lock()
-			ServerTimeMap["TestCurrentServerTime-server-behind"] = ServerTimeRecord{ServerTime: 27, LocalTimeRecorded: 23}
-			serverTimeMapMutex.Unlock()
-		}()
-
 		require.Zerof(t, currentTime, "server time for non-existing time is expected to be zero, but was %d instead", currentTime)
 	})
 
 	t.Run("server-behind", func(t *testing.T) {
+		serverTimeMapMutex.Lock()
+		ServerTimeMap["TestCurrentServerTime-server-behind"] = ServerTimeRecord{ServerTime: 27, LocalTimeRecorded: 23}
+		serverTimeMapMutex.Unlock()
+
 		currentTime := currentServerTime("TestCurrentServerTime-server-behind", 500)
 		defer func() {
 			serverTimeMapMutex.Lock()

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -58,7 +58,7 @@ func TestCheckMemoRequired(t *testing.T) {
 		Asset:       txnbuild.NativeAsset{},
 	}
 
-	asset := txnbuild.CreditAsset{"ABCD", kp.Address()}
+	asset := txnbuild.CreditAsset{Code: "ABCD", Issuer: kp.Address()}
 	pathPaymentStrictSend := txnbuild.PathPaymentStrictSend{
 		SendAsset:   asset,
 		SendAmount:  "10",
@@ -1455,7 +1455,9 @@ func TestFetchTimebounds(t *testing.T) {
 	// When no saved server time, return local time
 	st, err := client.FetchTimebounds(100)
 	if assert.NoError(t, err) {
+		serverTimeMapMutex.Lock()
 		assert.IsType(t, ServerTimeMap["localhost"], ServerTimeRecord{})
+		serverTimeMapMutex.Unlock()
 		assert.Equal(t, st.MinTime, int64(0))
 	}
 
@@ -1472,7 +1474,9 @@ func TestFetchTimebounds(t *testing.T) {
 	// get saved server time
 	st, err = client.FetchTimebounds(100)
 	if assert.NoError(t, err) {
+		serverTimeMapMutex.Lock()
 		assert.IsType(t, ServerTimeMap["localhost"], ServerTimeRecord{})
+		serverTimeMapMutex.Unlock()
 		assert.Equal(t, st.MinTime, int64(0))
 		// serverTime + 100seconds
 		assert.Equal(t, st.MaxTime, int64(1560947196))
@@ -1480,7 +1484,9 @@ func TestFetchTimebounds(t *testing.T) {
 
 	// mock server time
 	newRecord := ServerTimeRecord{ServerTime: 100, LocalTimeRecorded: 1560947096}
+	serverTimeMapMutex.Lock()
 	ServerTimeMap["localhost"] = newRecord
+	serverTimeMapMutex.Unlock()
 	st, err = client.FetchTimebounds(100)
 	assert.NoError(t, err)
 	assert.IsType(t, st, txnbuild.TimeBounds{})


### PR DESCRIPTION
## Description

The code in currentServerTime was not testing the existence of the entry in `ServerTimeMap` correctly. As a result, it would have missed the case where an entry could be missing from the map.

That being said, this is a benign bug. It would never triggered unless the clock is set around epoch time ( which is not really realistic ). This fix is just to make sure that our code is correct. There should be no expectation of any behavioral change.
### PR Structure

* [X] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [X] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [X] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [X] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The logic of `currentServerTime` is being update to properly test for absence of hosts entry in the map.

### Why

Potential issue was found during code review.

### Known limitations

N/A
