### PR TITLE
removed reference to remote captivecore package as it's been deprecated

### DIFF
--- a/services/horizon/docker/Dockerfile.dev
+++ b/services/horizon/docker/Dockerfile.dev
@@ -7,7 +7,6 @@ RUN go mod download
 COPY . ./
 ENV GOFLAGS="-ldflags=-X=github.com/stellar/go/support/app.version=${VERSION}-(built-from-source)"
 RUN go install github.com/stellar/go/services/horizon
-RUN go install github.com/stellar/go/exp/services/captivecore
 
 FROM ubuntu:20.04
 ARG STELLAR_CORE_VERSION 
@@ -24,7 +23,6 @@ RUN apt-get update && apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
 RUN apt-get clean
 
 COPY --from=builder /go/bin/horizon ./
-COPY --from=builder /go/bin/captivecore ./
 
 ENTRYPOINT ["./horizon"]
     


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
remove reference to now [deprecated captive core package](https://github.com/stellar/go/pull/4826) 'exp/services/captivecore' from the horizon dockerfile build.

### Why

causing a docker build error on the missing package now in downstream client usages, such as system-test in soroban-tools workflow trying to build horizon using Dockerfile.dev - https://github.com/stellar/soroban-tools/actions/runs/4722863134/jobs/8378028005#step:5:5155

### Known limitations


