### PR TITLE
Enable BucketListDB by default in captive core

### DIFF
--- a/exp/services/captivecore/main.go
+++ b/exp/services/captivecore/main.go
@@ -127,6 +127,7 @@ func main() {
 			captiveCoreTomlParams.HistoryArchiveURLs = historyArchiveURLs
 			captiveCoreTomlParams.NetworkPassphrase = networkPassphrase
 			captiveCoreTomlParams.Strict = true
+			captiveCoreTomlParams.CoreBinaryPath = binaryPath
 			captiveCoreToml, err := ledgerbackend.NewCaptiveCoreTomlFromFile(configPath, captiveCoreTomlParams)
 			if err != nil {
 				logger.WithError(err).Fatal("Invalid captive core toml")

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -7,6 +7,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changes
 
+- Ported Add support for BucketListDB params in captive core cfg/.toml file and enable BucketListDB by default when `--captive-core-use-db` set and `stellar-core` version >= 19.6. If `--captive-core-use-db` set but `stellar-core` version < 19.6, on-disk sqlite db used. This update will not automatically trigger a state rebuild. However, if EXPERIMENTAL_BUCKETLIST_DB is set to false in the captive-core toml, a state rebuild will be triggered ([4733](https://github.com/stellar/go/pull/4733)).
 - Update XDR definitions for soroban usage ([4576](https://github.com/stellar/go/pull/4576))
 - Include InvokeHostFunction Details on Operation API resources ([4608](https://github.com/stellar/go/pull/4608))
 

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -642,6 +642,7 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 					StellarCoreBinaryPathName, captiveCoreMigrationHint)
 			}
 
+			config.CaptiveCoreTomlParams.CoreBinaryPath = binaryPath
 			if config.RemoteCaptiveCoreURL == "" && (binaryPath == "" || config.CaptiveCoreConfigPath == "") {
 				if options.RequireCaptiveCoreConfig {
 					var err error


### PR DESCRIPTION
This is a port of a recent change that went in on mainline for enabling bucketlistdb for captive core on-disk mode:
https://github.com/stellar/go/pull/4733

it could potentially help performance, so wanted to see if we can port this into the soroban branch so that soroban-rpc can reference it?