### PR TITLE
services/horizon: remove references to wirex validators

### DIFF
--- a/services/horizon/configs/captive-core-pubnet.cfg
+++ b/services/horizon/configs/captive-core-pubnet.cfg
@@ -27,10 +27,6 @@ QUALITY="HIGH"
 HOME_DOMAIN="stellar.blockdaemon.com"
 QUALITY="HIGH"
 
-[[HOME_DOMAINS]]
-HOME_DOMAIN="wirexapp.com"
-QUALITY="HIGH"
-
 [[VALIDATORS]]
 NAME="sdf_1"
 HOME_DOMAIN="stellar.org"
@@ -170,24 +166,3 @@ HOME_DOMAIN="stellar.blockdaemon.com"
 PUBLIC_KEY="GAYXZ4PZ7P6QOX7EBHPIZXNWY4KCOBYWJCA4WKWRKC7XIUS3UJPT6EZ4"
 ADDRESS="stellar-full-validator3.bdnodes.net"
 HISTORY="curl -sf https://stellar-full-history3.bdnodes.net/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="wirexUS"
-ADDRESS="us.stellar.wirexapp.com"
-HOME_DOMAIN="wirexapp.com"
-PUBLIC_KEY="GDXUKFGG76WJC7ACEH3JUPLKM5N5S76QSMNDBONREUXPCZYVPOLFWXUS"
-HISTORY="curl -sf http://wxhorizonusstga1.blob.core.windows.net/history/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="wirexUK"
-ADDRESS="uk.stellar.wirexapp.com"
-HOME_DOMAIN="wirexapp.com"
-PUBLIC_KEY="GBBQQT3EIUSXRJC6TGUCGVA3FVPXVZLGG3OJYACWBEWYBHU46WJLWXEU"
-HISTORY="curl -sf http://wxhorizonukstga1.blob.core.windows.net/history/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="wirexSG"
-ADDRESS="sg.stellar.wirexapp.com"
-HOME_DOMAIN="wirexapp.com"
-PUBLIC_KEY="GAB3GZIE6XAYWXGZUDM4GMFFLJBFMLE2JDPUCWUZXMOMT3NHXDHEWXAS"
-HISTORY="curl -sf http://wxhorizonasiastga1.blob.core.windows.net/history/{0} -o {1}"

--- a/services/horizon/docker/captive-core-pubnet.cfg
+++ b/services/horizon/docker/captive-core-pubnet.cfg
@@ -26,10 +26,6 @@ QUALITY="HIGH"
 HOME_DOMAIN="stellar.blockdaemon.com"
 QUALITY="HIGH"
 
-[[HOME_DOMAINS]]
-HOME_DOMAIN="wirexapp.com"
-QUALITY="HIGH"
-
 [[VALIDATORS]]
 NAME="sdf_1"
 HOME_DOMAIN="stellar.org"
@@ -169,24 +165,3 @@ HOME_DOMAIN="stellar.blockdaemon.com"
 PUBLIC_KEY="GAYXZ4PZ7P6QOX7EBHPIZXNWY4KCOBYWJCA4WKWRKC7XIUS3UJPT6EZ4"
 ADDRESS="stellar-full-validator3.bdnodes.net"
 HISTORY="curl -sf https://stellar-full-history3.bdnodes.net/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="wirexUS"
-ADDRESS="us.stellar.wirexapp.com"
-HOME_DOMAIN="wirexapp.com"
-PUBLIC_KEY="GDXUKFGG76WJC7ACEH3JUPLKM5N5S76QSMNDBONREUXPCZYVPOLFWXUS"
-HISTORY="curl -sf http://wxhorizonusstga1.blob.core.windows.net/history/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="wirexUK"
-ADDRESS="uk.stellar.wirexapp.com"
-HOME_DOMAIN="wirexapp.com"
-PUBLIC_KEY="GBBQQT3EIUSXRJC6TGUCGVA3FVPXVZLGG3OJYACWBEWYBHU46WJLWXEU"
-HISTORY="curl -sf http://wxhorizonukstga1.blob.core.windows.net/history/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="wirexSG"
-ADDRESS="sg.stellar.wirexapp.com"
-HOME_DOMAIN="wirexapp.com"
-PUBLIC_KEY="GAB3GZIE6XAYWXGZUDM4GMFFLJBFMLE2JDPUCWUZXMOMT3NHXDHEWXAS"
-HISTORY="curl -sf http://wxhorizonasiastga1.blob.core.windows.net/history/{0} -o {1}"

--- a/services/horizon/docker/stellar-core-pubnet.cfg
+++ b/services/horizon/docker/stellar-core-pubnet.cfg
@@ -36,10 +36,6 @@ QUALITY="HIGH"
 HOME_DOMAIN="stellar.blockdaemon.com"
 QUALITY="HIGH"
 
-[[HOME_DOMAINS]]
-HOME_DOMAIN="wirexapp.com"
-QUALITY="HIGH"
-
 [[VALIDATORS]]
 NAME="sdf_1"
 HOME_DOMAIN="stellar.org"
@@ -179,24 +175,3 @@ HOME_DOMAIN="stellar.blockdaemon.com"
 PUBLIC_KEY="GAYXZ4PZ7P6QOX7EBHPIZXNWY4KCOBYWJCA4WKWRKC7XIUS3UJPT6EZ4"
 ADDRESS="stellar-full-validator3.bdnodes.net"
 HISTORY="curl -sf https://stellar-full-history3.bdnodes.net/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="wirexUS"
-ADDRESS="us.stellar.wirexapp.com"
-HOME_DOMAIN="wirexapp.com"
-PUBLIC_KEY="GDXUKFGG76WJC7ACEH3JUPLKM5N5S76QSMNDBONREUXPCZYVPOLFWXUS"
-HISTORY="curl -sf http://wxhorizonusstga1.blob.core.windows.net/history/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="wirexUK"
-ADDRESS="uk.stellar.wirexapp.com"
-HOME_DOMAIN="wirexapp.com"
-PUBLIC_KEY="GBBQQT3EIUSXRJC6TGUCGVA3FVPXVZLGG3OJYACWBEWYBHU46WJLWXEU"
-HISTORY="curl -sf http://wxhorizonukstga1.blob.core.windows.net/history/{0} -o {1}"
-
-[[VALIDATORS]]
-NAME="wirexSG"
-ADDRESS="sg.stellar.wirexapp.com"
-HOME_DOMAIN="wirexapp.com"
-PUBLIC_KEY="GAB3GZIE6XAYWXGZUDM4GMFFLJBFMLE2JDPUCWUZXMOMT3NHXDHEWXAS"
-HISTORY="curl -sf http://wxhorizonasiastga1.blob.core.windows.net/history/{0} -o {1}"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Wirex shut down their public nodes back in early January, so removing references to those from our config. 

### Why

Since Wirex shut down their nodes back in January, we've had at least 3 separate partners send us over  logs that indicate they're still including wirex in their configuration, likely because they're copying them from here. Removing these should reduce that confusion.
