### PR TITLE
services/horizon: Consolidate local captive core config steps

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -6,6 +6,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- The command line flag --remote-captive-core-url has been removed as remote captive core functionality is now deprecated  ([4940](https://github.com/stellar/go/pull/4940)).
 
 ## 2.26.0
 ### Changes

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -650,18 +650,23 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 					viper.Set(StellarCoreBinaryPathName, binaryPath)
 					config.CaptiveCoreBinaryPath = binaryPath
 				}
+			} else {
+				config.CaptiveCoreBinaryPath = binaryPath
 			}
+		}
+
+		// Create config for local captive core
+		if config.EnableCaptiveCoreIngestion && config.RemoteCaptiveCoreURL == "" {
 
 			// NOTE: If both of these are set (regardless of user- or PATH-supplied
 			//       defaults for the binary path), the Remote Captive Core URL
 			//       takes precedence.
-			if binaryPath == "" && config.RemoteCaptiveCoreURL == "" {
+			if config.CaptiveCoreBinaryPath == "" {
 				return fmt.Errorf("Invalid config: captive core requires that either --%s or --remote-captive-core-url is set. %s",
 					StellarCoreBinaryPathName, captiveCoreMigrationHint)
 			}
-
-			config.CaptiveCoreTomlParams.CoreBinaryPath = binaryPath
-			if config.RemoteCaptiveCoreURL == "" && (binaryPath == "" || config.CaptiveCoreConfigPath == "") {
+			config.CaptiveCoreTomlParams.CoreBinaryPath = config.CaptiveCoreBinaryPath
+			if config.CaptiveCoreConfigPath == "" {
 				if options.RequireCaptiveCoreConfig {
 					var err error
 					errorMessage := fmt.Errorf(
@@ -707,7 +712,7 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 						return fmt.Errorf("Invalid captive core toml file %v", err)
 					}
 				}
-			} else if config.RemoteCaptiveCoreURL == "" {
+			} else {
 				var err error
 				config.CaptiveCoreTomlParams.HistoryArchiveURLs = config.HistoryArchiveURLs
 				config.CaptiveCoreTomlParams.NetworkPassphrase = config.NetworkPassphrase
@@ -719,7 +724,7 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 
 			// If we don't supply an explicit core URL and we are running a local
 			// captive core process with the http port enabled, point to it.
-			if config.StellarCoreURL == "" && config.RemoteCaptiveCoreURL == "" && config.CaptiveCoreToml.HTTPPort != 0 {
+			if config.StellarCoreURL == "" && config.CaptiveCoreToml.HTTPPort != 0 {
 				config.StellarCoreURL = fmt.Sprintf("http://localhost:%d", config.CaptiveCoreToml.HTTPPort)
 				viper.Set(StellarCoreURLFlagName, config.StellarCoreURL)
 			}

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -126,16 +126,8 @@ func Flags() (*Config, support.ConfigOptions) {
 			OptType:     types.String,
 			FlagDefault: "",
 			Required:    false,
-			Usage:       "path to stellar core binary (--remote-captive-core-url has higher precedence). If captive core is enabled, look for the stellar-core binary in $PATH by default.",
+			Usage:       "path to stellar core binary, look for the stellar-core binary in $PATH by default.",
 			ConfigKey:   &config.CaptiveCoreBinaryPath,
-		},
-		&support.ConfigOption{
-			Name:        "remote-captive-core-url",
-			OptType:     types.String,
-			FlagDefault: "",
-			Required:    false,
-			Usage:       "url to access the remote captive core server",
-			ConfigKey:   &config.RemoteCaptiveCoreURL,
 		},
 		&support.ConfigOption{
 			Name:        captiveCoreConfigAppendPathName,
@@ -649,29 +641,21 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 					binaryPath = result
 					viper.Set(StellarCoreBinaryPathName, binaryPath)
 					config.CaptiveCoreBinaryPath = binaryPath
+				} else {
+					return fmt.Errorf("invalid config: captive core requires --%s. %s",
+						StellarCoreBinaryPathName, captiveCoreMigrationHint)
 				}
 			} else {
 				config.CaptiveCoreBinaryPath = binaryPath
 			}
-		}
 
-		// Create config for local captive core
-		if config.EnableCaptiveCoreIngestion && config.RemoteCaptiveCoreURL == "" {
-
-			// NOTE: If both of these are set (regardless of user- or PATH-supplied
-			//       defaults for the binary path), the Remote Captive Core URL
-			//       takes precedence.
-			if config.CaptiveCoreBinaryPath == "" {
-				return fmt.Errorf("Invalid config: captive core requires that either --%s or --remote-captive-core-url is set. %s",
-					StellarCoreBinaryPathName, captiveCoreMigrationHint)
-			}
 			config.CaptiveCoreTomlParams.CoreBinaryPath = config.CaptiveCoreBinaryPath
 			if config.CaptiveCoreConfigPath == "" {
 				if options.RequireCaptiveCoreConfig {
 					var err error
 					errorMessage := fmt.Errorf(
-						"Invalid config: captive core requires that both --%s and --%s are set. %s",
-						StellarCoreBinaryPathName, CaptiveCoreConfigPathName, captiveCoreMigrationHint,
+						"invalid config: captive core requires that --%s is set. %s",
+						CaptiveCoreConfigPathName, captiveCoreMigrationHint,
 					)
 
 					var configFileName string


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
The local captive core config steps have been consolidated into a single 'if' condition. Removed `--remote-captive-core-url` from flags.

### Why
This is a minor code refactoring aimed at simplifying code before adding the new NETWORK flag #4913.

### Known limitations

N/A
