### PR TITLE
ingest: Adds basic event parsing for standard Stellar Asset Contract events

### DIFF
--- a/ingest/event.go
+++ b/ingest/event.go
@@ -139,9 +139,9 @@ func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*Stel
 }
 
 // parseTransferEvent tries to parse the given topics and value as a SAC
-// "transfer" event. It assumes that the `topics` EXCLUDES the function name,
-// i.e. that its been validated previously. It will return a best-effort parsing
-// even in error cases.
+// "transfer" event. It assumes that the `topics` array has already validated
+// both the function name AND the asset <--> contract ID relationship. It will
+// return a best-effort parsing even in error cases.
 func (event *StellarAssetContractEvent) parseTransferEvent(topics xdr.ScVec, value xdr.ScVal) error {
 	//
 	// The transfer event format is:
@@ -157,7 +157,6 @@ func (event *StellarAssetContractEvent) parseTransferEvent(topics xdr.ScVec, val
 		return ErrNotTransferEvent
 	}
 
-	fmt.Println("xfer here")
 	from, to := topics[1], topics[2]
 	if from.Type != xdr.ScValTypeScvObject || to.Type != xdr.ScValTypeScvObject {
 		return ErrNotTransferEvent

--- a/ingest/event.go
+++ b/ingest/event.go
@@ -104,16 +104,20 @@ func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*Stel
 
 	asset, err := txnbuild.ParseAssetString(string(assetBytes))
 	if err != nil {
-		return evt, ErrNotStellarAssetContract
+		return evt, errors.Wrap(ErrNotStellarAssetContract, err.Error())
 	}
 
-	xdrAsset, err := xdr.NewCreditAsset(asset.GetCode(), asset.GetIssuer())
+	switch asset.IsNative() {
+	case true:
+		evt.Asset = xdr.MustNewNativeAsset()
+	case false:
+		evt.Asset, err = xdr.NewCreditAsset(asset.GetCode(), asset.GetIssuer())
+	}
 	if err != nil {
-		return evt, ErrNotStellarAssetContract
+		return evt, errors.Wrap(ErrNotStellarAssetContract, err.Error())
 	}
-	evt.Asset = xdrAsset
 
-	expectedId, err := xdrAsset.ContractID(networkPassphrase)
+	expectedId, err := evt.Asset.ContractID(networkPassphrase)
 	if err != nil {
 		return evt, errors.Wrap(ErrNotStellarAssetContract, err.Error())
 	}
@@ -121,6 +125,8 @@ func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*Stel
 	// This is the DEFINITIVE integrity check for whether or not this is a
 	// SAC event. At this point, we can parse the event and treat it as
 	// truth, mapping it to effects where appropriate.
+	fmt.Println(asset.IsNative(), "here?")
+
 	if expectedId != *event.ContractId { // nil check was earlier
 		return evt, ErrNotStellarAssetContract
 	}
@@ -202,6 +208,8 @@ func ScAddressToString(address *xdr.ScAddress) string {
 	switch address.Type {
 	case xdr.ScAddressTypeScAddressTypeAccount:
 		pubkey := address.MustAccountId().Ed25519
+		fmt.Println("pubkey:", address.MustAccountId())
+
 		result, err = strkey.Encode(strkey.VersionByteAccountID, pubkey[:])
 	case xdr.ScAddressTypeScAddressTypeContract:
 		contractId := *address.ContractId

--- a/ingest/event.go
+++ b/ingest/event.go
@@ -1,0 +1,186 @@
+package ingest
+
+import (
+	"fmt"
+
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stellar/go/xdr"
+)
+
+type Event = xdr.ContractEvent
+type EventType = int
+
+// Note that there is no distinction between xfer() and xfer_from() in events,
+// and this is true for the other *_from variants, as well.
+
+const (
+	// Implemented
+	EventTypeTransfer = iota
+	// TODO: Not implemented
+	EventTypeIncrAllow = iota
+	EventTypeDecrAllow = iota
+	EventTypeSetAuth   = iota
+	EventTypeSetAdmin  = iota
+	EventTypeMint      = iota
+	EventTypeClawback  = iota
+	EventTypeBurn      = iota
+)
+
+var (
+	STELLAR_ASSET_CONTRACT_TOPICS = map[xdr.ScSymbol]EventType{
+		xdr.ScSymbol("mint"):     EventTypeMint,
+		xdr.ScSymbol("transfer"): EventTypeTransfer,
+		xdr.ScSymbol("clawback"): EventTypeClawback,
+		xdr.ScSymbol("burn"):     EventTypeBurn,
+	}
+
+	// TODO: Better parsing errors
+	ErrNotStellarAssetContract = errors.New("event was not from a Stellar Asset Contract")
+	ErrEventUnsupported        = errors.New("this type of Stellar Asset Contract event is unsupported")
+	ErrNotTransferEvent        = errors.New("event is an invalid 'transfer' event")
+)
+
+type StellarAssetContractEvent struct {
+	Type  int
+	Asset xdr.Asset
+
+	From   *xdr.ScAddress   // transfer, clawback, burn
+	To     *xdr.ScAddress   // transfer, mint
+	Amount *xdr.Int128Parts // transfer, mint, clawback, burn
+	Admin  *xdr.ScAddress   // mint, clawback
+}
+
+func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*StellarAssetContractEvent, error) {
+	evt := &StellarAssetContractEvent{}
+
+	if event.Type != xdr.ContractEventTypeContract || event.ContractId == nil || event.Body.V != 0 {
+		return evt, ErrNotStellarAssetContract
+	}
+
+	// SAC event topics take the form <fn name>/<params...>/<token name>.
+	//
+	// For specific event forms, see here:
+	// https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-host/src/native_contract/token/event.rs#L44-L49
+	topics := event.Body.MustV0().Topics
+	value := event.Body.MustV0().Data
+
+	// No relevant SAC events have <= 2 topics
+	if len(topics) <= 2 {
+		return evt, ErrNotStellarAssetContract
+	}
+	fn := topics[0]
+
+	// Filter out events for function calls we don't care about
+	if fn.Type != xdr.ScValTypeScvSymbol {
+		return evt, ErrNotStellarAssetContract
+	}
+	if eventType, ok := STELLAR_ASSET_CONTRACT_TOPICS[fn.MustSym()]; !ok {
+		return evt, ErrNotStellarAssetContract
+	} else {
+		evt.Type = eventType
+	}
+
+	// This looks like a SAC event, but does it act like a SAC event?
+	//
+	// To check that, ensure that the contract ID of the event matches the
+	// contract ID that *would* represent the asset the event is claiming to
+	// be. The asset is in canonical SEP-11 form:
+	//  https://stellar.org/protocol/sep-11#alphanum4-alphanum12
+	//
+	// For all parsing errors, we just continue, since it's not a real
+	// error, just an event non-complaint with SAC events.
+	rawAsset := topics[len(topics)-1]
+	assetContainer, ok := rawAsset.GetObj()
+	if !ok || assetContainer == nil {
+		return evt, ErrNotStellarAssetContract
+	}
+
+	assetBytes, ok := assetContainer.GetBin()
+	fmt.Println("here", len(assetBytes), assetBytes)
+	if !ok || assetBytes == nil {
+		return evt, ErrNotStellarAssetContract
+	}
+
+	asset, err := txnbuild.ParseAssetString(string(assetBytes))
+	if err != nil {
+		return evt, ErrNotStellarAssetContract
+	}
+
+	xdrAsset, err := xdr.NewCreditAsset(asset.GetCode(), asset.GetIssuer())
+	if err != nil {
+		return evt, ErrNotStellarAssetContract
+	}
+
+	expectedId, err := xdrAsset.ContractID(networkPassphrase)
+	if err != nil {
+		return evt, errors.Wrap(ErrNotStellarAssetContract, err.Error())
+	}
+
+	// This is the DEFINITIVE integrity check for whether or not this is a
+	// SAC event. At this point, we can parse the event and treat it as
+	// truth, mapping it to effects where appropriate.
+	if expectedId != *event.ContractId { // nil check was earlier
+		return evt, ErrNotStellarAssetContract
+	}
+
+	switch evt.Type {
+	case EventTypeTransfer:
+		return evt, evt.parseTransferEvent(topics, value)
+	case EventTypeMint:
+	case EventTypeClawback:
+	case EventTypeBurn:
+	default:
+		return evt, errors.Wrapf(ErrEventUnsupported,
+			"event type %d ('%s') unsupported", evt.Type, fn.MustSym())
+	}
+
+	return evt, nil
+}
+
+// parseTransferEvent tries to parse the given topics and value as a SAC
+// "transfer" event. It assumes that the `topics` EXCLUDES the function name,
+// i.e. that its been validated previously. It will return a best-effort parsing
+// even in error cases.
+func (event *StellarAssetContractEvent) parseTransferEvent(topics xdr.ScVec, value xdr.ScVal) error {
+	//
+	// The transfer event format is:
+	//
+	// 	"transfer"  Symbol
+	//  <from> 		Address
+	//  <to> 		Address
+	// 	<asset>		Bytes
+	//
+	// 	<amount> 	i128
+	//
+	if len(topics) != 4 {
+		return ErrNotTransferEvent
+	}
+
+	fmt.Println("xfer here")
+	from, to := topics[1], topics[2]
+	if from.Type != xdr.ScValTypeScvObject || to.Type != xdr.ScValTypeScvObject {
+		return ErrNotTransferEvent
+	}
+
+	fromObj, ok := from.GetObj()
+	if !ok || fromObj == nil || fromObj.Type != xdr.ScObjectTypeScoAddress {
+		return ErrNotTransferEvent
+	}
+
+	toObj, ok := from.GetObj()
+	if !ok || toObj == nil || toObj.Type != xdr.ScObjectTypeScoAddress {
+		return ErrNotTransferEvent
+	}
+
+	event.From = fromObj.Address
+	event.To = toObj.Address
+
+	valueObj, ok := value.GetObj()
+	if !ok || valueObj == nil || valueObj.Type != xdr.ScObjectTypeScoI128 {
+		return ErrNotTransferEvent
+	}
+
+	event.Amount = valueObj.I128
+	return nil
+}

--- a/ingest/event.go
+++ b/ingest/event.go
@@ -42,18 +42,34 @@ var (
 	ErrNotTransferEvent        = errors.New("event is an invalid 'transfer' event")
 )
 
-type StellarAssetContractEvent struct {
-	Type  int
-	Asset xdr.Asset
-
-	From   string           // transfer, clawback, burn; encoded as strkey
-	To     string           // transfer, mint; encoded as strkey
-	Amount *xdr.Int128Parts // transfer, mint, clawback, burn
-	Admin  string           // mint, clawback; encoded as strkey
+type StellarAssetContractEvent interface {
+	GetType() int
+	GetAsset() xdr.Asset
 }
 
-func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*StellarAssetContractEvent, error) {
-	evt := &StellarAssetContractEvent{}
+type sacEvent struct {
+	Type  int
+	Asset xdr.Asset
+}
+
+func (e *sacEvent) GetAsset() xdr.Asset {
+	return e.Asset
+}
+
+func (e *sacEvent) GetType() int {
+	return e.Type
+}
+
+type TransferEvent struct {
+	sacEvent
+
+	From   string
+	To     string
+	Amount *xdr.Int128Parts
+}
+
+func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (StellarAssetContractEvent, error) {
+	evt := &sacEvent{}
 
 	if event.Type != xdr.ContractEventTypeContract || event.ContractId == nil || event.Body.V != 0 {
 		return evt, ErrNotStellarAssetContract
@@ -131,9 +147,11 @@ func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*Stel
 		return evt, ErrNotStellarAssetContract
 	}
 
-	switch evt.Type {
+	switch evt.GetType() {
 	case EventTypeTransfer:
-		return evt, evt.parseTransferEvent(topics, value)
+		xferEvent := TransferEvent{}
+		return &xferEvent, xferEvent.parse(topics, value)
+
 	case EventTypeMint:
 	case EventTypeClawback:
 	case EventTypeBurn:
@@ -149,7 +167,7 @@ func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*Stel
 // "transfer" event. It assumes that the `topics` array has already validated
 // both the function name AND the asset <--> contract ID relationship. It will
 // return a best-effort parsing even in error cases.
-func (event *StellarAssetContractEvent) parseTransferEvent(topics xdr.ScVec, value xdr.ScVal) error {
+func (event *TransferEvent) parse(topics xdr.ScVec, value xdr.ScVal) error {
 	//
 	// The transfer event format is:
 	//

--- a/ingest/event.go
+++ b/ingest/event.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"fmt"
 
+	"github.com/stellar/go/strkey"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
@@ -12,7 +13,7 @@ type Event = xdr.ContractEvent
 type EventType = int
 
 // Note that there is no distinction between xfer() and xfer_from() in events,
-// and this is true for the other *_from variants, as well.
+// nor the other *_from variants. This is intentional from the host environment.
 
 const (
 	// Implemented
@@ -45,10 +46,10 @@ type StellarAssetContractEvent struct {
 	Type  int
 	Asset xdr.Asset
 
-	From   *xdr.ScAddress   // transfer, clawback, burn
-	To     *xdr.ScAddress   // transfer, mint
+	From   string           // transfer, clawback, burn; encoded as strkey
+	To     string           // transfer, mint; encoded as strkey
 	Amount *xdr.Int128Parts // transfer, mint, clawback, burn
-	Admin  *xdr.ScAddress   // mint, clawback
+	Admin  string           // mint, clawback; encoded as strkey
 }
 
 func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*StellarAssetContractEvent, error) {
@@ -97,7 +98,6 @@ func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*Stel
 	}
 
 	assetBytes, ok := assetContainer.GetBin()
-	fmt.Println("here", len(assetBytes), assetBytes)
 	if !ok || assetBytes == nil {
 		return evt, ErrNotStellarAssetContract
 	}
@@ -111,6 +111,7 @@ func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*Stel
 	if err != nil {
 		return evt, ErrNotStellarAssetContract
 	}
+	evt.Asset = xdrAsset
 
 	expectedId, err := xdrAsset.ContractID(networkPassphrase)
 	if err != nil {
@@ -172,8 +173,9 @@ func (event *StellarAssetContractEvent) parseTransferEvent(topics xdr.ScVec, val
 		return ErrNotTransferEvent
 	}
 
-	event.From = fromObj.Address
-	event.To = toObj.Address
+	event.From = ScAddressToString(fromObj.Address)
+	event.To = ScAddressToString(toObj.Address)
+	event.Asset = xdr.Asset{} // TODO
 
 	valueObj, ok := value.GetObj()
 	if !ok || valueObj == nil || valueObj.Type != xdr.ScObjectTypeScoI128 {
@@ -182,4 +184,35 @@ func (event *StellarAssetContractEvent) parseTransferEvent(topics xdr.ScVec, val
 
 	event.Amount = valueObj.I128
 	return nil
+}
+
+// ScAddressToString converts the low-level `xdr.ScAddress` union into the
+// appropriate strkey (contract C... or account ID G...).
+//
+// TODO: Should this return errors or just panic? Maybe just slap the "Must"
+// prefix on the helper name?
+func ScAddressToString(address *xdr.ScAddress) string {
+	if address == nil {
+		return ""
+	}
+
+	var result string
+	var err error
+
+	switch address.Type {
+	case xdr.ScAddressTypeScAddressTypeAccount:
+		pubkey := address.MustAccountId().Ed25519
+		result, err = strkey.Encode(strkey.VersionByteAccountID, pubkey[:])
+	case xdr.ScAddressTypeScAddressTypeContract:
+		contractId := *address.ContractId
+		result, err = strkey.Encode(strkey.VersionByteContract, contractId[:])
+	default:
+		panic(fmt.Errorf("unfamiliar address type: %v", address.Type))
+	}
+
+	if err != nil {
+		panic(err)
+	}
+
+	return result
 }

--- a/ingest/event_test.go
+++ b/ingest/event_test.go
@@ -2,6 +2,7 @@ package ingest
 
 import (
 	"crypto/rand"
+	"fmt"
 	"testing"
 
 	"github.com/stellar/go/keypair"
@@ -15,10 +16,15 @@ const passphrase = "passphrase"
 func TestSACTransferEvent(t *testing.T) {
 	randomIssuer := keypair.MustRandom()
 	randomAsset := xdr.MustNewCreditAsset("TESTING", randomIssuer.Address())
+	randomAccount := keypair.MustRandom().Address()
 
-	rawContractId, err := randomAsset.ContractID(passphrase)
-	contractId := xdr.Hash(rawContractId)
+	rawNativeContractId, err := xdr.MustNewNativeAsset().ContractID(passphrase)
 	require.NoError(t, err)
+	rawContractId, err := randomAsset.ContractID(passphrase)
+	require.NoError(t, err)
+
+	nativeContractId := xdr.Hash(rawNativeContractId)
+	contractId := xdr.Hash(rawContractId)
 
 	baseXdrEvent := xdr.ContractEvent{
 		Ext:        xdr.ExtensionPoint{V: 0},
@@ -31,7 +37,7 @@ func TestSACTransferEvent(t *testing.T) {
 	}
 
 	baseXdrEvent.Body.V0 = &xdr.ContractEventV0{
-		Topics: makeTransferTopic(randomAsset),
+		Topics: makeTransferTopic(randomAsset, randomAccount),
 		Data:   makeAmount(10000),
 	}
 
@@ -45,8 +51,8 @@ func TestSACTransferEvent(t *testing.T) {
 	require.NotNil(t, sacEvent.To)
 	require.NotNil(t, sacEvent.Amount)
 
-	require.Equal(t, randomIssuer.Address(), sacEvent.From)
-	require.Equal(t, randomIssuer.Address(), sacEvent.To)
+	require.Equal(t, randomAccount, sacEvent.From)
+	require.Equal(t, randomAccount, sacEvent.To)
 	require.EqualValues(t, 10000, sacEvent.Amount.Lo)
 	require.EqualValues(t, 0, sacEvent.Amount.Hi)
 
@@ -55,19 +61,27 @@ func TestSACTransferEvent(t *testing.T) {
 	require.Error(t, err)
 
 	// Ensure that it works for the native asset
-	oldAsset := *(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin
-	*(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin = []byte("native")
+	baseXdrEvent.ContractId = &nativeContractId
+	baseXdrEvent.Body.V0.Topics = makeTransferTopic(xdr.MustNewNativeAsset(), randomAccount)
 	sacEvent, err = NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
 	require.NoError(t, err)
 	require.Equal(t, xdr.AssetTypeAssetTypeNative, sacEvent.Asset.Type)
 
 	// Ensure that invalid asset binaries are rejected
-	bsAsset := make([]byte, len(oldAsset))
+	bsAsset := make([]byte, 42)
 	rand.Read(bsAsset)
 	(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin = &bsAsset
 	_, err = NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
 	require.Error(t, err)
-	(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin = &oldAsset
+
+	// Ensure that valid asset binaries that mismatch the contract are rejected
+	baseXdrEvent.ContractId = &nativeContractId
+	baseXdrEvent.Body.V0.Topics = makeTransferTopic(randomAsset, randomAccount)
+	_, err = NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
+	require.Error(t, err)
+	baseXdrEvent.ContractId = &contractId
+	_, err = NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
+	require.NoError(t, err)
 
 	// Ensure that system events are invalid
 	baseXdrEvent.Type = xdr.ContractEventTypeSystem
@@ -76,8 +90,12 @@ func TestSACTransferEvent(t *testing.T) {
 	baseXdrEvent.Type = xdr.ContractEventTypeContract
 }
 
-func makeTransferTopic(asset xdr.Asset) xdr.ScVec {
-	accountId, _ := xdr.AddressToAccountId(asset.GetIssuer())
+func makeTransferTopic(asset xdr.Asset, participant string) xdr.ScVec {
+	accountId, err := xdr.AddressToAccountId(participant)
+	if err != nil {
+		panic(fmt.Errorf("participant (%s) isn't an account ID: %v",
+			participant, err))
+	}
 
 	fnName := xdr.ScSymbol("transfer")
 	account := &xdr.ScObject{
@@ -88,7 +106,12 @@ func makeTransferTopic(asset xdr.Asset) xdr.ScVec {
 		},
 	}
 
-	slice := []byte(asset.StringCanonical())
+	var slice []byte
+	if asset.Type == xdr.AssetTypeAssetTypeNative {
+		slice = []byte("native")
+	} else {
+		slice = []byte(asset.StringCanonical())
+	}
 	assetDetails := &xdr.ScObject{
 		Type: xdr.ScObjectTypeScoBytes,
 		Bin:  &slice,

--- a/ingest/event_test.go
+++ b/ingest/event_test.go
@@ -1,0 +1,107 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/xdr"
+
+	"github.com/stretchr/testify/require"
+)
+
+const passphrase = "passphrase"
+
+func TestStellarAssetContractEventParsing(t *testing.T) {
+	randomIssuer := keypair.MustRandom()
+	randomAsset := xdr.MustNewCreditAsset("TESTING", randomIssuer.Address())
+
+	rawContractId, err := randomAsset.ContractID(passphrase)
+	contractId := xdr.Hash(rawContractId)
+	require.NoError(t, err)
+
+	baseXdrEvent := xdr.ContractEvent{
+		Ext:        xdr.ExtensionPoint{V: 0},
+		ContractId: &contractId,
+		Type:       xdr.ContractEventTypeContract,
+		Body: xdr.ContractEventBody{
+			V:  0,
+			V0: nil,
+		},
+	}
+
+	baseXdrEvent.Body.V0 = &xdr.ContractEventV0{
+		Topics: makeTransferTopic(randomAsset),
+		Data:   makeAmount(10000),
+	}
+
+	sacEvent, err := NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
+	require.NoError(t, err)
+	require.NotNil(t, sacEvent)
+	require.Equal(t, EventTypeTransfer, sacEvent.Type)
+
+	require.NotNil(t, sacEvent.From)
+	require.NotNil(t, sacEvent.To)
+	require.NotNil(t, sacEvent.Amount)
+
+	require.Equal(t, randomIssuer.Address(), sacEvent.From.AccountId.Address())
+	require.Equal(t, randomIssuer.Address(), sacEvent.To.AccountId.Address())
+	require.EqualValues(t, 10000, sacEvent.Amount.Lo)
+	require.EqualValues(t, 0, sacEvent.Amount.Hi)
+}
+
+func makeTransferTopic(asset xdr.Asset) xdr.ScVec {
+	accountId, _ := xdr.AddressToAccountId(asset.GetIssuer())
+
+	fnName := xdr.ScSymbol("transfer")
+	account := &xdr.ScObject{
+		Type: xdr.ScObjectTypeScoAddress,
+		Address: &xdr.ScAddress{
+			Type:      xdr.ScAddressTypeScAddressTypeAccount,
+			AccountId: &accountId,
+		},
+	}
+
+	slice := []byte(asset.StringCanonical())
+	assetDetails := &xdr.ScObject{
+		Type: xdr.ScObjectTypeScoBytes,
+		Bin:  &slice,
+	}
+
+	return xdr.ScVec([]xdr.ScVal{
+		// event name
+		{
+			Type: xdr.ScValTypeScvSymbol,
+			Sym:  &fnName,
+		},
+		// from
+		{
+			Type: xdr.ScValTypeScvObject,
+			Obj:  &account,
+		},
+		// to
+		{
+			Type: xdr.ScValTypeScvObject,
+			Obj:  &account,
+		},
+		// asset details
+		{
+			Type: xdr.ScValTypeScvObject,
+			Obj:  &assetDetails,
+		},
+	})
+}
+
+func makeAmount(amount int) xdr.ScVal {
+	amountObj := &xdr.ScObject{
+		Type: xdr.ScObjectTypeScoI128,
+		I128: &xdr.Int128Parts{
+			Lo: xdr.Uint64(amount),
+			Hi: 0,
+		},
+	}
+
+	return xdr.ScVal{
+		Type: xdr.ScValTypeScvObject,
+		Obj:  &amountObj,
+	}
+}

--- a/ingest/event_test.go
+++ b/ingest/event_test.go
@@ -103,10 +103,8 @@ func makeTransferTopic(asset xdr.Asset, participant string) xdr.ScVec {
 		},
 	}
 
-	var slice []byte
-	if asset.Type == xdr.AssetTypeAssetTypeNative {
-		slice = []byte("native")
-	} else {
+	slice := []byte("native")
+	if asset.Type != xdr.AssetTypeAssetTypeNative {
 		slice = []byte(asset.StringCanonical())
 	}
 	assetDetails := &xdr.ScObject{

--- a/ingest/event_test.go
+++ b/ingest/event_test.go
@@ -45,8 +45,8 @@ func TestSACTransferEvent(t *testing.T) {
 	require.NotNil(t, sacEvent.To)
 	require.NotNil(t, sacEvent.Amount)
 
-	require.Equal(t, randomIssuer.Address(), sacEvent.From.AccountId.Address())
-	require.Equal(t, randomIssuer.Address(), sacEvent.To.AccountId.Address())
+	require.Equal(t, randomIssuer.Address(), sacEvent.From)
+	require.Equal(t, randomIssuer.Address(), sacEvent.To)
 	require.EqualValues(t, 10000, sacEvent.Amount.Lo)
 	require.EqualValues(t, 0, sacEvent.Amount.Hi)
 
@@ -54,8 +54,14 @@ func TestSACTransferEvent(t *testing.T) {
 	_, err = NewStellarAssetContractEvent(&baseXdrEvent, "different")
 	require.Error(t, err)
 
-	// Ensure that invalid asset binaries are rejected
+	// Ensure that it works for the native asset
 	oldAsset := *(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin
+	*(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin = []byte("native")
+	sacEvent, err = NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
+	require.NoError(t, err)
+	require.Equal(t, xdr.AssetTypeAssetTypeNative, sacEvent.Asset.Type)
+
+	// Ensure that invalid asset binaries are rejected
 	bsAsset := make([]byte, len(oldAsset))
 	rand.Read(bsAsset)
 	(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin = &bsAsset

--- a/ingest/event_test.go
+++ b/ingest/event_test.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/stellar/go/keypair"
@@ -11,7 +12,7 @@ import (
 
 const passphrase = "passphrase"
 
-func TestStellarAssetContractEventParsing(t *testing.T) {
+func TestSACTransferEvent(t *testing.T) {
 	randomIssuer := keypair.MustRandom()
 	randomAsset := xdr.MustNewCreditAsset("TESTING", randomIssuer.Address())
 
@@ -34,6 +35,7 @@ func TestStellarAssetContractEventParsing(t *testing.T) {
 		Data:   makeAmount(10000),
 	}
 
+	// Ensure the happy path for transfer events works
 	sacEvent, err := NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
 	require.NoError(t, err)
 	require.NotNil(t, sacEvent)
@@ -47,6 +49,25 @@ func TestStellarAssetContractEventParsing(t *testing.T) {
 	require.Equal(t, randomIssuer.Address(), sacEvent.To.AccountId.Address())
 	require.EqualValues(t, 10000, sacEvent.Amount.Lo)
 	require.EqualValues(t, 0, sacEvent.Amount.Hi)
+
+	// Ensure that changing the passphrase invalidates the event
+	_, err = NewStellarAssetContractEvent(&baseXdrEvent, "different")
+	require.Error(t, err)
+
+	// Ensure that invalid asset binaries are rejected
+	oldAsset := *(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin
+	bsAsset := make([]byte, len(oldAsset))
+	rand.Read(bsAsset)
+	(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin = &bsAsset
+	_, err = NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
+	require.Error(t, err)
+	(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin = &oldAsset
+
+	// Ensure that system events are invalid
+	baseXdrEvent.Type = xdr.ContractEventTypeSystem
+	_, err = NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
+	require.Error(t, err)
+	baseXdrEvent.Type = xdr.ContractEventTypeContract
 }
 
 func makeTransferTopic(asset xdr.Asset) xdr.ScVec {

--- a/ingest/event_test.go
+++ b/ingest/event_test.go
@@ -45,16 +45,13 @@ func TestSACTransferEvent(t *testing.T) {
 	sacEvent, err := NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
 	require.NoError(t, err)
 	require.NotNil(t, sacEvent)
-	require.Equal(t, EventTypeTransfer, sacEvent.Type)
+	require.Equal(t, EventTypeTransfer, sacEvent.GetType())
 
-	require.NotNil(t, sacEvent.From)
-	require.NotNil(t, sacEvent.To)
-	require.NotNil(t, sacEvent.Amount)
-
-	require.Equal(t, randomAccount, sacEvent.From)
-	require.Equal(t, randomAccount, sacEvent.To)
-	require.EqualValues(t, 10000, sacEvent.Amount.Lo)
-	require.EqualValues(t, 0, sacEvent.Amount.Hi)
+	xferEvent := sacEvent.(*TransferEvent)
+	require.Equal(t, randomAccount, xferEvent.From)
+	require.Equal(t, randomAccount, xferEvent.To)
+	require.EqualValues(t, 10000, xferEvent.Amount.Lo)
+	require.EqualValues(t, 0, xferEvent.Amount.Hi)
 
 	// Ensure that changing the passphrase invalidates the event
 	_, err = NewStellarAssetContractEvent(&baseXdrEvent, "different")
@@ -65,7 +62,7 @@ func TestSACTransferEvent(t *testing.T) {
 	baseXdrEvent.Body.V0.Topics = makeTransferTopic(xdr.MustNewNativeAsset(), randomAccount)
 	sacEvent, err = NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
 	require.NoError(t, err)
-	require.Equal(t, xdr.AssetTypeAssetTypeNative, sacEvent.Asset.Type)
+	require.Equal(t, xdr.AssetTypeAssetTypeNative, sacEvent.GetAsset().Type)
 
 	// Ensure that invalid asset binaries are rejected
 	bsAsset := make([]byte, 42)

--- a/xdr/asset.go
+++ b/xdr/asset.go
@@ -45,7 +45,7 @@ func MustNewCreditAsset(code string, issuer string) Asset {
 	return a
 }
 
-// NewAssetCodeFromString returns a new allow trust asset, panicking if it can't.
+// NewAssetCodeFromString returns a new credit asset, erroring if it can't.
 func NewAssetCodeFromString(code string) (AssetCode, error) {
 	a := AssetCode{}
 	length := len(code)

--- a/xdr/ledger_key.go
+++ b/xdr/ledger_key.go
@@ -183,7 +183,7 @@ func (key *LedgerKey) SetConfigSetting(configSettingID ConfigSettingId) error {
 
 // GetLedgerKeyFromData obtains a ledger key from LedgerEntryData
 //
-//lint:ignore gocyclo
+//nolint:gocyclo
 func GetLedgerKeyFromData(data LedgerEntryData) (LedgerKey, error) {
 	var key LedgerKey
 	switch data.Type {


### PR DESCRIPTION
### What
Adds an abstraction layer for standardized contract events that come from the Stellar Asset Contract.

### Why
Event parsing is necessary to generate effects and record payments as part of #4722 (and #4725).

### Known limitations
This only covers the `transfer` events generated by calling `xfer` and `xfer_from`. It could also use more test cases.

Ideally, @sreuland and I would build the parsing/testing on top of this PR for the events we need as they pertain to our issues.