### PR TITLE
Include full problem details when printing problem as an error

### DIFF
--- a/support/render/problem/problem.go
+++ b/support/render/problem/problem.go
@@ -61,7 +61,7 @@ type P struct {
 }
 
 func (p P) Error() string {
-	return fmt.Sprintf("problem: %s", p.Type)
+	return fmt.Sprintf("problem: %s. full details: %s", p.Type, p.Detail)
 }
 
 // LogFilter describes which errors should be logged when terminating requests in

--- a/support/render/problem/problem_test.go
+++ b/support/render/problem/problem_test.go
@@ -184,3 +184,9 @@ func TestProblemIsKnownError(t *testing.T) {
 	err = problem.IsKnownError(errors.New("foo"))
 	assert.NoError(t, err)
 }
+
+func TestErrorIncludesPInformation(t *testing.T) {
+	err_str := ServerError.Error()
+	assert.True(t, strings.Contains(err_str, ServerError.Detail))
+	assert.True(t, strings.Contains(err_str, ServerError.Type))
+}


### PR DESCRIPTION
See [this issue](https://github.com/stellar/go/issues/4691) for full context.

This PR aims to make error messages more useful by including more detail, instead of just the type of error.