### PR TITLE
horizon: Include the contract data key when compress-encoding ledger keys

### DIFF
--- a/xdr/ledger_key.go
+++ b/xdr/ledger_key.go
@@ -181,8 +181,10 @@ func (e *EncodingBuffer) ledgerKeyCompressEncodeTo(key LedgerKey) error {
 		_, err := e.xdrEncoderBuf.Write(key.LiquidityPool.LiquidityPoolId[:])
 		return err
 	case LedgerEntryTypeContractData:
-		_, err := e.xdrEncoderBuf.Write(key.ContractData.ContractId[:])
-		return err
+		if _, err := e.xdrEncoderBuf.Write(key.ContractData.ContractId[:]); err != nil {
+			return err
+		}
+		return key.ContractData.Key.EncodeTo(e.encoder)
 	case LedgerEntryTypeContractCode:
 		_, err := e.xdrEncoderBuf.Write(key.ContractCode.Hash[:])
 		return err


### PR DESCRIPTION
Without this change all the contract data entries of a contract resulted in the same serialization regardless of their keys.