### PR TITLE
merge latest from master to soroban-xdr-next

### DIFF
--- a/services/horizon/docker/Dockerfile.dev
+++ b/services/horizon/docker/Dockerfile.dev
@@ -7,7 +7,6 @@ RUN go mod download
 COPY . ./
 ENV GOFLAGS="-ldflags=-X=github.com/stellar/go/support/app.version=${VERSION}-(built-from-source)"
 RUN go install github.com/stellar/go/services/horizon
-RUN go install github.com/stellar/go/exp/services/captivecore
 
 FROM ubuntu:20.04
 ARG STELLAR_CORE_VERSION 
@@ -24,7 +23,6 @@ RUN apt-get update && apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
 RUN apt-get clean
 
 COPY --from=builder /go/bin/horizon ./
-COPY --from=builder /go/bin/captivecore ./
 
 ENTRYPOINT ["./horizon"]
     


### PR DESCRIPTION
porting latest from master back to soroban next branch, pull in a recent [small fix for dockerfile build related to deprecated captivecore package](https://github.com/stellar/go/pull/4846) that happened today.