### PR TITLE
exp/services/soroban-rpc: Add LedgerEntry in-memory storage

### DIFF
--- a/exp/services/soroban-rpc/internal/ledgerentry_storage.go
+++ b/exp/services/soroban-rpc/internal/ledgerentry_storage.go
@@ -1,0 +1,202 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/stellar/go/historyarchive"
+	"github.com/stellar/go/ingest"
+	backends "github.com/stellar/go/ingest/ledgerbackend"
+	"github.com/stellar/go/xdr"
+)
+
+type LedgerEntryStorage interface {
+	GetLedgerEntry(key xdr.LedgerKey) (xdr.LedgerEntry, bool, uint32, error)
+	io.Closer
+}
+
+func NewLedgerEntryStorage(
+	networkPassPhrase string,
+	archive historyarchive.ArchiveInterface,
+	ledgerBackend backends.LedgerBackend) (LedgerEntryStorage, error) {
+	root, err := archive.GetRootHAS()
+	if err != nil {
+		return nil, err
+	}
+	checkpointLedger := root.CurrentLedger
+	ctx, done := context.WithCancel(context.Background())
+	ls := ledgerEntryStorage{
+		networkPassPhrase: networkPassPhrase,
+		storage:           map[string]xdr.LedgerEntry{},
+		done:              done,
+	}
+	ls.wg.Add(1)
+	go ls.run(ctx, checkpointLedger, archive, ledgerBackend)
+	return &ls, nil
+}
+
+type ledgerEntryStorage struct {
+	networkPassPhrase string
+
+	// from serialized ledger key to ledger entry
+	storage map[string]xdr.LedgerEntry
+	// What's the latest processed ledger
+	latestLedger uint32
+	sync.RWMutex
+	done context.CancelFunc
+	wg   sync.WaitGroup
+}
+
+func (ls *ledgerEntryStorage) GetLedgerEntry(key xdr.LedgerKey) (xdr.LedgerEntry, bool, uint32, error) {
+
+	stringKey, err := xdr.MarshalBase64(key)
+	if err != nil {
+		return xdr.LedgerEntry{}, false, 0, err
+	}
+	ls.RLock()
+	defer ls.RUnlock()
+	if ls.latestLedger == 0 {
+		// we haven't yet processed the first checkpoint
+	}
+
+	entry, present := ls.storage[stringKey]
+	if !present {
+		return xdr.LedgerEntry{}, false, 0, nil
+	}
+	return entry, true, ls.latestLedger, nil
+}
+
+func (ls *ledgerEntryStorage) Close() error {
+	ls.done()
+	ls.wg.Wait()
+	return nil
+}
+
+func (ls *ledgerEntryStorage) run(ctx context.Context, startCheckpointLedger uint32, archive historyarchive.ArchiveInterface, ledgerBackend backends.LedgerBackend) {
+	defer ls.wg.Done()
+
+	// First, process the checkpoint
+	// TODO: use a logger
+	fmt.Println("Starting processing of checkpoint", startCheckpointLedger)
+	checkpointCtx, cancelCheckpointCtx := context.WithTimeout(ctx, 30*time.Minute)
+	reader, err := ingest.NewCheckpointChangeReader(checkpointCtx, archive, startCheckpointLedger)
+	if err != nil {
+		// TODO: implement retries instead
+		panic(err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			cancelCheckpointCtx()
+			return
+		default:
+		}
+		change, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			// TODO: we probably shouldn't panic, at least in case of timeout
+			panic(err)
+		}
+
+		entry := change.Post
+		key := getRelevantLedgerKey(entry.Data)
+		if key == "" {
+			// not relevant
+			continue
+		}
+
+		// no need to Write-lock until we process the full checkpoint, since the reader checks latestLedger to be non-zero
+		ls.storage[key] = *entry
+
+		if len(ls.storage)%200 == 0 {
+			fmt.Printf("  processed %d checkpoint ledger entries\n", len(ls.storage))
+		}
+	}
+
+	cancelCheckpointCtx()
+
+	fmt.Println("Finished checkpoint processing")
+	ls.Lock()
+	ls.latestLedger = startCheckpointLedger
+	ls.Unlock()
+
+	// Now, continuously process txmeta deltas
+
+	// TODO: we can probably do the preparation in parallel with the checkpoint processing
+	prepareRangeCtx, cancelPrepareRange := context.WithTimeout(ctx, 10*time.Minute)
+	if err := ledgerBackend.PrepareRange(prepareRangeCtx, backends.UnboundedRange(startCheckpointLedger)); err != nil {
+		// TODO: we probably shouldn't panic, at least in case of timeout
+		panic(err)
+	}
+	cancelPrepareRange()
+
+	nextLedger := startCheckpointLedger + 1
+	for {
+		fmt.Println("Processing txmeta of ledger", nextLedger)
+		reader, err := ingest.NewLedgerChangeReader(ctx, ledgerBackend, ls.networkPassPhrase, nextLedger)
+		if err != nil {
+			// TODO: we probably shouldn't panic, at least in case of timeout/cancellation
+			panic(err)
+		}
+
+		// TODO: completely blocking reads between ledgers being processed may not be acceptable
+		//       however, we don't want to return ledger entries inbetween ledger updates
+		ls.Lock()
+		for {
+			change, err := reader.Read()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				// TODO: we probably shouldn't panic, at least in case of timeout/cancellation
+				panic(err)
+			}
+			if change.Post == nil {
+				key := getRelevantLedgerKey(change.Pre.Data)
+				if key == "" {
+					continue
+				}
+				delete(ls.storage, key)
+			} else {
+				key := getRelevantLedgerKey(change.Post.Data)
+				if key == "" {
+					continue
+				}
+				ls.storage[key] = *change.Post
+			}
+		}
+		ls.latestLedger = nextLedger
+		nextLedger++
+		fmt.Println("Ledger entry count", len(ls.storage))
+		ls.Unlock()
+		reader.Close()
+	}
+
+}
+
+func getRelevantLedgerKey(data xdr.LedgerEntryData) string {
+	var key xdr.LedgerKey
+	switch data.Type {
+	case xdr.LedgerEntryTypeAccount:
+		key.SetAccount(data.Account.AccountId)
+	case xdr.LedgerEntryTypeTrustline:
+		key.SetTrustline(data.TrustLine.AccountId, data.TrustLine.Asset)
+	case xdr.LedgerEntryTypeContractData:
+		key.SetContractData(data.ContractData.ContractId, data.ContractData.Val)
+	default:
+		// we don't care about any other entry types for now
+		return ""
+	}
+	stringKey, err := xdr.MarshalBase64(key)
+	if err != nil {
+		// TODO: we probably don't want to panic
+		panic(err)
+	}
+	return stringKey
+}

