### PR TITLE
Fix a bug in ScVal.Equals after the xdr rebuild

### DIFF
--- a/xdr/ledger_entry.go
+++ b/xdr/ledger_entry.go
@@ -174,3 +174,19 @@ func (entry *LedgerEntry) Normalize() *LedgerEntry {
 
 	return entry
 }
+
+func (data *LedgerEntryData) SetContractData(entry *ContractDataEntry) error {
+	*data = LedgerEntryData{
+		Type:         LedgerEntryTypeContractData,
+		ContractData: entry,
+	}
+	return nil
+}
+
+func (data *LedgerEntryData) SetContractCode(entry *ContractCodeEntry) error {
+	*data = LedgerEntryData{
+		Type:         LedgerEntryTypeContractCode,
+		ContractCode: entry,
+	}
+	return nil
+}

--- a/xdr/scval.go
+++ b/xdr/scval.go
@@ -44,34 +44,7 @@ func (s ScContractExecutable) Equals(o ScContractExecutable) bool {
 }
 
 func (s ScError) Equals(o ScError) bool {
-	if s.Type != o.Type {
-		return false
-	}
-
-	switch s.Type {
-	case ScErrorTypeSceContract:
-		return s.Code == o.Code
-	case ScErrorTypeSceWasmVm:
-		return s.Code == o.Code
-	case ScErrorTypeSceContext:
-		return s.Code == o.Code
-	case ScErrorTypeSceStorage:
-		return s.Code == o.Code
-	case ScErrorTypeSceObject:
-		return s.Code == o.Code
-	case ScErrorTypeSceCrypto:
-		return s.Code == o.Code
-	case ScErrorTypeSceEvents:
-		return s.Code == o.Code
-	case ScErrorTypeSceBudget:
-		return s.Code == o.Code
-	case ScErrorTypeSceValue:
-		return s.Code == o.Code
-	case ScErrorTypeSceAuth:
-		return s.Code == o.Code
-	default:
-		panic("unknown ScError type: " + s.Type.String())
-	}
+	return s.Type == o.Type && s.Code == o.Code
 }
 
 func (s ScVal) Equals(o ScVal) bool {

--- a/xdr/scval.go
+++ b/xdr/scval.go
@@ -97,6 +97,8 @@ func (s ScVal) Equals(o ScVal) bool {
 		return true
 	case ScValTypeScvLedgerKeyNonce:
 		return s.MustNonceKey().Equals(o.MustNonceKey())
+	case ScValTypeScvStorageType:
+		return s.MustStorageType() == o.MustStorageType()
 	default:
 		panic("unknown ScVal type: " + s.Type.String())
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add a missing case to `ScVal.Equals` after the xdr upgrade.

### Why

Preview 10 work

### Known limitations

[TODO or N/A]
