### PR TITLE
services/submitter: refactor concurrency model

### DIFF
--- a/services/submitter/channel.go
+++ b/services/submitter/channel.go
@@ -17,7 +17,7 @@ type Channel struct {
 }
 
 // ReloadState loads the current state of the channel account using given horizon client
-func (ch *Channel) ReloadState(client horizonclient.ClientInterface) (accountID string, sequenceNumber uint64, err error) {
+func (ch *Channel) LoadState(client horizonclient.ClientInterface) (accountID string, sequenceNumber uint64, err error) {
 	ch.mutex.Lock()
 	defer ch.mutex.Unlock()
 

--- a/services/submitter/store.go
+++ b/services/submitter/store.go
@@ -32,7 +32,7 @@ func (s TransactionState) Value() (driver.Value, error) {
 const (
 	// TransactionStatePending indicates that a transaction is ready to be sent.
 	TransactionStatePending TransactionState = "pending"
-	// TransactionStateSending indicates that a transaction is submitted to Horizon and awaiting response.
+	// TransactionStateSending indicates that a transaction is being processed.
 	TransactionStateSending TransactionState = "sending"
 	// TransactionStateSent indicates that a transaction was successfully sent and is in the ledger.
 	TransactionStateSent TransactionState = "sent"

--- a/services/submitter/submitter.go
+++ b/services/submitter/submitter.go
@@ -91,8 +91,6 @@ func (ts *TransactionSubmitter) Start(ctx context.Context) {
 	}
 }
 
-// listenForPendingTransactions
-// If bad_seq error is returned it will call Channel.ReloadState()
 func (ts *TransactionSubmitter) listenForPendingTransactions(ctx context.Context, channel *Channel) {
 	for transaction := range ts.pendingTransactions {
 		ts.processTransaction(ctx, transaction, channel)


### PR DESCRIPTION
### What

Refactors @bartekn's initial implementation of the transaction submitter to better manage concurrent transaction submission.

- Each channel account is given a go routine that pull from a buffered queue of transactions
- Every second, the submitter checks if the queue is full, and if its not, fills the queue with more pending transactions
- For every transaction placed in the queue, a go routine picks up the transaction and uses it's channel account to submit it

This PR also adds the following:

- Signs the transactions with the root & channel account
- Uses fee bump transactions so channel accounts don't need to hold XLM

### Why

The existing implementation assigns transactions to channels that could still be working on submitting previously assigned transactions. This would cause the sequence number errors and channel accounts would constantly have to reload their state, reconstruct transactions, and resubmit them.

Using a buffered channel allows for:

1. the submitter to only query the DB when the channel is not full
2. The channel accounts to never be idle -- unless there are no pending transactions in the database