### PR TITLE
horizon: Run integration tests against Core protocol version 20 (Soroban)

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -15,7 +15,7 @@ jobs:
         go: [1.18.6, 1.19.1]
         pg: [9.6.5]
         ingestion-backend: [db, captive-core, captive-core-remote-storage]
-        protocol-version: [18, 19]
+        protocol-version: [18, 19, 20]
     runs-on: ${{ matrix.os }}
     services:
       postgres:
@@ -34,6 +34,8 @@ jobs:
     env:
       HORIZON_INTEGRATION_TESTS_ENABLED: true
       HORIZON_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL: ${{ matrix.protocol-version }}
+      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 2opremio/stellar-core:19.3.1-1069.056673a51.focal-soroban2
+      PROTOCOL_20_CORE_DOCKER_IMG: 19.3.1-1069.056673a51.focal~soroban2
       PROTOCOL_19_CORE_DEBIAN_PKG_VERSION: 19.3.0-1006.9ce6dc4e9.focal
       PROTOCOL_19_CORE_DOCKER_IMG: stellar/stellar-core:19.3.0-1006.9ce6dc4e9.focal
       PROTOCOL_18_CORE_DEBIAN_PKG_VERSION: 19.3.0-1006.9ce6dc4e9.focal


### PR DESCRIPTION
Integration tests should all be working in order for Horizon to support Soroban

CC @bartekn @sreuland @tamirms @paulbellamy 