### PR TITLE
verify-range: revert on-disk mode, use S3 URLs for history archives

### DIFF
--- a/services/horizon/docker/verify-range/captive-core-pubnet.cfg
+++ b/services/horizon/docker/verify-range/captive-core-pubnet.cfg
@@ -1,5 +1,4 @@
 PEER_PORT=11725
-DATABASE = "sqlite3:///cc/stellar.db"
 
 FAILURE_SAFETY=1
 
@@ -7,187 +6,23 @@ FAILURE_SAFETY=1
 HOME_DOMAIN="stellar.org"
 QUALITY="HIGH"
 
-[[HOME_DOMAINS]]
-HOME_DOMAIN="satoshipay.io"
-QUALITY="HIGH"
-
-[[HOME_DOMAINS]]
-HOME_DOMAIN="lobstr.co"
-QUALITY="HIGH"
-
-[[HOME_DOMAINS]]
-HOME_DOMAIN="www.coinqvest.com"
-QUALITY="HIGH"
-
-[[HOME_DOMAINS]]
-HOME_DOMAIN="publicnode.org"
-QUALITY="HIGH"
-
-[[HOME_DOMAINS]]
-HOME_DOMAIN="stellar.blockdaemon.com"
-QUALITY="HIGH"
-
-[[HOME_DOMAINS]]
-HOME_DOMAIN="wirexapp.com"
-QUALITY="HIGH"
-
 [[VALIDATORS]]
 NAME="sdf_1"
 HOME_DOMAIN="stellar.org"
 PUBLIC_KEY="GCGB2S2KGYARPVIA37HYZXVRM2YZUEXA6S33ZU5BUDC6THSB62LZSTYH"
 ADDRESS="core-live-a.stellar.org:11625"
-HISTORY="curl -sf https://history.stellar.org/prd/core-live/core_live_001/{0} -o {1}"
+HISTORY="curl -sf https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_001/{0} -o {1}"
 
 [[VALIDATORS]]
 NAME="sdf_2"
 HOME_DOMAIN="stellar.org"
 PUBLIC_KEY="GCM6QMP3DLRPTAZW2UZPCPX2LF3SXWXKPMP3GKFZBDSF3QZGV2G5QSTK"
 ADDRESS="core-live-b.stellar.org:11625"
-HISTORY="curl -sf https://history.stellar.org/prd/core-live/core_live_002/{0} -o {1}"
+HISTORY="curl -sf https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_002/{0} -o {1}"
 
 [[VALIDATORS]]
 NAME="sdf_3"
 HOME_DOMAIN="stellar.org"
 PUBLIC_KEY="GABMKJM6I25XI4K7U6XWMULOUQIQ27BCTMLS6BYYSOWKTBUXVRJSXHYQ"
 ADDRESS="core-live-c.stellar.org:11625"
