### PR TITLE
Use latest golang 1.19 tag

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.19.1]
+        go: [1.19]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.18.6, 1.19.1]
+        go: [1.18.6, 1.19]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.18.6, 1.19.1]
+        go: [1.18.6, 1.19]
         pg: [9.6.5, 10]
     runs-on: ${{ matrix.os }}
     services:

--- a/.github/workflows/horizon-release.yml
+++ b/.github/workflows/horizon-release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./.github/actions/setup-go
         with:
-          go-version: 1.19.1
+          go-version: 1.19
 
       - name: Check dependencies
         run: ./gomod.sh

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.18.6, 1.19.1]
+        go: [1.18.6, 1.19]
         pg: [9.6.5]
         ingestion-backend: [db, captive-core, captive-core-remote-storage]
         protocol-version: [18, 19]


### PR DESCRIPTION
Update Github Actions to use latest `golang:1.19` image for Horizon testing and releases. This is done to match internal pipeline that builds Debian packages.