### PR TITLE
all: Bump supported Go versions to 1.19 and 1.20.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        go: [1.19.4]
+        # lmao semvers aren't floats never 4get
+        go: ["1.19", "1.20"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -38,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        go: [1.18.6, 1.19.4]
+        go: ["1.19", "1.20"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -56,7 +57,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        go: [1.18.6, 1.19.4]
+        go: ["1.19", "1.20"]
         pg: [9.6.5, 10]
     runs-on: ${{ matrix.os }}
     services:
@@ -82,7 +83,7 @@ jobs:
           --health-retries 5
         ports:
         - 6379:6379
-    env: 
+    env:
       PGHOST: localhost
       PGPORT: 5432
       PGUSER: postgres

--- a/.github/workflows/horizon-release.yml
+++ b/.github/workflows/horizon-release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./.github/actions/setup-go
         with:
-          go-version: 1.19.4
+          go-version: "1.20"
 
       - name: Check dependencies
         run: ./gomod.sh

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        go: [1.18.6, 1.19.4]
+        go: ["1.19", "1.20"]
         pg: [9.6.5]
         ingestion-backend: [db, captive-core, captive-core-remote-storage]
         protocol-version: [19, 20]

--- a/staticcheck.sh
+++ b/staticcheck.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 set -e
 
-version='2022.1'
+version='2023.1'
 
 staticcheck='go run honnef.co/go/tools/cmd/staticcheck@'"$version"
 


### PR DESCRIPTION
It's time :eyes:

Also, stop using specific versions so that we always used the latest patch version of a major release. Didn't this used to be the case?