### PR TITLE
soroban release prep, update soroban core version for p20 integration tests

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -34,8 +34,8 @@ jobs:
     env:
       HORIZON_INTEGRATION_TESTS_ENABLED: true
       HORIZON_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL: ${{ matrix.protocol-version }}
-      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.5.1-1131.f55f88376.focal~soroban
-      PROTOCOL_20_CORE_DOCKER_IMG: 2opremio/stellar-core:19.5.1-1131.f55f88376.focal-soroban
+      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.5.1-1137.b3a6bc281.focal~soroban
+      PROTOCOL_20_CORE_DOCKER_IMG: sreuland/stellar-core:19.5.1-1137.b3a6bc281.focal-soroban
       PROTOCOL_19_CORE_DEBIAN_PKG_VERSION: 19.4.0-1075.39bee1a2b.focal
       PROTOCOL_19_CORE_DOCKER_IMG: stellar/stellar-core:19.4.0-1075.39bee1a2b.focal
       PROTOCOL_18_CORE_DEBIAN_PKG_VERSION: 19.4.0-1075.39bee1a2b.focal


### PR DESCRIPTION
new build of core came out for upcoming soroban release, include it here for integration test verification, the xdr updates are already in from https://github.com/stellar/go/pull/4704