### PR TITLE
services/horizon: update sac integration tests for new token interface changes

### DIFF
--- a/services/horizon/internal/ingest/processors/effects_processor.go
+++ b/services/horizon/internal/ingest/processors/effects_processor.go
@@ -1446,34 +1446,34 @@ func (e *effectsWrapper) addInvokeHostFunctionEffects(events []contractevents.Ev
 		// Transfer events generate an `account_debited` effect for the `from`
 		// (sender) and an `account_credited` effect for the `to` (recipient).
 		case contractevents.EventTypeTransfer:
-			xferEvent := evt.(*contractevents.TransferEvent)
-			details["amount"] = amount.String128(xferEvent.Amount)
+			transferEvent := evt.(*contractevents.TransferEvent)
+			details["amount"] = amount.String128(transferEvent.Amount)
 			toDetails := map[string]interface{}{}
 			for key, val := range details {
 				toDetails[key] = val
 			}
 
-			if strkey.IsValidEd25519PublicKey(xferEvent.From) {
+			if strkey.IsValidEd25519PublicKey(transferEvent.From) {
 				e.add(
-					xferEvent.From,
+					transferEvent.From,
 					null.String{},
 					history.EffectAccountDebited,
 					details,
 				)
 			} else {
-				details["contract"] = xferEvent.From
+				details["contract"] = transferEvent.From
 				e.addMuxed(source, history.EffectContractDebited, details)
 			}
 
-			if strkey.IsValidEd25519PublicKey(xferEvent.To) {
+			if strkey.IsValidEd25519PublicKey(transferEvent.To) {
 				e.add(
-					xferEvent.To,
+					transferEvent.To,
 					null.String{},
 					history.EffectAccountCredited,
 					toDetails,
 				)
 			} else {
-				toDetails["contract"] = xferEvent.To
+				toDetails["contract"] = transferEvent.To
 				e.addMuxed(source, history.EffectContractCredited, toDetails)
 			}
 

--- a/services/horizon/internal/ingest/processors/operations_processor_test.go
+++ b/services/horizon/internal/ingest/processors/operations_processor_test.go
@@ -203,7 +203,7 @@ func (s *OperationsProcessorTestSuiteLedger) TestInvokeFunctionDetails() {
 		zeroContractStrKey, err := strkey.Encode(strkey.VersionByteContract, contractId[:])
 		s.Assert().NoError(err)
 
-		xferContractEvent := contractevents.GenerateEvent(contractevents.EventTypeTransfer, randomAccount, zeroContractStrKey, "", randomAsset, big.NewInt(10000000), passphrase)
+		transferContractEvent := contractevents.GenerateEvent(contractevents.EventTypeTransfer, randomAccount, zeroContractStrKey, "", randomAsset, big.NewInt(10000000), passphrase)
 		burnContractEvent := contractevents.GenerateEvent(contractevents.EventTypeBurn, zeroContractStrKey, "", "", randomAsset, big.NewInt(10000000), passphrase)
 		mintContractEvent := contractevents.GenerateEvent(contractevents.EventTypeMint, "", zeroContractStrKey, randomAccount, randomAsset, big.NewInt(10000000), passphrase)
 		clawbackContractEvent := contractevents.GenerateEvent(contractevents.EventTypeClawback, zeroContractStrKey, "", randomAccount, randomAsset, big.NewInt(10000000), passphrase)
@@ -215,7 +215,7 @@ func (s *OperationsProcessorTestSuiteLedger) TestInvokeFunctionDetails() {
 					Events: []xdr.OperationEvents{
 						{
 							Events: []xdr.ContractEvent{
-								xferContractEvent,
+								transferContractEvent,
 								burnContractEvent,
 								mintContractEvent,
 								clawbackContractEvent,

--- a/services/horizon/internal/integration/contracts/sac_test/src/lib.rs
+++ b/services/horizon/internal/integration/contracts/sac_test/src/lib.rs
@@ -36,9 +36,9 @@ impl SACTest {
         client.burn(&env.current_contract_address(), &amount);
     }
 
-    pub fn xfer(env: Env, to: Address, amount: i128) {
+    pub fn transfer(env: Env, to: Address, amount: i128) {
         let client = token::Client::new(&env, &get_token(&env));
-        client.xfer(&env.current_contract_address(), &to, &amount);
+        client.transfer(&env.current_contract_address(), &to, &amount);
     }
 }
 
@@ -64,7 +64,7 @@ fn test() {
     assert_eq!(token.balance(&contract_address), 600);
 
     let user = Address::random(&env);
-    contract.xfer(&user, &100);
+    contract.transfer(&user, &100);
     assert_eq!(token.balance(&contract_address), 500);
     assert_eq!(token.balance(&user), 100);
 }

--- a/support/contractevents/event.go
+++ b/support/contractevents/event.go
@@ -23,7 +23,7 @@ const (
 	// TODO: Not implemented
 	EventTypeIncrAllow
 	EventTypeDecrAllow
-	EventTypeSetAuth
+	EventTypeSetAuthorized
 	EventTypeSetAdmin
 )
 

--- a/support/contractevents/event.go
+++ b/support/contractevents/event.go
@@ -11,7 +11,7 @@ import (
 type Event = xdr.ContractEvent
 type EventType int
 
-// Note that there is no distinction between xfer() and xfer_from() in events,
+// Note that there is no distinction between transfer() and transfer_from() in events,
 // nor the other *_from variants. This is intentional from the host environment.
 
 const (
@@ -123,8 +123,8 @@ func NewStellarAssetContractEvent(event *Event, networkPassphrase string) (Stell
 
 	switch evt.GetType() {
 	case EventTypeTransfer:
-		xferEvent := TransferEvent{sacEvent: *evt}
-		return &xferEvent, xferEvent.parse(topics, value)
+		transferEvent := TransferEvent{sacEvent: *evt}
+		return &transferEvent, transferEvent.parse(topics, value)
 
 	case EventTypeMint:
 		mintEvent := MintEvent{sacEvent: *evt}

--- a/support/contractevents/event_test.go
+++ b/support/contractevents/event_test.go
@@ -29,7 +29,7 @@ var (
 )
 
 //go:embed fixtures/transfer_event_xdr.bin
-var xferEventXdr []byte
+var transferEventXdr []byte
 
 func TestScValCreators(t *testing.T) {
 	val := makeSymbol("hello")
@@ -94,11 +94,11 @@ func TestSACTransferEvent(t *testing.T) {
 	require.NotNil(t, sacEvent)
 	require.Equal(t, EventTypeTransfer, sacEvent.GetType())
 
-	xferEvent := sacEvent.(*TransferEvent)
-	require.Equal(t, randomAccount, xferEvent.From)
-	require.Equal(t, zeroContract, xferEvent.To)
-	require.EqualValues(t, 10000, xferEvent.Amount.Lo)
-	require.EqualValues(t, 0, xferEvent.Amount.Hi)
+	transferEvent := sacEvent.(*TransferEvent)
+	require.Equal(t, randomAccount, transferEvent.From)
+	require.Equal(t, zeroContract, transferEvent.To)
+	require.EqualValues(t, 10000, transferEvent.Amount.Lo)
+	require.EqualValues(t, 0, transferEvent.Amount.Hi)
 }
 
 func TestSACEventCreation(t *testing.T) {
@@ -224,10 +224,10 @@ func TestFuzzingSACEventParser(t *testing.T) {
 }
 
 func TestRealTransferEvent(t *testing.T) {
-	decoded := base64.StdEncoding.EncodeToString(xferEventXdr)
+	decoded := base64.StdEncoding.EncodeToString(transferEventXdr)
 
 	event := xdr.ContractEvent{}
-	require.NoErrorf(t, event.UnmarshalBinary(xferEventXdr),
+	require.NoErrorf(t, event.UnmarshalBinary(transferEventXdr),
 		"couldn't unmarshal event: '%s'", decoded)
 
 	parsed, err := NewStellarAssetContractEvent(&event, "Standalone Network ; February 2017")


### PR DESCRIPTION
# What

services/horizon: update sac integration tests for new token interface changes


# Todo

- [x] Update the `support/contractevents/fixtures/transfer_event_xdr.bin`, with new xdr once we have that.
  - Event hasn't actually changed.