### PR TITLE
services/horizon, contractevents: Update tests to support `ScVal`ue overhaul

### DIFF
--- a/support/contractevents/burn.go
+++ b/support/contractevents/burn.go
@@ -36,19 +36,17 @@ func (event *BurnEvent) parse(topics xdr.ScVec, value xdr.ScVal) error {
 		return ErrNotBurnEvent
 	}
 
-	rawFrom := topics[1]
-	from := parseAddress(&rawFrom)
-	if from == nil {
+	from, ok := topics[1].GetAddress()
+	if !ok {
 		return ErrNotBurnEvent
 	}
-
 	event.From = MustScAddressToString(from)
 
-	amount := parseAmount(&value)
-	if amount == nil {
+	amount, ok := value.GetI128()
+	if !ok {
 		return ErrNotBurnEvent
 	}
+	event.Amount = amount
 
-	event.Amount = *amount
 	return nil
 }

--- a/support/contractevents/event.go
+++ b/support/contractevents/event.go
@@ -35,7 +35,6 @@ var (
 		xdr.ScSymbol("burn"):     EventTypeBurn,
 	}
 
-	// TODO: Finer-grained parsing errors
 	ErrNotStellarAssetContract = errors.New("event was not from a Stellar Asset Contract")
 	ErrEventUnsupported        = errors.New("this type of Stellar Asset Contract event is unsupported")
 	ErrEventIntegrity          = errors.New("contract ID doesn't match asset + passphrase")
@@ -99,12 +98,7 @@ func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (Stell
 	// For all parsing errors, we just continue, since it's not a real error,
 	// just an event non-complaint with SAC events.
 	rawAsset := topics[len(topics)-1]
-	assetContainer, ok := rawAsset.GetObj()
-	if !ok || assetContainer == nil {
-		return evt, ErrNotStellarAssetContract
-	}
-
-	assetBytes, ok := assetContainer.GetBin()
+	assetBytes, ok := rawAsset.GetBytes()
 	if !ok || assetBytes == nil {
 		return evt, ErrNotStellarAssetContract
 	}

--- a/support/contractevents/generate.go
+++ b/support/contractevents/generate.go
@@ -127,26 +127,17 @@ func makeBigAmount(amount *big.Int) xdr.ScVal {
 	hi := new(big.Int).Rsh(amount, 64)
 	lo := amount.And(amount, keepLower)
 
-	amountObj := &xdr.ScObject{
-		Type: xdr.ScObjectTypeScoI128,
+	return xdr.ScVal{
+		Type: xdr.ScValTypeScvI128,
 		I128: &xdr.Int128Parts{
 			Lo: xdr.Uint64(lo.Uint64()),
 			Hi: xdr.Uint64(hi.Uint64()),
 		},
 	}
-
-	return xdr.ScVal{
-		Type: xdr.ScValTypeScvObject,
-		Obj:  &amountObj,
-	}
 }
 
 func makeAddress(address string) xdr.ScVal {
 	scAddress := xdr.ScAddress{}
-	scObject := &xdr.ScObject{
-		Type:    xdr.ScObjectTypeScoAddress,
-		Address: &scAddress,
-	}
 
 	switch address[0] {
 	case 'C':
@@ -163,8 +154,8 @@ func makeAddress(address string) xdr.ScVal {
 	}
 
 	return xdr.ScVal{
-		Type: xdr.ScValTypeScvObject,
-		Obj:  &scObject,
+		Type:    xdr.ScValTypeScvAddress,
+		Address: &scAddress,
 	}
 }
 
@@ -212,14 +203,9 @@ func makeAsset(asset xdr.Asset) xdr.ScVal {
 		panic("unexpected asset type")
 	}
 
-	slice := buffer.Bytes()
-	scObject := &xdr.ScObject{
-		Type: xdr.ScObjectTypeScoBytes,
-		Bin:  &slice,
-	}
-
+	slice := xdr.ScBytes(buffer.Bytes())
 	return xdr.ScVal{
-		Type: xdr.ScValTypeScvObject,
-		Obj:  &scObject,
+		Type:  xdr.ScValTypeScvBytes,
+		Bytes: &slice,
 	}
 }


### PR DESCRIPTION
### What
Update `support/contractevents` to conform to the new `ScVal` interface.

### Why
Self-explanatory: `xdr.ScVal` has changed completely since the overhaul.

Closes part of #4790.

### Known limitations
I still need to update the `TestRealXdr` test with new, updated XDR.