### PR TITLE
updated xdr to pull in change for nonce on contract auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ xdr/Stellar-contract.x \
 xdr/Stellar-internal.x
 
 XDRGEN_COMMIT=57beb46bd3d1c77529218430bd6ed87cd69ac394
-XDRNEXT_COMMIT=24d5d5f196d2840f57384383c4c10546d9fe5d48
+XDRNEXT_COMMIT=df18148747e807618acf4639db41c4fd6f0be9fc
 
 .PHONY: xdr xdr-clean xdr-update
 

--- a/gxdr/xdr_generated.go
+++ b/gxdr/xdr_generated.go
@@ -2289,6 +2289,7 @@ type XdrAnon_HashIDPreimage_CreateContractArgs struct {
 }
 type XdrAnon_HashIDPreimage_ContractAuth struct {
 	NetworkID  Hash
+	Nonce      Uint64
 	Invocation AuthorizedInvocation
 }
 
@@ -3588,6 +3589,8 @@ type SCEnvMetaEntry struct {
 	_u   interface{}
 }
 
+const SC_SPEC_DOC_LIMIT = 1024
+
 type SCSpecType int32
 
 const (
@@ -3677,55 +3680,87 @@ type SCSpecTypeDef struct {
 }
 
 type SCSpecUDTStructFieldV0 struct {
+	Doc  string // bound SC_SPEC_DOC_LIMIT
 	Name string // bound 30
 	Type SCSpecTypeDef
 }
 
 type SCSpecUDTStructV0 struct {
+	Doc    string                   // bound SC_SPEC_DOC_LIMIT
 	Lib    string                   // bound 80
 	Name   string                   // bound 60
 	Fields []SCSpecUDTStructFieldV0 // bound 40
 }
 
-type SCSpecUDTUnionCaseV0 struct {
+type SCSpecUDTUnionCaseVoidV0 struct {
+	Doc  string // bound SC_SPEC_DOC_LIMIT
 	Name string // bound 60
-	Type *SCSpecTypeDef
+}
+
+type SCSpecUDTUnionCaseTupleV0 struct {
+	Doc  string          // bound SC_SPEC_DOC_LIMIT
+	Name string          // bound 60
+	Type []SCSpecTypeDef // bound 12
+}
+
+type SCSpecUDTUnionCaseV0Kind int32
+
+const (
+	SC_SPEC_UDT_UNION_CASE_VOID_V0  SCSpecUDTUnionCaseV0Kind = 0
+	SC_SPEC_UDT_UNION_CASE_TUPLE_V0 SCSpecUDTUnionCaseV0Kind = 1
+)
+
+type SCSpecUDTUnionCaseV0 struct {
+	// The union discriminant Kind selects among the following arms:
+	//   SC_SPEC_UDT_UNION_CASE_VOID_V0:
+	//      VoidCase() *SCSpecUDTUnionCaseVoidV0
+	//   SC_SPEC_UDT_UNION_CASE_TUPLE_V0:
+	//      TupleCase() *SCSpecUDTUnionCaseTupleV0
+	Kind SCSpecUDTUnionCaseV0Kind
+	_u   interface{}
 }
 
 type SCSpecUDTUnionV0 struct {
+	Doc   string                 // bound SC_SPEC_DOC_LIMIT
 	Lib   string                 // bound 80
 	Name  string                 // bound 60
 	Cases []SCSpecUDTUnionCaseV0 // bound 50
 }
 
 type SCSpecUDTEnumCaseV0 struct {
+	Doc   string // bound SC_SPEC_DOC_LIMIT
 	Name  string // bound 60
 	Value Uint32
 }
 
 type SCSpecUDTEnumV0 struct {
+	Doc   string                // bound SC_SPEC_DOC_LIMIT
 	Lib   string                // bound 80
 	Name  string                // bound 60
 	Cases []SCSpecUDTEnumCaseV0 // bound 50
 }
 
 type SCSpecUDTErrorEnumCaseV0 struct {
+	Doc   string // bound SC_SPEC_DOC_LIMIT
 	Name  string // bound 60
 	Value Uint32
 }
 
 type SCSpecUDTErrorEnumV0 struct {
+	Doc   string                     // bound SC_SPEC_DOC_LIMIT
 	Lib   string                     // bound 80
 	Name  string                     // bound 60
 	Cases []SCSpecUDTErrorEnumCaseV0 // bound 50
 }
 
 type SCSpecFunctionInputV0 struct {
+	Doc  string // bound SC_SPEC_DOC_LIMIT
 	Name string // bound 30
 	Type SCSpecTypeDef
 }
 
 type SCSpecFunctionV0 struct {
+	Doc     string // bound SC_SPEC_DOC_LIMIT
 	Name    SCSymbol
 	Inputs  []SCSpecFunctionInputV0 // bound 10
 	Outputs []SCSpecTypeDef         // bound 1
@@ -3797,6 +3832,7 @@ const (
 	SST_HOST_CONTEXT_ERROR  SCStatusType = 6
 	SST_VM_ERROR            SCStatusType = 7
 	SST_CONTRACT_ERROR      SCStatusType = 8
+	SST_HOST_AUTH_ERROR     SCStatusType = 9
 )
 
 type SCHostValErrorCode int32
@@ -3847,6 +3883,15 @@ const (
 	HOST_STORAGE_ACCESS_TO_UNKNOWN_ENTRY            SCHostStorageErrorCode = 3
 	HOST_STORAGE_MISSING_KEY_IN_GET                 SCHostStorageErrorCode = 4
 	HOST_STORAGE_GET_ON_DELETED_KEY                 SCHostStorageErrorCode = 5
+)
+
+type SCHostAuthErrorCode int32
+
+const (
+	HOST_AUTH_UNKNOWN_ERROR           SCHostAuthErrorCode = 0
+	HOST_AUTH_NONCE_ERROR             SCHostAuthErrorCode = 1
+	HOST_AUTH_DUPLICATE_AUTHORIZATION SCHostAuthErrorCode = 2
+	HOST_AUTH_NOT_AUTHORIZED          SCHostAuthErrorCode = 3
 )
 
 type SCHostContextErrorCode int32
@@ -3907,6 +3952,8 @@ type SCStatus struct {
 	//      VmCode() *SCVmErrorCode
 	//   SST_CONTRACT_ERROR:
 	//      ContractCode() *Uint32
+	//   SST_HOST_AUTH_ERROR:
+	//      AuthCode() *SCHostAuthErrorCode
 	Type SCStatusType
 	_u   interface{}
 }
@@ -16644,6 +16691,7 @@ func (v *XdrAnon_HashIDPreimage_ContractAuth) XdrRecurse(x XDR, name string) {
 		name = x.Sprintf("%s.", name)
 	}
 	x.Marshal(x.Sprintf("%snetworkID", name), XDR_Hash(&v.NetworkID))
+	x.Marshal(x.Sprintf("%snonce", name), XDR_Uint64(&v.Nonce))
 	x.Marshal(x.Sprintf("%sinvocation", name), XDR_AuthorizedInvocation(&v.Invocation))
 }
 func XDR_XdrAnon_HashIDPreimage_ContractAuth(v *XdrAnon_HashIDPreimage_ContractAuth) *XdrAnon_HashIDPreimage_ContractAuth {
@@ -24830,6 +24878,7 @@ func (v *SCSpecUDTStructFieldV0) XdrRecurse(x XDR, name string) {
 	if name != "" {
 		name = x.Sprintf("%s.", name)
 	}
+	x.Marshal(x.Sprintf("%sdoc", name), XdrString{&v.Doc, SC_SPEC_DOC_LIMIT})
 	x.Marshal(x.Sprintf("%sname", name), XdrString{&v.Name, 30})
 	x.Marshal(x.Sprintf("%stype", name), XDR_SCSpecTypeDef(&v.Type))
 }
@@ -24906,84 +24955,158 @@ func (v *SCSpecUDTStructV0) XdrRecurse(x XDR, name string) {
 	if name != "" {
 		name = x.Sprintf("%s.", name)
 	}
+	x.Marshal(x.Sprintf("%sdoc", name), XdrString{&v.Doc, SC_SPEC_DOC_LIMIT})
 	x.Marshal(x.Sprintf("%slib", name), XdrString{&v.Lib, 80})
 	x.Marshal(x.Sprintf("%sname", name), XdrString{&v.Name, 60})
 	x.Marshal(x.Sprintf("%sfields", name), (*_XdrVec_40_SCSpecUDTStructFieldV0)(&v.Fields))
 }
 func XDR_SCSpecUDTStructV0(v *SCSpecUDTStructV0) *SCSpecUDTStructV0 { return v }
 
-type _XdrPtr_SCSpecTypeDef struct {
-	p **SCSpecTypeDef
-}
-type _ptrflag_SCSpecTypeDef _XdrPtr_SCSpecTypeDef
+type XdrType_SCSpecUDTUnionCaseVoidV0 = *SCSpecUDTUnionCaseVoidV0
 
-func (v _ptrflag_SCSpecTypeDef) String() string {
-	if *v.p == nil {
-		return "nil"
+func (v *SCSpecUDTUnionCaseVoidV0) XdrPointer() interface{}       { return v }
+func (SCSpecUDTUnionCaseVoidV0) XdrTypeName() string              { return "SCSpecUDTUnionCaseVoidV0" }
+func (v SCSpecUDTUnionCaseVoidV0) XdrValue() interface{}          { return v }
+func (v *SCSpecUDTUnionCaseVoidV0) XdrMarshal(x XDR, name string) { x.Marshal(name, v) }
+func (v *SCSpecUDTUnionCaseVoidV0) XdrRecurse(x XDR, name string) {
+	if name != "" {
+		name = x.Sprintf("%s.", name)
 	}
-	return "non-nil"
+	x.Marshal(x.Sprintf("%sdoc", name), XdrString{&v.Doc, SC_SPEC_DOC_LIMIT})
+	x.Marshal(x.Sprintf("%sname", name), XdrString{&v.Name, 60})
 }
-func (v _ptrflag_SCSpecTypeDef) Scan(ss fmt.ScanState, r rune) error {
-	tok, err := ss.Token(true, func(c rune) bool {
-		return c == '-' || (c >= 'a' && c <= 'z')
-	})
-	if err != nil {
-		return err
+func XDR_SCSpecUDTUnionCaseVoidV0(v *SCSpecUDTUnionCaseVoidV0) *SCSpecUDTUnionCaseVoidV0 { return v }
+
+type XdrType_SCSpecUDTUnionCaseTupleV0 = *SCSpecUDTUnionCaseTupleV0
+
+func (v *SCSpecUDTUnionCaseTupleV0) XdrPointer() interface{}       { return v }
+func (SCSpecUDTUnionCaseTupleV0) XdrTypeName() string              { return "SCSpecUDTUnionCaseTupleV0" }
+func (v SCSpecUDTUnionCaseTupleV0) XdrValue() interface{}          { return v }
+func (v *SCSpecUDTUnionCaseTupleV0) XdrMarshal(x XDR, name string) { x.Marshal(name, v) }
+func (v *SCSpecUDTUnionCaseTupleV0) XdrRecurse(x XDR, name string) {
+	if name != "" {
+		name = x.Sprintf("%s.", name)
 	}
-	switch string(tok) {
-	case "nil":
-		v.SetU32(0)
-	case "non-nil":
-		v.SetU32(1)
+	x.Marshal(x.Sprintf("%sdoc", name), XdrString{&v.Doc, SC_SPEC_DOC_LIMIT})
+	x.Marshal(x.Sprintf("%sname", name), XdrString{&v.Name, 60})
+	x.Marshal(x.Sprintf("%stype", name), (*_XdrVec_12_SCSpecTypeDef)(&v.Type))
+}
+func XDR_SCSpecUDTUnionCaseTupleV0(v *SCSpecUDTUnionCaseTupleV0) *SCSpecUDTUnionCaseTupleV0 { return v }
+
+var _XdrNames_SCSpecUDTUnionCaseV0Kind = map[int32]string{
+	int32(SC_SPEC_UDT_UNION_CASE_VOID_V0):  "SC_SPEC_UDT_UNION_CASE_VOID_V0",
+	int32(SC_SPEC_UDT_UNION_CASE_TUPLE_V0): "SC_SPEC_UDT_UNION_CASE_TUPLE_V0",
+}
+var _XdrValues_SCSpecUDTUnionCaseV0Kind = map[string]int32{
+	"SC_SPEC_UDT_UNION_CASE_VOID_V0":  int32(SC_SPEC_UDT_UNION_CASE_VOID_V0),
+	"SC_SPEC_UDT_UNION_CASE_TUPLE_V0": int32(SC_SPEC_UDT_UNION_CASE_TUPLE_V0),
+}
+
+func (SCSpecUDTUnionCaseV0Kind) XdrEnumNames() map[int32]string {
+	return _XdrNames_SCSpecUDTUnionCaseV0Kind
+}
+func (v SCSpecUDTUnionCaseV0Kind) String() string {
+	if s, ok := _XdrNames_SCSpecUDTUnionCaseV0Kind[int32(v)]; ok {
+		return s
+	}
+	return fmt.Sprintf("SCSpecUDTUnionCaseV0Kind#%d", v)
+}
+func (v *SCSpecUDTUnionCaseV0Kind) Scan(ss fmt.ScanState, _ rune) error {
+	if tok, err := ss.Token(true, XdrSymChar); err != nil {
+		return err
+	} else {
+		stok := string(tok)
+		if val, ok := _XdrValues_SCSpecUDTUnionCaseV0Kind[stok]; ok {
+			*v = SCSpecUDTUnionCaseV0Kind(val)
+			return nil
+		} else if stok == "SCSpecUDTUnionCaseV0Kind" {
+			if n, err := fmt.Fscanf(ss, "#%d", (*int32)(v)); n == 1 && err == nil {
+				return nil
+			}
+		}
+		return XdrError(fmt.Sprintf("%s is not a valid SCSpecUDTUnionCaseV0Kind.", stok))
+	}
+}
+func (v SCSpecUDTUnionCaseV0Kind) GetU32() uint32                 { return uint32(v) }
+func (v *SCSpecUDTUnionCaseV0Kind) SetU32(n uint32)               { *v = SCSpecUDTUnionCaseV0Kind(n) }
+func (v *SCSpecUDTUnionCaseV0Kind) XdrPointer() interface{}       { return v }
+func (SCSpecUDTUnionCaseV0Kind) XdrTypeName() string              { return "SCSpecUDTUnionCaseV0Kind" }
+func (v SCSpecUDTUnionCaseV0Kind) XdrValue() interface{}          { return v }
+func (v *SCSpecUDTUnionCaseV0Kind) XdrMarshal(x XDR, name string) { x.Marshal(name, v) }
+
+type XdrType_SCSpecUDTUnionCaseV0Kind = *SCSpecUDTUnionCaseV0Kind
+
+func XDR_SCSpecUDTUnionCaseV0Kind(v *SCSpecUDTUnionCaseV0Kind) *SCSpecUDTUnionCaseV0Kind { return v }
+
+var _XdrTags_SCSpecUDTUnionCaseV0 = map[int32]bool{
+	XdrToI32(SC_SPEC_UDT_UNION_CASE_VOID_V0):  true,
+	XdrToI32(SC_SPEC_UDT_UNION_CASE_TUPLE_V0): true,
+}
+
+func (_ SCSpecUDTUnionCaseV0) XdrValidTags() map[int32]bool {
+	return _XdrTags_SCSpecUDTUnionCaseV0
+}
+func (u *SCSpecUDTUnionCaseV0) VoidCase() *SCSpecUDTUnionCaseVoidV0 {
+	switch u.Kind {
+	case SC_SPEC_UDT_UNION_CASE_VOID_V0:
+		if v, ok := u._u.(*SCSpecUDTUnionCaseVoidV0); ok {
+			return v
+		} else {
+			var zero SCSpecUDTUnionCaseVoidV0
+			u._u = &zero
+			return &zero
+		}
 	default:
-		return XdrError("SCSpecTypeDef flag should be \"nil\" or \"non-nil\"")
+		XdrPanic("SCSpecUDTUnionCaseV0.VoidCase accessed when Kind == %v", u.Kind)
+		return nil
+	}
+}
+func (u *SCSpecUDTUnionCaseV0) TupleCase() *SCSpecUDTUnionCaseTupleV0 {
+	switch u.Kind {
+	case SC_SPEC_UDT_UNION_CASE_TUPLE_V0:
+		if v, ok := u._u.(*SCSpecUDTUnionCaseTupleV0); ok {
+			return v
+		} else {
+			var zero SCSpecUDTUnionCaseTupleV0
+			u._u = &zero
+			return &zero
+		}
+	default:
+		XdrPanic("SCSpecUDTUnionCaseV0.TupleCase accessed when Kind == %v", u.Kind)
+		return nil
+	}
+}
+func (u SCSpecUDTUnionCaseV0) XdrValid() bool {
+	switch u.Kind {
+	case SC_SPEC_UDT_UNION_CASE_VOID_V0, SC_SPEC_UDT_UNION_CASE_TUPLE_V0:
+		return true
+	}
+	return false
+}
+func (u *SCSpecUDTUnionCaseV0) XdrUnionTag() XdrNum32 {
+	return XDR_SCSpecUDTUnionCaseV0Kind(&u.Kind)
+}
+func (u *SCSpecUDTUnionCaseV0) XdrUnionTagName() string {
+	return "Kind"
+}
+func (u *SCSpecUDTUnionCaseV0) XdrUnionBody() XdrType {
+	switch u.Kind {
+	case SC_SPEC_UDT_UNION_CASE_VOID_V0:
+		return XDR_SCSpecUDTUnionCaseVoidV0(u.VoidCase())
+	case SC_SPEC_UDT_UNION_CASE_TUPLE_V0:
+		return XDR_SCSpecUDTUnionCaseTupleV0(u.TupleCase())
 	}
 	return nil
 }
-func (v _ptrflag_SCSpecTypeDef) GetU32() uint32 {
-	if *v.p == nil {
-		return 0
+func (u *SCSpecUDTUnionCaseV0) XdrUnionBodyName() string {
+	switch u.Kind {
+	case SC_SPEC_UDT_UNION_CASE_VOID_V0:
+		return "VoidCase"
+	case SC_SPEC_UDT_UNION_CASE_TUPLE_V0:
+		return "TupleCase"
 	}
-	return 1
+	return ""
 }
-func (v _ptrflag_SCSpecTypeDef) SetU32(nv uint32) {
-	switch nv {
-	case 0:
-		*v.p = nil
-	case 1:
-		if *v.p == nil {
-			*v.p = new(SCSpecTypeDef)
-		}
-	default:
-		XdrPanic("*SCSpecTypeDef present flag value %d should be 0 or 1", nv)
-	}
-}
-func (_ptrflag_SCSpecTypeDef) XdrTypeName() string             { return "SCSpecTypeDef?" }
-func (v _ptrflag_SCSpecTypeDef) XdrPointer() interface{}       { return nil }
-func (v _ptrflag_SCSpecTypeDef) XdrValue() interface{}         { return v.GetU32() != 0 }
-func (v _ptrflag_SCSpecTypeDef) XdrMarshal(x XDR, name string) { x.Marshal(name, v) }
-func (v _ptrflag_SCSpecTypeDef) XdrBound() uint32              { return 1 }
-func (v _XdrPtr_SCSpecTypeDef) GetPresent() bool               { return *v.p != nil }
-func (v _XdrPtr_SCSpecTypeDef) SetPresent(present bool) {
-	if !present {
-		*v.p = nil
-	} else if *v.p == nil {
-		*v.p = new(SCSpecTypeDef)
-	}
-}
-func (v _XdrPtr_SCSpecTypeDef) XdrMarshalValue(x XDR, name string) {
-	if *v.p != nil {
-		XDR_SCSpecTypeDef(*v.p).XdrMarshal(x, name)
-	}
-}
-func (v _XdrPtr_SCSpecTypeDef) XdrMarshal(x XDR, name string) { x.Marshal(name, v) }
-func (v _XdrPtr_SCSpecTypeDef) XdrRecurse(x XDR, name string) {
-	x.Marshal(name, _ptrflag_SCSpecTypeDef(v))
-	v.XdrMarshalValue(x, name)
-}
-func (_XdrPtr_SCSpecTypeDef) XdrTypeName() string       { return "SCSpecTypeDef*" }
-func (v _XdrPtr_SCSpecTypeDef) XdrPointer() interface{} { return v.p }
-func (v _XdrPtr_SCSpecTypeDef) XdrValue() interface{}   { return *v.p }
 
 type XdrType_SCSpecUDTUnionCaseV0 = *SCSpecUDTUnionCaseV0
 
@@ -24991,12 +25114,20 @@ func (v *SCSpecUDTUnionCaseV0) XdrPointer() interface{}       { return v }
 func (SCSpecUDTUnionCaseV0) XdrTypeName() string              { return "SCSpecUDTUnionCaseV0" }
 func (v SCSpecUDTUnionCaseV0) XdrValue() interface{}          { return v }
 func (v *SCSpecUDTUnionCaseV0) XdrMarshal(x XDR, name string) { x.Marshal(name, v) }
-func (v *SCSpecUDTUnionCaseV0) XdrRecurse(x XDR, name string) {
+func (u *SCSpecUDTUnionCaseV0) XdrRecurse(x XDR, name string) {
 	if name != "" {
 		name = x.Sprintf("%s.", name)
 	}
-	x.Marshal(x.Sprintf("%sname", name), XdrString{&v.Name, 60})
-	x.Marshal(x.Sprintf("%stype", name), _XdrPtr_SCSpecTypeDef{&v.Type})
+	XDR_SCSpecUDTUnionCaseV0Kind(&u.Kind).XdrMarshal(x, x.Sprintf("%skind", name))
+	switch u.Kind {
+	case SC_SPEC_UDT_UNION_CASE_VOID_V0:
+		x.Marshal(x.Sprintf("%svoidCase", name), XDR_SCSpecUDTUnionCaseVoidV0(u.VoidCase()))
+		return
+	case SC_SPEC_UDT_UNION_CASE_TUPLE_V0:
+		x.Marshal(x.Sprintf("%stupleCase", name), XDR_SCSpecUDTUnionCaseTupleV0(u.TupleCase()))
+		return
+	}
+	XdrPanic("invalid Kind (%v) in SCSpecUDTUnionCaseV0", u.Kind)
 }
 func XDR_SCSpecUDTUnionCaseV0(v *SCSpecUDTUnionCaseV0) *SCSpecUDTUnionCaseV0 { return v }
 
@@ -25069,6 +25200,7 @@ func (v *SCSpecUDTUnionV0) XdrRecurse(x XDR, name string) {
 	if name != "" {
 		name = x.Sprintf("%s.", name)
 	}
+	x.Marshal(x.Sprintf("%sdoc", name), XdrString{&v.Doc, SC_SPEC_DOC_LIMIT})
 	x.Marshal(x.Sprintf("%slib", name), XdrString{&v.Lib, 80})
 	x.Marshal(x.Sprintf("%sname", name), XdrString{&v.Name, 60})
 	x.Marshal(x.Sprintf("%scases", name), (*_XdrVec_50_SCSpecUDTUnionCaseV0)(&v.Cases))
@@ -25085,6 +25217,7 @@ func (v *SCSpecUDTEnumCaseV0) XdrRecurse(x XDR, name string) {
 	if name != "" {
 		name = x.Sprintf("%s.", name)
 	}
+	x.Marshal(x.Sprintf("%sdoc", name), XdrString{&v.Doc, SC_SPEC_DOC_LIMIT})
 	x.Marshal(x.Sprintf("%sname", name), XdrString{&v.Name, 60})
 	x.Marshal(x.Sprintf("%svalue", name), XDR_Uint32(&v.Value))
 }
@@ -25157,6 +25290,7 @@ func (v *SCSpecUDTEnumV0) XdrRecurse(x XDR, name string) {
 	if name != "" {
 		name = x.Sprintf("%s.", name)
 	}
+	x.Marshal(x.Sprintf("%sdoc", name), XdrString{&v.Doc, SC_SPEC_DOC_LIMIT})
 	x.Marshal(x.Sprintf("%slib", name), XdrString{&v.Lib, 80})
 	x.Marshal(x.Sprintf("%sname", name), XdrString{&v.Name, 60})
 	x.Marshal(x.Sprintf("%scases", name), (*_XdrVec_50_SCSpecUDTEnumCaseV0)(&v.Cases))
@@ -25173,6 +25307,7 @@ func (v *SCSpecUDTErrorEnumCaseV0) XdrRecurse(x XDR, name string) {
 	if name != "" {
 		name = x.Sprintf("%s.", name)
 	}
+	x.Marshal(x.Sprintf("%sdoc", name), XdrString{&v.Doc, SC_SPEC_DOC_LIMIT})
 	x.Marshal(x.Sprintf("%sname", name), XdrString{&v.Name, 60})
 	x.Marshal(x.Sprintf("%svalue", name), XDR_Uint32(&v.Value))
 }
@@ -25249,6 +25384,7 @@ func (v *SCSpecUDTErrorEnumV0) XdrRecurse(x XDR, name string) {
 	if name != "" {
 		name = x.Sprintf("%s.", name)
 	}
+	x.Marshal(x.Sprintf("%sdoc", name), XdrString{&v.Doc, SC_SPEC_DOC_LIMIT})
 	x.Marshal(x.Sprintf("%slib", name), XdrString{&v.Lib, 80})
 	x.Marshal(x.Sprintf("%sname", name), XdrString{&v.Name, 60})
 	x.Marshal(x.Sprintf("%scases", name), (*_XdrVec_50_SCSpecUDTErrorEnumCaseV0)(&v.Cases))
@@ -25265,6 +25401,7 @@ func (v *SCSpecFunctionInputV0) XdrRecurse(x XDR, name string) {
 	if name != "" {
 		name = x.Sprintf("%s.", name)
 	}
+	x.Marshal(x.Sprintf("%sdoc", name), XdrString{&v.Doc, SC_SPEC_DOC_LIMIT})
 	x.Marshal(x.Sprintf("%sname", name), XdrString{&v.Name, 30})
 	x.Marshal(x.Sprintf("%stype", name), XDR_SCSpecTypeDef(&v.Type))
 }
@@ -25396,6 +25533,7 @@ func (v *SCSpecFunctionV0) XdrRecurse(x XDR, name string) {
 	if name != "" {
 		name = x.Sprintf("%s.", name)
 	}
+	x.Marshal(x.Sprintf("%sdoc", name), XdrString{&v.Doc, SC_SPEC_DOC_LIMIT})
 	x.Marshal(x.Sprintf("%sname", name), XDR_SCSymbol(&v.Name))
 	x.Marshal(x.Sprintf("%sinputs", name), (*_XdrVec_10_SCSpecFunctionInputV0)(&v.Inputs))
 	x.Marshal(x.Sprintf("%soutputs", name), (*_XdrVec_1_SCSpecTypeDef)(&v.Outputs))
@@ -25741,6 +25879,7 @@ var _XdrNames_SCStatusType = map[int32]string{
 	int32(SST_HOST_CONTEXT_ERROR):  "SST_HOST_CONTEXT_ERROR",
 	int32(SST_VM_ERROR):            "SST_VM_ERROR",
 	int32(SST_CONTRACT_ERROR):      "SST_CONTRACT_ERROR",
+	int32(SST_HOST_AUTH_ERROR):     "SST_HOST_AUTH_ERROR",
 }
 var _XdrValues_SCStatusType = map[string]int32{
 	"SST_OK":                  int32(SST_OK),
@@ -25752,6 +25891,7 @@ var _XdrValues_SCStatusType = map[string]int32{
 	"SST_HOST_CONTEXT_ERROR":  int32(SST_HOST_CONTEXT_ERROR),
 	"SST_VM_ERROR":            int32(SST_VM_ERROR),
 	"SST_CONTRACT_ERROR":      int32(SST_CONTRACT_ERROR),
+	"SST_HOST_AUTH_ERROR":     int32(SST_HOST_AUTH_ERROR),
 }
 
 func (SCStatusType) XdrEnumNames() map[int32]string {
@@ -26014,6 +26154,55 @@ type XdrType_SCHostStorageErrorCode = *SCHostStorageErrorCode
 
 func XDR_SCHostStorageErrorCode(v *SCHostStorageErrorCode) *SCHostStorageErrorCode { return v }
 
+var _XdrNames_SCHostAuthErrorCode = map[int32]string{
+	int32(HOST_AUTH_UNKNOWN_ERROR):           "HOST_AUTH_UNKNOWN_ERROR",
+	int32(HOST_AUTH_NONCE_ERROR):             "HOST_AUTH_NONCE_ERROR",
+	int32(HOST_AUTH_DUPLICATE_AUTHORIZATION): "HOST_AUTH_DUPLICATE_AUTHORIZATION",
+	int32(HOST_AUTH_NOT_AUTHORIZED):          "HOST_AUTH_NOT_AUTHORIZED",
+}
+var _XdrValues_SCHostAuthErrorCode = map[string]int32{
+	"HOST_AUTH_UNKNOWN_ERROR":           int32(HOST_AUTH_UNKNOWN_ERROR),
+	"HOST_AUTH_NONCE_ERROR":             int32(HOST_AUTH_NONCE_ERROR),
+	"HOST_AUTH_DUPLICATE_AUTHORIZATION": int32(HOST_AUTH_DUPLICATE_AUTHORIZATION),
+	"HOST_AUTH_NOT_AUTHORIZED":          int32(HOST_AUTH_NOT_AUTHORIZED),
+}
+
+func (SCHostAuthErrorCode) XdrEnumNames() map[int32]string {
+	return _XdrNames_SCHostAuthErrorCode
+}
+func (v SCHostAuthErrorCode) String() string {
+	if s, ok := _XdrNames_SCHostAuthErrorCode[int32(v)]; ok {
+		return s
+	}
+	return fmt.Sprintf("SCHostAuthErrorCode#%d", v)
+}
+func (v *SCHostAuthErrorCode) Scan(ss fmt.ScanState, _ rune) error {
+	if tok, err := ss.Token(true, XdrSymChar); err != nil {
+		return err
+	} else {
+		stok := string(tok)
+		if val, ok := _XdrValues_SCHostAuthErrorCode[stok]; ok {
+			*v = SCHostAuthErrorCode(val)
+			return nil
+		} else if stok == "SCHostAuthErrorCode" {
+			if n, err := fmt.Fscanf(ss, "#%d", (*int32)(v)); n == 1 && err == nil {
+				return nil
+			}
+		}
+		return XdrError(fmt.Sprintf("%s is not a valid SCHostAuthErrorCode.", stok))
+	}
+}
+func (v SCHostAuthErrorCode) GetU32() uint32                 { return uint32(v) }
+func (v *SCHostAuthErrorCode) SetU32(n uint32)               { *v = SCHostAuthErrorCode(n) }
+func (v *SCHostAuthErrorCode) XdrPointer() interface{}       { return v }
+func (SCHostAuthErrorCode) XdrTypeName() string              { return "SCHostAuthErrorCode" }
+func (v SCHostAuthErrorCode) XdrValue() interface{}          { return v }
+func (v *SCHostAuthErrorCode) XdrMarshal(x XDR, name string) { x.Marshal(name, v) }
+
+type XdrType_SCHostAuthErrorCode = *SCHostAuthErrorCode
+
+func XDR_SCHostAuthErrorCode(v *SCHostAuthErrorCode) *SCHostAuthErrorCode { return v }
+
 var _XdrNames_SCHostContextErrorCode = map[int32]string{
 	int32(HOST_CONTEXT_UNKNOWN_ERROR):       "HOST_CONTEXT_UNKNOWN_ERROR",
 	int32(HOST_CONTEXT_NO_CONTRACT_RUNNING): "HOST_CONTEXT_NO_CONTRACT_RUNNING",
@@ -26193,6 +26382,7 @@ var _XdrTags_SCStatus = map[int32]bool{
 	XdrToI32(SST_HOST_CONTEXT_ERROR):  true,
 	XdrToI32(SST_VM_ERROR):            true,
 	XdrToI32(SST_CONTRACT_ERROR):      true,
+	XdrToI32(SST_HOST_AUTH_ERROR):     true,
 }
 
 func (_ SCStatus) XdrValidTags() map[int32]bool {
@@ -26318,9 +26508,24 @@ func (u *SCStatus) ContractCode() *Uint32 {
 		return nil
 	}
 }
+func (u *SCStatus) AuthCode() *SCHostAuthErrorCode {
+	switch u.Type {
+	case SST_HOST_AUTH_ERROR:
+		if v, ok := u._u.(*SCHostAuthErrorCode); ok {
+			return v
+		} else {
+			var zero SCHostAuthErrorCode
+			u._u = &zero
+			return &zero
+		}
+	default:
+		XdrPanic("SCStatus.AuthCode accessed when Type == %v", u.Type)
+		return nil
+	}
+}
 func (u SCStatus) XdrValid() bool {
 	switch u.Type {
-	case SST_OK, SST_UNKNOWN_ERROR, SST_HOST_VALUE_ERROR, SST_HOST_OBJECT_ERROR, SST_HOST_FUNCTION_ERROR, SST_HOST_STORAGE_ERROR, SST_HOST_CONTEXT_ERROR, SST_VM_ERROR, SST_CONTRACT_ERROR:
+	case SST_OK, SST_UNKNOWN_ERROR, SST_HOST_VALUE_ERROR, SST_HOST_OBJECT_ERROR, SST_HOST_FUNCTION_ERROR, SST_HOST_STORAGE_ERROR, SST_HOST_CONTEXT_ERROR, SST_VM_ERROR, SST_CONTRACT_ERROR, SST_HOST_AUTH_ERROR:
 		return true
 	}
 	return false
@@ -26351,6 +26556,8 @@ func (u *SCStatus) XdrUnionBody() XdrType {
 		return XDR_SCVmErrorCode(u.VmCode())
 	case SST_CONTRACT_ERROR:
 		return XDR_Uint32(u.ContractCode())
+	case SST_HOST_AUTH_ERROR:
+		return XDR_SCHostAuthErrorCode(u.AuthCode())
 	}
 	return nil
 }
@@ -26374,6 +26581,8 @@ func (u *SCStatus) XdrUnionBodyName() string {
 		return "VmCode"
 	case SST_CONTRACT_ERROR:
 		return "ContractCode"
+	case SST_HOST_AUTH_ERROR:
+		return "AuthCode"
 	}
 	return ""
 }
@@ -26415,6 +26624,9 @@ func (u *SCStatus) XdrRecurse(x XDR, name string) {
 		return
 	case SST_CONTRACT_ERROR:
 		x.Marshal(x.Sprintf("%scontractCode", name), XDR_Uint32(u.ContractCode()))
+		return
+	case SST_HOST_AUTH_ERROR:
+		x.Marshal(x.Sprintf("%sauthCode", name), XDR_SCHostAuthErrorCode(u.AuthCode()))
 		return
 	}
 	XdrPanic("invalid Type (%v) in SCStatus", u.Type)

--- a/xdr/Stellar-contract-spec.x
+++ b/xdr/Stellar-contract-spec.x
@@ -10,6 +10,8 @@
 namespace stellar
 {
 
+const SC_SPEC_DOC_LIMIT = 1024;
+
 enum SCSpecType
 {
     SC_SPEC_TYPE_VAL = 0,
@@ -120,25 +122,49 @@ case SC_SPEC_TYPE_UDT:
 
 struct SCSpecUDTStructFieldV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string name<30>;
     SCSpecTypeDef type;
 };
 
 struct SCSpecUDTStructV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
     SCSpecUDTStructFieldV0 fields<40>;
 };
 
-struct SCSpecUDTUnionCaseV0
+struct SCSpecUDTUnionCaseVoidV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string name<60>;
-    SCSpecTypeDef *type;
+};
+
+struct SCSpecUDTUnionCaseTupleV0
+{
+    string doc<SC_SPEC_DOC_LIMIT>;
+    string name<60>;
+    SCSpecTypeDef type<12>;
+};
+
+enum SCSpecUDTUnionCaseV0Kind
+{
+    SC_SPEC_UDT_UNION_CASE_VOID_V0 = 0,
+    SC_SPEC_UDT_UNION_CASE_TUPLE_V0 = 1
+};
+
+union SCSpecUDTUnionCaseV0 switch (SCSpecUDTUnionCaseV0Kind kind)
+{
+case SC_SPEC_UDT_UNION_CASE_VOID_V0:
+    SCSpecUDTUnionCaseVoidV0 voidCase;
+case SC_SPEC_UDT_UNION_CASE_TUPLE_V0:
+    SCSpecUDTUnionCaseTupleV0 tupleCase;
 };
 
 struct SCSpecUDTUnionV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
     SCSpecUDTUnionCaseV0 cases<50>;
@@ -146,12 +172,14 @@ struct SCSpecUDTUnionV0
 
 struct SCSpecUDTEnumCaseV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string name<60>;
     uint32 value;
 };
 
 struct SCSpecUDTEnumV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
     SCSpecUDTEnumCaseV0 cases<50>;
@@ -159,12 +187,14 @@ struct SCSpecUDTEnumV0
 
 struct SCSpecUDTErrorEnumCaseV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string name<60>;
     uint32 value;
 };
 
 struct SCSpecUDTErrorEnumV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
     SCSpecUDTErrorEnumCaseV0 cases<50>;
@@ -172,12 +202,14 @@ struct SCSpecUDTErrorEnumV0
 
 struct SCSpecFunctionInputV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string name<30>;
     SCSpecTypeDef type;
 };
 
 struct SCSpecFunctionV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     SCSymbol name;
     SCSpecFunctionInputV0 inputs<10>;
     SCSpecTypeDef outputs<1>;

--- a/xdr/Stellar-contract.x
+++ b/xdr/Stellar-contract.x
@@ -78,7 +78,8 @@ enum SCStatusType
     SST_HOST_STORAGE_ERROR = 5,
     SST_HOST_CONTEXT_ERROR = 6,
     SST_VM_ERROR = 7,
-    SST_CONTRACT_ERROR = 8
+    SST_CONTRACT_ERROR = 8,
+    SST_HOST_AUTH_ERROR = 9
     // TODO: add more
 };
 
@@ -126,6 +127,14 @@ enum SCHostStorageErrorCode
     HOST_STORAGE_ACCESS_TO_UNKNOWN_ENTRY = 3,
     HOST_STORAGE_MISSING_KEY_IN_GET = 4,
     HOST_STORAGE_GET_ON_DELETED_KEY = 5
+};
+
+enum SCHostAuthErrorCode
+{
+    HOST_AUTH_UNKNOWN_ERROR = 0,
+    HOST_AUTH_NONCE_ERROR = 1,
+    HOST_AUTH_DUPLICATE_AUTHORIZATION = 2,
+    HOST_AUTH_NOT_AUTHORIZED = 3
 };
 
 enum SCHostContextErrorCode
@@ -182,6 +191,8 @@ case SST_VM_ERROR:
     SCVmErrorCode vmCode;
 case SST_CONTRACT_ERROR:
     uint32 contractCode;
+case SST_HOST_AUTH_ERROR:
+    SCHostAuthErrorCode authCode;
 };
 
 union SCVal switch (SCValType type)

--- a/xdr/Stellar-transaction.x
+++ b/xdr/Stellar-transaction.x
@@ -682,6 +682,7 @@ case ENVELOPE_TYPE_CONTRACT_AUTH:
     struct
     {
         Hash networkID;
+        uint64 nonce;
         AuthorizedInvocation invocation;
     } contractAuth;
 };

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -3,16 +3,16 @@
 
 // Package xdr is generated from:
 //
-//	xdr/Stellar-SCP.x
-//	xdr/Stellar-contract-env-meta.x
-//	xdr/Stellar-contract-spec.x
-//	xdr/Stellar-contract.x
-//	xdr/Stellar-internal.x
-//	xdr/Stellar-ledger-entries.x
-//	xdr/Stellar-ledger.x
-//	xdr/Stellar-overlay.x
-//	xdr/Stellar-transaction.x
-//	xdr/Stellar-types.x
+//  xdr/Stellar-SCP.x
+//  xdr/Stellar-contract-env-meta.x
+//  xdr/Stellar-contract-spec.x
+//  xdr/Stellar-contract.x
+//  xdr/Stellar-internal.x
+//  xdr/Stellar-ledger-entries.x
+//  xdr/Stellar-ledger.x
+//  xdr/Stellar-overlay.x
+//  xdr/Stellar-transaction.x
+//  xdr/Stellar-types.x
 //
 // DO NOT EDIT or your changes may be overwritten
 package xdr
@@ -30,13 +30,13 @@ import (
 var XdrFilesSHA256 = map[string]string{
 	"xdr/Stellar-SCP.x":               "8f32b04d008f8bc33b8843d075e69837231a673691ee41d8b821ca229a6e802a",
 	"xdr/Stellar-contract-env-meta.x": "928a30de814ee589bc1d2aadd8dd81c39f71b7e6f430f56974505ccb1f49654b",
-	"xdr/Stellar-contract-spec.x":     "f1b4562b21a38708e15b2e7f371d9171802ef7756bf5af2cb49b517149228e9c",
-	"xdr/Stellar-contract.x":          "5c254a97c31d08f0d1c5bd50867d71edad11338dd5653d87d3714475221e68d7",
+	"xdr/Stellar-contract-spec.x":     "83f5adc57ccaea49a67063352b869641049c4caf198a3070c4825c5f6e82802a",
+	"xdr/Stellar-contract.x":          "99696979513d389fabe843874b84dd75a7fec8f8f329ca9ae833c600850dee2d",
 	"xdr/Stellar-internal.x":          "368706dd6e2efafd16a8f63daf3374845b791d097b15c502aa7653a412b68b68",
 	"xdr/Stellar-ledger-entries.x":    "dae8eead47f2ce6b74b87fc196080cde2b432eedba9e58893f1d5ad315155e4e",
 	"xdr/Stellar-ledger.x":            "b19c10a07c9775594723ad12927259dd4bbd9ed9dfd0e70078662ec2e90e130d",
 	"xdr/Stellar-overlay.x":           "972f38a9d4a064273f3362cbfa7d3c563293fd5396d5f0774ce6cc690e27645d",
-	"xdr/Stellar-transaction.x":       "69d33701fac38c2e0ba861f8ff6c96ae126364a9606a8f21e36b823dceb6a004",
+	"xdr/Stellar-transaction.x":       "0ab9890a6ffbe3a7f0b4496f7f531606812c1207b862a0a7bc03b70e83dbdf72",
 	"xdr/Stellar-types.x":             "7b3e5470c4bcf7c19f9cc8f8bf81a494b540fc2157476329cf19863afab2343b",
 }
 
@@ -27812,10 +27812,12 @@ var _ xdrType = (*HashIdPreimageCreateContractArgs)(nil)
 //	struct
 //	     {
 //	         Hash networkID;
+//	         uint64 nonce;
 //	         AuthorizedInvocation invocation;
 //	     }
 type HashIdPreimageContractAuth struct {
 	NetworkId  Hash
+	Nonce      Uint64
 	Invocation AuthorizedInvocation
 }
 
@@ -27823,6 +27825,9 @@ type HashIdPreimageContractAuth struct {
 func (s *HashIdPreimageContractAuth) EncodeTo(e *xdr.Encoder) error {
 	var err error
 	if err = s.NetworkId.EncodeTo(e); err != nil {
+		return err
+	}
+	if err = s.Nonce.EncodeTo(e); err != nil {
 		return err
 	}
 	if err = s.Invocation.EncodeTo(e); err != nil {
@@ -27841,6 +27846,11 @@ func (s *HashIdPreimageContractAuth) DecodeFrom(d *xdr.Decoder) (int, error) {
 	n += nTmp
 	if err != nil {
 		return n, fmt.Errorf("decoding Hash: %s", err)
+	}
+	nTmp, err = s.Nonce.DecodeFrom(d)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Uint64: %s", err)
 	}
 	nTmp, err = s.Invocation.DecodeFrom(d)
 	n += nTmp
@@ -27935,6 +27945,7 @@ var _ xdrType = (*HashIdPreimageContractAuth)(nil)
 //	     struct
 //	     {
 //	         Hash networkID;
+//	         uint64 nonce;
 //	         AuthorizedInvocation invocation;
 //	     } contractAuth;
 //	 };
@@ -44197,6 +44208,11 @@ func (s ScEnvMetaEntry) xdrType() {}
 
 var _ xdrType = (*ScEnvMetaEntry)(nil)
 
+// ScSpecDocLimit is an XDR Const defines as:
+//
+//	const SC_SPEC_DOC_LIMIT = 1024;
+const ScSpecDocLimit = 1024
+
 // ScSpecType is an XDR Enum defines as:
 //
 //	enum SCSpecType
@@ -45499,10 +45515,12 @@ var _ xdrType = (*ScSpecTypeDef)(nil)
 //
 //	struct SCSpecUDTStructFieldV0
 //	 {
+//	     string doc<SC_SPEC_DOC_LIMIT>;
 //	     string name<30>;
 //	     SCSpecTypeDef type;
 //	 };
 type ScSpecUdtStructFieldV0 struct {
+	Doc  string `xdrmaxsize:"1024"`
 	Name string `xdrmaxsize:"30"`
 	Type ScSpecTypeDef
 }
@@ -45510,6 +45528,9 @@ type ScSpecUdtStructFieldV0 struct {
 // EncodeTo encodes this value using the Encoder.
 func (s *ScSpecUdtStructFieldV0) EncodeTo(e *xdr.Encoder) error {
 	var err error
+	if _, err = e.EncodeString(string(s.Doc)); err != nil {
+		return err
+	}
 	if _, err = e.EncodeString(string(s.Name)); err != nil {
 		return err
 	}
@@ -45525,6 +45546,11 @@ var _ decoderFrom = (*ScSpecUdtStructFieldV0)(nil)
 func (s *ScSpecUdtStructFieldV0) DecodeFrom(d *xdr.Decoder) (int, error) {
 	var err error
 	var n, nTmp int
+	s.Doc, nTmp, err = d.DecodeString(1024)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Doc: %s", err)
+	}
 	s.Name, nTmp, err = d.DecodeString(30)
 	n += nTmp
 	if err != nil {
@@ -45569,11 +45595,13 @@ var _ xdrType = (*ScSpecUdtStructFieldV0)(nil)
 //
 //	struct SCSpecUDTStructV0
 //	 {
+//	     string doc<SC_SPEC_DOC_LIMIT>;
 //	     string lib<80>;
 //	     string name<60>;
 //	     SCSpecUDTStructFieldV0 fields<40>;
 //	 };
 type ScSpecUdtStructV0 struct {
+	Doc    string                   `xdrmaxsize:"1024"`
 	Lib    string                   `xdrmaxsize:"80"`
 	Name   string                   `xdrmaxsize:"60"`
 	Fields []ScSpecUdtStructFieldV0 `xdrmaxsize:"40"`
@@ -45582,6 +45610,9 @@ type ScSpecUdtStructV0 struct {
 // EncodeTo encodes this value using the Encoder.
 func (s *ScSpecUdtStructV0) EncodeTo(e *xdr.Encoder) error {
 	var err error
+	if _, err = e.EncodeString(string(s.Doc)); err != nil {
+		return err
+	}
 	if _, err = e.EncodeString(string(s.Lib)); err != nil {
 		return err
 	}
@@ -45605,6 +45636,11 @@ var _ decoderFrom = (*ScSpecUdtStructV0)(nil)
 func (s *ScSpecUdtStructV0) DecodeFrom(d *xdr.Decoder) (int, error) {
 	var err error
 	var n, nTmp int
+	s.Doc, nTmp, err = d.DecodeString(1024)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Doc: %s", err)
+	}
 	s.Lib, nTmp, err = d.DecodeString(80)
 	n += nTmp
 	if err != nil {
@@ -45665,62 +45701,415 @@ func (s ScSpecUdtStructV0) xdrType() {}
 
 var _ xdrType = (*ScSpecUdtStructV0)(nil)
 
-// ScSpecUdtUnionCaseV0 is an XDR Struct defines as:
+// ScSpecUdtUnionCaseVoidV0 is an XDR Struct defines as:
 //
-//	struct SCSpecUDTUnionCaseV0
+//	struct SCSpecUDTUnionCaseVoidV0
 //	 {
+//	     string doc<SC_SPEC_DOC_LIMIT>;
 //	     string name<60>;
-//	     SCSpecTypeDef *type;
 //	 };
-type ScSpecUdtUnionCaseV0 struct {
+type ScSpecUdtUnionCaseVoidV0 struct {
+	Doc  string `xdrmaxsize:"1024"`
 	Name string `xdrmaxsize:"60"`
-	Type *ScSpecTypeDef
 }
 
 // EncodeTo encodes this value using the Encoder.
-func (s *ScSpecUdtUnionCaseV0) EncodeTo(e *xdr.Encoder) error {
+func (s *ScSpecUdtUnionCaseVoidV0) EncodeTo(e *xdr.Encoder) error {
 	var err error
+	if _, err = e.EncodeString(string(s.Doc)); err != nil {
+		return err
+	}
 	if _, err = e.EncodeString(string(s.Name)); err != nil {
 		return err
 	}
-	if _, err = e.EncodeBool(s.Type != nil); err != nil {
+	return nil
+}
+
+var _ decoderFrom = (*ScSpecUdtUnionCaseVoidV0)(nil)
+
+// DecodeFrom decodes this value using the Decoder.
+func (s *ScSpecUdtUnionCaseVoidV0) DecodeFrom(d *xdr.Decoder) (int, error) {
+	var err error
+	var n, nTmp int
+	s.Doc, nTmp, err = d.DecodeString(1024)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Doc: %s", err)
+	}
+	s.Name, nTmp, err = d.DecodeString(60)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Name: %s", err)
+	}
+	return n, nil
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s ScSpecUdtUnionCaseVoidV0) MarshalBinary() ([]byte, error) {
+	b := bytes.Buffer{}
+	e := xdr.NewEncoder(&b)
+	err := s.EncodeTo(e)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *ScSpecUdtUnionCaseVoidV0) UnmarshalBinary(inp []byte) error {
+	r := bytes.NewReader(inp)
+	d := xdr.NewDecoder(r)
+	_, err := s.DecodeFrom(d)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*ScSpecUdtUnionCaseVoidV0)(nil)
+	_ encoding.BinaryUnmarshaler = (*ScSpecUdtUnionCaseVoidV0)(nil)
+)
+
+// xdrType signals that this type is an type representing
+// representing XDR values defined by this package.
+func (s ScSpecUdtUnionCaseVoidV0) xdrType() {}
+
+var _ xdrType = (*ScSpecUdtUnionCaseVoidV0)(nil)
+
+// ScSpecUdtUnionCaseTupleV0 is an XDR Struct defines as:
+//
+//	struct SCSpecUDTUnionCaseTupleV0
+//	 {
+//	     string doc<SC_SPEC_DOC_LIMIT>;
+//	     string name<60>;
+//	     SCSpecTypeDef type<12>;
+//	 };
+type ScSpecUdtUnionCaseTupleV0 struct {
+	Doc  string          `xdrmaxsize:"1024"`
+	Name string          `xdrmaxsize:"60"`
+	Type []ScSpecTypeDef `xdrmaxsize:"12"`
+}
+
+// EncodeTo encodes this value using the Encoder.
+func (s *ScSpecUdtUnionCaseTupleV0) EncodeTo(e *xdr.Encoder) error {
+	var err error
+	if _, err = e.EncodeString(string(s.Doc)); err != nil {
 		return err
 	}
-	if s.Type != nil {
-		if err = (*s.Type).EncodeTo(e); err != nil {
+	if _, err = e.EncodeString(string(s.Name)); err != nil {
+		return err
+	}
+	if _, err = e.EncodeUint(uint32(len(s.Type))); err != nil {
+		return err
+	}
+	for i := 0; i < len(s.Type); i++ {
+		if err = s.Type[i].EncodeTo(e); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-var _ decoderFrom = (*ScSpecUdtUnionCaseV0)(nil)
+var _ decoderFrom = (*ScSpecUdtUnionCaseTupleV0)(nil)
 
 // DecodeFrom decodes this value using the Decoder.
-func (s *ScSpecUdtUnionCaseV0) DecodeFrom(d *xdr.Decoder) (int, error) {
+func (s *ScSpecUdtUnionCaseTupleV0) DecodeFrom(d *xdr.Decoder) (int, error) {
 	var err error
 	var n, nTmp int
+	s.Doc, nTmp, err = d.DecodeString(1024)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Doc: %s", err)
+	}
 	s.Name, nTmp, err = d.DecodeString(60)
 	n += nTmp
 	if err != nil {
 		return n, fmt.Errorf("decoding Name: %s", err)
 	}
-	var b bool
-	b, nTmp, err = d.DecodeBool()
+	var l uint32
+	l, nTmp, err = d.DecodeUint()
 	n += nTmp
 	if err != nil {
 		return n, fmt.Errorf("decoding ScSpecTypeDef: %s", err)
 	}
+	if l > 12 {
+		return n, fmt.Errorf("decoding ScSpecTypeDef: data size (%d) exceeds size limit (12)", l)
+	}
 	s.Type = nil
-	if b {
-		s.Type = new(ScSpecTypeDef)
-		nTmp, err = s.Type.DecodeFrom(d)
-		n += nTmp
-		if err != nil {
-			return n, fmt.Errorf("decoding ScSpecTypeDef: %s", err)
+	if l > 0 {
+		s.Type = make([]ScSpecTypeDef, l)
+		for i := uint32(0); i < l; i++ {
+			nTmp, err = s.Type[i].DecodeFrom(d)
+			n += nTmp
+			if err != nil {
+				return n, fmt.Errorf("decoding ScSpecTypeDef: %s", err)
+			}
 		}
 	}
 	return n, nil
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s ScSpecUdtUnionCaseTupleV0) MarshalBinary() ([]byte, error) {
+	b := bytes.Buffer{}
+	e := xdr.NewEncoder(&b)
+	err := s.EncodeTo(e)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *ScSpecUdtUnionCaseTupleV0) UnmarshalBinary(inp []byte) error {
+	r := bytes.NewReader(inp)
+	d := xdr.NewDecoder(r)
+	_, err := s.DecodeFrom(d)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*ScSpecUdtUnionCaseTupleV0)(nil)
+	_ encoding.BinaryUnmarshaler = (*ScSpecUdtUnionCaseTupleV0)(nil)
+)
+
+// xdrType signals that this type is an type representing
+// representing XDR values defined by this package.
+func (s ScSpecUdtUnionCaseTupleV0) xdrType() {}
+
+var _ xdrType = (*ScSpecUdtUnionCaseTupleV0)(nil)
+
+// ScSpecUdtUnionCaseV0Kind is an XDR Enum defines as:
+//
+//	enum SCSpecUDTUnionCaseV0Kind
+//	 {
+//	     SC_SPEC_UDT_UNION_CASE_VOID_V0 = 0,
+//	     SC_SPEC_UDT_UNION_CASE_TUPLE_V0 = 1
+//	 };
+type ScSpecUdtUnionCaseV0Kind int32
+
+const (
+	ScSpecUdtUnionCaseV0KindScSpecUdtUnionCaseVoidV0  ScSpecUdtUnionCaseV0Kind = 0
+	ScSpecUdtUnionCaseV0KindScSpecUdtUnionCaseTupleV0 ScSpecUdtUnionCaseV0Kind = 1
+)
+
+var scSpecUdtUnionCaseV0KindMap = map[int32]string{
+	0: "ScSpecUdtUnionCaseV0KindScSpecUdtUnionCaseVoidV0",
+	1: "ScSpecUdtUnionCaseV0KindScSpecUdtUnionCaseTupleV0",
+}
+
+// ValidEnum validates a proposed value for this enum.  Implements
+// the Enum interface for ScSpecUdtUnionCaseV0Kind
+func (e ScSpecUdtUnionCaseV0Kind) ValidEnum(v int32) bool {
+	_, ok := scSpecUdtUnionCaseV0KindMap[v]
+	return ok
+}
+
+// String returns the name of `e`
+func (e ScSpecUdtUnionCaseV0Kind) String() string {
+	name, _ := scSpecUdtUnionCaseV0KindMap[int32(e)]
+	return name
+}
+
+// EncodeTo encodes this value using the Encoder.
+func (e ScSpecUdtUnionCaseV0Kind) EncodeTo(enc *xdr.Encoder) error {
+	if _, ok := scSpecUdtUnionCaseV0KindMap[int32(e)]; !ok {
+		return fmt.Errorf("'%d' is not a valid ScSpecUdtUnionCaseV0Kind enum value", e)
+	}
+	_, err := enc.EncodeInt(int32(e))
+	return err
+}
+
+var _ decoderFrom = (*ScSpecUdtUnionCaseV0Kind)(nil)
+
+// DecodeFrom decodes this value using the Decoder.
+func (e *ScSpecUdtUnionCaseV0Kind) DecodeFrom(d *xdr.Decoder) (int, error) {
+	v, n, err := d.DecodeInt()
+	if err != nil {
+		return n, fmt.Errorf("decoding ScSpecUdtUnionCaseV0Kind: %s", err)
+	}
+	if _, ok := scSpecUdtUnionCaseV0KindMap[v]; !ok {
+		return n, fmt.Errorf("'%d' is not a valid ScSpecUdtUnionCaseV0Kind enum value", v)
+	}
+	*e = ScSpecUdtUnionCaseV0Kind(v)
+	return n, nil
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s ScSpecUdtUnionCaseV0Kind) MarshalBinary() ([]byte, error) {
+	b := bytes.Buffer{}
+	e := xdr.NewEncoder(&b)
+	err := s.EncodeTo(e)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *ScSpecUdtUnionCaseV0Kind) UnmarshalBinary(inp []byte) error {
+	r := bytes.NewReader(inp)
+	d := xdr.NewDecoder(r)
+	_, err := s.DecodeFrom(d)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*ScSpecUdtUnionCaseV0Kind)(nil)
+	_ encoding.BinaryUnmarshaler = (*ScSpecUdtUnionCaseV0Kind)(nil)
+)
+
+// xdrType signals that this type is an type representing
+// representing XDR values defined by this package.
+func (s ScSpecUdtUnionCaseV0Kind) xdrType() {}
+
+var _ xdrType = (*ScSpecUdtUnionCaseV0Kind)(nil)
+
+// ScSpecUdtUnionCaseV0 is an XDR Union defines as:
+//
+//	union SCSpecUDTUnionCaseV0 switch (SCSpecUDTUnionCaseV0Kind kind)
+//	 {
+//	 case SC_SPEC_UDT_UNION_CASE_VOID_V0:
+//	     SCSpecUDTUnionCaseVoidV0 voidCase;
+//	 case SC_SPEC_UDT_UNION_CASE_TUPLE_V0:
+//	     SCSpecUDTUnionCaseTupleV0 tupleCase;
+//	 };
+type ScSpecUdtUnionCaseV0 struct {
+	Kind      ScSpecUdtUnionCaseV0Kind
+	VoidCase  *ScSpecUdtUnionCaseVoidV0
+	TupleCase *ScSpecUdtUnionCaseTupleV0
+}
+
+// SwitchFieldName returns the field name in which this union's
+// discriminant is stored
+func (u ScSpecUdtUnionCaseV0) SwitchFieldName() string {
+	return "Kind"
+}
+
+// ArmForSwitch returns which field name should be used for storing
+// the value for an instance of ScSpecUdtUnionCaseV0
+func (u ScSpecUdtUnionCaseV0) ArmForSwitch(sw int32) (string, bool) {
+	switch ScSpecUdtUnionCaseV0Kind(sw) {
+	case ScSpecUdtUnionCaseV0KindScSpecUdtUnionCaseVoidV0:
+		return "VoidCase", true
+	case ScSpecUdtUnionCaseV0KindScSpecUdtUnionCaseTupleV0:
+		return "TupleCase", true
+	}
+	return "-", false
+}
+
+// NewScSpecUdtUnionCaseV0 creates a new  ScSpecUdtUnionCaseV0.
+func NewScSpecUdtUnionCaseV0(kind ScSpecUdtUnionCaseV0Kind, value interface{}) (result ScSpecUdtUnionCaseV0, err error) {
+	result.Kind = kind
+	switch ScSpecUdtUnionCaseV0Kind(kind) {
+	case ScSpecUdtUnionCaseV0KindScSpecUdtUnionCaseVoidV0:
+		tv, ok := value.(ScSpecUdtUnionCaseVoidV0)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be ScSpecUdtUnionCaseVoidV0")
+			return
+		}
+		result.VoidCase = &tv
+	case ScSpecUdtUnionCaseV0KindScSpecUdtUnionCaseTupleV0:
+		tv, ok := value.(ScSpecUdtUnionCaseTupleV0)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be ScSpecUdtUnionCaseTupleV0")
+			return
+		}
+		result.TupleCase = &tv
+	}
+	return
+}
+
+// MustVoidCase retrieves the VoidCase value from the union,
+// panicing if the value is not set.
+func (u ScSpecUdtUnionCaseV0) MustVoidCase() ScSpecUdtUnionCaseVoidV0 {
+	val, ok := u.GetVoidCase()
+
+	if !ok {
+		panic("arm VoidCase is not set")
+	}
+
+	return val
+}
+
+// GetVoidCase retrieves the VoidCase value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u ScSpecUdtUnionCaseV0) GetVoidCase() (result ScSpecUdtUnionCaseVoidV0, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Kind))
+
+	if armName == "VoidCase" {
+		result = *u.VoidCase
+		ok = true
+	}
+
+	return
+}
+
+// MustTupleCase retrieves the TupleCase value from the union,
+// panicing if the value is not set.
+func (u ScSpecUdtUnionCaseV0) MustTupleCase() ScSpecUdtUnionCaseTupleV0 {
+	val, ok := u.GetTupleCase()
+
+	if !ok {
+		panic("arm TupleCase is not set")
+	}
+
+	return val
+}
+
+// GetTupleCase retrieves the TupleCase value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u ScSpecUdtUnionCaseV0) GetTupleCase() (result ScSpecUdtUnionCaseTupleV0, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Kind))
+
+	if armName == "TupleCase" {
+		result = *u.TupleCase
+		ok = true
+	}
+
+	return
+}
+
+// EncodeTo encodes this value using the Encoder.
+func (u ScSpecUdtUnionCaseV0) EncodeTo(e *xdr.Encoder) error {
+	var err error
+	if err = u.Kind.EncodeTo(e); err != nil {
+		return err
+	}
+	switch ScSpecUdtUnionCaseV0Kind(u.Kind) {
+	case ScSpecUdtUnionCaseV0KindScSpecUdtUnionCaseVoidV0:
+		if err = (*u.VoidCase).EncodeTo(e); err != nil {
+			return err
+		}
+		return nil
+	case ScSpecUdtUnionCaseV0KindScSpecUdtUnionCaseTupleV0:
+		if err = (*u.TupleCase).EncodeTo(e); err != nil {
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("Kind (ScSpecUdtUnionCaseV0Kind) switch value '%d' is not valid for union ScSpecUdtUnionCaseV0", u.Kind)
+}
+
+var _ decoderFrom = (*ScSpecUdtUnionCaseV0)(nil)
+
+// DecodeFrom decodes this value using the Decoder.
+func (u *ScSpecUdtUnionCaseV0) DecodeFrom(d *xdr.Decoder) (int, error) {
+	var err error
+	var n, nTmp int
+	nTmp, err = u.Kind.DecodeFrom(d)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding ScSpecUdtUnionCaseV0Kind: %s", err)
+	}
+	switch ScSpecUdtUnionCaseV0Kind(u.Kind) {
+	case ScSpecUdtUnionCaseV0KindScSpecUdtUnionCaseVoidV0:
+		u.VoidCase = new(ScSpecUdtUnionCaseVoidV0)
+		nTmp, err = (*u.VoidCase).DecodeFrom(d)
+		n += nTmp
+		if err != nil {
+			return n, fmt.Errorf("decoding ScSpecUdtUnionCaseVoidV0: %s", err)
+		}
+		return n, nil
+	case ScSpecUdtUnionCaseV0KindScSpecUdtUnionCaseTupleV0:
+		u.TupleCase = new(ScSpecUdtUnionCaseTupleV0)
+		nTmp, err = (*u.TupleCase).DecodeFrom(d)
+		n += nTmp
+		if err != nil {
+			return n, fmt.Errorf("decoding ScSpecUdtUnionCaseTupleV0: %s", err)
+		}
+		return n, nil
+	}
+	return n, fmt.Errorf("union ScSpecUdtUnionCaseV0 has invalid Kind (ScSpecUdtUnionCaseV0Kind) switch value '%d'", u.Kind)
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.
@@ -45754,11 +46143,13 @@ var _ xdrType = (*ScSpecUdtUnionCaseV0)(nil)
 //
 //	struct SCSpecUDTUnionV0
 //	 {
+//	     string doc<SC_SPEC_DOC_LIMIT>;
 //	     string lib<80>;
 //	     string name<60>;
 //	     SCSpecUDTUnionCaseV0 cases<50>;
 //	 };
 type ScSpecUdtUnionV0 struct {
+	Doc   string                 `xdrmaxsize:"1024"`
 	Lib   string                 `xdrmaxsize:"80"`
 	Name  string                 `xdrmaxsize:"60"`
 	Cases []ScSpecUdtUnionCaseV0 `xdrmaxsize:"50"`
@@ -45767,6 +46158,9 @@ type ScSpecUdtUnionV0 struct {
 // EncodeTo encodes this value using the Encoder.
 func (s *ScSpecUdtUnionV0) EncodeTo(e *xdr.Encoder) error {
 	var err error
+	if _, err = e.EncodeString(string(s.Doc)); err != nil {
+		return err
+	}
 	if _, err = e.EncodeString(string(s.Lib)); err != nil {
 		return err
 	}
@@ -45790,6 +46184,11 @@ var _ decoderFrom = (*ScSpecUdtUnionV0)(nil)
 func (s *ScSpecUdtUnionV0) DecodeFrom(d *xdr.Decoder) (int, error) {
 	var err error
 	var n, nTmp int
+	s.Doc, nTmp, err = d.DecodeString(1024)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Doc: %s", err)
+	}
 	s.Lib, nTmp, err = d.DecodeString(80)
 	n += nTmp
 	if err != nil {
@@ -45854,10 +46253,12 @@ var _ xdrType = (*ScSpecUdtUnionV0)(nil)
 //
 //	struct SCSpecUDTEnumCaseV0
 //	 {
+//	     string doc<SC_SPEC_DOC_LIMIT>;
 //	     string name<60>;
 //	     uint32 value;
 //	 };
 type ScSpecUdtEnumCaseV0 struct {
+	Doc   string `xdrmaxsize:"1024"`
 	Name  string `xdrmaxsize:"60"`
 	Value Uint32
 }
@@ -45865,6 +46266,9 @@ type ScSpecUdtEnumCaseV0 struct {
 // EncodeTo encodes this value using the Encoder.
 func (s *ScSpecUdtEnumCaseV0) EncodeTo(e *xdr.Encoder) error {
 	var err error
+	if _, err = e.EncodeString(string(s.Doc)); err != nil {
+		return err
+	}
 	if _, err = e.EncodeString(string(s.Name)); err != nil {
 		return err
 	}
@@ -45880,6 +46284,11 @@ var _ decoderFrom = (*ScSpecUdtEnumCaseV0)(nil)
 func (s *ScSpecUdtEnumCaseV0) DecodeFrom(d *xdr.Decoder) (int, error) {
 	var err error
 	var n, nTmp int
+	s.Doc, nTmp, err = d.DecodeString(1024)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Doc: %s", err)
+	}
 	s.Name, nTmp, err = d.DecodeString(60)
 	n += nTmp
 	if err != nil {
@@ -45924,11 +46333,13 @@ var _ xdrType = (*ScSpecUdtEnumCaseV0)(nil)
 //
 //	struct SCSpecUDTEnumV0
 //	 {
+//	     string doc<SC_SPEC_DOC_LIMIT>;
 //	     string lib<80>;
 //	     string name<60>;
 //	     SCSpecUDTEnumCaseV0 cases<50>;
 //	 };
 type ScSpecUdtEnumV0 struct {
+	Doc   string                `xdrmaxsize:"1024"`
 	Lib   string                `xdrmaxsize:"80"`
 	Name  string                `xdrmaxsize:"60"`
 	Cases []ScSpecUdtEnumCaseV0 `xdrmaxsize:"50"`
@@ -45937,6 +46348,9 @@ type ScSpecUdtEnumV0 struct {
 // EncodeTo encodes this value using the Encoder.
 func (s *ScSpecUdtEnumV0) EncodeTo(e *xdr.Encoder) error {
 	var err error
+	if _, err = e.EncodeString(string(s.Doc)); err != nil {
+		return err
+	}
 	if _, err = e.EncodeString(string(s.Lib)); err != nil {
 		return err
 	}
@@ -45960,6 +46374,11 @@ var _ decoderFrom = (*ScSpecUdtEnumV0)(nil)
 func (s *ScSpecUdtEnumV0) DecodeFrom(d *xdr.Decoder) (int, error) {
 	var err error
 	var n, nTmp int
+	s.Doc, nTmp, err = d.DecodeString(1024)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Doc: %s", err)
+	}
 	s.Lib, nTmp, err = d.DecodeString(80)
 	n += nTmp
 	if err != nil {
@@ -46024,10 +46443,12 @@ var _ xdrType = (*ScSpecUdtEnumV0)(nil)
 //
 //	struct SCSpecUDTErrorEnumCaseV0
 //	 {
+//	     string doc<SC_SPEC_DOC_LIMIT>;
 //	     string name<60>;
 //	     uint32 value;
 //	 };
 type ScSpecUdtErrorEnumCaseV0 struct {
+	Doc   string `xdrmaxsize:"1024"`
 	Name  string `xdrmaxsize:"60"`
 	Value Uint32
 }
@@ -46035,6 +46456,9 @@ type ScSpecUdtErrorEnumCaseV0 struct {
 // EncodeTo encodes this value using the Encoder.
 func (s *ScSpecUdtErrorEnumCaseV0) EncodeTo(e *xdr.Encoder) error {
 	var err error
+	if _, err = e.EncodeString(string(s.Doc)); err != nil {
+		return err
+	}
 	if _, err = e.EncodeString(string(s.Name)); err != nil {
 		return err
 	}
@@ -46050,6 +46474,11 @@ var _ decoderFrom = (*ScSpecUdtErrorEnumCaseV0)(nil)
 func (s *ScSpecUdtErrorEnumCaseV0) DecodeFrom(d *xdr.Decoder) (int, error) {
 	var err error
 	var n, nTmp int
+	s.Doc, nTmp, err = d.DecodeString(1024)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Doc: %s", err)
+	}
 	s.Name, nTmp, err = d.DecodeString(60)
 	n += nTmp
 	if err != nil {
@@ -46094,11 +46523,13 @@ var _ xdrType = (*ScSpecUdtErrorEnumCaseV0)(nil)
 //
 //	struct SCSpecUDTErrorEnumV0
 //	 {
+//	     string doc<SC_SPEC_DOC_LIMIT>;
 //	     string lib<80>;
 //	     string name<60>;
 //	     SCSpecUDTErrorEnumCaseV0 cases<50>;
 //	 };
 type ScSpecUdtErrorEnumV0 struct {
+	Doc   string                     `xdrmaxsize:"1024"`
 	Lib   string                     `xdrmaxsize:"80"`
 	Name  string                     `xdrmaxsize:"60"`
 	Cases []ScSpecUdtErrorEnumCaseV0 `xdrmaxsize:"50"`
@@ -46107,6 +46538,9 @@ type ScSpecUdtErrorEnumV0 struct {
 // EncodeTo encodes this value using the Encoder.
 func (s *ScSpecUdtErrorEnumV0) EncodeTo(e *xdr.Encoder) error {
 	var err error
+	if _, err = e.EncodeString(string(s.Doc)); err != nil {
+		return err
+	}
 	if _, err = e.EncodeString(string(s.Lib)); err != nil {
 		return err
 	}
@@ -46130,6 +46564,11 @@ var _ decoderFrom = (*ScSpecUdtErrorEnumV0)(nil)
 func (s *ScSpecUdtErrorEnumV0) DecodeFrom(d *xdr.Decoder) (int, error) {
 	var err error
 	var n, nTmp int
+	s.Doc, nTmp, err = d.DecodeString(1024)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Doc: %s", err)
+	}
 	s.Lib, nTmp, err = d.DecodeString(80)
 	n += nTmp
 	if err != nil {
@@ -46194,10 +46633,12 @@ var _ xdrType = (*ScSpecUdtErrorEnumV0)(nil)
 //
 //	struct SCSpecFunctionInputV0
 //	 {
+//	     string doc<SC_SPEC_DOC_LIMIT>;
 //	     string name<30>;
 //	     SCSpecTypeDef type;
 //	 };
 type ScSpecFunctionInputV0 struct {
+	Doc  string `xdrmaxsize:"1024"`
 	Name string `xdrmaxsize:"30"`
 	Type ScSpecTypeDef
 }
@@ -46205,6 +46646,9 @@ type ScSpecFunctionInputV0 struct {
 // EncodeTo encodes this value using the Encoder.
 func (s *ScSpecFunctionInputV0) EncodeTo(e *xdr.Encoder) error {
 	var err error
+	if _, err = e.EncodeString(string(s.Doc)); err != nil {
+		return err
+	}
 	if _, err = e.EncodeString(string(s.Name)); err != nil {
 		return err
 	}
@@ -46220,6 +46664,11 @@ var _ decoderFrom = (*ScSpecFunctionInputV0)(nil)
 func (s *ScSpecFunctionInputV0) DecodeFrom(d *xdr.Decoder) (int, error) {
 	var err error
 	var n, nTmp int
+	s.Doc, nTmp, err = d.DecodeString(1024)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Doc: %s", err)
+	}
 	s.Name, nTmp, err = d.DecodeString(30)
 	n += nTmp
 	if err != nil {
@@ -46264,11 +46713,13 @@ var _ xdrType = (*ScSpecFunctionInputV0)(nil)
 //
 //	struct SCSpecFunctionV0
 //	 {
+//	     string doc<SC_SPEC_DOC_LIMIT>;
 //	     SCSymbol name;
 //	     SCSpecFunctionInputV0 inputs<10>;
 //	     SCSpecTypeDef outputs<1>;
 //	 };
 type ScSpecFunctionV0 struct {
+	Doc     string `xdrmaxsize:"1024"`
 	Name    ScSymbol
 	Inputs  []ScSpecFunctionInputV0 `xdrmaxsize:"10"`
 	Outputs []ScSpecTypeDef         `xdrmaxsize:"1"`
@@ -46277,6 +46728,9 @@ type ScSpecFunctionV0 struct {
 // EncodeTo encodes this value using the Encoder.
 func (s *ScSpecFunctionV0) EncodeTo(e *xdr.Encoder) error {
 	var err error
+	if _, err = e.EncodeString(string(s.Doc)); err != nil {
+		return err
+	}
 	if err = s.Name.EncodeTo(e); err != nil {
 		return err
 	}
@@ -46305,6 +46759,11 @@ var _ decoderFrom = (*ScSpecFunctionV0)(nil)
 func (s *ScSpecFunctionV0) DecodeFrom(d *xdr.Decoder) (int, error) {
 	var err error
 	var n, nTmp int
+	s.Doc, nTmp, err = d.DecodeString(1024)
+	n += nTmp
+	if err != nil {
+		return n, fmt.Errorf("decoding Doc: %s", err)
+	}
 	nTmp, err = s.Name.DecodeFrom(d)
 	n += nTmp
 	if err != nil {
@@ -47070,7 +47529,8 @@ var _ xdrType = (*ScStatic)(nil)
 //	     SST_HOST_STORAGE_ERROR = 5,
 //	     SST_HOST_CONTEXT_ERROR = 6,
 //	     SST_VM_ERROR = 7,
-//	     SST_CONTRACT_ERROR = 8
+//	     SST_CONTRACT_ERROR = 8,
+//	     SST_HOST_AUTH_ERROR = 9
 //	     // TODO: add more
 //	 };
 type ScStatusType int32
@@ -47085,6 +47545,7 @@ const (
 	ScStatusTypeSstHostContextError  ScStatusType = 6
 	ScStatusTypeSstVmError           ScStatusType = 7
 	ScStatusTypeSstContractError     ScStatusType = 8
+	ScStatusTypeSstHostAuthError     ScStatusType = 9
 )
 
 var scStatusTypeMap = map[int32]string{
@@ -47097,6 +47558,7 @@ var scStatusTypeMap = map[int32]string{
 	6: "ScStatusTypeSstHostContextError",
 	7: "ScStatusTypeSstVmError",
 	8: "ScStatusTypeSstContractError",
+	9: "ScStatusTypeSstHostAuthError",
 }
 
 // ValidEnum validates a proposed value for this enum.  Implements
@@ -47561,6 +48023,95 @@ func (s ScHostStorageErrorCode) xdrType() {}
 
 var _ xdrType = (*ScHostStorageErrorCode)(nil)
 
+// ScHostAuthErrorCode is an XDR Enum defines as:
+//
+//	enum SCHostAuthErrorCode
+//	 {
+//	     HOST_AUTH_UNKNOWN_ERROR = 0,
+//	     HOST_AUTH_NONCE_ERROR = 1,
+//	     HOST_AUTH_DUPLICATE_AUTHORIZATION = 2,
+//	     HOST_AUTH_NOT_AUTHORIZED = 3
+//	 };
+type ScHostAuthErrorCode int32
+
+const (
+	ScHostAuthErrorCodeHostAuthUnknownError           ScHostAuthErrorCode = 0
+	ScHostAuthErrorCodeHostAuthNonceError             ScHostAuthErrorCode = 1
+	ScHostAuthErrorCodeHostAuthDuplicateAuthorization ScHostAuthErrorCode = 2
+	ScHostAuthErrorCodeHostAuthNotAuthorized          ScHostAuthErrorCode = 3
+)
+
+var scHostAuthErrorCodeMap = map[int32]string{
+	0: "ScHostAuthErrorCodeHostAuthUnknownError",
+	1: "ScHostAuthErrorCodeHostAuthNonceError",
+	2: "ScHostAuthErrorCodeHostAuthDuplicateAuthorization",
+	3: "ScHostAuthErrorCodeHostAuthNotAuthorized",
+}
+
+// ValidEnum validates a proposed value for this enum.  Implements
+// the Enum interface for ScHostAuthErrorCode
+func (e ScHostAuthErrorCode) ValidEnum(v int32) bool {
+	_, ok := scHostAuthErrorCodeMap[v]
+	return ok
+}
+
+// String returns the name of `e`
+func (e ScHostAuthErrorCode) String() string {
+	name, _ := scHostAuthErrorCodeMap[int32(e)]
+	return name
+}
+
+// EncodeTo encodes this value using the Encoder.
+func (e ScHostAuthErrorCode) EncodeTo(enc *xdr.Encoder) error {
+	if _, ok := scHostAuthErrorCodeMap[int32(e)]; !ok {
+		return fmt.Errorf("'%d' is not a valid ScHostAuthErrorCode enum value", e)
+	}
+	_, err := enc.EncodeInt(int32(e))
+	return err
+}
+
+var _ decoderFrom = (*ScHostAuthErrorCode)(nil)
+
+// DecodeFrom decodes this value using the Decoder.
+func (e *ScHostAuthErrorCode) DecodeFrom(d *xdr.Decoder) (int, error) {
+	v, n, err := d.DecodeInt()
+	if err != nil {
+		return n, fmt.Errorf("decoding ScHostAuthErrorCode: %s", err)
+	}
+	if _, ok := scHostAuthErrorCodeMap[v]; !ok {
+		return n, fmt.Errorf("'%d' is not a valid ScHostAuthErrorCode enum value", v)
+	}
+	*e = ScHostAuthErrorCode(v)
+	return n, nil
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s ScHostAuthErrorCode) MarshalBinary() ([]byte, error) {
+	b := bytes.Buffer{}
+	e := xdr.NewEncoder(&b)
+	err := s.EncodeTo(e)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *ScHostAuthErrorCode) UnmarshalBinary(inp []byte) error {
+	r := bytes.NewReader(inp)
+	d := xdr.NewDecoder(r)
+	_, err := s.DecodeFrom(d)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*ScHostAuthErrorCode)(nil)
+	_ encoding.BinaryUnmarshaler = (*ScHostAuthErrorCode)(nil)
+)
+
+// xdrType signals that this type is an type representing
+// representing XDR values defined by this package.
+func (s ScHostAuthErrorCode) xdrType() {}
+
+var _ xdrType = (*ScHostAuthErrorCode)(nil)
+
 // ScHostContextErrorCode is an XDR Enum defines as:
 //
 //	enum SCHostContextErrorCode
@@ -47882,6 +48433,8 @@ var _ xdrType = (*ScUnknownErrorCode)(nil)
 //	     SCVmErrorCode vmCode;
 //	 case SST_CONTRACT_ERROR:
 //	     uint32 contractCode;
+//	 case SST_HOST_AUTH_ERROR:
+//	     SCHostAuthErrorCode authCode;
 //	 };
 type ScStatus struct {
 	Type         ScStatusType
@@ -47893,6 +48446,7 @@ type ScStatus struct {
 	ContextCode  *ScHostContextErrorCode
 	VmCode       *ScVmErrorCode
 	ContractCode *Uint32
+	AuthCode     *ScHostAuthErrorCode
 }
 
 // SwitchFieldName returns the field name in which this union's
@@ -47923,6 +48477,8 @@ func (u ScStatus) ArmForSwitch(sw int32) (string, bool) {
 		return "VmCode", true
 	case ScStatusTypeSstContractError:
 		return "ContractCode", true
+	case ScStatusTypeSstHostAuthError:
+		return "AuthCode", true
 	}
 	return "-", false
 }
@@ -47989,6 +48545,13 @@ func NewScStatus(aType ScStatusType, value interface{}) (result ScStatus, err er
 			return
 		}
 		result.ContractCode = &tv
+	case ScStatusTypeSstHostAuthError:
+		tv, ok := value.(ScHostAuthErrorCode)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be ScHostAuthErrorCode")
+			return
+		}
+		result.AuthCode = &tv
 	}
 	return
 }
@@ -48193,6 +48756,31 @@ func (u ScStatus) GetContractCode() (result Uint32, ok bool) {
 	return
 }
 
+// MustAuthCode retrieves the AuthCode value from the union,
+// panicing if the value is not set.
+func (u ScStatus) MustAuthCode() ScHostAuthErrorCode {
+	val, ok := u.GetAuthCode()
+
+	if !ok {
+		panic("arm AuthCode is not set")
+	}
+
+	return val
+}
+
+// GetAuthCode retrieves the AuthCode value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u ScStatus) GetAuthCode() (result ScHostAuthErrorCode, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Type))
+
+	if armName == "AuthCode" {
+		result = *u.AuthCode
+		ok = true
+	}
+
+	return
+}
+
 // EncodeTo encodes this value using the Encoder.
 func (u ScStatus) EncodeTo(e *xdr.Encoder) error {
 	var err error
@@ -48240,6 +48828,11 @@ func (u ScStatus) EncodeTo(e *xdr.Encoder) error {
 		return nil
 	case ScStatusTypeSstContractError:
 		if err = (*u.ContractCode).EncodeTo(e); err != nil {
+			return err
+		}
+		return nil
+	case ScStatusTypeSstHostAuthError:
+		if err = (*u.AuthCode).EncodeTo(e); err != nil {
 			return err
 		}
 		return nil
@@ -48324,6 +48917,14 @@ func (u *ScStatus) DecodeFrom(d *xdr.Decoder) (int, error) {
 		n += nTmp
 		if err != nil {
 			return n, fmt.Errorf("decoding Uint32: %s", err)
+		}
+		return n, nil
+	case ScStatusTypeSstHostAuthError:
+		u.AuthCode = new(ScHostAuthErrorCode)
+		nTmp, err = (*u.AuthCode).DecodeFrom(d)
+		n += nTmp
+		if err != nil {
+			return n, fmt.Errorf("decoding ScHostAuthErrorCode: %s", err)
 		}
 		return n, nil
 	}


### PR DESCRIPTION
recompiled xdr from latest on [xdr next](https://github.com/stellar/stellar-xdr/commits/next). ran `make xdr-update` , has one significant change for adding nonce to contract auth, also shows some other updates on ScSpec/Doc changes, which got sync'd in also.