### PR TITLE
Pinning and updating golang and ubuntu images

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
   complete:
     if: always()
     needs: [check, build, test]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
       run: exit 1
@@ -17,8 +17,8 @@ jobs:
   check:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        go: [1.20.1]
+        os: [ubuntu-22.04]
+        go: ["1.20"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -37,8 +37,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        go: [1.19.6, 1.20.1]
+        os: [ubuntu-22.04]
+        go: ["1.19", "1.20"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -55,8 +55,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        go: [1.19.6, 1.20.1]
+        os: [ubuntu-22.04]
+        go: ["1.19", "1.20"]
         pg: [9.6.5, 10]
     runs-on: ${{ matrix.os }}
     services:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   golangci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # version v3.0.2

--- a/.github/workflows/horizon-master.yml
+++ b/.github/workflows/horizon-master.yml
@@ -8,7 +8,7 @@ jobs:
 
   push-state-diff-image:
     name: Push stellar/ledger-state-diff:{sha,latest} to DockerHub
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/horizon-release.yml
+++ b/.github/workflows/horizon-release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   publish-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Upload artifacts to GitHub release
     steps:
       - name: Run deprecation tests
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./.github/actions/setup-go
         with:
-          go-version: 1.20.1
+          go-version: "1.20"
 
       - name: Check dependencies
         run: ./gomod.sh

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -11,8 +11,8 @@ jobs:
     name: Integration tests
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-        go: [1.19.6, 1.20.1]
+        os: [ubuntu-20.04, ubuntu-22.04]
+        go: ["1.19", "1.20"]
         pg: [9.6.5]
         ingestion-backend: [db, captive-core, captive-core-remote-storage]
         protocol-version: [19]
@@ -106,7 +106,7 @@ jobs:
 
   verify-range:
     name: Test (and push) verify-range image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       STELLAR_CORE_VERSION: 19.11.0-1323.7fb6d5e88.focal
       CAPTIVE_CORE_STORAGE_PATH: /tmp

--- a/exp/services/recoverysigner/docker/Dockerfile
+++ b/exp/services/recoverysigner/docker/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.19 as build
+FROM golang:1.20-bullseye as build
 
 ADD . /src/recoverysigner
 WORKDIR /src/recoverysigner
 RUN go build -o /bin/recoverysigner ./exp/services/recoverysigner
 
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 COPY --from=build /bin/recoverysigner /app/

--- a/exp/services/webauth/docker/Dockerfile
+++ b/exp/services/webauth/docker/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.19 as build
+FROM golang:1.20-bullseye as build
 
 ADD . /src/webauth
 WORKDIR /src/webauth
 RUN go build -o /bin/webauth ./exp/services/webauth
 
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates
 COPY --from=build /bin/webauth /app/

--- a/services/friendbot/docker/Dockerfile
+++ b/services/friendbot/docker/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.19.1 as build
+FROM golang:1.20-bullseye as build
 
 ADD . /src/friendbot
 WORKDIR /src/friendbot
 RUN go build -o /bin/friendbot ./services/friendbot
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates
 COPY --from=build /bin/friendbot /app/

--- a/services/horizon/docker/Dockerfile.dev
+++ b/services/horizon/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS builder
+FROM golang:1.20-bullseye AS builder
 
 ARG VERSION="devel"
 WORKDIR /go/src/github.com/stellar/go
@@ -8,7 +8,7 @@ COPY . ./
 ENV GOFLAGS="-ldflags=-X=github.com/stellar/go/support/app.version=${VERSION}-(built-from-source)"
 RUN go install github.com/stellar/go/services/horizon
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ARG STELLAR_CORE_VERSION 
 ENV STELLAR_CORE_VERSION=${STELLAR_CORE_VERSION:-*}
 ENV STELLAR_CORE_BINARY_PATH /usr/bin/stellar-core

--- a/services/horizon/docker/verify-range/Dockerfile
+++ b/services/horizon/docker/verify-range/Dockerfile
@@ -1,6 +1,4 @@
-FROM ubuntu:20.04
-
-MAINTAINER Bartek Nowotarski <bartek@stellar.org>
+FROM ubuntu:22.04
 
 ARG STELLAR_CORE_VERSION 
 ENV STELLAR_CORE_VERSION=${STELLAR_CORE_VERSION:-*}

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -8,8 +8,8 @@ fi
 rm -rf "$PGDATA"/* 
 sudo chown -R postgres "$PGDATA"
 sudo chmod -R 775 "$PGDATA"
-sudo -u postgres --preserve-env=PGDATA /usr/lib/postgresql/12/bin/initdb
-sudo -u postgres --preserve-env=PGDATA /usr/lib/postgresql/12/bin/pg_ctl start
+sudo -u postgres --preserve-env=PGDATA /usr/lib/postgresql/14/bin/initdb
+sudo -u postgres --preserve-env=PGDATA /usr/lib/postgresql/14/bin/pg_ctl start
 sudo -u postgres createdb horizon
 sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
 

--- a/services/horizon/internal/scripts/check_release_hash/Dockerfile
+++ b/services/horizon/internal/scripts/check_release_hash/Dockerfile
@@ -1,5 +1,5 @@
 # Change to Go version used in CI or rebuild with --build-arg.
-ARG GO_IMAGE=golang:1.19.1
+ARG GO_IMAGE=golang:1.20-bullseye
 FROM $GO_IMAGE
 
 WORKDIR /go/src/github.com/stellar/go


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

- Upgrade ubuntu versions from 20.04 to 22.04
- Pin golang images to specify the debian OS version we want to use (`bullseye`)
- Sync golang versioning across repos to latest (`1.20-bullseye`)
- Run horizon integration tests on the full matrix of ubuntu versions + golang versions which we support

### Why

- See https://stellarfoundation.slack.com/archives/CGY4VS8SZ/p1686928996932389 for more context on pinning the debian OS version in images
- Ubuntu 22.04 is what we run in production and the latest we support. Note: we should probably include updates in this repo to the process that #ops follows when upgrading to support/deprecate new versions of ubuntu
- In general, our versioning policy is to support the last 2 releases for libraries, but binaries we want to build/release on the latest versions (ex. test in CI for go 1.19/1.20, but build/release on 1.20)

### Known limitations

