### PR TITLE
services/horizon: Add `account_credited` and `account_debited` effects for smart contract events.

### DIFF
--- a/amount/main.go
+++ b/amount/main.go
@@ -117,6 +117,11 @@ func String(v xdr.Int64) string {
 	return StringFromInt64(int64(v))
 }
 
+// TODO: Make this actually work.
+func String128(v xdr.Int128Parts) string {
+	return StringFromInt64(int64(v.Lo))
+}
+
 // StringFromInt64 returns an "amount string" from the provided raw int64 value `v`.
 func StringFromInt64(v int64) string {
 	r := big.NewRat(v, 1)

--- a/ingest/event.go
+++ b/ingest/event.go
@@ -139,9 +139,9 @@ func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*Stel
 }
 
 // parseTransferEvent tries to parse the given topics and value as a SAC
-// "transfer" event. It assumes that the `topics` EXCLUDES the function name,
-// i.e. that its been validated previously. It will return a best-effort parsing
-// even in error cases.
+// "transfer" event. It assumes that the `topics` array has already validated
+// both the function name AND the asset <--> contract ID relationship. It will
+// return a best-effort parsing even in error cases.
 func (event *StellarAssetContractEvent) parseTransferEvent(topics xdr.ScVec, value xdr.ScVal) error {
 	//
 	// The transfer event format is:
@@ -157,7 +157,6 @@ func (event *StellarAssetContractEvent) parseTransferEvent(topics xdr.ScVec, val
 		return ErrNotTransferEvent
 	}
 
-	fmt.Println("xfer here")
 	from, to := topics[1], topics[2]
 	if from.Type != xdr.ScValTypeScvObject || to.Type != xdr.ScValTypeScvObject {
 		return ErrNotTransferEvent

--- a/ingest/event.go
+++ b/ingest/event.go
@@ -1,0 +1,186 @@
+package ingest
+
+import (
+	"fmt"
+
+	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stellar/go/xdr"
+)
+
+type Event = xdr.ContractEvent
+type EventType = int
+
+// Note that there is no distinction between xfer() and xfer_from() in events,
+// and this is true for the other *_from variants, as well.
+
+const (
+	// Implemented
+	EventTypeTransfer = iota
+	// TODO: Not implemented
+	EventTypeIncrAllow = iota
+	EventTypeDecrAllow = iota
+	EventTypeSetAuth   = iota
+	EventTypeSetAdmin  = iota
+	EventTypeMint      = iota
+	EventTypeClawback  = iota
+	EventTypeBurn      = iota
+)
+
+var (
+	STELLAR_ASSET_CONTRACT_TOPICS = map[xdr.ScSymbol]EventType{
+		xdr.ScSymbol("mint"):     EventTypeMint,
+		xdr.ScSymbol("transfer"): EventTypeTransfer,
+		xdr.ScSymbol("clawback"): EventTypeClawback,
+		xdr.ScSymbol("burn"):     EventTypeBurn,
+	}
+
+	// TODO: Better parsing errors
+	ErrNotStellarAssetContract = errors.New("event was not from a Stellar Asset Contract")
+	ErrEventUnsupported        = errors.New("this type of Stellar Asset Contract event is unsupported")
+	ErrNotTransferEvent        = errors.New("event is an invalid 'transfer' event")
+)
+
+type StellarAssetContractEvent struct {
+	Type  int
+	Asset xdr.Asset
+
+	From   *xdr.ScAddress   // transfer, clawback, burn
+	To     *xdr.ScAddress   // transfer, mint
+	Amount *xdr.Int128Parts // transfer, mint, clawback, burn
+	Admin  *xdr.ScAddress   // mint, clawback
+}
+
+func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*StellarAssetContractEvent, error) {
+	evt := &StellarAssetContractEvent{}
+
+	if event.Type != xdr.ContractEventTypeContract || event.ContractId == nil || event.Body.V != 0 {
+		return evt, ErrNotStellarAssetContract
+	}
+
+	// SAC event topics take the form <fn name>/<params...>/<token name>.
+	//
+	// For specific event forms, see here:
+	// https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-host/src/native_contract/token/event.rs#L44-L49
+	topics := event.Body.MustV0().Topics
+	value := event.Body.MustV0().Data
+
+	// No relevant SAC events have <= 2 topics
+	if len(topics) <= 2 {
+		return evt, ErrNotStellarAssetContract
+	}
+	fn := topics[0]
+
+	// Filter out events for function calls we don't care about
+	if fn.Type != xdr.ScValTypeScvSymbol {
+		return evt, ErrNotStellarAssetContract
+	}
+	if eventType, ok := STELLAR_ASSET_CONTRACT_TOPICS[fn.MustSym()]; !ok {
+		return evt, ErrNotStellarAssetContract
+	} else {
+		evt.Type = eventType
+	}
+
+	// This looks like a SAC event, but does it act like a SAC event?
+	//
+	// To check that, ensure that the contract ID of the event matches the
+	// contract ID that *would* represent the asset the event is claiming to
+	// be. The asset is in canonical SEP-11 form:
+	//  https://stellar.org/protocol/sep-11#alphanum4-alphanum12
+	//
+	// For all parsing errors, we just continue, since it's not a real
+	// error, just an event non-complaint with SAC events.
+	rawAsset := topics[len(topics)-1]
+	assetContainer, ok := rawAsset.GetObj()
+	if !ok || assetContainer == nil {
+		return evt, ErrNotStellarAssetContract
+	}
+
+	assetBytes, ok := assetContainer.GetBin()
+	fmt.Println("here", len(assetBytes), assetBytes)
+	if !ok || assetBytes == nil {
+		return evt, ErrNotStellarAssetContract
+	}
+
+	asset, err := txnbuild.ParseAssetString(string(assetBytes))
+	if err != nil {
+		return evt, ErrNotStellarAssetContract
+	}
+
+	xdrAsset, err := xdr.NewCreditAsset(asset.GetCode(), asset.GetIssuer())
+	if err != nil {
+		return evt, ErrNotStellarAssetContract
+	}
+
+	expectedId, err := xdrAsset.ContractID(networkPassphrase)
+	if err != nil {
+		return evt, errors.Wrap(ErrNotStellarAssetContract, err.Error())
+	}
+
+	// This is the DEFINITIVE integrity check for whether or not this is a
+	// SAC event. At this point, we can parse the event and treat it as
+	// truth, mapping it to effects where appropriate.
+	if expectedId != *event.ContractId { // nil check was earlier
+		return evt, ErrNotStellarAssetContract
+	}
+
+	switch evt.Type {
+	case EventTypeTransfer:
+		return evt, evt.parseTransferEvent(topics, value)
+	case EventTypeMint:
+	case EventTypeClawback:
+	case EventTypeBurn:
+	default:
+		return evt, errors.Wrapf(ErrEventUnsupported,
+			"event type %d ('%s') unsupported", evt.Type, fn.MustSym())
+	}
+
+	return evt, nil
+}
+
+// parseTransferEvent tries to parse the given topics and value as a SAC
+// "transfer" event. It assumes that the `topics` EXCLUDES the function name,
+// i.e. that its been validated previously. It will return a best-effort parsing
+// even in error cases.
+func (event *StellarAssetContractEvent) parseTransferEvent(topics xdr.ScVec, value xdr.ScVal) error {
+	//
+	// The transfer event format is:
+	//
+	// 	"transfer"  Symbol
+	//  <from> 		Address
+	//  <to> 		Address
+	// 	<asset>		Bytes
+	//
+	// 	<amount> 	i128
+	//
+	if len(topics) != 4 {
+		return ErrNotTransferEvent
+	}
+
+	fmt.Println("xfer here")
+	from, to := topics[1], topics[2]
+	if from.Type != xdr.ScValTypeScvObject || to.Type != xdr.ScValTypeScvObject {
+		return ErrNotTransferEvent
+	}
+
+	fromObj, ok := from.GetObj()
+	if !ok || fromObj == nil || fromObj.Type != xdr.ScObjectTypeScoAddress {
+		return ErrNotTransferEvent
+	}
+
+	toObj, ok := from.GetObj()
+	if !ok || toObj == nil || toObj.Type != xdr.ScObjectTypeScoAddress {
+		return ErrNotTransferEvent
+	}
+
+	event.From = fromObj.Address
+	event.To = toObj.Address
+
+	valueObj, ok := value.GetObj()
+	if !ok || valueObj == nil || valueObj.Type != xdr.ScObjectTypeScoI128 {
+		return ErrNotTransferEvent
+	}
+
+	event.Amount = valueObj.I128
+	return nil
+}

--- a/ingest/event.go
+++ b/ingest/event.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"fmt"
 
+	"github.com/stellar/go/strkey"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
@@ -12,7 +13,7 @@ type Event = xdr.ContractEvent
 type EventType = int
 
 // Note that there is no distinction between xfer() and xfer_from() in events,
-// and this is true for the other *_from variants, as well.
+// nor the other *_from variants. This is intentional from the host environment.
 
 const (
 	// Implemented
@@ -45,10 +46,10 @@ type StellarAssetContractEvent struct {
 	Type  int
 	Asset xdr.Asset
 
-	From   *xdr.ScAddress   // transfer, clawback, burn
-	To     *xdr.ScAddress   // transfer, mint
+	From   string           // transfer, clawback, burn; encoded as strkey
+	To     string           // transfer, mint; encoded as strkey
 	Amount *xdr.Int128Parts // transfer, mint, clawback, burn
-	Admin  *xdr.ScAddress   // mint, clawback
+	Admin  string           // mint, clawback; encoded as strkey
 }
 
 func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*StellarAssetContractEvent, error) {
@@ -97,7 +98,6 @@ func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*Stel
 	}
 
 	assetBytes, ok := assetContainer.GetBin()
-	fmt.Println("here", len(assetBytes), assetBytes)
 	if !ok || assetBytes == nil {
 		return evt, ErrNotStellarAssetContract
 	}
@@ -111,6 +111,7 @@ func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (*Stel
 	if err != nil {
 		return evt, ErrNotStellarAssetContract
 	}
+	evt.Asset = xdrAsset
 
 	expectedId, err := xdrAsset.ContractID(networkPassphrase)
 	if err != nil {
@@ -172,8 +173,9 @@ func (event *StellarAssetContractEvent) parseTransferEvent(topics xdr.ScVec, val
 		return ErrNotTransferEvent
 	}
 
-	event.From = fromObj.Address
-	event.To = toObj.Address
+	event.From = ScAddressToString(fromObj.Address)
+	event.To = ScAddressToString(toObj.Address)
+	event.Asset = xdr.Asset{} // TODO
 
 	valueObj, ok := value.GetObj()
 	if !ok || valueObj == nil || valueObj.Type != xdr.ScObjectTypeScoI128 {
@@ -182,4 +184,35 @@ func (event *StellarAssetContractEvent) parseTransferEvent(topics xdr.ScVec, val
 
 	event.Amount = valueObj.I128
 	return nil
+}
+
+// ScAddressToString converts the low-level `xdr.ScAddress` union into the
+// appropriate strkey (contract C... or account ID G...).
+//
+// TODO: Should this return errors or just panic? Maybe just slap the "Must"
+// prefix on the helper name?
+func ScAddressToString(address *xdr.ScAddress) string {
+	if address == nil {
+		return ""
+	}
+
+	var result string
+	var err error
+
+	switch address.Type {
+	case xdr.ScAddressTypeScAddressTypeAccount:
+		pubkey := address.MustAccountId().Ed25519
+		result, err = strkey.Encode(strkey.VersionByteAccountID, pubkey[:])
+	case xdr.ScAddressTypeScAddressTypeContract:
+		contractId := *address.ContractId
+		result, err = strkey.Encode(strkey.VersionByteContract, contractId[:])
+	default:
+		panic(fmt.Errorf("unfamiliar address type: %v", address.Type))
+	}
+
+	if err != nil {
+		panic(err)
+	}
+
+	return result
 }

--- a/ingest/event_test.go
+++ b/ingest/event_test.go
@@ -45,8 +45,8 @@ func TestSACTransferEvent(t *testing.T) {
 	require.NotNil(t, sacEvent.To)
 	require.NotNil(t, sacEvent.Amount)
 
-	require.Equal(t, randomIssuer.Address(), sacEvent.From.AccountId.Address())
-	require.Equal(t, randomIssuer.Address(), sacEvent.To.AccountId.Address())
+	require.Equal(t, randomIssuer.Address(), sacEvent.From)
+	require.Equal(t, randomIssuer.Address(), sacEvent.To)
 	require.EqualValues(t, 10000, sacEvent.Amount.Lo)
 	require.EqualValues(t, 0, sacEvent.Amount.Hi)
 

--- a/ingest/event_test.go
+++ b/ingest/event_test.go
@@ -1,0 +1,107 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/xdr"
+
+	"github.com/stretchr/testify/require"
+)
+
+const passphrase = "passphrase"
+
+func TestStellarAssetContractEventParsing(t *testing.T) {
+	randomIssuer := keypair.MustRandom()
+	randomAsset := xdr.MustNewCreditAsset("TESTING", randomIssuer.Address())
+
+	rawContractId, err := randomAsset.ContractID(passphrase)
+	contractId := xdr.Hash(rawContractId)
+	require.NoError(t, err)
+
+	baseXdrEvent := xdr.ContractEvent{
+		Ext:        xdr.ExtensionPoint{V: 0},
+		ContractId: &contractId,
+		Type:       xdr.ContractEventTypeContract,
+		Body: xdr.ContractEventBody{
+			V:  0,
+			V0: nil,
+		},
+	}
+
+	baseXdrEvent.Body.V0 = &xdr.ContractEventV0{
+		Topics: makeTransferTopic(randomAsset),
+		Data:   makeAmount(10000),
+	}
+
+	sacEvent, err := NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
+	require.NoError(t, err)
+	require.NotNil(t, sacEvent)
+	require.Equal(t, EventTypeTransfer, sacEvent.Type)
+
+	require.NotNil(t, sacEvent.From)
+	require.NotNil(t, sacEvent.To)
+	require.NotNil(t, sacEvent.Amount)
+
+	require.Equal(t, randomIssuer.Address(), sacEvent.From.AccountId.Address())
+	require.Equal(t, randomIssuer.Address(), sacEvent.To.AccountId.Address())
+	require.EqualValues(t, 10000, sacEvent.Amount.Lo)
+	require.EqualValues(t, 0, sacEvent.Amount.Hi)
+}
+
+func makeTransferTopic(asset xdr.Asset) xdr.ScVec {
+	accountId, _ := xdr.AddressToAccountId(asset.GetIssuer())
+
+	fnName := xdr.ScSymbol("transfer")
+	account := &xdr.ScObject{
+		Type: xdr.ScObjectTypeScoAddress,
+		Address: &xdr.ScAddress{
+			Type:      xdr.ScAddressTypeScAddressTypeAccount,
+			AccountId: &accountId,
+		},
+	}
+
+	slice := []byte(asset.StringCanonical())
+	assetDetails := &xdr.ScObject{
+		Type: xdr.ScObjectTypeScoBytes,
+		Bin:  &slice,
+	}
+
+	return xdr.ScVec([]xdr.ScVal{
+		// event name
+		{
+			Type: xdr.ScValTypeScvSymbol,
+			Sym:  &fnName,
+		},
+		// from
+		{
+			Type: xdr.ScValTypeScvObject,
+			Obj:  &account,
+		},
+		// to
+		{
+			Type: xdr.ScValTypeScvObject,
+			Obj:  &account,
+		},
+		// asset details
+		{
+			Type: xdr.ScValTypeScvObject,
+			Obj:  &assetDetails,
+		},
+	})
+}
+
+func makeAmount(amount int) xdr.ScVal {
+	amountObj := &xdr.ScObject{
+		Type: xdr.ScObjectTypeScoI128,
+		I128: &xdr.Int128Parts{
+			Lo: xdr.Uint64(amount),
+			Hi: 0,
+		},
+	}
+
+	return xdr.ScVal{
+		Type: xdr.ScValTypeScvObject,
+		Obj:  &amountObj,
+	}
+}

--- a/ingest/event_test.go
+++ b/ingest/event_test.go
@@ -54,8 +54,14 @@ func TestSACTransferEvent(t *testing.T) {
 	_, err = NewStellarAssetContractEvent(&baseXdrEvent, "different")
 	require.Error(t, err)
 
-	// Ensure that invalid asset binaries are rejected
+	// Ensure that it works for the native asset
 	oldAsset := *(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin
+	*(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin = []byte("native")
+	sacEvent, err = NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
+	require.NoError(t, err)
+	require.Equal(t, xdr.AssetTypeAssetTypeNative, sacEvent.Asset.Type)
+
+	// Ensure that invalid asset binaries are rejected
 	bsAsset := make([]byte, len(oldAsset))
 	rand.Read(bsAsset)
 	(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin = &bsAsset

--- a/ingest/event_test.go
+++ b/ingest/event_test.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/stellar/go/keypair"
@@ -11,7 +12,7 @@ import (
 
 const passphrase = "passphrase"
 
-func TestStellarAssetContractEventParsing(t *testing.T) {
+func TestSACTransferEvent(t *testing.T) {
 	randomIssuer := keypair.MustRandom()
 	randomAsset := xdr.MustNewCreditAsset("TESTING", randomIssuer.Address())
 
@@ -34,6 +35,7 @@ func TestStellarAssetContractEventParsing(t *testing.T) {
 		Data:   makeAmount(10000),
 	}
 
+	// Ensure the happy path for transfer events works
 	sacEvent, err := NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
 	require.NoError(t, err)
 	require.NotNil(t, sacEvent)
@@ -47,6 +49,25 @@ func TestStellarAssetContractEventParsing(t *testing.T) {
 	require.Equal(t, randomIssuer.Address(), sacEvent.To.AccountId.Address())
 	require.EqualValues(t, 10000, sacEvent.Amount.Lo)
 	require.EqualValues(t, 0, sacEvent.Amount.Hi)
+
+	// Ensure that changing the passphrase invalidates the event
+	_, err = NewStellarAssetContractEvent(&baseXdrEvent, "different")
+	require.Error(t, err)
+
+	// Ensure that invalid asset binaries are rejected
+	oldAsset := *(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin
+	bsAsset := make([]byte, len(oldAsset))
+	rand.Read(bsAsset)
+	(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin = &bsAsset
+	_, err = NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
+	require.Error(t, err)
+	(*baseXdrEvent.Body.V0.Topics[3].Obj).Bin = &oldAsset
+
+	// Ensure that system events are invalid
+	baseXdrEvent.Type = xdr.ContractEventTypeSystem
+	_, err = NewStellarAssetContractEvent(&baseXdrEvent, passphrase)
+	require.Error(t, err)
+	baseXdrEvent.Type = xdr.ContractEventTypeContract
 }
 
 func makeTransferTopic(asset xdr.Asset) xdr.ScVec {

--- a/ingest/ledger_transaction.go
+++ b/ingest/ledger_transaction.go
@@ -75,7 +75,9 @@ func (t *LedgerTransaction) GetChanges() ([]Change, error) {
 			afterChanges = v3Meta.TxChangesAfter
 			operationMeta = v3Meta.Operations
 		default:
-			panic("Invalid meta version, expected 2 or 3")
+			panic(fmt.Errorf(
+				"invalid meta version %d, expected 2 or 3",
+				t.UnsafeMeta.V))
 		}
 
 		txChangesBefore := GetChangesFromLedgerEntryChanges(beforeChanges)

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -36,11 +36,20 @@ const (
 	// EffectAccountRemoved effects occur when one account is merged into another
 	EffectAccountRemoved EffectType = 1 // from merge_account
 
-	// EffectAccountCredited effects occur when an account receives some currency
-	EffectAccountCredited EffectType = 2 // from create_account, payment, path_payment, merge_account
+	// EffectAccountCredited effects occur when an account receives some
+	// currency
+	//
+	// from create_account, payment, path_payment, merge_account, and SAC events
+	// involving transfers, mints, and burns.
+	EffectAccountCredited EffectType = 2
 
 	// EffectAccountDebited effects occur when an account sends some currency
-	EffectAccountDebited EffectType = 3 // from create_account, payment, path_payment, create_account
+	//
+	// from create_account, payment, path_payment, create_account, and SAC
+	// involving transfers, mints, and burns.
+	//
+	// https://github.com/stellar/rs-soroban-env/blob/5695440da452837555d8f7f259cc33341fdf07b0/soroban-env-host/src/native_contract/token/contract.rs#L51-L63
+	EffectAccountDebited EffectType = 3
 
 	// EffectAccountThresholdsUpdated effects occur when an account changes its
 	// multisig thresholds.

--- a/services/horizon/internal/ingest/processors/effects_processor.go
+++ b/services/horizon/internal/ingest/processors/effects_processor.go
@@ -1408,6 +1408,9 @@ func (e *effectsWrapper) addInvokeHostFunctionEffects(events []ingest.Event) err
 		}
 
 		switch sacEvent.Type {
+		// A transfer event generates an account_debited effect for the `to`
+		// (recipient) and an account_credited effect for the `from`
+		// (sender).
 		case ingest.EventTypeTransfer:
 			details := map[string]interface{}{"amount": amount.String128(*sacEvent.Amount)}
 			addAssetDetails(details, sacEvent.Asset, "")
@@ -1422,11 +1425,32 @@ func (e *effectsWrapper) addInvokeHostFunctionEffects(events []ingest.Event) err
 				details,
 			)
 
+		// A mint event implies a non-native asset, and it results in a debit to
+		// the `to` recipient.
 		case ingest.EventTypeMint:
+			details := map[string]interface{}{"amount": amount.String128(*sacEvent.Amount)}
+			addAssetDetails(details, sacEvent.Asset, "")
+			e.addUnmuxed(
+				xdr.MustAddressPtr(sacEvent.To),
+				history.EffectAccountDebited,
+				details,
+			)
+
+		// A clawback event results in a credit to the `from` address, but acts
+		// like a burn to the recipient, so these are functionally equivalent
 		case ingest.EventTypeClawback:
+			fallthrough
 		case ingest.EventTypeBurn:
+			details := map[string]interface{}{"amount": amount.String128(*sacEvent.Amount)}
+			addAssetDetails(details, sacEvent.Asset, "")
+			e.addUnmuxed(
+				xdr.MustAddressPtr(sacEvent.From),
+				history.EffectAccountCredited,
+				details,
+			)
+
+		// Other events are irrelevant to debit/credit effects
 		default:
-			// other events are irrelevant to debit/credit effects
 			continue
 		}
 	}

--- a/services/horizon/internal/ingest/processors/effects_processor.go
+++ b/services/horizon/internal/ingest/processors/effects_processor.go
@@ -210,8 +210,11 @@ func (operation *transactionOperationWrapper) effects() ([]effect, error) {
 		err = wrapper.addCreateClaimableBalanceEffects(changes)
 	case xdr.OperationTypeClaimClaimableBalance:
 		err = wrapper.addClaimClaimableBalanceEffects(changes)
-	case xdr.OperationTypeBeginSponsoringFutureReserves, xdr.OperationTypeEndSponsoringFutureReserves, xdr.OperationTypeRevokeSponsorship:
-	// The effects of these operations are obtained  indirectly from the ledger entries
+	case xdr.OperationTypeBeginSponsoringFutureReserves,
+		xdr.OperationTypeEndSponsoringFutureReserves,
+		xdr.OperationTypeRevokeSponsorship:
+		// The effects of these operations are obtained indirectly from the
+		// ledger entries
 	case xdr.OperationTypeClawback:
 		err = wrapper.addClawbackEffects()
 	case xdr.OperationTypeClawbackClaimableBalance:
@@ -223,8 +226,15 @@ func (operation *transactionOperationWrapper) effects() ([]effect, error) {
 	case xdr.OperationTypeLiquidityPoolWithdraw:
 		err = wrapper.addLiquidityPoolWithdrawEffect()
 	case xdr.OperationTypeInvokeHostFunction:
-		// TODO: https://github.com/stellar/go/issues/4585
-		return nil, nil
+		// If there's an invokeHostFunction operation, there's definitely V3
+		// meta in the transaction, which means this error is real.
+		events, err := operation.transaction.GetOperationEvents(operation.index)
+		if err != nil {
+			return nil, err
+		}
+
+		// For now, the only effects are related to the events themselves.
+		err = wrapper.addInvokeHostFunctionEffects(events)
 	default:
 		return nil, fmt.Errorf("Unknown operation type: %s", op.Body.Type)
 	}
@@ -1384,5 +1394,42 @@ func (e *effectsWrapper) addLiquidityPoolWithdrawEffect() error {
 		"shares_redeemed": amount.String(-delta.TotalPoolShares),
 	}
 	e.addMuxed(e.operation.SourceAccount(), history.EffectLiquidityPoolWithdrew, details)
+	return nil
+}
+
+// addInvokeHostFunctionEffects iterates through the events and generates
+// account_credited and account_debited effects when it sees events related to
+// the Stellar Asset Contract corresponding to those effects.
+func (e *effectsWrapper) addInvokeHostFunctionEffects(events []ingest.Event) error {
+	for _, event := range events {
+		sacEvent, err := ingest.NewStellarAssetContractEvent(&event, "TODO: Add network passphrase")
+		if err != nil {
+			continue // irrelevant or unsupported event
+		}
+
+		switch sacEvent.Type {
+		case ingest.EventTypeTransfer:
+			details := map[string]interface{}{"amount": amount.String128(*sacEvent.Amount)}
+			addAssetDetails(details, sacEvent.Asset, "")
+			e.addUnmuxed(
+				xdr.MustAddressPtr(sacEvent.From),
+				history.EffectAccountCredited,
+				details,
+			)
+			e.addUnmuxed(
+				xdr.MustAddressPtr(sacEvent.To),
+				history.EffectAccountDebited,
+				details,
+			)
+
+		case ingest.EventTypeMint:
+		case ingest.EventTypeClawback:
+		case ingest.EventTypeBurn:
+		default:
+			// other events are irrelevant to debit/credit effects
+			continue
+		}
+	}
+
 	return nil
 }

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -219,14 +219,15 @@ func (i *Test) runComposeCommand(args ...string) {
 		)
 	}
 	i.t.Log("Running", cmd.Env, cmd.Args)
-	out, innerErr := cmd.Output()
-	if exitErr, ok := innerErr.(*exec.ExitError); ok {
+	out, err := cmd.Output()
+
+	if exitErr, ok := err.(*exec.ExitError); ok {
 		fmt.Printf("stdout:\n%s\n", string(out))
 		fmt.Printf("stderr:\n%s\n", string(exitErr.Stderr))
 	}
 
-	if innerErr != nil {
-		i.t.Fatalf("Compose command failed: %v", innerErr)
+	if err != nil {
+		i.t.Fatalf("Compose command failed: %v", err)
 	}
 }
 

--- a/xdr/asset.go
+++ b/xdr/asset.go
@@ -45,7 +45,7 @@ func MustNewCreditAsset(code string, issuer string) Asset {
 	return a
 }
 
-// NewAssetCodeFromString returns a new allow trust asset, panicking if it can't.
+// NewAssetCodeFromString returns a new credit asset, erroring if it can't.
 func NewAssetCodeFromString(code string) (AssetCode, error) {
 	a := AssetCode{}
 	length := len(code)

--- a/xdr/ledger_key.go
+++ b/xdr/ledger_key.go
@@ -183,7 +183,7 @@ func (key *LedgerKey) SetConfigSetting(configSettingID ConfigSettingId) error {
 
 // GetLedgerKeyFromData obtains a ledger key from LedgerEntryData
 //
-//lint:ignore gocyclo
+//nolint:gocyclo
 func GetLedgerKeyFromData(data LedgerEntryData) (LedgerKey, error) {
 	var key LedgerKey
 	switch data.Type {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
This builds on #4798 and adds effects based on events from Stellar Asset Contracts.

### Why
#4725

### Known limitations
Unfinished, untested.
