### PR TITLE
support/http - Added default WriteTimeout of 30s to HTTP server

### DIFF
--- a/support/http/main.go
+++ b/support/http/main.go
@@ -33,6 +33,8 @@ const defaultShutdownGracePeriod = 10 * time.Second
 
 const defaultReadTimeout = 5 * time.Second
 
+const defaultWriteTimeout = 30 * time.Second
+
 // SimpleHTTPClientInterface helps mocking http.Client in tests
 type SimpleHTTPClientInterface interface {
 	PostForm(url string, data url.Values) (*stdhttp.Response, error)
@@ -103,6 +105,10 @@ func setup(conf Config) *graceful.Server {
 
 	if conf.ReadTimeout == time.Duration(0) {
 		conf.ReadTimeout = defaultReadTimeout
+	}
+
+	if conf.WriteTimeout == time.Duration(0) {
+		conf.WriteTimeout = defaultWriteTimeout
 	}
 
 	return &graceful.Server{

--- a/support/http/main_test.go
+++ b/support/http/main_test.go
@@ -25,7 +25,7 @@ func TestRun_setupDefault(t *testing.T) {
 
 	assert.Equal(t, defaultShutdownGracePeriod, srv.Timeout)
 	assert.Equal(t, defaultReadTimeout, srv.ReadTimeout)
-	assert.Equal(t, time.Duration(0), srv.WriteTimeout)
+	assert.Equal(t, defaultWriteTimeout, srv.WriteTimeout)
 	assert.Equal(t, time.Duration(0), srv.IdleTimeout)
 	assert.Equal(t, defaultListenAddr, srv.Server.Addr)
 	assert.Equal(t, time.Duration(0), srv.TCPKeepAlive)


### PR DESCRIPTION

See [this issue](https://github.com/stellar/go/issues/4785) for full context.

30 seconds seems like a reasonable default to account for large payloads and network congestion.