### PR TITLE
allow optional stellar_core_version to be passed to horizon docker build

### DIFF
--- a/services/horizon/docker/Dockerfile
+++ b/services/horizon/docker/Dockerfile
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y wget apt-transport-https gnupg2 && \
     wget -qO /etc/apt/trusted.gpg.d/SDF.asc https://apt.stellar.org/SDF.asc && \
     echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list && \
-    apt-get update && apt-cache madison stellar-core && apt-get install -y stellar-core && \
+    apt-get update && apt-cache madison stellar-core && apt-get install -y stellar-core=${STELLAR_CORE_VERSION} && \
     echo "deb https://apt.stellar.org focal testing" | tee -a /etc/apt/sources.list.d/SDF.list && \
     apt-get update && apt-cache madison stellar-horizon && apt-get install -y stellar-horizon=${VERSION} && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /var/log/*.log /var/log/*/*.log

--- a/services/horizon/docker/Dockerfile
+++ b/services/horizon/docker/Dockerfile
@@ -1,12 +1,13 @@
 FROM ubuntu:focal
 
 ARG VERSION
+ARG STELLAR_CORE_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y wget apt-transport-https gnupg2 && \
     wget -qO /etc/apt/trusted.gpg.d/SDF.asc https://apt.stellar.org/SDF.asc && \
     echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list && \
-    apt-get update && apt-cache madison stellar-core && apt-get install -y stellar-core=${STELLAR_CORE_VERSION} && \
+    apt-get update && apt-cache madison stellar-core && eval "apt-get install -y stellar-core${STELLAR_CORE_VERSION+=$STELLAR_CORE_VERSION}" && \
     echo "deb https://apt.stellar.org focal testing" | tee -a /etc/apt/sources.list.d/SDF.list && \
     apt-get update && apt-cache madison stellar-horizon && apt-get install -y stellar-horizon=${VERSION} && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /var/log/*.log /var/log/*/*.log

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -12,12 +12,12 @@ endif
 ifndef STELLAR_CORE_VERSION
 	$(SUDO) docker build --pull $(DOCKER_OPTS) \
 	--label org.opencontainers.image.created="$(BUILD_DATE)" \
-	--build-arg VERSION=$(VERSION) STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION)\
+	--build-arg VERSION=$(VERSION) \
 	-t $(TAG) .
 else
 	$(SUDO) docker build --pull $(DOCKER_OPTS) \
 	--label org.opencontainers.image.created="$(BUILD_DATE)" \
-	--build-arg VERSION=$(VERSION) \
+	--build-arg VERSION=$(VERSION) STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION) \
 	-t $(TAG) .
 endif
 

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -17,7 +17,7 @@ ifndef STELLAR_CORE_VERSION
 else
 	$(SUDO) docker build --pull $(DOCKER_OPTS) \
 	--label org.opencontainers.image.created="$(BUILD_DATE)" \
-	--build-arg VERSION=$(VERSION) STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION) \
+	--build-arg VERSION=$(VERSION) --build-arg STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION) \
 	-t $(TAG) .
 endif
 

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -9,10 +9,17 @@ docker-build:
 ifndef VERSION
 	$(error VERSION environment variable must be set. For example VERSION=2.4.1-101 )
 endif
+ifndef STELLAR_CORE_VERSION
+	$(SUDO) docker build --pull $(DOCKER_OPTS) \
+	--label org.opencontainers.image.created="$(BUILD_DATE)" \
+	--build-arg VERSION=$(VERSION) STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION)\
+	-t $(TAG) .
+else
 	$(SUDO) docker build --pull $(DOCKER_OPTS) \
 	--label org.opencontainers.image.created="$(BUILD_DATE)" \
 	--build-arg VERSION=$(VERSION) \
 	-t $(TAG) .
+endif
 
 docker-push:
 ifndef TAG


### PR DESCRIPTION
### What
allow optional stellar_core_version to be passed to horizon docker build

### Why
need it for the SRE hackathon project and could be useful for other things

### Testing
will test with branch

### Issue addressed by this PR
https://github.com/stellar/ops/issues/2076

