### PR TITLE
Allow Core version to be specified in stellar-horizon docker build DEV

### DIFF
--- a/services/horizon/docker/Dockerfile
+++ b/services/horizon/docker/Dockerfile
@@ -8,10 +8,10 @@ ARG ALLOW_CORE_UNSTABLE=no
 RUN apt-get update && apt-get install -y wget apt-transport-https gnupg2 && \
     wget -qO /etc/apt/trusted.gpg.d/SDF.asc https://apt.stellar.org/SDF.asc && \
     echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list && \
-    if [[ "${ALLOW_CORE_UNSTABLE}" == "yes" ]]; then echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list; fi && \
+    if [ "${ALLOW_CORE_UNSTABLE}" = "yes" ]; then echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list; fi && \
     cat /etc/apt/sources.list.d/SDF.list && \
     apt-get update && apt-cache madison stellar-core && eval "apt-get install -y stellar-core${STELLAR_CORE_VERSION+=$STELLAR_CORE_VERSION}" && \
-    if [[ "${ALLOW_CORE_UNSTABLE}" = "yes" ]]; then sed -i '/unstable/d' /etc/apt/sources.list.d/SDF.list; fi && \
+    if [ "${ALLOW_CORE_UNSTABLE}" = "yes" ]; then sed -i '/unstable/d' /etc/apt/sources.list.d/SDF.list; fi && \
     cat /etc/apt/sources.list.d/SDF.list && \
     echo "deb https://apt.stellar.org focal testing" | tee -a /etc/apt/sources.list.d/SDF.list && \
     apt-get update && apt-cache madison stellar-horizon && apt-get install -y stellar-horizon=${VERSION} && \

--- a/services/horizon/docker/Dockerfile
+++ b/services/horizon/docker/Dockerfile
@@ -8,9 +8,10 @@ ARG ALLOW_CORE_UNSTABLE=no
 RUN apt-get update && apt-get install -y wget apt-transport-https gnupg2 && \
     wget -qO /etc/apt/trusted.gpg.d/SDF.asc https://apt.stellar.org/SDF.asc && \
     echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list && \
-    if [[ "${ALLOW_CORE_UNSTABLE}" == "yes"]]; then echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list; fi && \
+    if [[ "${ALLOW_CORE_UNSTABLE}" == "yes" ]]; then echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list; fi && \
+    cat /etc/apt/sources.list.d/SDF.list && \
     apt-get update && apt-cache madison stellar-core && eval "apt-get install -y stellar-core${STELLAR_CORE_VERSION+=$STELLAR_CORE_VERSION}" && \
-    if [[ "${ALLOW_CORE_UNSTABLE}" = "yes"]]; then sed -i '/unstable/d' /etc/apt/sources.list.d/SDF.list; fi && \
+    if [[ "${ALLOW_CORE_UNSTABLE}" = "yes" ]]; then sed -i '/unstable/d' /etc/apt/sources.list.d/SDF.list; fi && \
     cat /etc/apt/sources.list.d/SDF.list && \
     echo "deb https://apt.stellar.org focal testing" | tee -a /etc/apt/sources.list.d/SDF.list && \
     apt-get update && apt-cache madison stellar-horizon && apt-get install -y stellar-horizon=${VERSION} && \

--- a/services/horizon/docker/Dockerfile
+++ b/services/horizon/docker/Dockerfile
@@ -3,11 +3,15 @@ FROM ubuntu:focal
 ARG VERSION
 ARG STELLAR_CORE_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
+ARG ALLOW_CORE_UNSTABLE=no
 
 RUN apt-get update && apt-get install -y wget apt-transport-https gnupg2 && \
     wget -qO /etc/apt/trusted.gpg.d/SDF.asc https://apt.stellar.org/SDF.asc && \
     echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list && \
