### PR TITLE
horizon\ingest: fix LedgerEntryTypeContractData

### DIFF
--- a/ingest/checkpoint_change_reader.go
+++ b/ingest/checkpoint_change_reader.go
@@ -415,7 +415,6 @@ LoopBucketEntry:
 		case xdr.BucketEntryTypeLiveentry, xdr.BucketEntryTypeInitentry:
 			liveEntry := entry.MustLiveEntry()
 			key = liveEntry.LedgerKey()
-			// check if ContractData
 		case xdr.BucketEntryTypeDeadentry:
 			key = entry.MustDeadEntry()
 		default:

--- a/ingest/checkpoint_change_reader.go
+++ b/ingest/checkpoint_change_reader.go
@@ -362,6 +362,9 @@ LoopBucketEntry:
 				case xdr.BucketEntryTypeLiveentry, xdr.BucketEntryTypeInitentry:
 					liveEntry := entry.MustLiveEntry()
 					key = liveEntry.LedgerKey()
+					if (key.ContractData != nil) {
+						continue
+					}
 				case xdr.BucketEntryTypeDeadentry:
 					key = entry.MustDeadEntry()
 				default:

--- a/ingest/checkpoint_change_reader.go
+++ b/ingest/checkpoint_change_reader.go
@@ -362,9 +362,6 @@ LoopBucketEntry:
 				case xdr.BucketEntryTypeLiveentry, xdr.BucketEntryTypeInitentry:
 					liveEntry := entry.MustLiveEntry()
 					key = liveEntry.LedgerKey()
-					if (key.ContractData != nil) {
-						continue
-					}
 				case xdr.BucketEntryTypeDeadentry:
 					key = entry.MustDeadEntry()
 				default:
@@ -418,6 +415,7 @@ LoopBucketEntry:
 		case xdr.BucketEntryTypeLiveentry, xdr.BucketEntryTypeInitentry:
 			liveEntry := entry.MustLiveEntry()
 			key = liveEntry.LedgerKey()
+			// check if ContractData
 		case xdr.BucketEntryTypeDeadentry:
 			key = entry.MustDeadEntry()
 		default:

--- a/xdr/ledger_entry.go
+++ b/xdr/ledger_entry.go
@@ -44,8 +44,8 @@ func (entry *LedgerEntry) LedgerKey() LedgerKey {
 		contractData := entry.Data.MustContractData()
 		body = LedgerKeyContractData{
 			ContractId: contractData.ContractId,
-			Key: contractData.Key,
-		}	
+			Key:        contractData.Key,
+		}
 	default:
 		panic(fmt.Errorf("Unknown entry type: %v", entry.Data.Type))
 	}

--- a/xdr/ledger_entry.go
+++ b/xdr/ledger_entry.go
@@ -40,6 +40,12 @@ func (entry *LedgerEntry) LedgerKey() LedgerKey {
 		body = LedgerKeyLiquidityPool{
 			LiquidityPoolId: lPool.LiquidityPoolId,
 		}
+	case LedgerEntryTypeContractData:
+		contractData := entry.Data.MustContractData()
+		body = LedgerKeyContractData{
+			ContractId: contractData.ContractId,
+			Key: contractData.Key,
+		}	
 	default:
 		panic(fmt.Errorf("Unknown entry type: %v", entry.Data.Type))
 	}

--- a/xdr/ledger_key.go
+++ b/xdr/ledger_key.go
@@ -148,6 +148,9 @@ func (e *EncodingBuffer) ledgerKeyCompressEncodeTo(key LedgerKey) error {
 	case LedgerEntryTypeLiquidityPool:
 		_, err := e.xdrEncoderBuf.Write(key.LiquidityPool.LiquidityPoolId[:])
 		return err
+	case LedgerEntryTypeContractData:
+		_, err := e.xdrEncoderBuf.Write(key.ContractData.ContractId[:])
+		return err	
 	default:
 		panic("Unknown type")
 	}

--- a/xdr/ledger_key.go
+++ b/xdr/ledger_key.go
@@ -150,7 +150,7 @@ func (e *EncodingBuffer) ledgerKeyCompressEncodeTo(key LedgerKey) error {
 		return err
 	case LedgerEntryTypeContractData:
 		_, err := e.xdrEncoderBuf.Write(key.ContractData.ContractId[:])
-		return err	
+		return err
 	default:
 		panic("Unknown type")
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

```
time="2022-10-07T22:32:45.491Z" level=info msg="Processing entries from History Archive Snapshot" pid=23460 sequence=149503 service=ingest
time="2022-10-07T22:32:46.491Z" level=info msg="Finished request" app_name=undefined app_version=undefined bytes=4178 client_name=undefined client_version=undefined duration=0.001830334 host="localhost:8001" ip=127.0.0.1 ip_port="127.0.0.1:47760" method=GET path=/ pid=23460 referer=undefined req=1384c5028f80/ulxwsmsjGY-000003 route=/ status=200 streaming=false x_forwarder_for=
panic: Unknown entry type: LedgerEntryTypeContractData

goroutine 233 [running]:
github.com/stellar/go/xdr.(*LedgerEntry).LedgerKey(0xc00073dd28)
	github.com/stellar/go/xdr/ledger_entry.go:44 +0x933
github.com/stellar/go/ingest.(*CheckpointChangeReader).streamBucketContents(0xc0002d00b0, {0x80, 0xa3, 0xb6, 0xd6, 0xbf, 0xa4, 0x22, 0xc8, 0x8a, ...}, ...)
	github.com/stellar/go/ingest/checkpoint_change_reader.go:364 +0xf86
github.com/stellar/go/ingest.(*CheckpointChangeReader).streamBuckets(0xc0002d00b0)
	github.com/stellar/go/ingest/checkpoint_change_reader.go:229 +0x607
created by github.com/stellar/go/ingest.(*CheckpointChangeReader).Read.func1
	github.com/stellar/go/ingest/checkpoint_change_reader.go:513 +0x5a
starting horizon...

```

https://github.com/stellar/go/issues/4647#issuecomment-1272166215

### Why
enable horizon to ingest against futurenet for e2e tests 
https://github.com/stellar/go/issues/4646

### Known limitations

