### PR TITLE
Trying to make captive core handle starting from genesis more graceful

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -76,6 +76,8 @@ type CaptiveStellarCore struct {
 	// spawn new instances of Stellar Core.
 	cancel context.CancelFunc
 
+	logger *log.Entry
+
 	stellarCoreRunner stellarCoreRunnerInterface
 	// stellarCoreLock protects access to stellarCoreRunner. When the read lock
 	// is acquired stellarCoreRunner can be accessed. When the write lock is acquired
@@ -172,6 +174,7 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 		archive:           &archivePool,
 		ledgerHashStore:   config.LedgerHashStore,
 		cancel:            cancel,
+		logger:            config.Log,
 		checkpointManager: historyarchive.NewCheckpointManager(config.CheckpointFrequency),
 	}
 
@@ -279,8 +282,7 @@ func (c *CaptiveStellarCore) runFromParams(ctx context.Context, from uint32) (ui
 		// Target ledger 1 is not newer than last closed ledger 1 - nothing to do
 		// TODO maybe we can fix it by generating 1st ledger meta
 		// like GenesisLedgerStateReader?
-		err := errors.New("CaptiveCore is unable to start from ledger 1, start from ledger 2")
-		return 0, "", err
+		c.logger.Warn("CaptiveCore is unable to start from ledger 1, starting from ledger 2")
 	}
 
 	if from <= 63 {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Auto-start from ledger 2, (the earliest we can start ingesting from with captive core), instead of erroring.

### Why

https://github.com/stellar/quickstart/actions/runs/4135191252/jobs/7147629224#step:13:288 when starting soroban-rpc with an empty db on a standalone network.

### Known limitations

Is this actually a valid way to handle this? Or is there some special-handling we need to do for the genesis ledger?