### PR TITLE
exp/lighthorizon: Minor error-handling and deployment improvements.

### DIFF
--- a/exp/lighthorizon/actions/accounts.go
+++ b/exp/lighthorizon/actions/accounts.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"errors"
 	"net/http"
+	"os"
 	"strconv"
 
 	"github.com/stellar/go/support/log"
@@ -69,7 +70,11 @@ func NewTXByAccountHandler(lightHorizon services.LightHorizon) func(http.Respons
 		txns, err := lightHorizon.Transactions.GetTransactionsByAccount(ctx, paginate.Cursor, paginate.Limit, accountId)
 		if err != nil {
 			log.Error(err)
-			sendErrorResponse(r.Context(), w, supportProblem.ServerError)
+			if os.IsNotExist(err) {
+				sendErrorResponse(r.Context(), w, supportProblem.NotFound)
+			} else if err != nil {
+				sendErrorResponse(r.Context(), w, supportProblem.ServerError)
+			}
 			return
 		}
 

--- a/exp/lighthorizon/build/k8s/lighthorizon_web.yml
+++ b/exp/lighthorizon/build/k8s/lighthorizon_web.yml
@@ -10,6 +10,7 @@ data:
   TXMETA_SOURCE: "s3://horizon-ledgermeta-prodnet-test"
   INDEXES_SOURCE: "s3://horizon-index-prodnet-test"
   NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015"
+  MAX_PARALLEL_DOWNLOADS: 16
   CACHE_PATH: "/ledgercache"
 ---  
 apiVersion: v1

--- a/exp/lighthorizon/build/web/Dockerfile
+++ b/exp/lighthorizon/build/web/Dockerfile
@@ -17,4 +17,5 @@ COPY --from=builder /go/bin/lighthorizon ./
 ENTRYPOINT ./lighthorizon serve \
   --network-passphrase "$NETWORK_PASSPHRASE" \
   --ledger-cache "$CACHE_PATH" \
+  --parallel-downloads "$MAX_PARALLEL_DOWNLOADS" \
   "$TXMETA_SOURCE" "$INDEXES_SOURCE" \

--- a/exp/lighthorizon/services/main.go
+++ b/exp/lighthorizon/services/main.go
@@ -204,5 +204,8 @@ func searchAccountTransactions(ctx context.Context,
 func getAverageDuration[
 	T constraints.Signed | constraints.Float,
 ](d time.Duration, count T) time.Duration {
+	if count == 0 {
+		return 0 // don't bomb on div-by-zero
+	}
 	return time.Duration(int64(float64(d.Nanoseconds()) / float64(count)))
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Three small things:
 * actually set the `PARALLEL_DOWNLOADS` parameter to use #4468 
 * return a 404 rather than a 500 if a ledger is missing as its more descriptive
 * handle `count = 0` in average calculations

### Why
In order:
* use the feature we added
* getting 500s is less helpful than 404s
* logs are ugly on errors
