### PR TITLE
services/horizon: Create stellar/horizon deprecation image

### DIFF
--- a/services/horizon/docker/Dockerfile.deprecate-horizon
+++ b/services/horizon/docker/Dockerfile.deprecate-horizon
@@ -1,0 +1,6 @@
+FROM stellar/horizon
+
+RUN mv /horizon /horizon.bin
+RUN echo "#!/bin/sh\necho WARNING: The stellar/horizon Docker image is outdated deprecated, please use stellar/stellar-horizon instead.\necho WARNING: The stellar/horizon image will be removed from DockerHub on March 27 2023.\nexec /horizon.bin" > /horizon
+RUN chmod +x /horizon
+

--- a/services/horizon/docker/Dockerfile.deprecate-horizon
+++ b/services/horizon/docker/Dockerfile.deprecate-horizon
@@ -1,6 +1,6 @@
 FROM stellar/horizon
 
-RUN mv /horizon /horizon.bin
-RUN echo "#!/bin/sh\necho WARNING: The stellar/horizon Docker image is outdated deprecated, please use stellar/stellar-horizon instead.\necho WARNING: The stellar/horizon image will be removed from DockerHub on March 27 2023.\nexec /horizon.bin" > /horizon
+#RUN mv /horizon /horizon.bin
+RUN echo "#!/bin/sh\necho WARNING: The stellar/horizon Docker image is outdated deprecated, please use stellar/stellar-horizon instead.\necho WARNING: The stellar/horizon image will be removed from DockerHub on March 27 2023.\nexec /horizon.bin \$@" > /horizon
 RUN chmod +x /horizon
 


### PR DESCRIPTION
This PR creates a deprecation image for `stellar/horizon`. Addresses part of #4669 

The idea is to (as a one-time-thing) build it and push it to dockerhub.

It works as follows:

```
$ docker build -f services/horizon/docker/Dockerfile.deprecate-horizon -t stellar/horizon services/horizon/docker
[...]

$ docker run stellar/horizon 
WARNING: The stellar/horizon Docker image is outdated deprecated, please use stellar/stellar-horizon instead.
WARNING: The stellar/horizon image will be removed from DockerHub on March 27 2023.
[...]
```

@jacekn Could you build and push the image? Do you want to proceed in any other (more formal) way?