### PR TITLE
Include full problem details when printing problem as an error

### DIFF
--- a/support/http/main.go
+++ b/support/http/main.go
@@ -33,6 +33,8 @@ const defaultShutdownGracePeriod = 10 * time.Second
 
 const defaultReadTimeout = 5 * time.Second
 
+const defaultWriteTimeout = 30 * time.Second
+
 // SimpleHTTPClientInterface helps mocking http.Client in tests
 type SimpleHTTPClientInterface interface {
 	PostForm(url string, data url.Values) (*stdhttp.Response, error)
@@ -103,6 +105,10 @@ func setup(conf Config) *graceful.Server {
 
 	if conf.ReadTimeout == time.Duration(0) {
 		conf.ReadTimeout = defaultReadTimeout
+	}
+
+	if conf.WriteTimeout == time.Duration(0) {
+		conf.WriteTimeout = defaultWriteTimeout
 	}
 
 	return &graceful.Server{

--- a/support/http/main_test.go
+++ b/support/http/main_test.go
@@ -25,7 +25,7 @@ func TestRun_setupDefault(t *testing.T) {
 
 	assert.Equal(t, defaultShutdownGracePeriod, srv.Timeout)
 	assert.Equal(t, defaultReadTimeout, srv.ReadTimeout)
-	assert.Equal(t, time.Duration(0), srv.WriteTimeout)
+	assert.Equal(t, defaultWriteTimeout, srv.WriteTimeout)
 	assert.Equal(t, time.Duration(0), srv.IdleTimeout)
 	assert.Equal(t, defaultListenAddr, srv.Server.Addr)
 	assert.Equal(t, time.Duration(0), srv.TCPKeepAlive)

--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -61,7 +61,7 @@ type P struct {
 }
 
 func (p P) Error() string {
-	return fmt.Sprintf("problem: %s", p.Type)
+	return fmt.Sprintf("problem: %s. full details: %s", p.Type, p.Detail)
 }
 
 // LogFilter describes which errors should be logged when terminating requests in

--- a/support/render/problem/problem_test.go
+++ b/support/render/problem/problem_test.go
@@ -184,3 +184,9 @@ func TestProblemIsKnownError(t *testing.T) {
 	err = problem.IsKnownError(errors.New("foo"))
 	assert.NoError(t, err)
 }
+
+func TestErrorIncludesPInformation(t *testing.T) {
+	err_str := ServerError.Error()
+	assert.True(t, strings.Contains(err_str, ServerError.Detail))
+	assert.True(t, strings.Contains(err_str, ServerError.Type))
+}


### PR DESCRIPTION
See [this issue](https://github.com/stellar/go/issues/4691) for full context.

This PR aims to make error messages more useful by including more detail, instead of just the type of error.