### PR TITLE
all: add golangci linter as a GitHub action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,10 +19,8 @@ jobs:
         with:
           fetch-depth: 0 # required for new-from-rev option in .golangci.yml
       - uses: actions/setup-go@v3
-    steps:
-      - run: >
-        mkdir -p /home/runner/work/go/src/github.com/stellar
-        mv /home/runner/work/go/go /home/runner/work/go/src/github.com/stellar
+      - run: mkdir -p /home/runner/work/go/src/github.com/stellar
+      - run: mv /home/runner/work/go/go /home/runner/work/go/src/github.com/stellar
       - name: Run linters & report
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,4 +1,4 @@
-name: golangci-lint
+name: Linters
 on:
   push:
     branches:
@@ -8,26 +8,26 @@ on:
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
+  pull-requests: read
 
 jobs:
   golangci:
-    name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # version v3.0.2
         with:
           fetch-depth: 0 # required for new-from-rev option in .golangci.yml
-      - uses: actions/setup-go@v3
-      - run: rm -f /home/runner/work/go/src; mkdir -p /home/runner/work/go/src/github.com/stellar
-      - run: cp -r /home/runner/work/go/go /home/runner/work/go/src/github.com/stellar
-      - name: Run linters & report
-        uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
+      - name: Setup GO
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # version v3.3.0
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc # version v3.2.0
         with:
-          version: v1.49.0
-          args: --issues-exit-code=0
+          version: v1.49.0 # this is the golangci-lint version
+          args: --issues-exit-code=0 # exit without errors for now - won't fail the build
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          working-directory: /home/runner/work/go/src/github.com/stellar/go
+          only-new-issues: true
+
 
 
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,8 +18,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # required for new-from-rev option in .golangci.yml
-          path: /home/runner/work/go/src/github.com/stellar
       - uses: actions/setup-go@v3
+    steps:
+      - run: |
+        mkdir -p /home/runner/work/go/src/github.com/stellar
+        mv /home/runner/work/go/go /home/runner/work/go/src/github.com/stellar
       - name: Run linters & report
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # required for new-from-rev option in .golangci.yml
-          path: /home/runner/go/src/github.com/stellar
+          path: /home/runner/work/go/src/github.com/stellar
       - uses: actions/setup-go@v3
       - name: Run linters & report
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
@@ -26,7 +26,7 @@ jobs:
           version: v1.49.0
           args: --issues-exit-code=0
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          working-directory: /home/runner/go/src/github.com/stellar/go
+          working-directory: /home/runner/work/go/src/github.com/stellar/go
 
 
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           fetch-depth: 0 # required for new-from-rev option in .golangci.yml
       - uses: actions/setup-go@v3
-      - run: mkdir -p /home/runner/work/go/src/github.com/stellar
-      - run: mv /home/runner/work/go/go /home/runner/work/go/src/github.com/stellar
+      - run: rm -f /home/runner/work/go/src; mkdir -p /home/runner/work/go/src/github.com/stellar
+      - run: cp -r /home/runner/work/go/go /home/runner/work/go/src/github.com/stellar
       - name: Run linters & report
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,4 +1,4 @@
-name: reviewdog
+name: golangci-lint
 on:
   push:
     branches:
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0 # required for new-from-rev option in .golangci.yml
       - uses: actions/setup-go@v3
     steps:
-      - run: |
+      - run: >
         mkdir -p /home/runner/work/go/src/github.com/stellar
         mv /home/runner/work/go/go /home/runner/work/go/src/github.com/stellar
       - name: Run linters & report

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,19 +5,20 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+
 jobs:
-  golangci-lint:
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: write
-    if: github.event_name == 'pull_request'
-    name: runner / golangci-lint
+  golangci:
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # required for new-from-rev option in .golangci.yml
+          path: /home/runner/go/src/github.com/stellar
       - uses: actions/setup-go@v3
       - name: Run linters & report
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
@@ -25,6 +26,7 @@ jobs:
           version: v1.49.0
           args: --issues-exit-code=0
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: /home/runner/go/src/github.com/stellar/go
 
 
 

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -18,12 +18,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # required for new-from-rev option in .golangci.yml
+      - uses: actions/setup-go@v3
       - name: Run linters & report
-        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
+        uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
         with:
-          version: v1.45.2
-          args: "-c .golangci.yml --allow-parallel-runners --out-format github-actions"
+          version: v3.2.0
+          args: --issues-exit-code=0
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          skip-go-installation: true
+
 
 

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -19,10 +19,11 @@ jobs:
         with:
           fetch-depth: 0 # required for new-from-rev option in .golangci.yml
       - name: Run linters & report
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
         with:
           version: v1.45.2
-          golangci_lint_flags: "-c .golangci.yml --allow-parallel-runners"
+          args: "-c .golangci.yml --allow-parallel-runners --out-format github-actions"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-go-installation: true
+
 

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -18,9 +18,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # required for new-from-rev option in .golangci.yml
-      - uses: reviewdog/action-golangci-lint@v2
+      - name: Run linters & report
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: reviewdog/action-golangci-lint@v2
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           golangci_lint_flags: "-c .golangci.yml --allow-parallel-runners"
           level: "warning"
           reporter: github-pr-check

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,26 @@
+name: reviewdog
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  golangci-lint:
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    if: github.event_name == 'pull_request'
+    name: runner / golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # required for new-from-rev option in .golangci.yml
+      - uses: reviewdog/action-golangci-lint@v2
+        with:
+          github_token: ${{ secrets.github_token }}
+          golangci_lint_flags: "--enable-all --exclude-use-default=false -D wsl -D testpackage"
+          level: "warning"
+          reporter: github-pr-check

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -21,6 +21,6 @@ jobs:
       - uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ secrets.github_token }}
-          golangci_lint_flags: "--enable-all --exclude-use-default=false -D wsl -D testpackage"
+          golangci_lint_flags: "-c .golangci.yml --allow-parallel-runners"
           level: "warning"
           reporter: github-pr-check

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run linters & report
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: reviewdog/action-golangci-lint@v2
+        uses: reviewdog/action-golangci-lint@70498f2d1f75a55ee9a4d719e74e21ed68aebea3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           golangci_lint_flags: "-c .golangci.yml --allow-parallel-runners"

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -21,9 +21,8 @@ jobs:
       - name: Run linters & report
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: reviewdog/action-golangci-lint@70498f2d1f75a55ee9a4d719e74e21ed68aebea3
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: v1.45.2
           golangci_lint_flags: "-c .golangci.yml --allow-parallel-runners"
-          level: "warning"
-          reporter: github-pr-check
+

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run linters & report
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
         with:
-          version: v3.2.0
+          version: v1.49.0
           args: --issues-exit-code=0
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,129 @@
+linters-settings:
+  depguard:
+    list-type: denylist
+    packages:
+      # logging is allowed only by logutils.Log, logrus
+      # is allowed to use only in logutils package
+      - github.com/sirupsen/logrus
+    packages-with-error-message:
+      - github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  goconst:
+    min-len: 2
+    min-occurrences: 3
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - whyNoLint
+  gocyclo:
+    min-complexity: 15
+  goimports:
+    local-prefixes: github.com/golangci/golangci-lint
+  gomnd:
+    # don't include the "operation" and "assign"
+    checks:
+      - argument
+      - case
+      - condition
+      - return
+    ignored-numbers:
+      - '0'
+      - '1'
+      - '2'
+      - '3'
+    ignored-functions:
+      - strings.SplitN
+
+  govet:
+    check-shadowing: true
+    settings:
+      printf:
+        funcs:
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+  lll:
+    line-length: 140
+  misspell:
+    locale: US
+  nolintlint:
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - funlen
+    - gochecknoinits
+    - goconst
+    #- gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    #- whitespace
+
+  # don't enable:
+  # - asciicheck
+  # - scopelint
+  # - gochecknoglobals
+  # - gocognit
+  # - godot
+  # - godox
+  # - goerr113
+  # - interfacer
+  # - maligned
+  # - nestif
+  # - prealloc
+  # - testpackage
+  # - revive
+  # - wsl
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - govet
+
+run:
+  timeout: 5m
+  skip-dirs:
+    - docs
+    - vendor


### PR DESCRIPTION

### PR Structure

* [X] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [X] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [X] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR adds the golangci linter as a GitHub action.

The command line version would be more capable than this version, as the integration with GitHub isn't that great.
( adding comments require elevated privileges, which might be a security issue ).

### Why

It would allow us to get *some* linting feedback for our proposed changes.

### Known limitations

Using this without code comments won't make it as useful as it could be.. but it's better than not having this at all. We should re-iterate on this one once in a month or so - after we've gathered some feedback from engineers.