+    if [[ "${ALLOW_CORE_UNSTABLE}" == "yes"]]; then echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list; fi && \
     apt-get update && apt-cache madison stellar-core && eval "apt-get install -y stellar-core${STELLAR_CORE_VERSION+=$STELLAR_CORE_VERSION}" && \
+    if [[ "${ALLOW_CORE_UNSTABLE}" = "yes"]]; then sed -i '/unstable/d' /etc/apt/sources.list.d/SDF.list; fi && \
+    cat /etc/apt/sources.list.d/SDF.list && \
     echo "deb https://apt.stellar.org focal testing" | tee -a /etc/apt/sources.list.d/SDF.list && \
     apt-get update && apt-cache madison stellar-horizon && apt-get install -y stellar-horizon=${VERSION} && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /var/log/*.log /var/log/*/*.log

--- a/services/horizon/docker/Dockerfile
+++ b/services/horizon/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG ALLOW_CORE_UNSTABLE=no
 RUN apt-get update && apt-get install -y wget apt-transport-https gnupg2 && \
     wget -qO /etc/apt/trusted.gpg.d/SDF.asc https://apt.stellar.org/SDF.asc && \
     echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list && \
-    if [ "${ALLOW_CORE_UNSTABLE}" = "yes" ]; then echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list; fi && \
+    if [ "${ALLOW_CORE_UNSTABLE}" = "yes" ]; then echo "deb https://apt.stellar.org focal unstable" | tee -a /etc/apt/sources.list.d/SDF.list; fi && \
     cat /etc/apt/sources.list.d/SDF.list && \
     apt-get update && apt-cache madison stellar-core && eval "apt-get install -y stellar-core${STELLAR_CORE_VERSION+=$STELLAR_CORE_VERSION}" && \
     if [ "${ALLOW_CORE_UNSTABLE}" = "yes" ]; then sed -i '/unstable/d' /etc/apt/sources.list.d/SDF.list; fi && \

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -4,14 +4,16 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 BUILD_DATE := $(shell date -u +%FT%TZ)
 
 ifeq ($(ALLOW_CORE_UNSTABLE),yes)
-	@echo Tagging UNSTABLE
 	TAG ?= stellar/stellar-horizon:$(VERSION)-UNSTABLE
 else
-	@echo Tagging normal
 	TAG ?= stellar/stellar-horizon:$(VERSION)
 endif
 
 docker-build:
+ifeq ($(ALLOW_CORE_UNSTABLE),yes)
+	@echo UNSTABLE specified
+endif
+
 ifndef VERSION
 	$(error VERSION environment variable must be set. For example VERSION=2.4.1-101 )
 endif

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -3,17 +3,13 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 BUILD_DATE := $(shell date -u +%FT%TZ)
 
+TAG ?= stellar/stellar-horizon:$(VERSION)
 ifeq ($(ALLOW_CORE_UNSTABLE),yes)
-	TAG ?= stellar/stellar-horizon:$(VERSION)-UNSTABLE
-else
-	TAG ?= stellar/stellar-horizon:$(VERSION)
+	TAG += -UNSTABLE
 endif
 
 docker-build:
-ifeq ($(ALLOW_CORE_UNSTABLE),yes)
-	@echo UNSTABLE specified
-endif
-
+@echo Tag is $(TAG)
 ifndef VERSION
 	$(error VERSION environment variable must be set. For example VERSION=2.4.1-101 )
 endif

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -3,7 +3,11 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 BUILD_DATE := $(shell date -u +%FT%TZ)
 
-TAG ?= stellar/stellar-horizon:$(VERSION)
+ifeq ($(ALLOW_CORE_UNSTABLE),yes)
+	TAG ?= stellar/stellar-horizon:$(VERSION)-UNSTABLE
+else
+	TAG ?= stellar/stellar-horizon:$(VERSION)
+endif
 
 docker-build:
 ifndef VERSION

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -4,8 +4,10 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 BUILD_DATE := $(shell date -u +%FT%TZ)
 
 ifeq ($(ALLOW_CORE_UNSTABLE),yes)
