### PR TITLE
Add a simple test for asset case sorting in ascii

### DIFF
--- a/xdr/asset_test.go
+++ b/xdr/asset_test.go
@@ -473,6 +473,16 @@ func TestAssetLessThan(t *testing.T) {
 		assert.False(t, assetIssuerB.LessThan(assetIssuerA))
 		assert.False(t, assetIssuerB.LessThan(assetIssuerB))
 	})
+
+	t.Run("test if codes with upper-case letters are sorted before lower-case letters", func(t *testing.T) {
+		// All upper-case letters should come before any lower-case ones
+		assetA, err := NewCreditAsset("B", "GA7NLOF4EHWMJF6DBXXV2H6AYI7IHYWNFZR6R52BYBLY7TE5Q74AIDRA")
+		require.NoError(t, err)
+		assetB, err := NewCreditAsset("a", "GA7NLOF4EHWMJF6DBXXV2H6AYI7IHYWNFZR6R52BYBLY7TE5Q74AIDRA")
+		require.NoError(t, err)
+
+		assert.True(t, assetA.LessThan(assetB))
+	})
 }
 
 func BenchmarkAssetString(b *testing.B) {


### PR DESCRIPTION
Based on https://github.com/stellar/js-stellar-base/issues/593, I added a small unit test for the go xdr asset sorting with mixed upper/lower case assets.