### PR TITLE
txnbuild: add muxed account & memo support to SEP-10 utility functions

### DIFF
--- a/exp/services/webauth/internal/serve/challenge.go
+++ b/exp/services/webauth/internal/serve/challenge.go
@@ -34,7 +34,9 @@ func (h challengeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	queryValues := r.URL.Query()
 
 	account := queryValues.Get("account")
-	if !strkey.IsValidEd25519PublicKey(account) {
+	isStellarAccount := strkey.IsValidEd25519PublicKey(account)
+	isMuxedAccount := strkey.IsValidMuxedAccountEd25519PublicKey(account)
+	if !isStellarAccount && !isMuxedAccount {
 		badRequest.Render(w)
 		return
 	}
@@ -60,6 +62,10 @@ func (h challengeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	var memo txnbuild.MemoID
 	if queryValues.Get("memo") != "" {
+		if isMuxedAccount {
+			badRequest.Render(w)
+			return
+		}
 		memoInt, err := strconv.ParseUint(queryValues.Get("memo"), 10, 64)
 		if err != nil {
 			badRequest.Render(w)

--- a/exp/services/webauth/internal/serve/challenge.go
+++ b/exp/services/webauth/internal/serve/challenge.go
@@ -60,7 +60,7 @@ func (h challengeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		homeDomain = h.HomeDomains[0]
 	}
 
-	var memo txnbuild.MemoID
+	var memo txnbuild.Memo
 	if queryValues.Get("memo") != "" {
 		if isMuxedAccount {
 			badRequest.Render(w)

--- a/exp/services/webauth/internal/serve/challenge.go
+++ b/exp/services/webauth/internal/serve/challenge.go
@@ -63,10 +63,6 @@ func (h challengeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var memo *txnbuild.MemoID
 	memoParam := queryValues.Get("memo")
 	if memoParam != "" {
-		if isMuxedAccount {
-			badRequest.Render(w)
-			return
-		}
 		memoInt, err := strconv.ParseUint(memoParam, 10, 64)
 		if err != nil {
 			badRequest.Render(w)
@@ -87,7 +83,7 @@ func (h challengeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	)
 	if err != nil {
 		h.Logger.Ctx(ctx).WithStack(err).Error(err)
-		serverError.Render(w)
+		badRequest.Render(w)
 		return
 	}
 

--- a/exp/services/webauth/internal/serve/challenge.go
+++ b/exp/services/webauth/internal/serve/challenge.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -57,6 +58,16 @@ func (h challengeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		homeDomain = h.HomeDomains[0]
 	}
 
+	var memo txnbuild.MemoID
+	if queryValues.Get("memo") != "" {
+		memoInt, err := strconv.ParseUint(queryValues.Get("memo"), 10, 64)
+		if err != nil {
+			badRequest.Render(w)
+			return
+		}
+		memo = txnbuild.MemoID(memoInt)
+	}
+
 	tx, err := txnbuild.BuildChallengeTx(
 		h.SigningKey.Seed(),
 		account,
@@ -64,6 +75,7 @@ func (h challengeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		homeDomain,
 		h.NetworkPassphrase,
 		h.ChallengeExpiresIn,
+		memo,
 	)
 	if err != nil {
 		h.Logger.Ctx(ctx).WithStack(err).Error(err)

--- a/exp/services/webauth/internal/serve/challenge.go
+++ b/exp/services/webauth/internal/serve/challenge.go
@@ -60,7 +60,7 @@ func (h challengeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		homeDomain = h.HomeDomains[0]
 	}
 
-	var memo txnbuild.MemoID
+	var memo *txnbuild.MemoID
 	memoParam := queryValues.Get("memo")
 	if memoParam != "" {
 		if isMuxedAccount {
@@ -72,7 +72,8 @@ func (h challengeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			badRequest.Render(w)
 			return
 		}
-		memo = txnbuild.MemoID(memoInt)
+		memoId := txnbuild.MemoID(memoInt)
+		memo = &memoId
 	}
 
 	tx, err := txnbuild.BuildChallengeTx(
@@ -82,7 +83,7 @@ func (h challengeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		homeDomain,
 		h.NetworkPassphrase,
 		h.ChallengeExpiresIn,
-		&memo,
+		memo,
 	)
 	if err != nil {
 		h.Logger.Ctx(ctx).WithStack(err).Error(err)

--- a/exp/services/webauth/internal/serve/challenge.go
+++ b/exp/services/webauth/internal/serve/challenge.go
@@ -60,13 +60,14 @@ func (h challengeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		homeDomain = h.HomeDomains[0]
 	}
 
-	var memo txnbuild.Memo
-	if queryValues.Get("memo") != "" {
+	var memo txnbuild.MemoID
+	memoParam := queryValues.Get("memo")
+	if memoParam != "" {
 		if isMuxedAccount {
 			badRequest.Render(w)
 			return
 		}
-		memoInt, err := strconv.ParseUint(queryValues.Get("memo"), 10, 64)
+		memoInt, err := strconv.ParseUint(memoParam, 10, 64)
 		if err != nil {
 			badRequest.Render(w)
 			return
@@ -81,7 +82,7 @@ func (h challengeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		homeDomain,
 		h.NetworkPassphrase,
 		h.ChallengeExpiresIn,
-		memo,
+		&memo,
 	)
 	if err != nil {
 		h.Logger.Ctx(ctx).WithStack(err).Error(err)

--- a/exp/services/webauth/internal/serve/challenge_test.go
+++ b/exp/services/webauth/internal/serve/challenge_test.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/network"
+	"github.com/stellar/go/strkey"
 	supportlog "github.com/stellar/go/support/log"
+	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -184,4 +186,82 @@ func TestChallenge_invalidHomeDomain(t *testing.T) {
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"error":"The request was invalid in some way."}`, string(body))
+}
+
+func TestChallengeWithMemo(t *testing.T) {
+	serverKey := keypair.MustRandom()
+	account := keypair.MustRandom()
+
+	h := challengeHandler{
+		Logger:             supportlog.DefaultLogger,
+		NetworkPassphrase:  network.TestNetworkPassphrase,
+		SigningKey:         serverKey,
+		ChallengeExpiresIn: time.Minute,
+		Domain:             "webauthdomain",
+		HomeDomains:        []string{"testdomain"},
+	}
+
+	r := httptest.NewRequest("GET", "/?account="+account.Address()+"&memo=1", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	res := struct {
+		Transaction       string `json:"transaction"`
+		NetworkPassphrase string `json:"network_passphrase"`
+	}{}
+	err := json.NewDecoder(resp.Body).Decode(&res)
+	require.NoError(t, err)
+
+	var tx xdr.TransactionEnvelope
+	err = xdr.SafeUnmarshalBase64(res.Transaction, &tx)
+	require.NoError(t, err)
+
+	memo, err := txnbuild.MemoID(1).ToXDR()
+	require.NoError(t, err)
+	require.Equal(t, tx.Memo(), memo)
+}
+
+func TestChallengeWithMuxedAccount(t *testing.T) {
+	serverKey := keypair.MustRandom()
+	account := keypair.MustRandom()
+
+	muxedAccount := strkey.MuxedAccount{}
+	muxedAccount.SetAccountID(account.Address())
+	muxedAccount.SetID(1)
+	muxedAccountAddress, err := muxedAccount.Address()
+	require.NoError(t, err)
+
+	h := challengeHandler{
+		Logger:             supportlog.DefaultLogger,
+		NetworkPassphrase:  network.TestNetworkPassphrase,
+		SigningKey:         serverKey,
+		ChallengeExpiresIn: time.Minute,
+		Domain:             "webauthdomain",
+		HomeDomains:        []string{"testdomain"},
+	}
+
+	r := httptest.NewRequest("GET", "/?account="+muxedAccountAddress, nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	resp := w.Result()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+
+	res := struct {
+		Transaction       string `json:"transaction"`
+		NetworkPassphrase string `json:"network_passphrase"`
+	}{}
+	err = json.NewDecoder(resp.Body).Decode(&res)
+	require.NoError(t, err)
+
+	var tx xdr.TransactionEnvelope
+	err = xdr.SafeUnmarshalBase64(res.Transaction, &tx)
+	require.NoError(t, err)
+
+	require.Equal(t, tx.Operations()[0].SourceAccount.Address(), muxedAccountAddress)
 }

--- a/exp/services/webauth/internal/serve/token.go
+++ b/exp/services/webauth/internal/serve/token.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -148,10 +149,21 @@ func (h tokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var sub string
+	if muxedAccount == (xdr.MuxedAccount{}) {
+		sub = clientAccountID
+		if memo != nil {
+			xdrMemo, _ := memo.ToXDR()
+			sub += ":" + strconv.FormatUint(uint64(xdrMemo.MustId()), 10)
+		}
+	} else {
+		sub = muxedAccount.Address()
+	}
+
 	issuedAt := time.Unix(tx.Timebounds().MinTime, 0)
 	claims := jwt.Claims{
 		Issuer:   h.JWTIssuer,
-		Subject:  muxedAccount.Address(),
+		Subject:  sub,
 		IssuedAt: jwt.NewNumericDate(issuedAt),
 		Expiry:   jwt.NewNumericDate(issuedAt.Add(h.JWTExpiresIn)),
 	}

--- a/exp/services/webauth/internal/serve/token.go
+++ b/exp/services/webauth/internal/serve/token.go
@@ -90,7 +90,7 @@ func (h tokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	muxedAccount, err := xdr.AddressToMuxedAccount(clientAccountID)
 	if err != nil {
-		serverError.Render(w)
+		badRequest.Render(w)
 		return
 	}
 	if muxedAccount.Type == xdr.CryptoKeyTypeKeyTypeMuxedEd25519 {

--- a/exp/services/webauth/internal/serve/token.go
+++ b/exp/services/webauth/internal/serve/token.go
@@ -88,8 +88,8 @@ func (h tokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	l.Info("Start verifying challenge transaction.")
 
-	var muxedAccount xdr.MuxedAccount
-	if muxedAccount, err = xdr.AddressToMuxedAccount(clientAccountID); err == nil {
+	muxedAccount, err := xdr.AddressToMuxedAccount(clientAccountID)
+	if err == nil {
 		clientAccountID = muxedAccount.ToAccountId().Address()
 	}
 

--- a/exp/services/webauth/internal/serve/token.go
+++ b/exp/services/webauth/internal/serve/token.go
@@ -89,7 +89,11 @@ func (h tokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	l.Info("Start verifying challenge transaction.")
 
 	muxedAccount, err := xdr.AddressToMuxedAccount(clientAccountID)
-	if err == nil {
+	if err != nil {
+		serverError.Render(w)
+		return
+	}
+	if muxedAccount.Type == xdr.CryptoKeyTypeKeyTypeMuxedEd25519 {
 		clientAccountID = muxedAccount.ToAccountId().Address()
 	}
 
@@ -150,7 +154,7 @@ func (h tokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var sub string
-	if muxedAccount == (xdr.MuxedAccount{}) {
+	if muxedAccount.Type == xdr.CryptoKeyTypeKeyTypeEd25519 {
 		sub = clientAccountID
 		if memo != nil {
 			sub += ":" + strconv.FormatUint(uint64(*memo), 10)

--- a/exp/services/webauth/internal/serve/token.go
+++ b/exp/services/webauth/internal/serve/token.go
@@ -54,7 +54,7 @@ func (h tokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		clientAccountID string
 		signingAddress  *keypair.FromAddress
 		homeDomain      string
-		memo            txnbuild.Memo
+		memo            *txnbuild.MemoID
 	)
 	for _, s := range h.SigningAddresses {
 		tx, clientAccountID, homeDomain, memo, err = txnbuild.ReadChallengeTx(req.Transaction, s.Address(), h.NetworkPassphrase, h.Domain, h.HomeDomains)
@@ -153,8 +153,7 @@ func (h tokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if muxedAccount == (xdr.MuxedAccount{}) {
 		sub = clientAccountID
 		if memo != nil {
-			xdrMemo, _ := memo.ToXDR()
-			sub += ":" + strconv.FormatUint(uint64(xdrMemo.MustId()), 10)
+			sub += ":" + strconv.FormatUint(uint64(*memo), 10)
 		}
 	} else {
 		sub = muxedAccount.Address()

--- a/exp/services/webauth/internal/serve/token_test.go
+++ b/exp/services/webauth/internal/serve/token_test.go
@@ -46,6 +46,7 @@ func TestToken_formInputSuccess(t *testing.T) {
 		homeDomain,
 		network.TestNetworkPassphrase,
 		time.Minute,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -146,6 +147,7 @@ func TestToken_formInputSuccess_jwtHeaderAndPayloadAreDeterministic(t *testing.T
 		homeDomain,
 		network.TestNetworkPassphrase,
 		time.Minute,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -255,6 +257,7 @@ func TestToken_jsonInputSuccess(t *testing.T) {
 		homeDomain,
 		network.TestNetworkPassphrase,
 		time.Minute,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -412,6 +415,7 @@ func TestToken_jsonInputValidRotatingServerSigners(t *testing.T) {
 				homeDomain,
 				network.TestNetworkPassphrase,
 				time.Minute,
+				nil,
 			)
 			require.NoError(t, err)
 
@@ -497,6 +501,7 @@ func TestToken_jsonInputValidMultipleSigners(t *testing.T) {
 		homeDomain,
 		network.TestNetworkPassphrase,
 		time.Minute,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -605,6 +610,7 @@ func TestToken_jsonInputNotEnoughWeight(t *testing.T) {
 		homeDomain,
 		network.TestNetworkPassphrase,
 		time.Minute,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -691,6 +697,7 @@ func TestToken_jsonInputUnrecognizedSigner(t *testing.T) {
 		homeDomain,
 		network.TestNetworkPassphrase,
 		time.Minute,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -777,6 +784,7 @@ func TestToken_jsonInputAccountNotExistSuccess(t *testing.T) {
 		homeDomain,
 		network.TestNetworkPassphrase,
 		time.Minute,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -881,6 +889,7 @@ func TestToken_jsonInputAccountNotExistFail(t *testing.T) {
 		homeDomain,
 		network.TestNetworkPassphrase,
 		time.Minute,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -963,6 +972,7 @@ func TestToken_jsonInputAccountNotExistNotAllowed(t *testing.T) {
 		homeDomain,
 		network.TestNetworkPassphrase,
 		time.Minute,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -1047,6 +1057,7 @@ func TestToken_jsonInputUnrecognizedServerSigner(t *testing.T) {
 		homeDomain,
 		network.TestNetworkPassphrase,
 		time.Minute,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -1248,6 +1259,7 @@ func TestToken_jsonInputInvalidWebAuthDomainFail(t *testing.T) {
 		homeDomain,
 		network.TestNetworkPassphrase,
 		time.Minute,
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -11,10 +11,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 * Muxed accounts and ID memos can be used in the `BuildChallengeTx()` and `ReadChallengeTx()` SEP-10 utilitiy functions to identify users of shared Stellar accounts. ([#4746](https://github.com/stellar/go/pull/4746))
   * `BuildChallengeTx()`:
     * Muxed account addresses can be passed as the `clientAccountID`.
-    * Adds an additional parameter of type `txnbuild.Memo`. Memos must be of type ID and cannot be specified if the `clientAccoutID` id a muxed account address.
+    * Adds an additional parameter of type `*txnbuild.MemoID`. Memos cannot be specified if the `clientAccoutID` id a muxed account address.
   * `ReadChallengeTx()`:
     * Muxed account addresses may be returned as the `clientAccountID`.
-    * Adds an additional return value of type `txnbuild.Memo`, which if non-nil, will always be a memo of type ID.
+    * Adds an additional return value of type `*txnbuild.MemoID`.
 
 
 ## [10.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v9.0.0) - 2022-04-18

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -6,6 +6,16 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Breaking changes
+
+* Muxed accounts and ID memos can be used in the `BuildChallengeTx()` and `ReadChallengeTx()` SEP-10 utilitiy functions to identify users of shared Stellar accounts. ([#4746](https://github.com/stellar/go/pull/4746))
+  * `BuildChallengeTx()`:
+    * Muxed account addresses can be passed as the `clientAccountID`.
+    * Adds an additional parameter of type `txnbuild.Memo`. Memos must be of type ID and cannot be specified if the `clientAccoutID` id a muxed account address.
+  * `ReadChallengeTx()`:
+    * Muxed account addresses may be returned as the `clientAccountID`.
+    * Adds an additional return value of type `txnbuild.Memo`, which if non-nil, will always be a memo of type ID.
+
 
 ## [10.0.0](https://github.com/stellar/go/releases/tag/horizonclient-v9.0.0) - 2022-04-18
 

--- a/txnbuild/example_test.go
+++ b/txnbuild/example_test.go
@@ -760,7 +760,7 @@ func ExampleBuildChallengeTx() {
 	webAuthDomain := "webauthdomain.example.org"
 	timebound := time.Duration(5 * time.Minute)
 
-	tx, err := BuildChallengeTx(serverSignerSeed, clientAccountID, webAuthDomain, anchorName, network.TestNetworkPassphrase, timebound)
+	tx, err := BuildChallengeTx(serverSignerSeed, clientAccountID, webAuthDomain, anchorName, network.TestNetworkPassphrase, timebound, nil)
 	check(err)
 
 	txeBase64, err := tx.Base64()

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -1027,7 +1027,7 @@ func BuildChallengeTx(serverSignerSecret, clientAccountID, webAuthDomain, homeDo
 			return nil, errors.New("memos are not valid for challenge transactions with a muxed client account")
 		}
 	} else if memo != nil {
-		if _, err := memo.ToXDR(); err != nil {
+		if xdrMemo, err := memo.ToXDR(); err != nil || xdrMemo.Type != xdr.MemoTypeMemoId {
 			return nil, errors.New("memo must be of type MemoID")
 		}
 	}

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -1116,7 +1116,7 @@ func generateRandomNonce(n int) ([]byte, error) {
 // - VerifyChallengeTxThreshold
 // - VerifyChallengeTxSigners
 //
-// The returned clientAccountID may be a Stellar account or Muxed account address. If
+// The returned clientAccountID may be a Stellar account (G...) or Muxed account (M...) address. If
 // the address is muxed, or if the memo returned is non-nil, the challenge transaction
 // is being used to authenticate a user of a shared Stellar account.
 func ReadChallengeTx(challengeTx, serverAccountID, network, webAuthDomain string, homeDomains []string) (tx *Transaction, clientAccountID string, matchedHomeDomain string, memo Memo, err error) {

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -998,6 +998,7 @@ func NewFeeBumpTransaction(params FeeBumpTransactionParams) (*FeeBumpTransaction
 
 // BuildChallengeTx is a factory method that creates a valid SEP 10 challenge, for use in web authentication.
 // "timebound" is the time duration the transaction should be valid for, and must be greater than 1s (300s is recommended).
+// Muxed accounts or ID memos can be provided to identity a user of a shared Stellar account.
 // More details on SEP 10: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md
 func BuildChallengeTx(serverSignerSecret, clientAccountID, webAuthDomain, homeDomain, network string, timebound time.Duration, memo Memo) (*Transaction, error) {
 	if timebound < time.Second {
@@ -1114,6 +1115,10 @@ func generateRandomNonce(n int) ([]byte, error) {
 // one of the following functions to completely verify the transaction:
 // - VerifyChallengeTxThreshold
 // - VerifyChallengeTxSigners
+//
+// The returned clientAccountID may be a Stellar account or Muxed account address. If
+// the address is muxed, or if the memo returned is non-nil, the challenge transaction
+// is being used to authenticate a user of a shared Stellar account.
 func ReadChallengeTx(challengeTx, serverAccountID, network, webAuthDomain string, homeDomains []string) (tx *Transaction, clientAccountID string, matchedHomeDomain string, memo Memo, err error) {
 	parsed, err := TransactionFromXDR(challengeTx)
 	if err != nil {

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -1027,7 +1027,8 @@ func BuildChallengeTx(serverSignerSecret, clientAccountID, webAuthDomain, homeDo
 			return nil, errors.New("memos are not valid for challenge transactions with a muxed client account")
 		}
 	} else if memo != nil {
-		if xdrMemo, err := memo.ToXDR(); err != nil || xdrMemo.Type != xdr.MemoTypeMemoId {
+		var xdrMemo xdr.Memo
+		if xdrMemo, err = memo.ToXDR(); err != nil || xdrMemo.Type != xdr.MemoTypeMemoId {
 			return nil, errors.New("memo must be of type MemoID")
 		}
 	}
@@ -1182,7 +1183,8 @@ func ReadChallengeTx(challengeTx, serverAccountID, network, webAuthDomain string
 		err = errors.New("memos are not valid for challenge transactions with a muxed client account")
 		return tx, clientAccountID, matchedHomeDomain, memo, err
 	} else if rawOperations[0].SourceAccount.Type == xdr.CryptoKeyTypeKeyTypeEd25519 && memo != nil {
-		if rawMemo, err := memo.ToXDR(); err != nil || rawMemo.Type != xdr.MemoTypeMemoId {
+		var rawMemo xdr.Memo
+		if rawMemo, err = memo.ToXDR(); err != nil || rawMemo.Type != xdr.MemoTypeMemoId {
 			err = errors.New("invalid memo, only ID memos are permitted")
 			return tx, clientAccountID, matchedHomeDomain, memo, err
 		}

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -999,7 +999,7 @@ func NewFeeBumpTransaction(params FeeBumpTransactionParams) (*FeeBumpTransaction
 // BuildChallengeTx is a factory method that creates a valid SEP 10 challenge, for use in web authentication.
 // "timebound" is the time duration the transaction should be valid for, and must be greater than 1s (300s is recommended).
 // More details on SEP 10: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md
-func BuildChallengeTx(serverSignerSecret, clientAccountID, webAuthDomain, homeDomain, network string, timebound time.Duration) (*Transaction, error) {
+func BuildChallengeTx(serverSignerSecret, clientAccountID, webAuthDomain, homeDomain, network string, timebound time.Duration, memo Memo) (*Transaction, error) {
 	if timebound < time.Second {
 		return nil, errors.New("provided timebound must be at least 1s (300s is recommended)")
 	}
@@ -1021,7 +1021,15 @@ func BuildChallengeTx(serverSignerSecret, clientAccountID, webAuthDomain, homeDo
 	}
 
 	if _, err = xdr.AddressToAccountId(clientAccountID); err != nil {
-		return nil, errors.Wrapf(err, "%s is not a valid account id", clientAccountID)
+		if _, err = xdr.AddressToMuxedAccount(clientAccountID); err != nil {
+			return nil, errors.Wrapf(err, "%s is not a valid account id or muxed account", clientAccountID)
+		} else if memo != nil {
+			return nil, errors.New("memos are not valid for challenge transactions with a muxed client account")
+		}
+	} else if memo != nil {
+		if _, err := memo.ToXDR(); err != nil {
+			return nil, errors.New("memo must be of type MemoID")
+		}
 	}
 
 	// represent server signing account as SimpleAccount
@@ -1052,7 +1060,7 @@ func BuildChallengeTx(serverSignerSecret, clientAccountID, webAuthDomain, homeDo
 				},
 			},
 			BaseFee: MinBaseFee,
-			Memo:    nil,
+			Memo:    memo,
 			Preconditions: Preconditions{
 				TimeBounds: NewTimebounds(currentTime.Unix(), maxTime.Unix()),
 			},
@@ -1105,57 +1113,57 @@ func generateRandomNonce(n int) ([]byte, error) {
 // one of the following functions to completely verify the transaction:
 // - VerifyChallengeTxThreshold
 // - VerifyChallengeTxSigners
-func ReadChallengeTx(challengeTx, serverAccountID, network, webAuthDomain string, homeDomains []string) (tx *Transaction, clientAccountID string, matchedHomeDomain string, err error) {
+func ReadChallengeTx(challengeTx, serverAccountID, network, webAuthDomain string, homeDomains []string) (tx *Transaction, clientAccountID string, matchedHomeDomain string, memo MemoID, err error) {
 	parsed, err := TransactionFromXDR(challengeTx)
 	if err != nil {
-		return tx, clientAccountID, matchedHomeDomain, errors.Wrap(err, "could not parse challenge")
+		return tx, clientAccountID, matchedHomeDomain, memo, errors.Wrap(err, "could not parse challenge")
 	}
 
 	var isSimple bool
 	tx, isSimple = parsed.Transaction()
 	if !isSimple {
-		return tx, clientAccountID, matchedHomeDomain, errors.New("challenge cannot be a fee bump transaction")
+		return tx, clientAccountID, matchedHomeDomain, memo, errors.New("challenge cannot be a fee bump transaction")
 	}
 
 	// Enforce no muxed accounts (at least until we understand their impact)
 	if tx.envelope.SourceAccount().Type == xdr.CryptoKeyTypeKeyTypeMuxedEd25519 {
 		err = errors.New("invalid source account: only valid Ed25519 accounts are allowed in challenge transactions")
-		return tx, clientAccountID, matchedHomeDomain, err
+		return tx, clientAccountID, matchedHomeDomain, memo, err
 	}
 
 	// verify transaction source
 	if tx.SourceAccount().AccountID != serverAccountID {
-		return tx, clientAccountID, matchedHomeDomain, errors.New("transaction source account is not equal to server's account")
+		return tx, clientAccountID, matchedHomeDomain, memo, errors.New("transaction source account is not equal to server's account")
 	}
 
 	// verify sequence number
 	if tx.SourceAccount().Sequence != 0 {
-		return tx, clientAccountID, matchedHomeDomain, errors.New("transaction sequence number must be 0")
+		return tx, clientAccountID, matchedHomeDomain, memo, errors.New("transaction sequence number must be 0")
 	}
 
 	// verify timebounds
 	if tx.Timebounds().MaxTime == TimeoutInfinite {
-		return tx, clientAccountID, matchedHomeDomain, errors.New("transaction requires non-infinite timebounds")
+		return tx, clientAccountID, matchedHomeDomain, memo, errors.New("transaction requires non-infinite timebounds")
 	}
 	// Apply a grace period to the challenge MinTime to account for clock drift between the server and client
 	var gracePeriod int64 = 5 * 60 // seconds
 	currentTime := time.Now().UTC().Unix()
 	if currentTime+gracePeriod < tx.Timebounds().MinTime || currentTime > tx.Timebounds().MaxTime {
-		return tx, clientAccountID, matchedHomeDomain, errors.Errorf("transaction is not within range of the specified timebounds (currentTime=%d, MinTime=%d, MaxTime=%d)",
+		return tx, clientAccountID, matchedHomeDomain, memo, errors.Errorf("transaction is not within range of the specified timebounds (currentTime=%d, MinTime=%d, MaxTime=%d)",
 			currentTime, tx.Timebounds().MinTime, tx.Timebounds().MaxTime)
 	}
 
 	// verify operation
 	operations := tx.Operations()
 	if len(operations) < 1 {
-		return tx, clientAccountID, matchedHomeDomain, errors.New("transaction requires at least one manage_data operation")
+		return tx, clientAccountID, matchedHomeDomain, memo, errors.New("transaction requires at least one manage_data operation")
 	}
 	op, ok := operations[0].(*ManageData)
 	if !ok {
-		return tx, clientAccountID, matchedHomeDomain, errors.New("operation type should be manage_data")
+		return tx, clientAccountID, matchedHomeDomain, memo, errors.New("operation type should be manage_data")
 	}
 	if op.SourceAccount == "" {
-		return tx, clientAccountID, matchedHomeDomain, errors.New("operation should have a source account")
+		return tx, clientAccountID, matchedHomeDomain, memo, errors.New("operation should have a source account")
 	}
 	for _, homeDomain := range homeDomains {
 		if op.Name == homeDomain+" auth" {
@@ -1164,60 +1172,60 @@ func ReadChallengeTx(challengeTx, serverAccountID, network, webAuthDomain string
 		}
 	}
 	if matchedHomeDomain == "" {
-		return tx, clientAccountID, matchedHomeDomain, errors.Errorf("operation key does not match any homeDomains passed (key=%q, homeDomains=%v)", op.Name, homeDomains)
+		return tx, clientAccountID, matchedHomeDomain, memo, errors.Errorf("operation key does not match any homeDomains passed (key=%q, homeDomains=%v)", op.Name, homeDomains)
 	}
 
 	clientAccountID = op.SourceAccount
 	rawOperations := tx.envelope.Operations()
-	if len(rawOperations) > 0 && rawOperations[0].SourceAccount.Type == xdr.CryptoKeyTypeKeyTypeMuxedEd25519 {
-		err = errors.New("invalid operation source account: only valid Ed25519 accounts are allowed in challenge transactions")
-		return tx, clientAccountID, matchedHomeDomain, err
+	if len(rawOperations) > 0 && rawOperations[0].SourceAccount.Type == xdr.CryptoKeyTypeKeyTypeMuxedEd25519 && tx.Memo() != nil {
+		err = errors.New("memos are not valid for challenge transactions with a muxed client account")
+		return tx, clientAccountID, matchedHomeDomain, memo, err
 	}
 
 	// verify manage data value
 	nonceB64 := string(op.Value)
 	if len(nonceB64) != 64 {
-		return tx, clientAccountID, matchedHomeDomain, errors.New("random nonce encoded as base64 should be 64 bytes long")
+		return tx, clientAccountID, matchedHomeDomain, memo, errors.New("random nonce encoded as base64 should be 64 bytes long")
 	}
 	nonceBytes, err := base64.StdEncoding.DecodeString(nonceB64)
 	if err != nil {
-		return tx, clientAccountID, matchedHomeDomain, errors.Wrap(err, "failed to decode random nonce provided in manage_data operation")
+		return tx, clientAccountID, matchedHomeDomain, memo, errors.Wrap(err, "failed to decode random nonce provided in manage_data operation")
 	}
 	if len(nonceBytes) != 48 {
-		return tx, clientAccountID, matchedHomeDomain, errors.New("random nonce before encoding as base64 should be 48 bytes long")
+		return tx, clientAccountID, matchedHomeDomain, memo, errors.New("random nonce before encoding as base64 should be 48 bytes long")
 	}
 
 	// verify subsequent operations are manage data ops and known, or unknown with source account set to server account
 	for _, op := range operations[1:] {
 		op, ok := op.(*ManageData)
 		if !ok {
-			return tx, clientAccountID, matchedHomeDomain, errors.New("operation type should be manage_data")
+			return tx, clientAccountID, matchedHomeDomain, memo, errors.New("operation type should be manage_data")
 		}
 		if op.SourceAccount == "" {
-			return tx, clientAccountID, matchedHomeDomain, errors.New("operation should have a source account")
+			return tx, clientAccountID, matchedHomeDomain, memo, errors.New("operation should have a source account")
 		}
 		switch op.Name {
 		case "web_auth_domain":
 			if op.SourceAccount != serverAccountID {
-				return tx, clientAccountID, matchedHomeDomain, errors.New("web auth domain operation must have server source account")
+				return tx, clientAccountID, matchedHomeDomain, memo, errors.New("web auth domain operation must have server source account")
 			}
 			if !bytes.Equal(op.Value, []byte(webAuthDomain)) {
-				return tx, clientAccountID, matchedHomeDomain, errors.Errorf("web auth domain operation value is %q but expect %q", string(op.Value), webAuthDomain)
+				return tx, clientAccountID, matchedHomeDomain, memo, errors.Errorf("web auth domain operation value is %q but expect %q", string(op.Value), webAuthDomain)
 			}
 		default:
 			// verify unknown subsequent operations are manage data ops with source account set to server account
 			if op.SourceAccount != serverAccountID {
-				return tx, clientAccountID, matchedHomeDomain, errors.New("subsequent operations are unrecognized")
+				return tx, clientAccountID, matchedHomeDomain, memo, errors.New("subsequent operations are unrecognized")
 			}
 		}
 	}
 
 	err = verifyTxSignature(tx, network, serverAccountID)
 	if err != nil {
-		return tx, clientAccountID, matchedHomeDomain, err
+		return tx, clientAccountID, matchedHomeDomain, memo, err
 	}
 
-	return tx, clientAccountID, matchedHomeDomain, nil
+	return tx, clientAccountID, matchedHomeDomain, memo, nil
 }
 
 // VerifyChallengeTxThreshold verifies that for a SEP 10 challenge transaction

--- a/txnbuild/transaction_challenge_example_test.go
+++ b/txnbuild/transaction_challenge_example_test.go
@@ -37,7 +37,7 @@ func ExampleVerifyChallengeTxThreshold() {
 	// Server builds challenge transaction
 	var challengeTx string
 	{
-		tx, err := txnbuild.BuildChallengeTx(serverAccount.Seed(), clientAccount.Address(), "webauthdomain.stellar.org", "test", network.TestNetworkPassphrase, time.Minute)
+		tx, err := txnbuild.BuildChallengeTx(serverAccount.Seed(), clientAccount.Address(), "webauthdomain.stellar.org", "test", network.TestNetworkPassphrase, time.Minute, nil)
 		if err != nil {
 			fmt.Println("Error:", err)
 			return
@@ -52,7 +52,7 @@ func ExampleVerifyChallengeTxThreshold() {
 	// Client reads and signs challenge transaction
 	var signedChallengeTx string
 	{
-		tx, txClientAccountID, _, err := txnbuild.ReadChallengeTx(challengeTx, serverAccount.Address(), network.TestNetworkPassphrase, "webauthdomain.stellar.org", []string{"test"})
+		tx, txClientAccountID, _, _, err := txnbuild.ReadChallengeTx(challengeTx, serverAccount.Address(), network.TestNetworkPassphrase, "webauthdomain.stellar.org", []string{"test"})
 		if err != nil {
 			fmt.Println("Error:", err)
 			return
@@ -75,7 +75,7 @@ func ExampleVerifyChallengeTxThreshold() {
 
 	// Server verifies signed challenge transaction
 	{
-		_, txClientAccountID, _, err := txnbuild.ReadChallengeTx(challengeTx, serverAccount.Address(), network.TestNetworkPassphrase, "webauthdomain.stellar.org", []string{"test"})
+		_, txClientAccountID, _, _, err := txnbuild.ReadChallengeTx(challengeTx, serverAccount.Address(), network.TestNetworkPassphrase, "webauthdomain.stellar.org", []string{"test"})
 		if err != nil {
 			fmt.Println("Error:", err)
 			return

--- a/txnbuild/transaction_challenge_example_test.go
+++ b/txnbuild/transaction_challenge_example_test.go
@@ -75,9 +75,12 @@ func ExampleVerifyChallengeTxThreshold() {
 
 	// Server verifies signed challenge transaction
 	{
-		_, txClientAccountID, _, _, err := txnbuild.ReadChallengeTx(challengeTx, serverAccount.Address(), network.TestNetworkPassphrase, "webauthdomain.stellar.org", []string{"test"})
+		_, txClientAccountID, _, memo, err := txnbuild.ReadChallengeTx(challengeTx, serverAccount.Address(), network.TestNetworkPassphrase, "webauthdomain.stellar.org", []string{"test"})
 		if err != nil {
 			fmt.Println("Error:", err)
+			return
+		} else if memo != nil {
+			fmt.Println("Expected memo to be nil, got: ", memo)
 			return
 		}
 

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1073,7 +1073,7 @@ func TestBuildChallengeTx(t *testing.T) {
 
 	{
 		// 1 minute timebound
-		tx, err := BuildChallengeTx(kp0.Seed(), kp0.Address(), "testwebauth.stellar.org", "testanchor.stellar.org", network.TestNetworkPassphrase, time.Minute)
+		tx, err := BuildChallengeTx(kp0.Seed(), kp0.Address(), "testwebauth.stellar.org", "testanchor.stellar.org", network.TestNetworkPassphrase, time.Minute, nil)
 		assert.NoError(t, err)
 		txeBase64, err := tx.Base64()
 		assert.NoError(t, err)
@@ -1097,7 +1097,7 @@ func TestBuildChallengeTx(t *testing.T) {
 
 	{
 		// 5 minutes timebound
-		tx, err := BuildChallengeTx(kp0.Seed(), kp0.Address(), "testwebauth.stellar.org", "testanchor.stellar.org", network.TestNetworkPassphrase, time.Duration(5*time.Minute))
+		tx, err := BuildChallengeTx(kp0.Seed(), kp0.Address(), "testwebauth.stellar.org", "testanchor.stellar.org", network.TestNetworkPassphrase, time.Duration(5*time.Minute), nil)
 		assert.NoError(t, err)
 		txeBase64, err := tx.Base64()
 		assert.NoError(t, err)
@@ -1121,7 +1121,7 @@ func TestBuildChallengeTx(t *testing.T) {
 	}
 
 	//transaction with infinite timebound
-	_, err := BuildChallengeTx(kp0.Seed(), kp0.Address(), "webauthdomain", "sdf", network.TestNetworkPassphrase, 0)
+	_, err := BuildChallengeTx(kp0.Seed(), kp0.Address(), "webauthdomain", "sdf", network.TestNetworkPassphrase, 0, nil)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "provided timebound must be at least 1s (300s is recommended)")
 	}
@@ -1878,7 +1878,7 @@ func TestReadChallengeTx_validSignedByServerAndClient(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.NoError(t, err)
@@ -1913,7 +1913,7 @@ func TestReadChallengeTx_validSignedByServer(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.NoError(t, err)
@@ -1946,7 +1946,7 @@ func TestReadChallengeTx_invalidNotSignedByServer(t *testing.T) {
 
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "transaction not signed by "+serverKP.Address())
@@ -1982,7 +1982,7 @@ func TestReadChallengeTx_invalidCorrupted(t *testing.T) {
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
 	tx64 = strings.ReplaceAll(tx64, "A", "B")
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Nil(t, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(
@@ -2022,7 +2022,7 @@ func TestReadChallengeTx_invalidServerAccountIDMismatch(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(t, err, "transaction source account is not equal to server's account")
@@ -2057,7 +2057,7 @@ func TestReadChallengeTx_invalidSeqNoNotZero(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(t, err, "transaction sequence number must be 0")
@@ -2092,7 +2092,7 @@ func TestReadChallengeTx_invalidTimeboundsInfinite(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(t, err, "transaction requires non-infinite timebounds")
@@ -2127,7 +2127,7 @@ func TestReadChallengeTx_invalidTimeboundsOutsideRange(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.Error(t, err)
@@ -2164,7 +2164,7 @@ func TestReadChallengeTx_validTimeboundsWithGracePeriod(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.NoError(t, err)
@@ -2200,7 +2200,7 @@ func TestReadChallengeTx_invalidTimeboundsWithGracePeriod(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.Error(t, err)
@@ -2230,7 +2230,7 @@ func TestReadChallengeTx_invalidOperationWrongType(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, "", readClientAccountID)
 	assert.EqualError(t, err, "operation type should be manage_data")
@@ -2258,7 +2258,7 @@ func TestReadChallengeTx_invalidOperationNoSourceAccount(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	_, _, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.EqualError(t, err, "operation should have a source account")
 }
 
@@ -2291,7 +2291,7 @@ func TestReadChallengeTx_invalidDataValueWrongEncodedLength(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "random nonce encoded as base64 should be 64 bytes long")
@@ -2326,7 +2326,7 @@ func TestReadChallengeTx_invalidDataValueCorruptBase64(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "failed to decode random nonce provided in manage_data operation: illegal base64 data at input byte 37")
@@ -2362,7 +2362,7 @@ func TestReadChallengeTx_invalidDataValueWrongByteLength(t *testing.T) {
 	tx64, err := tx.Base64()
 	assert.NoError(t, err)
 
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "random nonce before encoding as base64 should be 48 bytes long")
@@ -2377,6 +2377,7 @@ func TestReadChallengeTx_acceptsV0AndV1Transactions(t *testing.T) {
 		"testanchor.stellar.org",
 		network.TestNetworkPassphrase,
 		time.Hour,
+		nil,
 	)
 	assert.NoError(t, err)
 
@@ -2391,7 +2392,7 @@ func TestReadChallengeTx_acceptsV0AndV1Transactions(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, challenge := range []string{v1Challenge, v0Challenge} {
-		parsedTx, clientAccountID, _, err := ReadChallengeTx(
+		parsedTx, clientAccountID, _, _, err := ReadChallengeTx(
 			challenge,
 			kp0.Address(),
 			network.TestNetworkPassphrase,
@@ -2417,6 +2418,7 @@ func TestReadChallengeTx_forbidsFeeBumpTransactions(t *testing.T) {
 		"testanchor.stellar.org",
 		network.TestNetworkPassphrase,
 		time.Hour,
+		nil,
 	)
 	assert.NoError(t, err)
 
@@ -2435,7 +2437,7 @@ func TestReadChallengeTx_forbidsFeeBumpTransactions(t *testing.T) {
 
 	challenge, err := feeBumpTx.Base64()
 	assert.NoError(t, err)
-	_, _, _, err = ReadChallengeTx(
+	_, _, _, _, err = ReadChallengeTx(
 		challenge,
 		kp0.Address(),
 		network.TestNetworkPassphrase,
@@ -2445,20 +2447,10 @@ func TestReadChallengeTx_forbidsFeeBumpTransactions(t *testing.T) {
 	assert.EqualError(t, err, "challenge cannot be a fee bump transaction")
 }
 
-func TestReadChallengeTx_forbidsMuxedAccounts(t *testing.T) {
+func TestReadChallengeTx_allowsMuxedAccounts(t *testing.T) {
 	kp0 := newKeypair0()
-	tx, err := BuildChallengeTx(
-		kp0.Seed(),
-		kp0.Address(),
-		"testwebauth.stellar.org",
-		"testanchor.stellar.org",
-		network.TestNetworkPassphrase,
-		time.Hour,
-	)
-
-	env := tx.ToXDR()
-	assert.NoError(t, err)
-	aid := xdr.MustAddress(kp0.Address())
+	kp1 := newKeypair1()
+	aid := xdr.MustAddress(kp1.Address())
 	muxedAccount := xdr.MuxedAccount{
 		Type: xdr.CryptoKeyTypeKeyTypeMuxedEd25519,
 		Med25519: &xdr.MuxedAccountMed25519{
@@ -2466,20 +2458,29 @@ func TestReadChallengeTx_forbidsMuxedAccounts(t *testing.T) {
 			Ed25519: *aid.Ed25519,
 		},
 	}
-	*env.V1.Tx.Operations[0].SourceAccount = muxedAccount
-
-	challenge, err := marshallBase64(env, env.Signatures())
+	tx, err := BuildChallengeTx(
+		kp0.Seed(),
+		muxedAccount.Address(),
+		"testwebauth.stellar.org",
+		"testanchor.stellar.org",
+		network.TestNetworkPassphrase,
+		time.Hour,
+		nil,
+	)
 	assert.NoError(t, err)
 
-	_, _, _, err = ReadChallengeTx(
+	challenge, err := marshallBase64(tx.ToXDR(), tx.Signatures())
+	assert.NoError(t, err)
+
+	tx, _, _, _, err = ReadChallengeTx(
 		challenge,
 		kp0.Address(),
 		network.TestNetworkPassphrase,
 		"testwebauth.stellar.org",
 		[]string{"testanchor.stellar.org"},
 	)
-	errorMessage := "only valid Ed25519 accounts are allowed in challenge transactions"
-	assert.Contains(t, err.Error(), errorMessage)
+	assert.NoError(t, err)
+	assert.Equal(t, tx.envelope.Operations()[0].SourceAccount, &muxedAccount)
 }
 
 func TestReadChallengeTx_doesVerifyHomeDomainFailure(t *testing.T) {
@@ -2511,7 +2512,7 @@ func TestReadChallengeTx_doesVerifyHomeDomainFailure(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"willfail"})
+	_, _, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"willfail"})
 	assert.EqualError(t, err, "operation key does not match any homeDomains passed (key=\"testanchor.stellar.org auth\", homeDomains=[willfail])")
 }
 
@@ -2544,7 +2545,7 @@ func TestReadChallengeTx_doesVerifyHomeDomainSuccess(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	_, _, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, nil, err)
 }
 
@@ -2582,7 +2583,7 @@ func TestReadChallengeTx_allowsAdditionalManageDataOpsWithSourceAccountSetToServ
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.NoError(t, err)
@@ -2622,7 +2623,7 @@ func TestReadChallengeTx_disallowsAdditionalManageDataOpsWithoutSourceAccountSet
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	_, _, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.EqualError(t, err, "subsequent operations are unrecognized")
 }
 
@@ -2659,7 +2660,7 @@ func TestReadChallengeTx_disallowsAdditionalOpsOfOtherTypes(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	readTx, readClientAccountID, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	readTx, readClientAccountID, _, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.Equal(t, tx, readTx)
 	assert.Equal(t, clientKP.Address(), readClientAccountID)
 	assert.EqualError(t, err, "operation type should be manage_data")
@@ -2693,7 +2694,7 @@ func TestReadChallengeTx_matchesHomeDomain(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, matchedHomeDomain, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	_, _, matchedHomeDomain, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	require.NoError(t, err)
 	assert.Equal(t, matchedHomeDomain, "testanchor.stellar.org")
 }
@@ -2726,7 +2727,7 @@ func TestReadChallengeTx_doesNotMatchHomeDomain(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, matchedHomeDomain, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"not", "going", "to", "match"})
+	_, _, matchedHomeDomain, _, err := ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"not", "going", "to", "match"})
 	assert.Equal(t, matchedHomeDomain, "")
 	assert.EqualError(t, err, "operation key does not match any homeDomains passed (key=\"testanchor.stellar.org auth\", homeDomains=[not going to match])")
 }
@@ -2754,7 +2755,7 @@ func TestReadChallengeTx_validWhenWebAuthDomainMissing(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	_, _, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.NoError(t, err)
 }
 
@@ -2786,7 +2787,7 @@ func TestReadChallengeTx_invalidWebAuthDomainSourceAccount(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	_, _, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.EqualError(t, err, `web auth domain operation must have server source account`)
 }
 
@@ -2818,7 +2819,7 @@ func TestReadChallengeTx_invalidWebAuthDomain(t *testing.T) {
 	assert.NoError(t, err)
 	tx64, err := tx.Base64()
 	require.NoError(t, err)
-	_, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
+	_, _, _, _, err = ReadChallengeTx(tx64, serverKP.Address(), network.TestNetworkPassphrase, "testwebauth.stellar.org", []string{"testanchor.stellar.org"})
 	assert.EqualError(t, err, `web auth domain operation value is "testwebauth.example.org" but expect "testwebauth.stellar.org"`)
 }
 

--- a/txnbuild/transaction_test.go
+++ b/txnbuild/transaction_test.go
@@ -1122,15 +1122,10 @@ func TestBuildChallengeTx(t *testing.T) {
 
 	// transaction with memo
 	{
-		tx, err := BuildChallengeTx(kp0.Seed(), kp0.Address(), "testwebauth.stellar.org", "testanchor.stellar.org", network.TestNetworkPassphrase, time.Minute, MemoID(1))
+		var memo MemoID = MemoID(1)
+		tx, err := BuildChallengeTx(kp0.Seed(), kp0.Address(), "testwebauth.stellar.org", "testanchor.stellar.org", network.TestNetworkPassphrase, time.Minute, &memo)
 		assert.NoError(t, err)
-		assert.Equal(t, tx.Memo(), MemoID(1))
-	}
-
-	// transaction with bad memo
-	{
-		_, err := BuildChallengeTx(kp0.Seed(), kp0.Address(), "testwebauth.stellar.org", "testanchor.stellar.org", network.TestNetworkPassphrase, time.Minute, MemoText("test"))
-		assert.EqualError(t, err, "memo must be of type MemoID")
+		assert.Equal(t, tx.Memo(), &memo)
 	}
 
 	// transaction with muxed account
@@ -1143,7 +1138,8 @@ func TestBuildChallengeTx(t *testing.T) {
 
 	// transaction with memo and muxed account
 	{
-		_, err := BuildChallengeTx(kp0.Seed(), "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK", "testwebauth.stellar.org", "testanchor.stellar.org", network.TestNetworkPassphrase, time.Minute, MemoID(1))
+		var memo MemoID = MemoID(1)
+		_, err := BuildChallengeTx(kp0.Seed(), "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK", "testwebauth.stellar.org", "testanchor.stellar.org", network.TestNetworkPassphrase, time.Minute, &memo)
 		assert.EqualError(t, err, "memos are not valid for challenge transactions with a muxed client account")
 	}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

resolves #3937

Adds support for muxed accounts to be specified as client account IDs and memos to be added to challenge transactions. This is a breaking change.

### Why

SEP-10 was modified to support users of shared Stellar accounts. The two approaches to identifying users of a shared account, in the context of SEP-10, is by assigning each user a muxed account address or an integer memo. 

### Outstanding Questions

The Python SDK moved away from returning mutliple values from the `BuildChallengeTx()` and `ReadChallengeTx()` equivalent functions and instead introduced a `ChallengeTransaction` container object for all the relevant values. We could use this same approach in the Go SDK instead of adding an additional value to the existing set.