### PR TITLE
exp/ledgerexporter: Drop unneeded dependency on `historyarchive`.

### DIFF
--- a/exp/lighthorizon/build/ledgerexporter/captive-core-pubnet.cfg
+++ b/exp/lighthorizon/build/ledgerexporter/captive-core-pubnet.cfg
@@ -191,16 +191,8 @@ ADDRESS = "stellar2.franklintempleton.com:11625"
 HISTORY = "curl -sf https://stellar-history-usc.franklintempleton.com/azuscshf401/{0} -o {1}"
 
 [[VALIDATORS]]
-<<<<<<<< HEAD:exp/lighthorizon/build/ledgerexporter/captive-core-pubnet.cfg
-NAME="wirexSG"
-ADDRESS="sg.stellar.wirexapp.com"
-HOME_DOMAIN="wirexapp.com"
-PUBLIC_KEY="GAB3GZIE6XAYWXGZUDM4GMFFLJBFMLE2JDPUCWUZXMOMT3NHXDHEWXAS"
-HISTORY="curl -sf http://wxhorizonasiastga1.blob.core.windows.net/history/{0} -o {1}"
-========
 NAME = "FT_SCV_3"
 HOME_DOMAIN = "www.franklintempleton.com"
 PUBLIC_KEY = "GA7DV63PBUUWNUFAF4GAZVXU2OZMYRATDLKTC7VTCG7AU4XUPN5VRX4A"
 ADDRESS = "stellar3.franklintempleton.com:11625"
 HISTORY = "curl -sf https://stellar-history-ins.franklintempleton.com/azinsshf401/{0} -o {1}"
->>>>>>>> master:services/horizon/internal/configs/captive-core-pubnet.cfg

--- a/exp/services/ledgerexporter/main.go
+++ b/exp/services/ledgerexporter/main.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest/ledgerbackend"
 	"github.com/stellar/go/network"
 	supportlog "github.com/stellar/go/support/log"
@@ -60,7 +59,7 @@ func main() {
 	core, err := ledgerbackend.NewCaptive(captiveConfig)
 	logFatalIf(err, "Could not create captive core instance")
 
-	target, err := historyarchive.ConnectBackend(
+	target, err := storage.ConnectBackend(
 		*targetUrl,
 		storage.ConnectOptions{
 			Context:    context.Background(),


### PR DESCRIPTION
Just noticed a quirk in the `ledgerexporter` tool (which I believe @sydneynotthecity was investigating for Hubble purposes) in that it still uses `historyarchive` when it really just needs `storage`. Previously, `historyarchive` was a convenient "crutch" package that provided backend-agnostic, "file-like" access, but the `storage` package abstracted this concept.