### PR TITLE
services/horizon: Update default for  --captive-core-use-db to true

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -5,6 +5,11 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## Unreleased
+### Changes
+### Breaking Changes
+- Modify the default value of `--captive-core-use-db` to true ([4856](https://github.com/stellar/go/issues/4856))
+  - This updates the default behavior of captive core to start in on-disk mode.
+  - To continue using the previous in-memory mode, explicitly set the `--captive-core-use-db` flag to false
 
 ## 2.24.1
 

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -177,7 +177,7 @@ func Flags() (*Config, support.ConfigOptions) {
 		&support.ConfigOption{
 			Name:        CaptiveCoreConfigUseDB,
 			OptType:     types.Bool,
-			FlagDefault: false,
+			FlagDefault: true,
 			Required:    false,
 			Usage: `when enabled, Horizon ingestion will instruct the captive
 			              core invocation to use an external db url for ledger states rather than in memory(RAM).\n 
@@ -735,9 +735,6 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 		}
 		if config.StellarCoreDatabaseURL != "" {
 			return fmt.Errorf("Invalid config: --%s passed but --ingest not set. ", StellarCoreDBURLFlagName)
-		}
-		if config.CaptiveCoreConfigUseDB {
-			return fmt.Errorf("Invalid config: --%s has been set, but --ingest not set. ", CaptiveCoreConfigUseDB)
 		}
 	}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Modify the default value of the `--captive-core-use-db` command line flag to true. This modification ensures that CaptiveCore utilizes an external database instead of relying on memory (RAM). The configuration of the external database can be customized within the CaptiveCore configuration file with the default setting being `sqlite3://stellar.db.`

If the `ingest` option is not enabled, this particular flag will be disregarded. Previously, when it was necessary to explicitly set this flag, an error message would be displayed if it was set without configuring other ingestion parameters. However, now, if the ingest option is disabled, this flag will simply be ignored.

To explicitly set it to false via the command line, use the following syntax: `--captive-core-use-db=false`. Alternatively, you can set the environment variable `CAPTIVE_CORE_USE_DB=false` in order to revert to the in-memory option.

### Why
See [4856](https://github.com/stellar/go/issues/4856) for details

### Known limitations
Due to the increasing size of the ledger, supporting the in-memory option is no longer practical and should be deprecated.
