### PR TITLE
horizon: update core version in p20 integration tests, to latest 1085 build

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -34,8 +34,8 @@ jobs:
     env:
       HORIZON_INTEGRATION_TESTS_ENABLED: true
       HORIZON_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL: ${{ matrix.protocol-version }}
-      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.4.1-1080.d3b80614c.focal~soroban
-      PROTOCOL_20_CORE_DOCKER_IMG: sreuland/stellar-core:19.4.1-1080.d3b80614c.focal-soroban
+      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.4.1-1085.fc63f3a6a.focal~soroban
+      PROTOCOL_20_CORE_DOCKER_IMG: sreuland/stellar-core:19.4.1-1085.fc63f3a6a.focal-soroban
       PROTOCOL_19_CORE_DEBIAN_PKG_VERSION: 19.4.0-1075.39bee1a2b.focal
       PROTOCOL_19_CORE_DOCKER_IMG: stellar/stellar-core:19.4.0-1075.39bee1a2b.focal
       PROTOCOL_18_CORE_DEBIAN_PKG_VERSION: 19.4.0-1075.39bee1a2b.focal


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

update the horizon p20 integration tests to use latest soroban build of core

### Why
need to confirm ingestion works with newest xdr and core versions
Closes: #4604 

### Known limitations


