### PR TITLE
services/horizon: Suppress Core timeout error when ingestion state ma…

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -218,6 +218,14 @@ func (a *App) Paths() paths.Finder {
 func (a *App) UpdateCoreLedgerState(ctx context.Context) {
 	var next ledger.CoreStatus
 
+	// #4446 If the ingestion state machine is in the build state, the query can time out
+	// because the captive-core buffer may be full. In this case, skip the check.
+	if a.config.CaptiveCoreToml != nil &&
+		a.config.StellarCoreURL == fmt.Sprintf("http://localhost:%d", a.config.CaptiveCoreToml.HTTPPort) &&
+		a.ingester != nil && a.ingester.GetCurrentState() == ingest.Build {
+		return
+	}
+
 	logErr := func(err error, msg string) {
 		log.WithStack(err).WithField("err", err.Error()).Error(msg)
 	}
@@ -229,13 +237,6 @@ func (a *App) UpdateCoreLedgerState(ctx context.Context) {
 
 	coreInfo, err := coreClient.Info(ctx)
 	if err != nil {
-		// #4446 If the ingestion state machine is in the build state, the query can time out
-		// because the captive-core buffer may be full. In this case, it is not really an error.
-		localCaptiveCoreUrl := fmt.Sprintf("http://localhost:%d", a.config.CaptiveCoreToml.HTTPPort)
-		if a.config.StellarCoreURL == localCaptiveCoreUrl &&
-			a.ingester != nil && a.ingester.GetCurrentState() == ingest.Build {
-			return
-		}
 		logErr(err, "failed to load the stellar-core info")
 		return
 	}

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -229,7 +229,11 @@ func (a *App) UpdateCoreLedgerState(ctx context.Context) {
 
 	coreInfo, err := coreClient.Info(ctx)
 	if err != nil {
-		if a.ingester != nil && a.ingester.GetCurrentState() == ingest.Build {
+		// #4446 If the ingestion state machine is in the build state, the query can time out
+		// because the captive-core buffer may be full. In this case, it is not really an error.
+		localCaptiveCoreUrl := fmt.Sprintf("http://localhost:%d", a.config.CaptiveCoreToml.HTTPPort)
+		if a.config.StellarCoreURL == localCaptiveCoreUrl &&
+			a.ingester != nil && a.ingester.GetCurrentState() == ingest.Build {
 			return
 		}
 		logErr(err, "failed to load the stellar-core info")

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -229,6 +229,9 @@ func (a *App) UpdateCoreLedgerState(ctx context.Context) {
 
 	coreInfo, err := coreClient.Info(ctx)
 	if err != nil {
+		if a.ingester != nil && a.ingester.GetCurrentState() == ingest.Build {
+			return
+		}
 		logErr(err, "failed to load the stellar-core info")
 		return
 	}

--- a/services/horizon/internal/ingest/fsm.go
+++ b/services/horizon/internal/ingest/fsm.go
@@ -30,10 +30,10 @@ func (e ErrReingestRangeConflict) Error() string {
 	return fmt.Sprintf("reingest range overlaps with horizon ingestion, supplied range shouldn't contain ledger %d", e.maximumLedgerSequence)
 }
 
-type StateName int
+type State int
 
 const (
-	None StateName = iota
+	None State = iota
 	Start
 	Stop
 	Build
@@ -48,7 +48,7 @@ const (
 type stateMachineNode interface {
 	run(*system) (transition, error)
 	String() string
-	GetName() StateName
+	GetState() State
 }
 
 type transition struct {
@@ -121,7 +121,7 @@ func (stopState) String() string {
 	return "stop"
 }
 
-func (stopState) GetName() StateName {
+func (stopState) GetState() State {
 	return Stop
 }
 
@@ -137,7 +137,7 @@ func (startState) String() string {
 	return "start"
 }
 
-func (startState) GetName() StateName {
+func (startState) GetState() State {
 	return Start
 }
 
@@ -258,7 +258,7 @@ func (b buildState) String() string {
 	return fmt.Sprintf("buildFromCheckpoint(checkpointLedger=%d, skipChecks=%t)", b.checkpointLedger, b.skipChecks)
 }
 
-func (buildState) GetName() StateName {
+func (buildState) GetState() State {
 	return Build
 }
 
@@ -405,7 +405,7 @@ func (r resumeState) String() string {
 	return fmt.Sprintf("resume(latestSuccessfullyProcessedLedger=%d)", r.latestSuccessfullyProcessedLedger)
 }
 
-func (resumeState) GetName() StateName {
+func (resumeState) GetState() State {
 	return Resume
 }
 
@@ -598,7 +598,7 @@ func (h historyRangeState) String() string {
 	)
 }
 
-func (historyRangeState) GetName() StateName {
+func (historyRangeState) GetState() State {
 	return HistoryRange
 }
 
@@ -715,7 +715,7 @@ func (h reingestHistoryRangeState) String() string {
 	)
 }
 
-func (reingestHistoryRangeState) GetName() StateName {
+func (reingestHistoryRangeState) GetState() State {
 	return ReingestHistoryRange
 }
 
@@ -873,7 +873,7 @@ func (waitForCheckpointState) String() string {
 	return "waitForCheckpoint"
 }
 
-func (waitForCheckpointState) GetName() StateName {
+func (waitForCheckpointState) GetState() State {
 	return WaitForCheckpoint
 }
 
@@ -898,7 +898,7 @@ func (v verifyRangeState) String() string {
 	)
 }
 
-func (verifyRangeState) GetName() StateName {
+func (verifyRangeState) GetState() State {
 	return VerifyRange
 }
 
@@ -1033,7 +1033,7 @@ func (stressTestState) String() string {
 	return "stressTest"
 }
 
-func (stressTestState) GetName() StateName {
+func (stressTestState) GetState() State {
 	return StressTest
 }
 

--- a/services/horizon/internal/ingest/fsm.go
+++ b/services/horizon/internal/ingest/fsm.go
@@ -30,9 +30,25 @@ func (e ErrReingestRangeConflict) Error() string {
 	return fmt.Sprintf("reingest range overlaps with horizon ingestion, supplied range shouldn't contain ledger %d", e.maximumLedgerSequence)
 }
 
+type StateName int
+
+const (
+	None StateName = iota
+	Start
+	Stop
+	Build
+	Resume
+	WaitForCheckpoint
+	StressTest
+	VerifyRange
+	HistoryRange
+	ReingestHistoryRange
+)
+
 type stateMachineNode interface {
 	run(*system) (transition, error)
 	String() string
+	GetName() StateName
 }
 
 type transition struct {
@@ -105,6 +121,10 @@ func (stopState) String() string {
 	return "stop"
 }
 
+func (stopState) GetName() StateName {
+	return Stop
+}
+
 func (stopState) run(s *system) (transition, error) {
 	return stop(), errors.New("Cannot run terminal state")
 }
@@ -115,6 +135,10 @@ type startState struct {
 
 func (startState) String() string {
 	return "start"
+}
+
+func (startState) GetName() StateName {
+	return Start
 }
 
 func (state startState) run(s *system) (transition, error) {
@@ -232,6 +256,10 @@ type buildState struct {
 
 func (b buildState) String() string {
 	return fmt.Sprintf("buildFromCheckpoint(checkpointLedger=%d, skipChecks=%t)", b.checkpointLedger, b.skipChecks)
+}
+
+func (buildState) GetName() StateName {
+	return Build
 }
 
 func (b buildState) run(s *system) (transition, error) {
@@ -375,6 +403,10 @@ type resumeState struct {
 
 func (r resumeState) String() string {
 	return fmt.Sprintf("resume(latestSuccessfullyProcessedLedger=%d)", r.latestSuccessfullyProcessedLedger)
+}
+
+func (resumeState) GetName() StateName {
+	return Resume
 }
 
 func (r resumeState) run(s *system) (transition, error) {
@@ -566,6 +598,10 @@ func (h historyRangeState) String() string {
 	)
 }
 
+func (historyRangeState) GetName() StateName {
+	return HistoryRange
+}
+
 // historyRangeState is used when catching up history data
 func (h historyRangeState) run(s *system) (transition, error) {
 	if h.fromLedger == 0 || h.toLedger == 0 ||
@@ -677,6 +713,10 @@ func (h reingestHistoryRangeState) String() string {
 		h.toLedger,
 		h.force,
 	)
+}
+
+func (reingestHistoryRangeState) GetName() StateName {
+	return ReingestHistoryRange
 }
 
 func (h reingestHistoryRangeState) ingestRange(s *system, fromLedger, toLedger uint32) error {
@@ -833,6 +873,10 @@ func (waitForCheckpointState) String() string {
 	return "waitForCheckpoint"
 }
 
+func (waitForCheckpointState) GetName() StateName {
+	return WaitForCheckpoint
+}
+
 func (waitForCheckpointState) run(*system) (transition, error) {
 	log.Info("Waiting for the next checkpoint...")
 	time.Sleep(10 * time.Second)
@@ -852,6 +896,10 @@ func (v verifyRangeState) String() string {
 		v.toLedger,
 		v.verifyState,
 	)
+}
+
+func (verifyRangeState) GetName() StateName {
+	return VerifyRange
 }
 
 func (v verifyRangeState) run(s *system) (transition, error) {
@@ -983,6 +1031,10 @@ type stressTestState struct{}
 
 func (stressTestState) String() string {
 	return "stressTest"
+}
+
+func (stressTestState) GetName() StateName {
+	return StressTest
 }
 
 func (stressTestState) run(s *system) (transition, error) {

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -196,6 +196,7 @@ type System interface {
 	ReingestRange(ledgerRanges []history.LedgerRange, force bool) error
 	BuildGenesisState() error
 	Shutdown()
+	GetCurrentState() StateName
 }
 
 type system struct {
@@ -228,6 +229,8 @@ type system struct {
 	runStateVerificationOnLedger func(uint32) bool
 
 	reapOffsets map[string]int64
+
+	currentState StateName
 }
 
 func NewSystem(config Config) (System, error) {
@@ -292,6 +295,7 @@ func NewSystem(config Config) (System, error) {
 		cancel:                      cancel,
 		config:                      config,
 		ctx:                         ctx,
+		currentState:                None,
 		disableStateVerification:    config.DisableStateVerification,
 		historyAdapter:              historyAdapter,
 		historyQ:                    historyQ,
@@ -479,6 +483,10 @@ func (s *system) initMetrics() {
 	)
 }
 
+func (s *system) GetCurrentState() StateName {
+	return s.currentState
+}
+
 func (s *system) Metrics() Metrics {
 	return s.metrics
 }
@@ -644,6 +652,7 @@ func (s *system) runStateMachine(cur stateMachineNode) error {
 			panic("unexpected transaction")
 		}
 
+		s.currentState = cur.GetName()
 		next, err := cur.run(s)
 		if err != nil {
 			logger := log.WithFields(logpkg.F{

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -196,7 +196,7 @@ type System interface {
 	ReingestRange(ledgerRanges []history.LedgerRange, force bool) error
 	BuildGenesisState() error
 	Shutdown()
-	GetCurrentState() StateName
+	GetCurrentState() State
 }
 
 type system struct {
@@ -230,7 +230,7 @@ type system struct {
 
 	reapOffsets map[string]int64
 
-	currentState StateName
+	currentState State
 }
 
 func NewSystem(config Config) (System, error) {
@@ -483,7 +483,7 @@ func (s *system) initMetrics() {
 	)
 }
 
-func (s *system) GetCurrentState() StateName {
+func (s *system) GetCurrentState() State {
 	return s.currentState
 }
 
@@ -652,7 +652,7 @@ func (s *system) runStateMachine(cur stateMachineNode) error {
 			panic("unexpected transaction")
 		}
 
-		s.currentState = cur.GetName()
+		s.currentState = cur.GetState()
 		next, err := cur.run(s)
 		if err != nil {
 			logger := log.WithFields(logpkg.F{

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -556,9 +556,9 @@ func (m *mockSystem) BuildGenesisState() error {
 	return args.Error(0)
 }
 
-func (m *mockSystem) GetCurrentState() StateName {
+func (m *mockSystem) GetCurrentState() State {
 	args := m.Called()
-	return args.Get(0).(StateName)
+	return args.Get(0).(State)
 }
 
 func (m *mockSystem) Shutdown() {

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -556,6 +556,11 @@ func (m *mockSystem) BuildGenesisState() error {
 	return args.Error(0)
 }
 
+func (m *mockSystem) GetCurrentState() StateName {
+	args := m.Called()
+	return args.Get(0).(StateName)
+}
+
 func (m *mockSystem) Shutdown() {
 	m.Called()
 }


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

In the ingest package, I have added a state variable to store the current state of the ingestion state machine. I query this state from the `app` and suppress the error message only when the state is in the `build` state.


### Why

Fixes https://github.com/stellar/go/issues/4446


### Known limitations

I'm unsure if this is the best approach. It seems like overkill to reveal the current state of the ingestion state machine to suppress an error message. 