### PR TITLE
services/horizon: Enable BucketListDB by default in captive core

### DIFF
--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -127,6 +127,7 @@ func main() {
 			captiveCoreTomlParams.HistoryArchiveURLs = historyArchiveURLs
 			captiveCoreTomlParams.NetworkPassphrase = networkPassphrase
 			captiveCoreTomlParams.Strict = true
+			captiveCoreTomlParams.CoreBinaryPath = binaryPath
 			captiveCoreToml, err := ledgerbackend.NewCaptiveCoreTomlFromFile(configPath, captiveCoreTomlParams)
 			if err != nil {
 				logger.WithError(err).Fatal("Invalid captive core toml")

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,10 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changes
+
+- Add support for BucketListDB params in captive core cfg/.toml file and enable BucketListDB by default when `--captive-core-use-db` set and `stellar-core` version >= 19.6. If `--captive-core-use-db` set but `stellar-core` version < 19.6, on-disk sqlite db used. This update will not automatically trigger a state rebuild. However, if EXPERIMENTAL_BUCKETLIST_DB is set to false in the captive-core toml, a state rebuild will be triggered ([4733](https://github.com/stellar/go/pull/4733)).
+
 ### Fixes
 
 * Update error when setting `BUCKET_DIR_PATH` and using Captive Core ([4736](https://github.com/stellar/go/pull/4736)).

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -642,6 +642,7 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 					StellarCoreBinaryPathName, captiveCoreMigrationHint)
 			}
 
+			config.CaptiveCoreTomlParams.CoreBinaryPath = binaryPath
 			if config.RemoteCaptiveCoreURL == "" && (binaryPath == "" || config.CaptiveCoreConfigPath == "") {
 				if options.RequireCaptiveCoreConfig {
 					var err error


### PR DESCRIPTION
Addresses #4710.

This PR exposes BucketListDB related configuration parameters in the captive-core toml file and enables BucketListDB by default in captive-core when using `--captive-core-use-db`. When enabled, BucketListDB reduces captive-core disk usage by around 50% and significantly reduces startup and catchup time.

This update exposes the captive core flags `EXPERIMENTAL_BUCKETLIST_DB`, `EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT`, and `EXPERIMENTAL_BUCKETLIST_DB_INDEX_CUTOFF`. These flags control the memory usage of BucketListDB. See the [stellar-core docs](https://github.com/stellar/stellar-core/blob/master/src/bucket/readme.md) for more information on configuring these flags.

By default, captive-core will enable BucketListDB with a page size of 4 KB. This is different than the validator's default page size of 16 KB. While SDF's validators have NVME storage, the Horizon SKU uses EBS, requiring a different page size. If a Horizon operator is using storage medium other than AWS EBS, the page size parameter should be tuned accordingly.

With the default BucketListDB configuration, captive-core will use an additional ~2 GB of memory. However, this is partially offset by the memory savings from reducing the size of the SQL database. Should this memory overhead be too high, memory usage can be configured using the exposed configuration parameters.

 This update will not automatically trigger a state rebuild. However, if `EXPERIMENTAL_BUCKETLIST_DB` is set to false in the captive-core toml, a state rebuild will be triggered. 