--- a/exp/services/soroban-rpc/internal/ledgerentry_storage.go
+++ b/exp/services/soroban-rpc/internal/ledgerentry_storage.go
@@ -39,8 +39,8 @@ func NewLedgerEntryStorage(
 }
 
 type ledgerEntryStorage struct {
+	encodingBuffer    *xdr.EncodingBuffer
 	networkPassPhrase string
-
 	// from serialized ledger key to ledger entry
 	storage map[string]xdr.LedgerEntry
 	// What's the latest processed ledger
@@ -51,10 +51,9 @@ type ledgerEntryStorage struct {
 }
 
 func (ls *ledgerEntryStorage) GetLedgerEntry(key xdr.LedgerKey) (xdr.LedgerEntry, bool, uint32, error) {
-
-	stringKey, err := xdr.MarshalBase64(key)
-	if err != nil {
-		return xdr.LedgerEntry{}, false, 0, err
+	stringKey := getRelevantLedgerKey(ls.encodingBuffer, key)
+	if stringKey == "" {
+		return xdr.LedgerEntry{}, false, 0, nil
 	}
 	ls.RLock()
 	defer ls.RUnlock()
@@ -87,6 +86,8 @@ func (ls *ledgerEntryStorage) run(ctx context.Context, startCheckpointLedger uin
 		// TODO: implement retries instead
 		panic(err)
 	}
+	// We intentionally use this local encoding buffer to avoid race conditions with the main one
+	buffer := xdr.NewEncodingBuffer()
 
 	for {
 		select {
@@ -105,7 +106,7 @@ func (ls *ledgerEntryStorage) run(ctx context.Context, startCheckpointLedger uin
 		}
 
 		entry := change.Post
-		key := getRelevantLedgerKey(entry.Data)
+		key := getRelevantLedgerKeyFromData(buffer, entry.Data)
 		if key == "" {
 			// not relevant
 			continue
@@ -114,7 +115,7 @@ func (ls *ledgerEntryStorage) run(ctx context.Context, startCheckpointLedger uin
 		// no need to Write-lock until we process the full checkpoint, since the reader checks latestLedger to be non-zero
 		ls.storage[key] = *entry
 
-		if len(ls.storage)%200 == 0 {
+		if len(ls.storage)%2000 == 0 {
 			fmt.Printf("  processed %d checkpoint ledger entries\n", len(ls.storage))
 		}
 	}
@@ -129,7 +130,7 @@ func (ls *ledgerEntryStorage) run(ctx context.Context, startCheckpointLedger uin
 	// Now, continuously process txmeta deltas
 
 	// TODO: we can probably do the preparation in parallel with the checkpoint processing
-	prepareRangeCtx, cancelPrepareRange := context.WithTimeout(ctx, 10*time.Minute)
+	prepareRangeCtx, cancelPrepareRange := context.WithTimeout(ctx, 30*time.Minute)
 	if err := ledgerBackend.PrepareRange(prepareRangeCtx, backends.UnboundedRange(startCheckpointLedger)); err != nil {
 		// TODO: we probably shouldn't panic, at least in case of timeout
 		panic(err)
@@ -158,13 +159,13 @@ func (ls *ledgerEntryStorage) run(ctx context.Context, startCheckpointLedger uin
 				panic(err)
 			}
 			if change.Post == nil {
-				key := getRelevantLedgerKey(change.Pre.Data)
+				key := getRelevantLedgerKeyFromData(buffer, change.Pre.Data)
 				if key == "" {
 					continue
 				}
 				delete(ls.storage, key)
 			} else {
-				key := getRelevantLedgerKey(change.Post.Data)
+				key := getRelevantLedgerKeyFromData(buffer, change.Post.Data)
 				if key == "" {
 					continue
 				}
@@ -180,7 +181,17 @@ func (ls *ledgerEntryStorage) run(ctx context.Context, startCheckpointLedger uin
 
 }
 
-func getRelevantLedgerKey(data xdr.LedgerEntryData) string {
+func getRelevantLedgerKey(buffer *xdr.EncodingBuffer, key xdr.LedgerKey) string {
+	// this is safe since we are converting to string right away, which causes a copy
+	binKey, err := buffer.LedgerKeyUnsafeMarshalBinaryCompress(key)
+	if err != nil {
+		// TODO: we probably don't want to panic
+		panic(err)
+	}
+	return string(binKey)
+}
+
+func getRelevantLedgerKeyFromData(buffer *xdr.EncodingBuffer, data xdr.LedgerEntryData) string {
 	var key xdr.LedgerKey
 	switch data.Type {
 	case xdr.LedgerEntryTypeAccount:
@@ -193,10 +204,5 @@ func getRelevantLedgerKey(data xdr.LedgerEntryData) string {
 		// we don't care about any other entry types for now
 		return ""
 	}
-	stringKey, err := xdr.MarshalBase64(key)
-	if err != nil {
-		// TODO: we probably don't want to panic
-		panic(err)
-	}
-	return stringKey
+	return getRelevantLedgerKey(buffer, key)
 }

--- a/exp/services/soroban-rpc/main.go
+++ b/exp/services/soroban-rpc/main.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	"go/types"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/stellar/go/historyarchive"
+	"github.com/stellar/go/ingest/ledgerbackend"
 
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/clients/stellarcore"
@@ -21,7 +24,10 @@ import (
 )
 
 func main() {
-	var endpoint, horizonURL, stellarCoreURL, networkPassphrase string
+	var endpoint, horizonURL, binaryPath, configPath, networkPassphrase string
+	var captiveCoreTomlParams ledgerbackend.CaptiveCoreTomlParams
+	var historyArchiveURLs []string
+	var checkpointFrequency uint32
 	var txConcurrency, txQueueSize int
 	var logLevel logrus.Level
 	logger := supportlog.New()
@@ -44,12 +50,13 @@ func main() {
 			Usage:       "URL used to query Horizon",
 		},
 		&config.ConfigOption{
-			Name:        "stellar-core-url",
-			ConfigKey:   &stellarCoreURL,
-			OptType:     types.String,
-			Required:    true,
-			FlagDefault: "",
-			Usage:       "URL used to query Stellar Core",
+			Name:           "stellar-captive-core-http-port",
+			ConfigKey:      &captiveCoreTomlParams.HTTPPort,
+			OptType:        types.Uint,
+			CustomSetValue: config.SetOptionalUint,
+			Required:       false,
+			FlagDefault:    uint(11626),
+			Usage:          "HTTP port for Captive Core to listen on (0 disables the HTTP server)",
 		},
 		&config.ConfigOption{
 			Name:        "log-level",
@@ -65,6 +72,37 @@ func main() {
 				return nil
 			},
 			Usage: "minimum log severity (debug, info, warn, error) to log",
+		},
+		&config.ConfigOption{
+			Name:        "stellar-core-binary-path",
+			OptType:     types.String,
+			FlagDefault: "",
+			Required:    true,
+			Usage:       "path to stellar core binary",
+			ConfigKey:   &binaryPath,
+		},
+		&config.ConfigOption{
+			Name:        "captive-core-config-path",
+			OptType:     types.String,
+			FlagDefault: "",
+			Required:    true,
+			Usage:       "path to additional configuration for the Stellar Core configuration file used by captive core. It must, at least, include enough details to define a quorum set",
+			ConfigKey:   &configPath,
+		},
+		&config.ConfigOption{
+			Name:        "history-archive-urls",
+			ConfigKey:   &historyArchiveURLs,
+			OptType:     types.String,
+			Required:    true,
+			FlagDefault: "",
+			CustomSetValue: func(co *config.ConfigOption) error {
+				stringOfUrls := viper.GetString(co.Name)
+				urlStrings := strings.Split(stringOfUrls, ",")
+
+				*(co.ConfigKey.(*[]string)) = urlStrings
+				return nil
+			},
+			Usage: "comma-separated list of stellar history archives to connect with",
 		},
 		{
 			Name:        "network-passphrase",
@@ -116,11 +154,43 @@ func main() {
 				5*time.Minute,
 			)
 
+			captiveCoreTomlParams.HistoryArchiveURLs = historyArchiveURLs
+			captiveCoreTomlParams.NetworkPassphrase = networkPassphrase
+			captiveCoreTomlParams.Strict = true
+			captiveCoreToml, err := ledgerbackend.NewCaptiveCoreTomlFromFile(configPath, captiveCoreTomlParams)
+			if err != nil {
+				logger.WithError(err).Fatal("Invalid captive core toml")
+			}
+
+			captiveConfig := ledgerbackend.CaptiveCoreConfig{
+				BinaryPath:          binaryPath,
+				NetworkPassphrase:   networkPassphrase,
+				HistoryArchiveURLs:  historyArchiveURLs,
+				CheckpointFrequency: checkpointFrequency,
+				Log:                 logger.WithField("subservice", "stellar-core"),
+				Toml:                captiveCoreToml,
+				UserAgent:           "captivecore",
+			}
+			core, err := ledgerbackend.NewCaptive(captiveConfig)
+			if err != nil {
+				logger.Fatalf("could not create captive core: %v", err)
+			}
+
+			defer core.Close()
+
+			historyArchive, err := historyarchive.Connect(
+				historyArchiveURLs[0],
+				historyarchive.ConnectOptions{},
+			)
+
+			storage, err := internal.NewLedgerEntryStorage(networkPassphrase, historyArchive, core)
+			defer storage.Close()
+
 			handler, err := internal.NewJSONRPCHandler(internal.HandlerParams{
 				AccountStore:     methods.AccountStore{Client: hc},
 				Logger:           logger,
 				TransactionProxy: transactionProxy,
-				CoreClient:       &stellarcore.Client{URL: stellarCoreURL},
+				CoreClient:       &stellarcore.Client{URL: fmt.Sprintf("http://localhost:%d/", captiveCoreTomlParams.HTTPPort)},
 			})
 			if err != nil {
 				logger.Fatalf("could not create handler: %v", err)

--- a/xdr/ledger_key.go
+++ b/xdr/ledger_key.go
@@ -131,6 +131,22 @@ func (key *LedgerKey) SetLiquidityPool(poolID PoolId) error {
 	return nil
 }
 
+// SetContractData mutates `key` such that it represents the identity of a
+// contract data entry.
+func (key *LedgerKey) SetContractData(contractID Hash, keyVal ScVal) error {
+	data := LedgerKeyContractData{
+		ContractId: contractID,
+		Key:        keyVal,
+	}
+	nkey, err := NewLedgerKey(LedgerEntryTypeContractData, data)
+	if err != nil {
+		return err
+	}
+
+	*key = nkey
+	return nil
+}
+
 func (e *EncodingBuffer) ledgerKeyCompressEncodeTo(key LedgerKey) error {
 	if err := e.xdrEncoderBuf.WriteByte(byte(key.Type)); err != nil {
 		return err


### PR DESCRIPTION
Use a history archive checkpoint + captivecore txmeta to maintain an in-memory storage for the ledger entries needed for:

1. Obtaining preflight information (see #4692 ) for the `simulateTransaction` method
2. Implementing the `getContractData` method
3. Implemeting `getAccount` method.

Using this storage (together with #4692) we should be able to completely remove the existing Soroban RPC dependencies on 

* Core's `getledgerentry` endpoint
* Horizon (used for the `getAccount` method)


https://github.com/stellar/go/pull/4694 could also piggyback onto the txmeta stream of captive core to remove its Horizon dependency.

The PR has only been very mildly tested on futurenet.

TODO:
 * ~Test on pubnet to check feasibility:~
   * ~whether the memory consumed is overkill~
   * ~whether the initialization time is overkill~
* Fix tests
* Address code TODOs
* Make the code production ready (more robust/readable)