### PR TITLE
horizon/internal/check_release_hash: update apt repo to focal 

### DIFF
--- a/services/horizon/internal/scripts/check_release_hash/Dockerfile
+++ b/services/horizon/internal/scripts/check_release_hash/Dockerfile
@@ -8,8 +8,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 # ca-certificates are required to make tls connections
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl wget gnupg apt-utils git zip unzip apt-transport-https ca-certificates
 RUN wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key add -
-RUN echo "deb https://apt.stellar.org xenial stable" >/etc/apt/sources.list.d/SDF.list
-RUN echo "deb https://apt.stellar.org xenial testing" >/etc/apt/sources.list.d/SDF-testing.list
+RUN echo "deb https://apt.stellar.org focal stable" >/etc/apt/sources.list.d/SDF.list
+RUN echo "deb https://apt.stellar.org focal testing" >/etc/apt/sources.list.d/SDF-testing.list
 
 RUN git clone https://github.com/stellar/go.git /go/src/github.com/stellar/go
 # Fetch dependencies and prebuild binaries. Not necessary but will make check faster.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

changed the apt repo reference in check hash dockerfile to use `focal`

### Why

dep pkg builder pushes to focal now - https://github.com/stellar/pipelines/pull/537/files

### Known limitations


