### PR TITLE
  exp/services/soroban-rpc: Add getTransactionStatus and sendTransaction json rpc methods

### DIFF
--- a/exp/services/soroban-rpc/internal/jsonrpc.go
+++ b/exp/services/soroban-rpc/internal/jsonrpc.go
@@ -30,16 +30,19 @@ func (h Handler) Close() {
 }
 
 type HandlerParams struct {
-	AccountStore methods.AccountStore
-	Logger       *log.Entry
+	AccountStore     methods.AccountStore
+	TransactionProxy *methods.TransactionProxy
+	Logger           *log.Entry
 }
 
 // NewJSONRPCHandler constructs a Handler instance
 func NewJSONRPCHandler(params HandlerParams) (Handler, error) {
 	return Handler{
 		bridge: jhttp.NewBridge(handler.Map{
-			"getHealth":  methods.NewHealthCheck(),
-			"getAccount": methods.NewAccountHandler(params.AccountStore),
+			"getHealth":            methods.NewHealthCheck(),
+			"getAccount":           methods.NewAccountHandler(params.AccountStore),
+			"getTransactionStatus": methods.NewGetTransactionHandler(params.TransactionProxy),
+			"sendTransaction":      methods.NewSendTransactionHandler(params.TransactionProxy),
 		}, nil),
 		logger: params.Logger,
 	}, nil

--- a/exp/services/soroban-rpc/internal/jsonrpc.go
+++ b/exp/services/soroban-rpc/internal/jsonrpc.go
@@ -12,8 +12,14 @@ import (
 
 // Handler is the HTTP handler which serves the Soroban JSON RPC responses
 type Handler struct {
-	bridge jhttp.Bridge
-	logger *log.Entry
+	bridge           jhttp.Bridge
+	logger           *log.Entry
+	transactionProxy *methods.TransactionProxy
+}
+
+// Start spawns the background workers necessary for the JSON RPC handlers.
+func (h Handler) Start() {
+	h.transactionProxy.Start()
 }
 
 // ServeHTTP implements the http.Handler interface
@@ -27,6 +33,7 @@ func (h Handler) Close() {
 	if err := h.bridge.Close(); err != nil {
 		h.logger.WithError(err).Warn("could not close bridge")
 	}
+	h.transactionProxy.Close()
 }
 
 type HandlerParams struct {
@@ -41,9 +48,10 @@ func NewJSONRPCHandler(params HandlerParams) (Handler, error) {
 		bridge: jhttp.NewBridge(handler.Map{
 			"getHealth":            methods.NewHealthCheck(),
 			"getAccount":           methods.NewAccountHandler(params.AccountStore),
-			"getTransactionStatus": methods.NewGetTransactionHandler(params.TransactionProxy),
+			"getTransactionStatus": methods.NewGetTransactionStatusHandler(params.TransactionProxy),
 			"sendTransaction":      methods.NewSendTransactionHandler(params.TransactionProxy),
 		}, nil),
-		logger: params.Logger,
+		logger:           params.Logger,
+		transactionProxy: params.TransactionProxy,
 	}, nil
 }

--- a/exp/services/soroban-rpc/internal/jsonrpc.go
+++ b/exp/services/soroban-rpc/internal/jsonrpc.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/creachadair/jrpc2/handler"
@@ -19,7 +20,7 @@ type Handler struct {
 
 // Start spawns the background workers necessary for the JSON RPC handlers.
 func (h Handler) Start() {
-	h.transactionProxy.Start()
+	h.transactionProxy.Start(context.Background())
 }
 
 // ServeHTTP implements the http.Handler interface

--- a/exp/services/soroban-rpc/internal/methods/transaction.go
+++ b/exp/services/soroban-rpc/internal/methods/transaction.go
@@ -3,23 +3,25 @@ package methods
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
 
 	"github.com/creachadair/jrpc2"
-	"github.com/creachadair/jrpc2/code"
 	"github.com/creachadair/jrpc2/handler"
 
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/xdr"
 )
 
 const (
-	TransactionComplete = "complete"
-	TransactionPending  = "pending"
+	TransactionSuccess = "success"
+	TransactionPending = "pending"
+	TransactionError   = "error"
 )
 
 type SendTransactionRequest struct {
@@ -34,16 +36,19 @@ type TransactionStatusResponse struct {
 	ID     string               `json:"id"`
 	Status string               `json:"status"`
 	Result *horizon.Transaction `json:"result"`
+	Error  *problem.P           `json:"error"`
 }
 
 type SendTransactionResponse struct {
-	ID string `json:"id"`
+	ID     string     `json:"id"`
+	Status string     `json:"status"`
+	Error  *problem.P `json:"error"`
 }
 
 type transactionResult struct {
 	timestamp time.Time
 	pending   bool
-	err       error
+	err       *problem.P
 }
 
 type horizonRequest struct {
@@ -52,57 +57,77 @@ type horizonRequest struct {
 }
 
 type TransactionProxy struct {
-	lock            sync.RWMutex
-	results         map[string]transactionResult
-	client          *horizonclient.Client
-	passphrase      string
-	queue           chan horizonRequest
-	workers         int
-	expiryFrequency time.Duration
-	ttl             time.Duration
+	lock       sync.RWMutex
+	results    map[string]transactionResult
+	client     *horizonclient.Client
+	passphrase string
+	queue      chan horizonRequest
+	workers    int
+	ttl        time.Duration
+	ctx        context.Context
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
 }
 
 func NewTransactionProxy(
 	client *horizonclient.Client,
 	workers, queueSize int,
 	networkPassphrase string,
-	expiryFrequency, ttl time.Duration) *TransactionProxy {
+	ttl time.Duration,
+) *TransactionProxy {
+	if workers > queueSize {
+		queueSize = workers
+	}
+	ctx, cancel := context.WithCancel(context.Background())
 	return &TransactionProxy{
-		results:         map[string]transactionResult{},
-		client:          client,
-		passphrase:      networkPassphrase,
-		queue:           make(chan horizonRequest, queueSize),
-		workers:         workers,
-		expiryFrequency: expiryFrequency,
-		ttl:             ttl,
+		results:    map[string]transactionResult{},
+		client:     client,
+		passphrase: networkPassphrase,
+		queue:      make(chan horizonRequest, queueSize),
+		workers:    workers,
+		ttl:        ttl,
+		ctx:        ctx,
+		cancel:     cancel,
 	}
 }
 
-func (p *TransactionProxy) Start(ctx context.Context) {
+func (p *TransactionProxy) Start() {
 	for i := 0; i < p.workers; i++ {
-		go p.startWorker(ctx)
+		p.wg.Add(1)
+		go p.startWorker(p.ctx)
 	}
-
-	go p.startExpiryTicker(ctx)
 }
 
-func (p *TransactionProxy) SendTransaction(ctx context.Context, request SendTransactionRequest) (SendTransactionResponse, error) {
+func (p *TransactionProxy) Close() {
+	p.cancel()
+	p.wg.Wait()
+}
+
+func (p *TransactionProxy) SendTransaction(ctx context.Context, request SendTransactionRequest) SendTransactionResponse {
+	defer p.deleteExpiredEntries(time.Now())
+
 	var envelope xdr.TransactionEnvelope
 	err := xdr.SafeUnmarshalBase64(request.Transaction, &envelope)
 	if err != nil {
-		return SendTransactionResponse{}, (&jrpc2.Error{
-			Code:    code.InvalidParams,
-			Message: "Invalid transaction XDR",
-		}).WithData(err)
+		return SendTransactionResponse{
+			Status: TransactionError,
+			Error: problem.MakeInvalidFieldProblem(
+				"transaction",
+				fmt.Errorf("cannot unmarshall transaction: %v", err),
+			),
+		}
 	}
 
 	var hash [32]byte
 	hash, err = network.HashTransactionInEnvelope(envelope, p.passphrase)
 	if err != nil {
-		return SendTransactionResponse{}, (&jrpc2.Error{
-			Code:    code.InvalidParams,
-			Message: "Transaction could not be hashed",
-		}).WithData(err)
+		return SendTransactionResponse{
+			Status: TransactionError,
+			Error: problem.MakeInvalidFieldProblem(
+				"transaction",
+				fmt.Errorf("cannot hash transaction: %v", err),
+			),
+		}
 	}
 	txHash := hex.EncodeToString(hash[:])
 
@@ -114,21 +139,26 @@ func (p *TransactionProxy) SendTransaction(ctx context.Context, request SendTran
 	// response
 	if result.pending || (ok && result.err == nil) {
 		return SendTransactionResponse{
-			ID: txHash,
-		}, nil
+			ID:     txHash,
+			Status: TransactionPending,
+		}
 	}
 
 	p.results[txHash] = transactionResult{pending: true}
 	select {
 	case p.queue <- horizonRequest{txHash: txHash, transactionXDR: request.Transaction}:
 		return SendTransactionResponse{
-			ID: txHash,
-		}, nil
+			ID:     txHash,
+			Status: TransactionPending,
+		}
 	default:
 		delete(p.results, txHash)
-		return SendTransactionResponse{}, &jrpc2.Error{
-			Code:    code.InternalError,
-			Message: "Request queue is full",
+		problemErr := problem.ServerError
+		problemErr.Detail = "Transaction queue is full"
+		return SendTransactionResponse{
+			ID:     txHash,
+			Status: TransactionError,
+			Error:  &problemErr,
 		}
 	}
 }
@@ -146,6 +176,7 @@ func (p *TransactionProxy) deletePendingEntry(txHash string) {
 }
 
 func (p *TransactionProxy) startWorker(ctx context.Context) {
+	defer p.wg.Done()
 	for {
 		select {
 		case <-ctx.Done():
@@ -155,12 +186,11 @@ func (p *TransactionProxy) startWorker(ctx context.Context) {
 			if err != nil {
 				result := transactionResult{timestamp: time.Now()}
 				if herr, ok := err.(*horizonclient.Error); ok {
-					result.err = (&jrpc2.Error{
-						Code:    code.InvalidRequest,
-						Message: herr.Problem.Title,
-					}).WithData(herr.Problem.Extras)
+					result.err = &herr.Problem
 				} else {
-					result.err = err
+					problemErr := problem.ServerError
+					problemErr.Detail = fmt.Sprintf("transaction submission failed: %v", err)
+					result.err = &problemErr
 				}
 				p.setTxResult(request.txHash, result)
 			} else {
@@ -170,34 +200,48 @@ func (p *TransactionProxy) startWorker(ctx context.Context) {
 	}
 }
 
-func (p *TransactionProxy) GetTransactionStatus(ctx context.Context, request GetTransactionStatusRequest) (TransactionStatusResponse, error) {
+func (p *TransactionProxy) GetTransactionStatus(ctx context.Context, request GetTransactionStatusRequest) TransactionStatusResponse {
 	tx, err := p.client.TransactionDetail(request.Hash)
 	if err != nil {
 		if herr, ok := err.(*horizonclient.Error); ok {
 			if herr.Problem.Status != http.StatusNotFound {
-				return TransactionStatusResponse{}, (&jrpc2.Error{
-					Code:    code.InvalidRequest,
-					Message: herr.Problem.Title,
-				}).WithData(herr.Problem.Extras)
+				return TransactionStatusResponse{
+					ID:     request.Hash,
+					Status: TransactionError,
+					Error:  &herr.Problem,
+				}
 			}
 		} else {
-			return TransactionStatusResponse{}, err
+			problemErr := problem.ServerError
+			problemErr.Detail = fmt.Sprintf("transaction submission failed: %v", err)
+			return TransactionStatusResponse{
+				ID:     request.Hash,
+				Status: TransactionError,
+				Error:  &problemErr,
+			}
 		}
 	} else {
+		status := TransactionSuccess
+		if !tx.Successful {
+			status = TransactionError
+		}
 		return TransactionStatusResponse{
 			ID:     request.Hash,
-			Status: TransactionComplete,
+			Status: status,
 			Result: &tx,
-		}, nil
+		}
 	}
 
+	// herr.Problem.Status == http.StatusNotFound
+	// if the tx is not found perform the request
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 	result, ok := p.results[request.Hash]
 	if !ok {
-		return TransactionStatusResponse{}, jrpc2.Error{
-			Code:    code.InvalidRequest,
-			Message: "Not Found",
+		return TransactionStatusResponse{
+			ID:     request.Hash,
+			Status: TransactionError,
+			Error:  problem.MakeInvalidFieldProblem("hash", fmt.Errorf("transaction not found")),
 		}
 	}
 
@@ -205,23 +249,13 @@ func (p *TransactionProxy) GetTransactionStatus(ctx context.Context, request Get
 		return TransactionStatusResponse{
 			ID:     request.Hash,
 			Status: TransactionPending,
-			Result: nil,
-		}, nil
+		}
 	}
 
-	return TransactionStatusResponse{}, result.err
-}
-
-func (p *TransactionProxy) startExpiryTicker(ctx context.Context) {
-	ticker := time.NewTicker(p.expiryFrequency)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			p.deleteExpiredEntries(time.Now())
-		case <-ctx.Done():
-			return
-		}
+	return TransactionStatusResponse{
+		ID:     request.Hash,
+		Status: TransactionError,
+		Error:  result.err,
 	}
 }
 
@@ -236,8 +270,8 @@ func (p *TransactionProxy) deleteExpiredEntries(now time.Time) {
 	}
 }
 
-// NewGetTransactionHandler returns a get transaction json rpc handler
-func NewGetTransactionHandler(proxy *TransactionProxy) jrpc2.Handler {
+// NewGetTransactionStatusHandler returns a get transaction json rpc handler
+func NewGetTransactionStatusHandler(proxy *TransactionProxy) jrpc2.Handler {
 	return handler.New(proxy.GetTransactionStatus)
 }
 

--- a/exp/services/soroban-rpc/internal/methods/transaction.go
+++ b/exp/services/soroban-rpc/internal/methods/transaction.go
@@ -36,7 +36,8 @@ type TransactionStatusResponse struct {
 	ID     string               `json:"id"`
 	Status string               `json:"status"`
 	Result *horizon.Transaction `json:"result"`
-	Error  *problem.P           `json:"error"`
+	// Error will be nil unless Status is equal to "error"
+	Error *problem.P `json:"error"`
 }
 
 type SendTransactionResponse struct {
@@ -64,7 +65,6 @@ type TransactionProxy struct {
 	queue      chan horizonRequest
 	workers    int
 	ttl        time.Duration
-	ctx        context.Context
 	cancel     context.CancelFunc
 	wg         sync.WaitGroup
 }
@@ -78,7 +78,6 @@ func NewTransactionProxy(
 	if workers > queueSize {
 		queueSize = workers
 	}
-	ctx, cancel := context.WithCancel(context.Background())
 	return &TransactionProxy{
 		results:    map[string]transactionResult{},
 		client:     client,
@@ -86,26 +85,25 @@ func NewTransactionProxy(
 		queue:      make(chan horizonRequest, queueSize),
 		workers:    workers,
 		ttl:        ttl,
-		ctx:        ctx,
-		cancel:     cancel,
 	}
 }
 
-func (p *TransactionProxy) Start() {
+func (p *TransactionProxy) Start(ctx context.Context) {
+	ctx, p.cancel = context.WithCancel(ctx)
+	p.wg.Add(p.workers)
 	for i := 0; i < p.workers; i++ {
-		p.wg.Add(1)
-		go p.startWorker(p.ctx)
+		go p.startWorker(ctx)
 	}
 }
 
 func (p *TransactionProxy) Close() {
+	// signal the worker go routines to abort
 	p.cancel()
+	// wait until the worker go routines are done
 	p.wg.Wait()
 }
 
 func (p *TransactionProxy) SendTransaction(ctx context.Context, request SendTransactionRequest) SendTransactionResponse {
-	defer p.deleteExpiredEntries(time.Now())
-
 	var envelope xdr.TransactionEnvelope
 	err := xdr.SafeUnmarshalBase64(request.Transaction, &envelope)
 	if err != nil {
@@ -132,7 +130,11 @@ func (p *TransactionProxy) SendTransaction(ctx context.Context, request SendTran
 	txHash := hex.EncodeToString(hash[:])
 
 	p.lock.Lock()
-	defer p.lock.Unlock()
+	defer func() {
+		p.deleteExpiredEntries(time.Now())
+		p.lock.Unlock()
+	}()
+
 	result, ok := p.results[txHash]
 	// if pending or completed without any errors use
 	// getTransactionStatus method with tx hash to obtain
@@ -259,10 +261,8 @@ func (p *TransactionProxy) GetTransactionStatus(ctx context.Context, request Get
 	}
 }
 
+// deleteExpiredEntries should only be called while the write lock is held
 func (p *TransactionProxy) deleteExpiredEntries(now time.Time) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
 	for key, val := range p.results {
 		if !val.pending && now.Sub(val.timestamp) > p.ttl {
 			delete(p.results, key)

--- a/exp/services/soroban-rpc/internal/methods/transaction.go
+++ b/exp/services/soroban-rpc/internal/methods/transaction.go
@@ -1,0 +1,247 @@
+package methods
+
+import (
+	"context"
+	"encoding/hex"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2/handler"
+
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/xdr"
+)
+
+const (
+	TransactionComplete = "complete"
+	TransactionPending  = "pending"
+)
+
+type SendTransactionRequest struct {
+	Transaction string `json:"transaction"`
+}
+
+type GetTransactionStatusRequest struct {
+	Hash string `json:"hash"`
+}
+
+type TransactionStatusResponse struct {
+	ID     string               `json:"id"`
+	Status string               `json:"status"`
+	Result *horizon.Transaction `json:"result"`
+}
+
+type SendTransactionResponse struct {
+	ID string `json:"id"`
+}
+
+type transactionResult struct {
+	timestamp time.Time
+	pending   bool
+	err       error
+}
+
+type horizonRequest struct {
+	txHash         string
+	transactionXDR string
+}
+
+type TransactionProxy struct {
+	lock            sync.RWMutex
+	results         map[string]transactionResult
+	client          *horizonclient.Client
+	passphrase      string
+	queue           chan horizonRequest
+	workers         int
+	expiryFrequency time.Duration
+	ttl             time.Duration
+}
+
+func NewTransactionProxy(
+	client *horizonclient.Client,
+	workers, queueSize int,
+	networkPassphrase string,
+	expiryFrequency, ttl time.Duration) *TransactionProxy {
+	return &TransactionProxy{
+		results:         map[string]transactionResult{},
+		client:          client,
+		passphrase:      networkPassphrase,
+		queue:           make(chan horizonRequest, queueSize),
+		workers:         workers,
+		expiryFrequency: expiryFrequency,
+		ttl:             ttl,
+	}
+}
+
+func (p *TransactionProxy) Start(ctx context.Context) {
+	for i := 0; i < p.workers; i++ {
+		go p.startWorker(ctx)
+	}
+
+	go p.startExpiryTicker(ctx)
+}
+
+func (p *TransactionProxy) SendTransaction(ctx context.Context, request SendTransactionRequest) (SendTransactionResponse, error) {
+	var envelope xdr.TransactionEnvelope
+	err := xdr.SafeUnmarshalBase64(request.Transaction, &envelope)
+	if err != nil {
+		return SendTransactionResponse{}, (&jrpc2.Error{
+			Code:    code.InvalidParams,
+			Message: "Invalid transaction XDR",
+		}).WithData(err)
+	}
+
+	var hash [32]byte
+	hash, err = network.HashTransactionInEnvelope(envelope, p.passphrase)
+	if err != nil {
+		return SendTransactionResponse{}, (&jrpc2.Error{
+			Code:    code.InvalidParams,
+			Message: "Transaction could not be hashed",
+		}).WithData(err)
+	}
+	txHash := hex.EncodeToString(hash[:])
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	result, ok := p.results[txHash]
+	// if pending or completed without any errors use
+	// getTransactionStatus method with tx hash to obtain
+	// response
+	if result.pending || (ok && result.err == nil) {
+		return SendTransactionResponse{
+			ID: txHash,
+		}, nil
+	}
+
+	p.results[txHash] = transactionResult{pending: true}
+	select {
+	case p.queue <- horizonRequest{txHash: txHash, transactionXDR: request.Transaction}:
+		return SendTransactionResponse{
+			ID: txHash,
+		}, nil
+	default:
+		delete(p.results, txHash)
+		return SendTransactionResponse{}, &jrpc2.Error{
+			Code:    code.InternalError,
+			Message: "Request queue is full",
+		}
+	}
+}
+
+func (p *TransactionProxy) setTxResult(txHash string, result transactionResult) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.results[txHash] = result
+}
+
+func (p *TransactionProxy) deletePendingEntry(txHash string) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	delete(p.results, txHash)
+}
+
+func (p *TransactionProxy) startWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case request := <-p.queue:
+			_, err := p.client.SubmitTransactionXDR(request.transactionXDR)
+			if err != nil {
+				result := transactionResult{timestamp: time.Now()}
+				if herr, ok := err.(*horizonclient.Error); ok {
+					result.err = (&jrpc2.Error{
+						Code:    code.InvalidRequest,
+						Message: herr.Problem.Title,
+					}).WithData(herr.Problem.Extras)
+				} else {
+					result.err = err
+				}
+				p.setTxResult(request.txHash, result)
+			} else {
+				p.deletePendingEntry(request.txHash)
+			}
+		}
+	}
+}
+
+func (p *TransactionProxy) GetTransactionStatus(ctx context.Context, request GetTransactionStatusRequest) (TransactionStatusResponse, error) {
+	tx, err := p.client.TransactionDetail(request.Hash)
+	if err != nil {
+		if herr, ok := err.(*horizonclient.Error); ok {
+			if herr.Problem.Status != http.StatusNotFound {
+				return TransactionStatusResponse{}, (&jrpc2.Error{
+					Code:    code.InvalidRequest,
+					Message: herr.Problem.Title,
+				}).WithData(herr.Problem.Extras)
+			}
+		} else {
+			return TransactionStatusResponse{}, err
+		}
+	} else {
+		return TransactionStatusResponse{
+			ID:     request.Hash,
+			Status: TransactionComplete,
+			Result: &tx,
+		}, nil
+	}
+
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	result, ok := p.results[request.Hash]
+	if !ok {
+		return TransactionStatusResponse{}, jrpc2.Error{
+			Code:    code.InvalidRequest,
+			Message: "Not Found",
+		}
+	}
+
+	if result.pending {
+		return TransactionStatusResponse{
+			ID:     request.Hash,
+			Status: TransactionPending,
+			Result: nil,
+		}, nil
+	}
+
+	return TransactionStatusResponse{}, result.err
+}
+
+func (p *TransactionProxy) startExpiryTicker(ctx context.Context) {
+	ticker := time.NewTicker(p.expiryFrequency)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			p.deleteExpiredEntries(time.Now())
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (p *TransactionProxy) deleteExpiredEntries(now time.Time) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	for key, val := range p.results {
+		if !val.pending && now.Sub(val.timestamp) > p.ttl {
+			delete(p.results, key)
+		}
+	}
+}
+
+// NewGetTransactionHandler returns a get transaction json rpc handler
+func NewGetTransactionHandler(proxy *TransactionProxy) jrpc2.Handler {
+	return handler.New(proxy.GetTransactionStatus)
+}
+
+// NewSendTransactionHandler returns a submit transaction json rpc handler
+func NewSendTransactionHandler(proxy *TransactionProxy) jrpc2.Handler {
+	return handler.New(proxy.SendTransaction)
+}

--- a/exp/services/soroban-rpc/internal/methods/transaction_test.go
+++ b/exp/services/soroban-rpc/internal/methods/transaction_test.go
@@ -1,0 +1,54 @@
+package methods
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestDeleteExpiredTransaction(t *testing.T) {
+	ttl := time.Minute
+	proxy := NewTransactionProxy(
+		nil,
+		10,
+		10,
+		"",
+		2*time.Minute,
+		ttl,
+	)
+	pending := transactionResult{
+		pending: true,
+	}
+	proxy.results["a"] = pending
+	proxy.results["b"] = pending
+	t.Run("ignores pending", func(t *testing.T) {
+		proxy.deleteExpiredEntries(time.Now())
+		assert.Len(t, proxy.results, 2)
+
+		assert.Equal(t, pending, proxy.results["a"])
+		assert.Equal(t, pending, proxy.results["b"])
+	})
+
+	proxy.results = map[string]transactionResult{}
+	proxy.results["a"] = transactionResult{
+		pending: false,
+	}
+	proxy.results["b"] = transactionResult{
+		pending:   false,
+		timestamp: time.Now().Add(-time.Hour),
+	}
+	notYetExpired := transactionResult{
+		pending:   false,
+		timestamp: time.Now().Add(-time.Second),
+	}
+	proxy.results["c"] = notYetExpired
+	proxy.results["d"] = pending
+	t.Run("ignores pending", func(t *testing.T) {
+		proxy.deleteExpiredEntries(time.Now())
+		assert.Len(t, proxy.results, 2)
+
+		assert.Equal(t, notYetExpired, proxy.results["c"])
+		assert.Equal(t, pending, proxy.results["d"])
+	})
+
+}

--- a/exp/services/soroban-rpc/internal/methods/transaction_test.go
+++ b/exp/services/soroban-rpc/internal/methods/transaction_test.go
@@ -13,7 +13,6 @@ func TestDeleteExpiredTransaction(t *testing.T) {
 		10,
 		10,
 		"",
-		2*time.Minute,
 		ttl,
 	)
 	pending := transactionResult{

--- a/exp/services/soroban-rpc/internal/test/integration.go
+++ b/exp/services/soroban-rpc/internal/test/integration.go
@@ -69,13 +69,11 @@ func NewTest(t *testing.T) *Test {
 func (i *Test) configureJSONRPCServer() {
 	logger := log.New()
 
-	ctx, cancel := context.WithCancel(context.Background())
 	proxy := methods.NewTransactionProxy(
 		i.horizonClient,
 		10,
 		10,
 		StandaloneNetworkPassphrase,
-		2*time.Minute,
 		2*time.Minute,
 	)
 
@@ -88,11 +86,9 @@ func (i *Test) configureJSONRPCServer() {
 		Logger:           logger,
 	})
 	if err != nil {
-		cancel()
 		i.t.Fatalf("cannot create handler: %v", err)
 	}
-	i.shutdownCalls = append(i.shutdownCalls, cancel)
-	proxy.Start(ctx)
+	i.handler.Start()
 	i.server = httptest.NewServer(i.handler)
 }
 

--- a/exp/services/soroban-rpc/internal/test/integration.go
+++ b/exp/services/soroban-rpc/internal/test/integration.go
@@ -69,16 +69,30 @@ func NewTest(t *testing.T) *Test {
 func (i *Test) configureJSONRPCServer() {
 	logger := log.New()
 
+	ctx, cancel := context.WithCancel(context.Background())
+	proxy := methods.NewTransactionProxy(
+		i.horizonClient,
+		10,
+		10,
+		StandaloneNetworkPassphrase,
+		2*time.Minute,
+		2*time.Minute,
+	)
+
 	var err error
 	i.handler, err = internal.NewJSONRPCHandler(internal.HandlerParams{
 		AccountStore: methods.AccountStore{
 			Client: i.horizonClient,
 		},
-		Logger: logger,
+		TransactionProxy: proxy,
+		Logger:           logger,
 	})
 	if err != nil {
+		cancel()
 		i.t.Fatalf("cannot create handler: %v", err)
 	}
+	i.shutdownCalls = append(i.shutdownCalls, cancel)
+	proxy.Start(ctx)
 	i.server = httptest.NewServer(i.handler)
 }
 

--- a/exp/services/soroban-rpc/internal/test/transaction_test.go
+++ b/exp/services/soroban-rpc/internal/test/transaction_test.go
@@ -1,0 +1,221 @@
+package test
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/code"
+	"github.com/creachadair/jrpc2/jhttp"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/go/amount"
+	"github.com/stellar/go/exp/services/soroban-rpc/internal/methods"
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/txnbuild"
+)
+
+func TestSendTransactionSucceeds(t *testing.T) {
+	test := NewTest(t)
+
+	ch := jhttp.NewChannel(test.server.URL, nil)
+	cli := jrpc2.NewClient(ch, nil)
+
+	kp := keypair.Root(StandaloneNetworkPassphrase)
+	address := kp.Address()
+	account := txnbuild.NewSimpleAccount(address, 0)
+
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount:        &account,
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.SetOptions{HomeDomain: txnbuild.NewHomeDomain("soroban.com")},
+		},
+		BaseFee: txnbuild.MinBaseFee,
+		Preconditions: txnbuild.Preconditions{
+			TimeBounds: txnbuild.NewInfiniteTimeout(),
+		},
+	})
+	assert.NoError(t, err)
+	tx, err = tx.Sign(StandaloneNetworkPassphrase, kp)
+	assert.NoError(t, err)
+	b64, err := tx.Base64()
+	assert.NoError(t, err)
+
+	request := methods.SendTransactionRequest{Transaction: b64}
+	var result methods.SendTransactionResponse
+	err = cli.CallResult(context.Background(), "sendTransaction", request, &result)
+	assert.NoError(t, err)
+
+	expectedHash, err := tx.HashHex(StandaloneNetworkPassphrase)
+	assert.NoError(t, err)
+
+	assert.Equal(t, methods.SendTransactionResponse{ID: expectedHash}, result)
+
+	getTransactionStatus(t, cli, expectedHash, func(t *testing.T, response methods.TransactionStatusResponse) {
+		assert.Equal(t, methods.TransactionComplete, response.Status)
+		assert.Equal(t, expectedHash, response.ID)
+		assert.Equal(t, true, response.Result.Successful)
+
+		accountInfoRequest := methods.AccountRequest{
+			Address: address,
+		}
+		var accountInfoResponse methods.AccountInfo
+		err = cli.CallResult(context.Background(), "getAccount", accountInfoRequest, &accountInfoResponse)
+		assert.NoError(t, err)
+		assert.Equal(t, methods.AccountInfo{ID: address, Sequence: 1}, accountInfoResponse)
+	})
+}
+
+func getTransactionStatus(t *testing.T, cli *jrpc2.Client, hash string, f func(*testing.T, methods.TransactionStatusResponse)) {
+	for i := 0; i < 60; i++ {
+		var result methods.TransactionStatusResponse
+		request := methods.GetTransactionStatusRequest{Hash: hash}
+		err := cli.CallResult(context.Background(), "getTransactionStatus", request, &result)
+		assert.NoError(t, err)
+
+		if result.Status == methods.TransactionPending {
+			time.Sleep(time.Second)
+			continue
+		}
+
+		f(t, result)
+		return
+	}
+	t.Fatal("getTransactionStatus timed out")
+}
+
+func assertTransactionStatusError(t *testing.T, cli *jrpc2.Client, hash string, f func(*testing.T, error)) {
+	for i := 0; i < 60; i++ {
+		var result methods.TransactionStatusResponse
+		request := methods.GetTransactionStatusRequest{Hash: hash}
+		err := cli.CallResult(context.Background(), "getTransactionStatus", request, &result)
+
+		if err == nil && result.Status == methods.TransactionPending {
+			time.Sleep(time.Second)
+			continue
+		} else if err == nil {
+			t.Fatalf("expected transaction to fail but got %v", result)
+		}
+
+		f(t, err)
+		return
+	}
+	t.Fatal("getTransactionStatus timed out")
+}
+
+func TestSendTransactionBadSequence(t *testing.T) {
+	test := NewTest(t)
+
+	ch := jhttp.NewChannel(test.server.URL, nil)
+	cli := jrpc2.NewClient(ch, nil)
+
+	kp := keypair.Root(StandaloneNetworkPassphrase)
+	address := kp.Address()
+	account := txnbuild.NewSimpleAccount(address, 0)
+
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount: &account,
+		Operations: []txnbuild.Operation{
+			&txnbuild.SetOptions{HomeDomain: txnbuild.NewHomeDomain("soroban.com")},
+		},
+		BaseFee: txnbuild.MinBaseFee,
+		Preconditions: txnbuild.Preconditions{
+			TimeBounds: txnbuild.NewInfiniteTimeout(),
+		},
+	})
+	assert.NoError(t, err)
+	tx, err = tx.Sign(StandaloneNetworkPassphrase, kp)
+	assert.NoError(t, err)
+	b64, err := tx.Base64()
+	assert.NoError(t, err)
+
+	request := methods.SendTransactionRequest{Transaction: b64}
+	var result methods.SendTransactionResponse
+	err = cli.CallResult(context.Background(), "sendTransaction", request, &result)
+	assert.NoError(t, err)
+
+	expectedHash, err := tx.HashHex(StandaloneNetworkPassphrase)
+	assert.NoError(t, err)
+
+	assert.Equal(t, methods.SendTransactionResponse{ID: expectedHash}, result)
+
+	assertTransactionStatusError(t, cli, expectedHash, func(t *testing.T, err error) {
+		rpcErr := err.(*jrpc2.Error)
+		assert.Equal(t, "Transaction Failed", rpcErr.Message)
+		assert.Equal(t, code.InvalidRequest, rpcErr.Code)
+		assert.Equal(
+			t,
+			"{\"envelope_xdr\":\"AAAAAgAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1gAAAGQAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAC3Nvcm9iYW4uY29tAAAAAAAAAAAAAAAAARG5RtYAAABAvSifLEf7tP1tZ5sN/GYzqNmZnGV2BnMHHSaaRLSC7tzKu6vedJrdFX/u8iJRQZICF4T7FQQGl2BFEMmdF+8uCg==\",\"result_codes\":{\"transaction\":\"tx_bad_seq\"},\"result_xdr\":\"AAAAAAAAAAD////7AAAAAA==\"}",
+			string(rpcErr.Data),
+		)
+	})
+
+	// assert that the transaction was not included in any ledger
+	accountInfoRequest := methods.AccountRequest{
+		Address: address,
+	}
+	var accountInfoResponse methods.AccountInfo
+	err = cli.CallResult(context.Background(), "getAccount", accountInfoRequest, &accountInfoResponse)
+	assert.NoError(t, err)
+	assert.Equal(t, methods.AccountInfo{ID: address, Sequence: 0}, accountInfoResponse)
+}
+
+func TestSendTransactionFailed(t *testing.T) {
+	test := NewTest(t)
+
+	ch := jhttp.NewChannel(test.server.URL, nil)
+	cli := jrpc2.NewClient(ch, nil)
+
+	kp := keypair.Root(StandaloneNetworkPassphrase)
+	address := kp.Address()
+	account := txnbuild.NewSimpleAccount(address, 0)
+
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount:        &account,
+		IncrementSequenceNum: true,
+		Operations: []txnbuild.Operation{
+			&txnbuild.Payment{
+				Destination: "GD5KD2KEZJIGTC63IGW6UMUSMVUVG5IHG64HUTFWCHVZH2N2IBOQN7PS",
+				Amount:      amount.StringFromInt64(math.MaxInt64),
+				Asset:       txnbuild.NativeAsset{},
+			},
+		},
+		BaseFee: txnbuild.MinBaseFee,
+		Preconditions: txnbuild.Preconditions{
+			TimeBounds: txnbuild.NewInfiniteTimeout(),
+		},
+	})
+	assert.NoError(t, err)
+	tx, err = tx.Sign(StandaloneNetworkPassphrase, kp)
+	assert.NoError(t, err)
+	b64, err := tx.Base64()
+	assert.NoError(t, err)
+
+	request := methods.SendTransactionRequest{Transaction: b64}
+	var result methods.SendTransactionResponse
+	err = cli.CallResult(context.Background(), "sendTransaction", request, &result)
+	assert.NoError(t, err)
+
+	expectedHash, err := tx.HashHex(StandaloneNetworkPassphrase)
+	assert.NoError(t, err)
+
+	assert.Equal(t, methods.SendTransactionResponse{ID: expectedHash}, result)
+
+	getTransactionStatus(t, cli, expectedHash, func(t *testing.T, response methods.TransactionStatusResponse) {
+		assert.Equal(t, methods.TransactionComplete, response.Status)
+		assert.Equal(t, expectedHash, response.ID)
+		assert.Equal(t, false, response.Result.Successful)
+
+		// assert that the transaction was not included in any ledger
+		accountInfoRequest := methods.AccountRequest{
+			Address: address,
+		}
+		var accountInfoResponse methods.AccountInfo
+		err = cli.CallResult(context.Background(), "getAccount", accountInfoRequest, &accountInfoResponse)
+		assert.NoError(t, err)
+		assert.Equal(t, methods.AccountInfo{ID: address, Sequence: 1}, accountInfoResponse)
+	})
+}

--- a/exp/services/soroban-rpc/internal/test/transaction_test.go
+++ b/exp/services/soroban-rpc/internal/test/transaction_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/creachadair/jrpc2"
-	"github.com/creachadair/jrpc2/code"
 	"github.com/creachadair/jrpc2/jhttp"
 	"github.com/stretchr/testify/assert"
 
@@ -52,26 +51,29 @@ func TestSendTransactionSucceeds(t *testing.T) {
 	expectedHash, err := tx.HashHex(StandaloneNetworkPassphrase)
 	assert.NoError(t, err)
 
-	assert.Equal(t, methods.SendTransactionResponse{ID: expectedHash}, result)
+	assert.Equal(t, methods.SendTransactionResponse{
+		ID:     expectedHash,
+		Status: methods.TransactionPending,
+	}, result)
 
-	getTransactionStatus(t, cli, expectedHash, func(t *testing.T, response methods.TransactionStatusResponse) {
-		assert.Equal(t, methods.TransactionComplete, response.Status)
-		assert.Equal(t, expectedHash, response.ID)
-		assert.Equal(t, true, response.Result.Successful)
+	response := getTransactionStatus(t, cli, expectedHash)
+	assert.Equal(t, methods.TransactionSuccess, response.Status)
+	assert.Equal(t, expectedHash, response.ID)
+	assert.Equal(t, true, response.Result.Successful)
+	assert.Nil(t, response.Error)
 
-		accountInfoRequest := methods.AccountRequest{
-			Address: address,
-		}
-		var accountInfoResponse methods.AccountInfo
-		err = cli.CallResult(context.Background(), "getAccount", accountInfoRequest, &accountInfoResponse)
-		assert.NoError(t, err)
-		assert.Equal(t, methods.AccountInfo{ID: address, Sequence: 1}, accountInfoResponse)
-	})
+	accountInfoRequest := methods.AccountRequest{
+		Address: address,
+	}
+	var accountInfoResponse methods.AccountInfo
+	err = cli.CallResult(context.Background(), "getAccount", accountInfoRequest, &accountInfoResponse)
+	assert.NoError(t, err)
+	assert.Equal(t, methods.AccountInfo{ID: address, Sequence: 1}, accountInfoResponse)
 }
 
-func getTransactionStatus(t *testing.T, cli *jrpc2.Client, hash string, f func(*testing.T, methods.TransactionStatusResponse)) {
+func getTransactionStatus(t *testing.T, cli *jrpc2.Client, hash string) methods.TransactionStatusResponse {
+	var result methods.TransactionStatusResponse
 	for i := 0; i < 60; i++ {
-		var result methods.TransactionStatusResponse
 		request := methods.GetTransactionStatusRequest{Hash: hash}
 		err := cli.CallResult(context.Background(), "getTransactionStatus", request, &result)
 		assert.NoError(t, err)
@@ -81,29 +83,10 @@ func getTransactionStatus(t *testing.T, cli *jrpc2.Client, hash string, f func(*
 			continue
 		}
 
-		f(t, result)
-		return
+		return result
 	}
 	t.Fatal("getTransactionStatus timed out")
-}
-
-func assertTransactionStatusError(t *testing.T, cli *jrpc2.Client, hash string, f func(*testing.T, error)) {
-	for i := 0; i < 60; i++ {
-		var result methods.TransactionStatusResponse
-		request := methods.GetTransactionStatusRequest{Hash: hash}
-		err := cli.CallResult(context.Background(), "getTransactionStatus", request, &result)
-
-		if err == nil && result.Status == methods.TransactionPending {
-			time.Sleep(time.Second)
-			continue
-		} else if err == nil {
-			t.Fatalf("expected transaction to fail but got %v", result)
-		}
-
-		f(t, err)
-		return
-	}
-	t.Fatal("getTransactionStatus timed out")
+	return result
 }
 
 func TestSendTransactionBadSequence(t *testing.T) {
@@ -140,18 +123,20 @@ func TestSendTransactionBadSequence(t *testing.T) {
 	expectedHash, err := tx.HashHex(StandaloneNetworkPassphrase)
 	assert.NoError(t, err)
 
-	assert.Equal(t, methods.SendTransactionResponse{ID: expectedHash}, result)
+	assert.Equal(t, methods.SendTransactionResponse{
+		ID:     expectedHash,
+		Status: methods.TransactionPending,
+	}, result)
 
-	assertTransactionStatusError(t, cli, expectedHash, func(t *testing.T, err error) {
-		rpcErr := err.(*jrpc2.Error)
-		assert.Equal(t, "Transaction Failed", rpcErr.Message)
-		assert.Equal(t, code.InvalidRequest, rpcErr.Code)
-		assert.Equal(
-			t,
-			"{\"envelope_xdr\":\"AAAAAgAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1gAAAGQAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAC3Nvcm9iYW4uY29tAAAAAAAAAAAAAAAAARG5RtYAAABAvSifLEf7tP1tZ5sN/GYzqNmZnGV2BnMHHSaaRLSC7tzKu6vedJrdFX/u8iJRQZICF4T7FQQGl2BFEMmdF+8uCg==\",\"result_codes\":{\"transaction\":\"tx_bad_seq\"},\"result_xdr\":\"AAAAAAAAAAD////7AAAAAA==\"}",
-			string(rpcErr.Data),
-		)
-	})
+	response := getTransactionStatus(t, cli, expectedHash)
+	assert.Equal(t, methods.TransactionError, response.Status)
+	assert.Equal(t, expectedHash, response.ID)
+	assert.Nil(t, response.Result)
+	assert.Equal(t, "Transaction Failed", response.Error.Title)
+	assert.Equal(t, 400, response.Error.Status)
+	assert.Equal(t, map[string]interface{}{
+		"transaction": "tx_bad_seq",
+	}, response.Error.Extras["result_codes"])
 
 	// assert that the transaction was not included in any ledger
 	accountInfoRequest := methods.AccountRequest{
@@ -163,7 +148,7 @@ func TestSendTransactionBadSequence(t *testing.T) {
 	assert.Equal(t, methods.AccountInfo{ID: address, Sequence: 0}, accountInfoResponse)
 }
 
-func TestSendTransactionFailed(t *testing.T) {
+func TestSendTransactionFailedInLedger(t *testing.T) {
 	test := NewTest(t)
 
 	ch := jhttp.NewChannel(test.server.URL, nil)
@@ -202,20 +187,44 @@ func TestSendTransactionFailed(t *testing.T) {
 	expectedHash, err := tx.HashHex(StandaloneNetworkPassphrase)
 	assert.NoError(t, err)
 
-	assert.Equal(t, methods.SendTransactionResponse{ID: expectedHash}, result)
+	assert.Equal(t, methods.SendTransactionResponse{
+		ID:     expectedHash,
+		Status: methods.TransactionPending,
+	}, result)
 
-	getTransactionStatus(t, cli, expectedHash, func(t *testing.T, response methods.TransactionStatusResponse) {
-		assert.Equal(t, methods.TransactionComplete, response.Status)
-		assert.Equal(t, expectedHash, response.ID)
-		assert.Equal(t, false, response.Result.Successful)
+	response := getTransactionStatus(t, cli, expectedHash)
+	assert.Equal(t, methods.TransactionError, response.Status)
+	assert.Equal(t, expectedHash, response.ID)
+	assert.Equal(t, false, response.Result.Successful)
+	assert.Nil(t, response.Error)
 
-		// assert that the transaction was not included in any ledger
-		accountInfoRequest := methods.AccountRequest{
-			Address: address,
-		}
-		var accountInfoResponse methods.AccountInfo
-		err = cli.CallResult(context.Background(), "getAccount", accountInfoRequest, &accountInfoResponse)
-		assert.NoError(t, err)
-		assert.Equal(t, methods.AccountInfo{ID: address, Sequence: 1}, accountInfoResponse)
-	})
+	// assert that the transaction was not included in any ledger
+	accountInfoRequest := methods.AccountRequest{
+		Address: address,
+	}
+	var accountInfoResponse methods.AccountInfo
+	err = cli.CallResult(context.Background(), "getAccount", accountInfoRequest, &accountInfoResponse)
+	assert.NoError(t, err)
+	assert.Equal(t, methods.AccountInfo{ID: address, Sequence: 1}, accountInfoResponse)
+}
+
+func TestSendTransactionFailedInvalidXDR(t *testing.T) {
+	test := NewTest(t)
+
+	ch := jhttp.NewChannel(test.server.URL, nil)
+	cli := jrpc2.NewClient(ch, nil)
+
+	request := methods.SendTransactionRequest{Transaction: "abcdef"}
+	var response methods.SendTransactionResponse
+	err := cli.CallResult(context.Background(), "sendTransaction", request, &response)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "", response.ID)
+	assert.Equal(t, methods.TransactionError, response.Status)
+
+	assert.Equal(t, 400, response.Error.Status)
+	assert.Equal(t, map[string]interface{}{
+		"invalid_field": "transaction",
+		"reason":        "cannot unmarshall transaction: decoding EnvelopeType: decoding EnvelopeType: xdr:DecodeInt: unexpected EOF while decoding 4 bytes - read: '[105 183 29]'",
+	}, response.Error.Extras)
 }

--- a/exp/services/soroban-rpc/main.go
+++ b/exp/services/soroban-rpc/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/stellar/go/network"
 	"go/types"
 	"net/http"
 	"time"
@@ -14,6 +13,7 @@ import (
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/exp/services/soroban-rpc/internal"
 	"github.com/stellar/go/exp/services/soroban-rpc/internal/methods"
+	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/config"
 	supporthttp "github.com/stellar/go/support/http"
 	supportlog "github.com/stellar/go/support/log"

--- a/exp/services/soroban-rpc/main.go
+++ b/exp/services/soroban-rpc/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"github.com/stellar/go/network"
 	"go/types"
 	"net/http"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -19,7 +22,8 @@ import (
 
 func main() {
 	var port int
-	var horizonURL string
+	var horizonURL, networkPassphrase string
+	var txConcurrency, txQueueSize int
 	var logLevel logrus.Level
 	logger := supportlog.New()
 
@@ -55,6 +59,30 @@ func main() {
 			},
 			Usage: "minimum log severity (debug, info, warn, error) to log",
 		},
+		{
+			Name:        "network-passphrase",
+			Usage:       "Network passphrase of the Stellar network transactions should be signed for",
+			OptType:     types.String,
+			ConfigKey:   &networkPassphrase,
+			FlagDefault: network.TestNetworkPassphrase,
+			Required:    true,
+		},
+		{
+			Name:        "tx-concurrency",
+			Usage:       "Maximum number of concurrent transaction submissions",
+			OptType:     types.Int,
+			ConfigKey:   &txConcurrency,
+			FlagDefault: 10,
+			Required:    false,
+		},
+		{
+			Name:        "tx-queue",
+			Usage:       "Maximum length of pending transactions queue",
+			OptType:     types.Int,
+			ConfigKey:   &txQueueSize,
+			FlagDefault: 10,
+			Required:    false,
+		},
 	}
 	cmd := &cobra.Command{
 		Use:   "soroban-rpc",
@@ -73,20 +101,33 @@ func main() {
 			}
 			hc.SetHorizonTimeout(horizonclient.HorizonTimeout)
 
+			transactionProxy := methods.NewTransactionProxy(
+				hc,
+				txConcurrency,
+				txQueueSize,
+				networkPassphrase,
+				10*time.Minute,
+				5*time.Minute,
+			)
+
 			handler, err := internal.NewJSONRPCHandler(internal.HandlerParams{
-				AccountStore: methods.AccountStore{Client: hc},
-				Logger:       logger,
+				AccountStore:     methods.AccountStore{Client: hc},
+				Logger:           logger,
+				TransactionProxy: transactionProxy,
 			})
 			if err != nil {
 				logger.Fatalf("could not create handler: %v", err)
 			}
+			ctx, cancel := context.WithCancel(context.Background())
 			supporthttp.Run(supporthttp.Config{
 				ListenAddr: fmt.Sprintf(":%d", port),
 				Handler:    handler,
 				OnStarting: func() {
 					logger.Infof("Starting Soroban JSON RPC server on %v", port)
+					transactionProxy.Start(ctx)
 				},
 				OnStopping: func() {
+					cancel()
 					handler.Close()
 				},
 			})

--- a/exp/services/soroban-rpc/main.go
+++ b/exp/services/soroban-rpc/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"github.com/stellar/go/network"
 	"go/types"
@@ -21,20 +20,19 @@ import (
 )
 
 func main() {
-	var port int
-	var horizonURL, networkPassphrase string
+	var endpoint, horizonURL, networkPassphrase string
 	var txConcurrency, txQueueSize int
 	var logLevel logrus.Level
 	logger := supportlog.New()
 
 	configOpts := config.ConfigOptions{
 		{
-			Name:        "port",
-			Usage:       "Port to listen and serve on",
-			OptType:     types.Int,
-			ConfigKey:   &port,
-			FlagDefault: 8000,
-			Required:    true,
+			Name:        "endpoint",
+			Usage:       "Endpoint to listen and serve on",
+			OptType:     types.String,
+			ConfigKey:   &endpoint,
+			FlagDefault: "localhost:8000",
+			Required:    false,
 		},
 		&config.ConfigOption{
 			Name:        "horizon-url",
@@ -64,7 +62,7 @@ func main() {
 			Usage:       "Network passphrase of the Stellar network transactions should be signed for",
 			OptType:     types.String,
 			ConfigKey:   &networkPassphrase,
-			FlagDefault: network.TestNetworkPassphrase,
+			FlagDefault: network.FutureNetworkPassphrase,
 			Required:    true,
 		},
 		{
@@ -106,7 +104,6 @@ func main() {
 				txConcurrency,
 				txQueueSize,
 				networkPassphrase,
-				10*time.Minute,
 				5*time.Minute,
 			)
 
@@ -118,16 +115,14 @@ func main() {
 			if err != nil {
 				logger.Fatalf("could not create handler: %v", err)
 			}
-			ctx, cancel := context.WithCancel(context.Background())
 			supporthttp.Run(supporthttp.Config{
-				ListenAddr: fmt.Sprintf(":%d", port),
+				ListenAddr: endpoint,
 				Handler:    handler,
 				OnStarting: func() {
-					logger.Infof("Starting Soroban JSON RPC server on %v", port)
-					transactionProxy.Start(ctx)
+					logger.Infof("Starting Soroban JSON RPC server on %v", endpoint)
+					handler.Start()
 				},
 				OnStopping: func() {
-					cancel()
 					handler.Close()
 				},
 			})

--- a/network/main.go
+++ b/network/main.go
@@ -17,6 +17,8 @@ const (
 	PublicNetworkPassphrase = "Public Global Stellar Network ; September 2015"
 	// TestNetworkPassphrase is the pass phrase used for every transaction intended for the SDF-run test network
 	TestNetworkPassphrase = "Test SDF Network ; September 2015"
+	// FutureNetworkPassphrase is the pass phrase used for every transaction intended for the SDF-run future network
+	FutureNetworkPassphrase = "Test SDF Future Network ; October 2022"
 )
 
 // ID returns the network ID derived from the provided passphrase.  This value


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add json rpc methods for sending a transaction and querying a transaction status. This is implemented by proxying to the horizon txsub endpoint and the horizon transaction detail endpoint.

### Why

https://github.com/stellar/go/issues/4595
https://github.com/stellar/go/issues/4595

### Known limitations

* As a shortcut to save time ahead of meridian, we proxy transaction submissions to Horizon instead of submitting directly to captive core
* Pending transactions and transaction submission validation errors are stored in an memory data structure 
* I have not yet tested creating soroban smart contracts or invoking host functions because horizon does not support that functionality yet
* No websocket functionality implemented, so the client will need to poll the getTransactionStatus method