-HISTORY="curl -sf https://history.stellar.org/prd/core-live/core_live_003/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="satoshipay_singapore"
-HOME_DOMAIN="satoshipay.io"
-PUBLIC_KEY="GBJQUIXUO4XSNPAUT6ODLZUJRV2NPXYASKUBY4G5MYP3M47PCVI55MNT"
-ADDRESS="stellar-sg-sin.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-sg-sin.satoshipay.io/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="satoshipay_iowa"
-HOME_DOMAIN="satoshipay.io"
-PUBLIC_KEY="GAK6Z5UVGUVSEK6PEOCAYJISTT5EJBB34PN3NOLEQG2SUKXRVV2F6HZY"
-ADDRESS="stellar-us-iowa.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-us-iowa.satoshipay.io/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="satoshipay_frankfurt"
-HOME_DOMAIN="satoshipay.io"
-PUBLIC_KEY="GC5SXLNAM3C4NMGK2PXK4R34B5GNZ47FYQ24ZIBFDFOCU6D4KBN4POAE"
-ADDRESS="stellar-de-fra.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-de-fra.satoshipay.io/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="lobstr_1_europe"
-HOME_DOMAIN="lobstr.co"
-PUBLIC_KEY="GCFONE23AB7Y6C5YZOMKUKGETPIAJA4QOYLS5VNS4JHBGKRZCPYHDLW7"
-ADDRESS="v1.stellar.lobstr.co:11625"
-HISTORY="curl -sf https://stellar-archive-1-lobstr.s3.amazonaws.com/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="lobstr_2_europe"
-HOME_DOMAIN="lobstr.co"
-PUBLIC_KEY="GDXQB3OMMQ6MGG43PWFBZWBFKBBDUZIVSUDAZZTRAWQZKES2CDSE5HKJ"
-ADDRESS="v2.stellar.lobstr.co:11625"
-HISTORY="curl -sf https://stellar-archive-2-lobstr.s3.amazonaws.com/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="lobstr_3_north_america"
-HOME_DOMAIN="lobstr.co"
-PUBLIC_KEY="GD5QWEVV4GZZTQP46BRXV5CUMMMLP4JTGFD7FWYJJWRL54CELY6JGQ63"
-ADDRESS="v3.stellar.lobstr.co:11625"
-HISTORY="curl -sf https://stellar-archive-3-lobstr.s3.amazonaws.com/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="lobstr_4_asia"
-HOME_DOMAIN="lobstr.co"
-PUBLIC_KEY="GA7TEPCBDQKI7JQLQ34ZURRMK44DVYCIGVXQQWNSWAEQR6KB4FMCBT7J"
-ADDRESS="v4.stellar.lobstr.co:11625"
-HISTORY="curl -sf https://stellar-archive-4-lobstr.s3.amazonaws.com/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="lobstr_5_australia"
-HOME_DOMAIN="lobstr.co"
-PUBLIC_KEY="GA5STBMV6QDXFDGD62MEHLLHZTPDI77U3PFOD2SELU5RJDHQWBR5NNK7"
-ADDRESS="v5.stellar.lobstr.co:11625"
-HISTORY="curl -sf https://stellar-archive-5-lobstr.s3.amazonaws.com/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="coinqvest_hong_kong"
-HOME_DOMAIN="www.coinqvest.com"
-PUBLIC_KEY="GAZ437J46SCFPZEDLVGDMKZPLFO77XJ4QVAURSJVRZK2T5S7XUFHXI2Z"
-ADDRESS="hongkong.stellar.coinqvest.com:11625"
-HISTORY="curl -sf https://hongkong.stellar.coinqvest.com/history/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="coinqvest_germany"
-HOME_DOMAIN="www.coinqvest.com"
-PUBLIC_KEY="GD6SZQV3WEJUH352NTVLKEV2JM2RH266VPEM7EH5QLLI7ZZAALMLNUVN"
-ADDRESS="germany.stellar.coinqvest.com:11625"
-HISTORY="curl -sf https://germany.stellar.coinqvest.com/history/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="coinqvest_finland"
-HOME_DOMAIN="www.coinqvest.com"
-PUBLIC_KEY="GADLA6BJK6VK33EM2IDQM37L5KGVCY5MSHSHVJA4SCNGNUIEOTCR6J5T"
-ADDRESS="finland.stellar.coinqvest.com:11625"
-HISTORY="curl -sf https://finland.stellar.coinqvest.com/history/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="bootes"
-HOME_DOMAIN="publicnode.org"
-PUBLIC_KEY="GCVJ4Z6TI6Z2SOGENSPXDQ2U4RKH3CNQKYUHNSSPYFPNWTLGS6EBH7I2"
-ADDRESS="bootes.publicnode.org"
-HISTORY="curl -sf https://bootes-history.publicnode.org/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="hercules"
-HOME_DOMAIN="publicnode.org"
-PUBLIC_KEY="GBLJNN3AVZZPG2FYAYTYQKECNWTQYYUUY2KVFN2OUKZKBULXIXBZ4FCT"
-ADDRESS="hercules.publicnode.org"
-HISTORY="curl -sf https://hercules-history.publicnode.org/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="lyra"
-HOME_DOMAIN="publicnode.org"
-PUBLIC_KEY="GCIXVKNFPKWVMKJKVK2V4NK7D4TC6W3BUMXSIJ365QUAXWBRPPJXIR2Z"
-ADDRESS="lyra.publicnode.org"
-HISTORY="curl -sf https://lyra-history.publicnode.org/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="Blockdaemon_Validator_1"
-HOME_DOMAIN="stellar.blockdaemon.com"
-PUBLIC_KEY="GAAV2GCVFLNN522ORUYFV33E76VPC22E72S75AQ6MBR5V45Z5DWVPWEU"
-ADDRESS="stellar-full-validator1.bdnodes.net"
-HISTORY="curl -sf https://stellar-full-history1.bdnodes.net/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="Blockdaemon_Validator_2"
-HOME_DOMAIN="stellar.blockdaemon.com"
-PUBLIC_KEY="GAVXB7SBJRYHSG6KSQHY74N7JAFRL4PFVZCNWW2ARI6ZEKNBJSMSKW7C"
-ADDRESS="stellar-full-validator2.bdnodes.net"
-HISTORY="curl -sf https://stellar-full-history2.bdnodes.net/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="Blockdaemon_Validator_3"
-HOME_DOMAIN="stellar.blockdaemon.com"
-PUBLIC_KEY="GAYXZ4PZ7P6QOX7EBHPIZXNWY4KCOBYWJCA4WKWRKC7XIUS3UJPT6EZ4"
-ADDRESS="stellar-full-validator3.bdnodes.net"
-HISTORY="curl -sf https://stellar-full-history3.bdnodes.net/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="wirexUS"
-ADDRESS="us.stellar.wirexapp.com"
-HOME_DOMAIN="wirexapp.com"
-PUBLIC_KEY="GDXUKFGG76WJC7ACEH3JUPLKM5N5S76QSMNDBONREUXPCZYVPOLFWXUS"
-HISTORY="curl -sf http://wxhorizonusstga1.blob.core.windows.net/history/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="wirexUK"
-ADDRESS="uk.stellar.wirexapp.com"
-HOME_DOMAIN="wirexapp.com"
-PUBLIC_KEY="GBBQQT3EIUSXRJC6TGUCGVA3FVPXVZLGG3OJYACWBEWYBHU46WJLWXEU"
-HISTORY="curl -sf http://wxhorizonukstga1.blob.core.windows.net/history/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="wirexSG"
-ADDRESS="sg.stellar.wirexapp.com"
-HOME_DOMAIN="wirexapp.com"
-PUBLIC_KEY="GAB3GZIE6XAYWXGZUDM4GMFFLJBFMLE2JDPUCWUZXMOMT3NHXDHEWXAS"
-HISTORY="curl -sf http://wxhorizonasiastga1.blob.core.windows.net/history/{0} -o {1}"
+HISTORY="curl -sf https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_003/{0} -o {1}"

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -71,19 +71,9 @@ dump_horizon_db() {
 export NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 export HISTORY_ARCHIVE_URLS="https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_001"
 export DATABASE_URL="postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable"
-export CAPTIVE_CORE_USE_DB="true"
 export CAPTIVE_CORE_CONFIG_APPEND_PATH="/captive-core-pubnet.cfg" 
 export STELLAR_CORE_BINARY_PATH="/usr/bin/stellar-core"
 export ENABLE_CAPTIVE_CORE_INGESTION="true"
-
-# CAPTIVE_CORE_STORAGE_PATH will store the archive files that core downloads
-# /cc path in this vm will have the sqlite3://stellar.db file which captive core will use for on-disk 
-# do a docker volume mount on /cc if the main disk storage devivce won't have at least 3k IOPS and 256GB
-# which is required by core for the i/o it will do against sqlite3:///cc/stellardb  
-if [ -z "${CAPTIVE_CORE_STORAGE_PATH}" ]; then
-    export CAPTIVE_CORE_STORAGE_PATH="/cc"
-fi	
-export CAPTIVE_CORE_REUSE_STORAGE_PATH="false"
 
 cd stellar-go
 git pull origin


### PR DESCRIPTION
Revert on-disk mode in Captive-Core config and use S3 URLs for history archives. The first change ensures that verify-range container runs fast (currently it takes 2 hours in AWS to ingest state alone for a single range), the second makes the download of bucket files faster in AWS Batch.