### PR TITLE
Don't use the singleton viper. This makes support/config more flexible and reusable

### DIFF
--- a/exp/services/recoverysigner/cmd/db.go
+++ b/exp/services/recoverysigner/cmd/db.go
@@ -7,6 +7,7 @@ import (
 
 	migrate "github.com/rubenv/sql-migrate"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	dbpkg "github.com/stellar/go/exp/services/recoverysigner/internal/db"
 	"github.com/stellar/go/exp/services/recoverysigner/internal/db/dbmigrate"
 	"github.com/stellar/go/support/config"
@@ -33,8 +34,9 @@ func (c *DBCommand) Command() *cobra.Command {
 		Use:   "db",
 		Short: "Run database operations",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			configOpts.Require()
-			configOpts.SetValues()
+			v := viper.New()
+			configOpts.Require(v)
+			configOpts.SetValues(v)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()

--- a/exp/services/recoverysigner/cmd/serve.go
+++ b/exp/services/recoverysigner/cmd/serve.go
@@ -4,6 +4,7 @@ import (
 	"go/types"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stellar/go/exp/services/recoverysigner/internal/serve"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/support/config"
@@ -107,8 +108,9 @@ func (c *ServeCommand) Command() *cobra.Command {
 		Use:   "serve",
 		Short: "Run the SEP-30 Recovery Signer server",
 		Run: func(_ *cobra.Command, _ []string) {
-			configOpts.Require()
-			configOpts.SetValues()
+			v := viper.New()
+			configOpts.Require(v)
+			configOpts.SetValues(v)
 			c.Run(opts)
 		},
 	}

--- a/exp/services/webauth/cmd/serve.go
+++ b/exp/services/webauth/cmd/serve.go
@@ -4,6 +4,7 @@ import (
 	"go/types"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/exp/services/webauth/internal/serve"
 	"github.com/stellar/go/network"
@@ -109,8 +110,9 @@ func (c *ServeCommand) Command() *cobra.Command {
 		Use:   "serve",
 		Short: "Run the SEP-10 Web Authentication server",
 		Run: func(_ *cobra.Command, _ []string) {
-			configOpts.Require()
-			configOpts.SetValues()
+			v := viper.New()
+			configOpts.Require(v)
+			configOpts.SetValues(v)
 			c.Run(opts)
 		},
 	}

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -34,14 +34,15 @@ var dbMigrateCmd = &cobra.Command{
 }
 
 func requireAndSetFlags(names ...string) error {
+	v := viper.New()
 	set := map[string]bool{}
 	for _, name := range names {
 		set[name] = true
 	}
 	for _, flag := range flags {
 		if set[flag.Name] {
-			flag.Require()
-			if err := flag.SetValue(); err != nil {
+			flag.Require(v)
+			if err := flag.SetValue(v); err != nil {
 				return err
 			}
 			delete(set, flag.Name)
@@ -300,10 +301,11 @@ var dbReingestRangeCmd = &cobra.Command{
 	Short: "reingests ledgers within a range",
 	Long:  "reingests ledgers between X and Y sequence number (closed intervals)",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := dbReingestRangeCmdOpts.RequireE(); err != nil {
+		v := viper.New()
+		if err := dbReingestRangeCmdOpts.RequireE(v); err != nil {
 			return err
 		}
-		if err := dbReingestRangeCmdOpts.SetValues(); err != nil {
+		if err := dbReingestRangeCmdOpts.SetValues(v); err != nil {
 			return err
 		}
 
@@ -340,10 +342,11 @@ var dbFillGapsCmd = &cobra.Command{
 	Short: "Ingests any gaps found in the horizon db",
 	Long:  "Ingests any gaps found in the horizon db. The command takes an optional start and end parameters which restrict the range of ledgers ingested.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := dbFillGapsCmdOpts.RequireE(); err != nil {
+		v := viper.New()
+		if err := dbFillGapsCmdOpts.RequireE(v); err != nil {
 			return err
 		}
-		if err := dbFillGapsCmdOpts.SetValues(); err != nil {
+		if err := dbFillGapsCmdOpts.SetValues(v); err != nil {
 			return err
 		}
 

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -87,11 +87,12 @@ var ingestVerifyRangeCmd = &cobra.Command{
 	Short: "runs ingestion pipeline within a range. warning! requires clean DB.",
 	Long:  "runs ingestion pipeline between X and Y sequence number (inclusive)",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		v := viper.New()
 		for _, co := range ingestVerifyRangeCmdOpts {
-			if err := co.RequireE(); err != nil {
+			if err := co.RequireE(v); err != nil {
 				return err
 			}
-			co.SetValue()
+			co.SetValue(v)
 		}
 
 		if err := horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true}); err != nil {
@@ -196,11 +197,12 @@ var ingestStressTestCmd = &cobra.Command{
 	Short: "runs ingestion pipeline on a ledger with many changes. warning! requires clean DB.",
 	Long:  "runs ingestion pipeline on a ledger with many changes. warning! requires clean DB.",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		v := viper.New()
 		for _, co := range stressTestCmdOpts {
-			if err := co.RequireE(); err != nil {
+			if err := co.RequireE(v); err != nil {
 				return err
 			}
-			co.SetValue()
+			co.SetValue(v)
 		}
 
 		if err := horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true}); err != nil {
@@ -356,11 +358,12 @@ var ingestBuildStateCmd = &cobra.Command{
 	Short: "builds state at a given checkpoint. warning! requires clean DB.",
 	Long:  "useful for debugging or starting Horizon at specific checkpoint.",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		v := viper.New()
 		for _, co := range ingestBuildStateCmdOpts {
-			if err := co.RequireE(); err != nil {
+			if err := co.RequireE(v); err != nil {
 				return err
 			}
-			co.SetValue()
+			co.SetValue(v)
 		}
 
 		if err := horizon.ApplyFlags(config, flags, horizon.ApplyOptions{RequireCaptiveCoreConfig: false, AlwaysIngest: true}); err != nil {

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -599,11 +599,12 @@ type ApplyOptions struct {
 
 // ApplyFlags applies the command line flags on the given Config instance
 func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOptions) error {
+	v := viper.New()
 	// Verify required options and load the config struct
-	if err := flags.RequireE(); err != nil {
+	if err := flags.RequireE(v); err != nil {
 		return err
 	}
-	if err := flags.SetValues(); err != nil {
+	if err := flags.SetValues(v); err != nil {
 		return err
 	}
 

--- a/services/regulated-assets-approval-server/cmd/configureissuer.go
+++ b/services/regulated-assets-approval-server/cmd/configureissuer.go
@@ -4,6 +4,7 @@ import (
 	"go/types"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/services/regulated-assets-approval-server/internal/configureissuer"
@@ -57,8 +58,9 @@ func (c *ConfigureIssuer) Command() *cobra.Command {
 		Use:   "configure-issuer",
 		Short: "Configure the Asset Issuer Account for SEP-8 Regulated Assets",
 		Run: func(_ *cobra.Command, _ []string) {
-			configOpts.Require()
-			configOpts.SetValues()
+			v := viper.New()
+			configOpts.Require(v)
+			configOpts.SetValues(v)
 			c.Run(opts)
 		},
 	}

--- a/services/regulated-assets-approval-server/cmd/migrate.go
+++ b/services/regulated-assets-approval-server/cmd/migrate.go
@@ -7,6 +7,7 @@ import (
 
 	migrate "github.com/rubenv/sql-migrate"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stellar/go/services/regulated-assets-approval-server/internal/db"
 	"github.com/stellar/go/services/regulated-assets-approval-server/internal/db/dbmigrate"
 	"github.com/stellar/go/support/config"
@@ -32,8 +33,9 @@ func (c *MigrateCommand) Command() *cobra.Command {
 		Use:   "migrate [up|down] [count]",
 		Short: "Run migrations on the database",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			configOpts.Require()
-			configOpts.SetValues()
+			v := viper.New()
+			configOpts.Require(v)
+			configOpts.SetValues(v)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			c.Migrate(cmd, args)

--- a/services/regulated-assets-approval-server/cmd/serve.go
+++ b/services/regulated-assets-approval-server/cmd/serve.go
@@ -4,6 +4,7 @@ import (
 	"go/types"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/network"
 	"github.com/stellar/go/services/regulated-assets-approval-server/internal/serve"
@@ -89,8 +90,9 @@ func (c *ServeCommand) Command() *cobra.Command {
 		Use:   "serve",
 		Short: "Serve the SEP-8 Approval Server",
 		Run: func(_ *cobra.Command, _ []string) {
-			configOpts.Require()
-			configOpts.SetValues()
+			v := viper.New()
+			configOpts.Require(v)
+			configOpts.SetValues(v)
 			c.Run(opts)
 		},
 	}

--- a/support/config/config_option.go
+++ b/support/config/config_option.go
@@ -32,16 +32,16 @@ func (cos ConfigOptions) Init(cmd *cobra.Command) error {
 }
 
 // Require calls Require on each ConfigOption.
-func (cos ConfigOptions) Require() {
+func (cos ConfigOptions) Require(v *viper.Viper) {
 	for _, co := range cos {
-		co.Require()
+		co.Require(v)
 	}
 }
 
 // RequireE is like Require, but returns the error instead of Fatal
-func (cos ConfigOptions) RequireE() error {
+func (cos ConfigOptions) RequireE(v *viper.Viper) error {
 	for _, co := range cos {
-		if err := co.RequireE(); err != nil {
+		if err := co.RequireE(v); err != nil {
 			return err
 		}
 	}
@@ -49,9 +49,9 @@ func (cos ConfigOptions) RequireE() error {
 }
 
 // SetValues calls SetValue on each ConfigOption.
-func (cos ConfigOptions) SetValues() error {
+func (cos ConfigOptions) SetValues(v *viper.Viper) error {
 	for _, co := range cos {
-		if err := co.SetValue(); err != nil {
+		if err := co.SetValue(v); err != nil {
 			return err
 		}
 	}
@@ -69,6 +69,7 @@ type ConfigOption struct {
 	CustomSetValue func(*ConfigOption) error // Optional function for custom validation/transformation
 	ConfigKey      interface{}               // Pointer to the final key in the linked Config struct
 	flag           *pflag.Flag               // The persistent flag that the config option is attached to
+	viper          *viper.Viper              // The viper instance that the config option is attached to
 }
 
 // Init handles initialisation steps, including configuring and binding the env variable name.
@@ -83,30 +84,31 @@ func (co *ConfigOption) Init(cmd *cobra.Command) error {
 }
 
 // Bind binds the config option to viper.
-func (co *ConfigOption) Bind() {
-	viper.BindPFlag(co.Name, co.flag)
-	viper.BindEnv(co.Name, co.EnvVar)
+func (co *ConfigOption) Bind(v *viper.Viper) {
+	co.viper = v
+	co.viper.BindPFlag(co.Name, co.flag)
+	co.viper.BindEnv(co.Name, co.EnvVar)
 }
 
 // Require checks that a required string configuration option is not empty, raising a user error if it is.
-func (co *ConfigOption) Require() {
-	if err := co.RequireE(); err != nil {
+func (co *ConfigOption) Require(v *viper.Viper) {
+	if err := co.RequireE(v); err != nil {
 		stdLog.Fatal(err.Error())
 	}
 }
 
 // RequireE is like Require, but returns the error instead of Fatal
-func (co *ConfigOption) RequireE() error {
-	co.Bind()
-	if co.Required && viper.GetString(co.Name) == "" {
+func (co *ConfigOption) RequireE(v *viper.Viper) error {
+	co.Bind(v)
+	if co.Required && co.viper.GetString(co.Name) == "" {
 		return fmt.Errorf("Invalid config: %s is blank. Please specify --%s on the command line or set the %s environment variable.", co.Name, co.Name, co.EnvVar)
 	}
 	return nil
 }
 
 // SetValue sets a value in the global config, using a custom function, if one was provided.
-func (co *ConfigOption) SetValue() error {
-	co.Bind()
+func (co *ConfigOption) SetValue(v *viper.Viper) error {
+	co.Bind(v)
 
 	// Use a custom setting function, if one is provided
 	if co.CustomSetValue != nil {
@@ -132,17 +134,17 @@ func (co *ConfigOption) setSimpleValue() {
 	if co.ConfigKey != nil {
 		switch co.OptType {
 		case types.String:
-			*(co.ConfigKey.(*string)) = viper.GetString(co.Name)
+			*(co.ConfigKey.(*string)) = co.viper.GetString(co.Name)
 		case types.Int:
-			*(co.ConfigKey.(*int)) = viper.GetInt(co.Name)
+			*(co.ConfigKey.(*int)) = co.viper.GetInt(co.Name)
 		case types.Bool:
-			*(co.ConfigKey.(*bool)) = viper.GetBool(co.Name)
+			*(co.ConfigKey.(*bool)) = co.viper.GetBool(co.Name)
 		case types.Uint:
-			*(co.ConfigKey.(*uint)) = uint(viper.GetInt(co.Name))
+			*(co.ConfigKey.(*uint)) = uint(co.viper.GetInt(co.Name))
 		case types.Uint32:
-			*(co.ConfigKey.(*uint32)) = uint32(viper.GetInt(co.Name))
+			*(co.ConfigKey.(*uint32)) = uint32(co.viper.GetInt(co.Name))
 		case types.Float64:
-			*(co.ConfigKey.(*float64)) = float64(viper.GetFloat64(co.Name))
+			*(co.ConfigKey.(*float64)) = float64(co.viper.GetFloat64(co.Name))
 		}
 	}
 }
@@ -177,19 +179,19 @@ func (co *ConfigOption) setFlag(cmd *cobra.Command) error {
 
 // SetDuration converts a command line int to a duration, and stores it in the final config.
 func SetDuration(co *ConfigOption) error {
-	*(co.ConfigKey.(*time.Duration)) = time.Duration(viper.GetInt(co.Name)) * time.Second
+	*(co.ConfigKey.(*time.Duration)) = time.Duration(co.viper.GetInt(co.Name)) * time.Second
 	return nil
 }
 
 // SetDurationMinutes converts a command line minutes value to a duration, and stores it in the final config.
 func SetDurationMinutes(co *ConfigOption) error {
-	*(co.ConfigKey.(*time.Duration)) = time.Duration(viper.GetInt(co.Name)) * time.Minute
+	*(co.ConfigKey.(*time.Duration)) = time.Duration(co.viper.GetInt(co.Name)) * time.Minute
 	return nil
 }
 
 // SetURL converts a command line string to a URL, and stores it in the final config.
 func SetURL(co *ConfigOption) error {
-	urlString := viper.GetString(co.Name)
+	urlString := co.viper.GetString(co.Name)
 	if urlString != "" {
 		urlType, err := url.Parse(urlString)
 		if err != nil {
@@ -206,7 +208,7 @@ func SetOptionalUint(co *ConfigOption) error {
 	key := co.ConfigKey.(**uint)
 	if IsExplicitlySet(co) {
 		*key = new(uint)
-		**key = uint(viper.GetInt(co.Name))
+		**key = uint(co.viper.GetInt(co.Name))
 	} else {
 		*key = nil
 	}
@@ -238,7 +240,7 @@ func SetOptionalString(co *ConfigOption) error {
 	key := co.ConfigKey.(**string)
 	if IsExplicitlySet(co) {
 		*key = new(string)
-		**key = viper.GetString(co.Name)
+		**key = co.viper.GetString(co.Name)
 	} else {
 		*key = nil
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Instead of using the `viper` singleton instance, create a new instance and use that for `support/config` flags.

### Why

[Viper](https://github.com/spf13/viper) CLI flag parsing by default uses a singleton. This is convenient, but makes `support/config` less reusable.

### Known limitations

[TODO or N/A]
