### PR TITLE
ingest/ledgerbackend: Skip removing storage dir when Captive-Core in front of requested ledger

### DIFF
--- a/ingest/ledgerbackend/stellar_core_runner.go
+++ b/ingest/ledgerbackend/stellar_core_runner.go
@@ -373,7 +373,7 @@ func (r *stellarCoreRunner) runFrom(from uint32, hash string) error {
 		if err != nil {
 			r.log.Infof("Error running offline-info: %v, removing existing storage-dir contents", err)
 			removeStorageDir = true
-		} else if uint32(info.Info.Ledger.Num) != from {
+		} else if uint32(info.Info.Ledger.Num) > from {
 			r.log.Infof("Unexpected LCL in Stellar-Core DB: %d (want: %d), removing existing storage-dir contents", info.Info.Ledger.Num, from)
 			removeStorageDir = true
 		}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This commit improves `stellarCoreRunner` code to not remove storage dir if LCL of Captive-Core is greater than or equal requested `from` ledger.

### Why

In e3d3abc01de7bfb3e1e7e675d17fb2e45a250257 we added a code that skips removing storage dir but it was not removed if and only if `from` argument matched the LCL of Stellar-Core. The problem is that in clusters with more than one ingesting instance it's possible that other ingesting node would ingest one or more ledgers while Captive-Core instance is being restarted. In such case we should not remove storage dir but just skip the ledgers we don't need.

### Known limitations

[TODO or N/A]
