### PR TITLE
services/horizon: Remove (unused) stellar/horizon docker image push

### DIFF
--- a/.github/workflows/horizon-master.yml
+++ b/.github/workflows/horizon-master.yml
@@ -6,31 +6,6 @@ on:
 
 jobs:
 
-  push-horizon-image-sha:
-    name: Push stellar/horizon:sha to DockerHub
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Get image tag (short sha)
-        shell: bash
-        id: get_tag
-        run: echo ::set-output name=TAG::$(git rev-parse --short ${{ github.sha }} )
-
-      - name: Login to DockerHub
-        uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push to DockerHub
-        uses: docker/build-push-action@7f9d37fa544684fb73bfe4835ed7214c255ce02b
-        with:
-          # TODO: Commented out until we disable the CircleCI jobs
-          # push: true
-          tags: stellar/horizon:${{ steps.get_tag.outputs.TAG }}
-          file: services/horizon/docker/Dockerfile.dev
-
   push-state-diff-image:
     name: Push stellar/ledger-state-diff:{sha,latest} to DockerHub
     runs-on: ubuntu-latest


### PR DESCRIPTION
When migrating the repository from CircleCI to GitHub we were planning on enabling pushing docker image `stellar/horizon:<commit-sha>` from the master branch on every merged commit.

However, we never enabled it (note the commented `# push: true` line)

If we haven't used this in 8 months and we haven't missed it, it's clear we don't need it. Also, `stellar/horizon` is confusing due to the name similarity with `stellar/stellar-horizon`, see #4669).