+	@echo Tagging UNSTABLE
 	TAG ?= stellar/stellar-horizon:$(VERSION)-UNSTABLE
 else
+	@echo Tagging normal
 	TAG ?= stellar/stellar-horizon:$(VERSION)
 endif
 

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -5,7 +5,7 @@ BUILD_DATE := $(shell date -u +%FT%TZ)
 
 TAG ?= stellar/stellar-horizon:$(VERSION)
 ifeq ($(ALLOW_CORE_UNSTABLE),yes)
-	TAG += -UNSTABLE
+	TAG +=-UNSTABLE
 endif
 
 docker-build:

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -5,9 +5,8 @@ BUILD_DATE := $(shell date -u +%FT%TZ)
 
 TAG ?= stellar/stellar-horizon:$(VERSION)
 ifeq ($(ALLOW_CORE_UNSTABLE),yes)
-	TAG += -UNSTABLE
+	TAG := $(TAG)-UNSTABLE
 endif
-TAG := $(strip $(TAG))
 
 docker-build:
 ifndef VERSION

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -12,12 +12,13 @@ endif
 ifndef STELLAR_CORE_VERSION
 	$(SUDO) docker build --pull $(DOCKER_OPTS) \
 	--label org.opencontainers.image.created="$(BUILD_DATE)" \
-	--build-arg VERSION=$(VERSION) \
+	--build-arg VERSION=$(VERSION) --build-arg ALLOW_CORE_UNSTABLE=$(ALLOW_CORE_UNSTABLE) \
 	-t $(TAG) .
 else
 	$(SUDO) docker build --pull $(DOCKER_OPTS) \
 	--label org.opencontainers.image.created="$(BUILD_DATE)" \
 	--build-arg VERSION=$(VERSION) --build-arg STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION) \
+        --build-arg ALLOW_CORE_UNSTABLE=$(ALLOW_CORE_UNSTABLE) \
 	-t $(TAG) .
 endif
 

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -7,9 +7,9 @@ TAG ?= stellar/stellar-horizon:$(VERSION)
 ifeq ($(ALLOW_CORE_UNSTABLE),yes)
 	TAG += -UNSTABLE
 endif
+TAG := $(strip $(TAG))
 
 docker-build:
-@echo Tag is $(TAG)
 ifndef VERSION
 	$(error VERSION environment variable must be set. For example VERSION=2.4.1-101 )
 endif
@@ -27,7 +27,6 @@ else
 endif
 
 docker-push:
-@echo Tag is $(TAG)
 ifndef TAG
 	$(error Must set VERSION or TAG environment variable. For example VERSION=2.4.1-101 )
 endif

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -5,7 +5,7 @@ BUILD_DATE := $(shell date -u +%FT%TZ)
 
 TAG ?= stellar/stellar-horizon:$(VERSION)
 ifeq ($(ALLOW_CORE_UNSTABLE),yes)
-	TAG +=-UNSTABLE
+	TAG += $(strip -UNSTABLE)
 endif
 
 docker-build:
@@ -27,6 +27,7 @@ else
 endif
 
 docker-push:
+@echo Tag is $(TAG)
 ifndef TAG
 	$(error Must set VERSION or TAG environment variable. For example VERSION=2.4.1-101 )
 endif

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -5,7 +5,7 @@ BUILD_DATE := $(shell date -u +%FT%TZ)
 
 TAG ?= stellar/stellar-horizon:$(VERSION)
 ifeq ($(ALLOW_CORE_UNSTABLE),yes)
-	TAG += $(strip -UNSTABLE)
+	TAG += -UNSTABLE
 endif
 
 docker-build:


### PR DESCRIPTION
### What
Update the Makefile and Dockerfile to allow for an optional core_version.
If no version is specified, behavior is same as before.

### Why
To allow versions of Core from the Unstable repo to be used in builds of horizon for testing.

### More information
https://github.com/stellar/ops/issues/2076
