### PR TITLE
horizon/ingest/processors: SAC storage entry by different key name

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -34,8 +34,8 @@ jobs:
     env:
       HORIZON_INTEGRATION_TESTS_ENABLED: true
       HORIZON_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL: ${{ matrix.protocol-version }}
-      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.10.1-1282.57cc8198c.focal~soroban
-      PROTOCOL_20_CORE_DOCKER_IMG: 2opremio/stellar-core:19.10.1-1282.57cc8198c.focal-soroban
+      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.10.1-1310.6649f5173.focal~soroban
+      PROTOCOL_20_CORE_DOCKER_IMG: sreuland/stellar-core:19.10.1-1310.6649f5173.focal-soroban
       PROTOCOL_19_CORE_DEBIAN_PKG_VERSION: 19.5.0-1108.ca2fb0605.focal
       PROTOCOL_19_CORE_DOCKER_IMG: stellar/stellar-core:19.5.0-1108.ca2fb0605.focal
       PGHOST: localhost

--- a/services/horizon/internal/ingest/processors/contract_data.go
+++ b/services/horizon/internal/ingest/processors/contract_data.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	// https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/public_types.rs#L22
-	nativeAssetSym     = xdr.ScSymbol("Native")
+	nativeAssetSym = xdr.ScSymbol("Native")
 	// these are storage DataKey enum
 	// https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/storage_types.rs#L23
 	balanceMetadataSym = xdr.ScSymbol("Balance")
@@ -40,7 +40,7 @@ var (
 //
 // References:
 // https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/contract.rs#L115
-// https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/asset_info.rs#L6//	
+// https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/asset_info.rs#L6//
 // https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/public_types.rs#L21
 //
 // The `ContractData` entry takes the following form:

--- a/services/horizon/internal/ingest/processors/contract_data.go
+++ b/services/horizon/internal/ingest/processors/contract_data.go
@@ -8,9 +8,12 @@ import (
 )
 
 var (
+	// https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/public_types.rs#L22
 	nativeAssetSym     = xdr.ScSymbol("Native")
+	// these are storage DataKey enum
+	// https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/storage_types.rs#L23
 	balanceMetadataSym = xdr.ScSymbol("Balance")
-	assetMetadataSym   = xdr.ScSymbol("Metadata")
+	assetMetadataSym   = xdr.ScSymbol("AssetInfo")
 	assetMetadataVec   = &xdr.ScVec{
 		xdr.ScVal{
 			Type: xdr.ScValTypeScvSymbol,
@@ -36,22 +39,21 @@ var (
 // it returns nil.
 //
 // References:
-//
-//	https://github.com/stellar/rs-soroban-env/blob/da325551829d31dcbfa71427d51c18e71a121c5f/soroban-env-host/src/native_contract/token/public_types.rs#L21
-//	https://github.com/stellar/rs-soroban-env/blob/da325551829d31dcbfa71427d51c18e71a121c5f/soroban-env-host/src/native_contract/token/metadata.rs#L8
-//	https://github.com/stellar/rs-soroban-env/blob/da325551829d31dcbfa71427d51c18e71a121c5f/soroban-env-host/src/native_contract/token/contract.rs#L108
+// https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/contract.rs#L115
+// https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/asset_info.rs#L6//	
+// https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/public_types.rs#L21
 //
 // The `ContractData` entry takes the following form:
 //
-//   - Key: a vector with one element, which is the symbol "Metadata"
+//   - Key: a vector with one element, which is the symbol "AssetInfo"
 //
-//     ScVal{ Vec: ScVec({ ScVal{ Sym: ScSymbol("metadata") }})}
+//     ScVal{ Vec: ScVec({ ScVal{ Sym: ScSymbol("AssetInfo") }})}
 //
 //   - Value: a map with two key-value pairs: code and issuer
 //
 //     ScVal{ Map: ScMap(
 //     { ScVal{ Sym: ScSymbol("asset_code") } -> ScVal{ Bytes: ScBytes(...) } },
-//     { ScVal{ Sym: ScSymbol("asset_code") } -> ScVal{ Bytes: ScBytes(...) } }
+//     { ScVal{ Sym: ScSymbol("issuer") } -> ScVal{ Bytes: ScBytes(...) } }
 //     )}
 func AssetFromContractData(ledgerEntry xdr.LedgerEntry, passphrase string) *xdr.Asset {
 	contractData, ok := ledgerEntry.Data.GetContractData()

--- a/services/horizon/internal/integration/sac_test.go
+++ b/services/horizon/internal/integration/sac_test.go
@@ -26,7 +26,7 @@ const sac_contract = "soroban_sac_test.wasm"
 // Refer to ./services/horizon/internal/integration/contracts/README.md on how to recompile
 // contract code if needed to new wasm.
 
-//TODO - need to figure out simulation tx data for contract invocations to re-enable tests
+// TODO - need to figure out simulation tx data for contract invocations to re-enable tests
 func TestContractMintToAccount(t *testing.T) {
 	t.Skip("sac contract tests disabled until footprint/fees are set correctly")
 

--- a/services/horizon/internal/integration/sac_test.go
+++ b/services/horizon/internal/integration/sac_test.go
@@ -25,6 +25,8 @@ const sac_contract = "soroban_sac_test.wasm"
 // Tests use precompiled wasm bin files that are added to the testdata directory.
 // Refer to ./services/horizon/internal/integration/contracts/README.md on how to recompile
 // contract code if needed to new wasm.
+
+//TODO - need to figure out simulation tx data for contract invocations to re-enable tests
 func TestContractMintToAccount(t *testing.T) {
 	t.Skip("sac contract tests disabled until footprint/fees are set correctly")
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

changed the key name to check for presence of SAC contract storage in ledger entries to `AssetInfo`, it used to be `Metadata`.

### Why

Getting an error in ingestion state verifier on asset stats, due to processor is missing the contract data changes which affect asset stats also.

### Known limitations

not able to test the change locally in the code at present, the sac integration tests would normally provide coverage, but have been temporarily disabled until simulation footprint and soroban tx data can be obtained for inclusion in invokehostfn operations, https://github.com/stellar/go/issues/4883 is tracking that. will need to look for alternative testing approach to verify this change in short term.



