### PR TITLE
4902 Add mutex for concurrent access in GetLatestLedgerSequence

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -97,6 +97,12 @@ type CaptiveStellarCore struct {
 	// cachedMeta keeps that ledger data of the last fetched ledger. Updated in GetLedger().
 	cachedMeta *xdr.LedgerCloseMeta
 
+	// ledgerSequenceLock mutex is used to protect the member variables used in the
+	// read-only GetLatestLedgerSequence method from concurrent write operations.
+	// This is required when GetLatestLedgerSequence is called from other goroutine
+	// such as writing Prometheus metric captive_stellar_core_latest_ledger.
+	ledgerSequenceLock sync.RWMutex
+
 	prepared           *Range  // non-nil if any range is prepared
 	closed             bool    // False until the core is closed
 	nextLedger         uint32  // next ledger expected, error w/ restart if not seen
@@ -307,9 +313,12 @@ func (c *CaptiveStellarCore) openOfflineReplaySubprocess(from, to uint32) error 
 	// The next ledger should be the first ledger of the checkpoint containing
 	// the requested ledger
 	ran := BoundedRange(from, to)
+	c.ledgerSequenceLock.Lock()
 	c.prepared = &ran
 	c.nextLedger = c.roundDownToFirstReplayAfterCheckpointStart(from)
 	c.lastLedger = &to
+	c.ledgerSequenceLock.Unlock()
+
 	c.previousLedgerHash = nil
 
 	return nil
@@ -330,10 +339,13 @@ func (c *CaptiveStellarCore) openOnlineReplaySubprocess(ctx context.Context, fro
 	// In the online mode we update nextLedger after streaming the first ledger.
 	// This is to support versions before and after/including v17.1.0 that
 	// introduced minimal persistent DB.
+	c.ledgerSequenceLock.Lock()
 	c.nextLedger = 0
 	ran := UnboundedRange(from)
 	c.prepared = &ran
 	c.lastLedger = nil
+	c.ledgerSequenceLock.Unlock()
+
 	c.previousLedgerHash = nil
 
 	return nil
@@ -647,7 +659,10 @@ func (c *CaptiveStellarCore) handleMetaPipeResult(sequence uint32, result metaRe
 		)
 	}
 
+	c.ledgerSequenceLock.Lock()
 	c.nextLedger = result.LedgerSequence() + 1
+	c.ledgerSequenceLock.Unlock()
+
 	currentLedgerHash := result.LedgerCloseMeta.LedgerHash().HexString()
 	c.previousLedgerHash = &currentLedgerHash
 
@@ -707,6 +722,9 @@ func (c *CaptiveStellarCore) checkMetaPipeResult(result metaResult, ok bool) err
 func (c *CaptiveStellarCore) GetLatestLedgerSequence(ctx context.Context) (uint32, error) {
 	c.stellarCoreLock.RLock()
 	defer c.stellarCoreLock.RUnlock()
+
+	c.ledgerSequenceLock.RLock()
+	defer c.ledgerSequenceLock.RUnlock()
 
 	if c.closed {
 		return 0, errors.New("stellar-core is no longer usable")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add a mutex in `CaptiveStellarCore` to ensure concurrent read access to `GetLatestLedgerSequence` method. The mutex ensures that no write operations occur concurrently with read operations. This is required because of read access of `c.nextLedger` when posting `captive_stellar_core_latest_ledger` metric while being concurrently written in `handleMetaPipeResult`.

This issue does not occur in master because we're not posting `captive_stellar_core_latest_ledger` metric in master. However, `GetLatestLedgerSequence` does get called from outside in `maybeReapLookupTables` in master but it's in the same thread as the ingestion so the mutex is not necessary.

### Why
Fixes data race reported in #4902 

### Known limitations
Locking can have an impact on the performance but we're not expecting any noticeable impact in this case.