### PR TITLE
fix sac tests for preview 10 data model

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -34,9 +34,9 @@ jobs:
     env:
       HORIZON_INTEGRATION_TESTS_ENABLED: true
       HORIZON_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL: ${{ matrix.protocol-version }}
-      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.11.1-1371.6c004ae12.focal~soroban
-      PROTOCOL_20_CORE_DOCKER_IMG: sreuland/stellar-core:19.11.1-1371.6c004ae12.focal-soroban
-      PROTOCOL_20_SOROBAN_RPC_DOCKER_IMG: sreuland/stellar-soroban-rpc:b18a52c085206
+      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 19.11.1-1373.875f47e24.focal~soroban
+      PROTOCOL_20_CORE_DOCKER_IMG: sreuland/stellar-core:19.11.1-1373.875f47e24.focal-soroban
+      PROTOCOL_20_SOROBAN_RPC_DOCKER_IMG: sreuland/stellar-soroban-rpc:c584da283e24
       PROTOCOL_19_CORE_DEBIAN_PKG_VERSION: 19.11.0-1323.7fb6d5e88.focal
       PROTOCOL_19_CORE_DOCKER_IMG: stellar/stellar-core:19.11.0-1323.7fb6d5e88.focal
       PGHOST: localhost

--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -361,7 +361,6 @@ type InvokeHostFunction struct {
 	Base
 	Function            string                       `json:"function"`
 	Parameters          []HostFunctionParameter      `json:"parameters"`
-	Type                string                       `json:"type"`
 	Address             string                       `json:"address"`
 	Salt                string                       `json:"salt"`
 	AssetBalanceChanges []AssetContractBalanceChange `json:"asset_balance_changes"`

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -65,7 +65,7 @@ func TestInvokeHostFnDetailsInPaymentOperations(t *testing.T) {
 		1,
 		xdr.OperationTypeInvokeHostFunction,
 		[]byte(`{
-			"type": "invoke_contract",
+			"function": "HostFunctionTypeHostFunctionTypeInvokeContract",
 			"parameters": [
 				{
 					"value": "AAAADwAAAAdmbl9uYW1lAA==",
@@ -129,7 +129,7 @@ func TestInvokeHostFnDetailsInPaymentOperations(t *testing.T) {
 	tt.Assert.Len(records, 1)
 
 	op := records[0].(operations.InvokeHostFunction)
-	tt.Assert.Equal(op.Type, "invoke_contract")
+	tt.Assert.Equal(op.Function, "HostFunctionTypeHostFunctionTypeInvokeContract")
 	tt.Assert.Equal(len(op.Parameters), 2)
 	tt.Assert.Equal(op.Parameters[0].Value, "AAAADwAAAAdmbl9uYW1lAA==")
 	tt.Assert.Equal(op.Parameters[0].Type, "Sym")

--- a/services/horizon/internal/ingest/processors/contract_data.go
+++ b/services/horizon/internal/ingest/processors/contract_data.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
+const (
+	scDecimalPrecision = 7
+)
+
 var (
 	// https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/public_types.rs#L22
 	nativeAssetSym = xdr.ScSymbol("Native")
@@ -23,7 +27,7 @@ var (
 	alphaNum12Sym      = xdr.ScSymbol("AlphaNum12")
 	decimalSym         = xdr.ScSymbol("decimal")
 	assetInfoSym       = xdr.ScSymbol("AssetInfo")
-	decimalVal         = xdr.Uint32(7)
+	decimalVal         = xdr.Uint32(scDecimalPrecision)
 	assetInfoVec       = &xdr.ScVec{
 		xdr.ScVal{
 			Type: xdr.ScValTypeScvSymbol,
@@ -91,13 +95,13 @@ func AssetFromContractData(ledgerEntry xdr.LedgerEntry, passphrase string) *xdr.
 	for _, mapEntry := range *contractInstanceData.Storage {
 		if mapEntry.Key.Equals(assetInfoKey) {
 			// clone the map entry to avoid reference to loop iterator
-			mapValXdr, err := mapEntry.Val.MarshalBinary()
-			if err != nil {
+			mapValXdr, cloneErr := mapEntry.Val.MarshalBinary()
+			if cloneErr != nil {
 				return nil
 			}
 			assetInfo = &xdr.ScVal{}
-			err = assetInfo.UnmarshalBinary(mapValXdr)
-			if err != nil {
+			cloneErr = assetInfo.UnmarshalBinary(mapValXdr)
+			if cloneErr != nil {
 				return nil
 			}
 			break

--- a/services/horizon/internal/ingest/processors/contract_data.go
+++ b/services/horizon/internal/ingest/processors/contract_data.go
@@ -13,6 +13,15 @@ var (
 	// these are storage DataKey enum
 	// https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/storage_types.rs#L23
 	balanceMetadataSym = xdr.ScSymbol("Balance")
+	metadataSym        = xdr.ScSymbol("METADATA")
+	metadataNameSym    = xdr.ScSymbol("name")
+	metadataSymbolSym  = xdr.ScSymbol("symbol")
+	adminSym           = xdr.ScSymbol("Admin")
+	issuerSym          = xdr.ScSymbol("issuer")
+	assetCodeSym       = xdr.ScSymbol("asset_code")
+	alphaNum4Sym       = xdr.ScSymbol("AlphaNum4")
+	alphaNum12Sym      = xdr.ScSymbol("AlphaNum12")
+	decimalSym         = xdr.ScSymbol("decimal")
 	assetInfoSym       = xdr.ScSymbol("AssetInfo")
 	assetInfoVec       = &xdr.ScVec{
 		xdr.ScVal{
@@ -43,7 +52,9 @@ var (
 // https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/asset_info.rs#L6
 // https://github.com/stellar/rs-soroban-env/blob/v0.0.16/soroban-env-host/src/native_contract/token/contract.rs#L115
 //
-// The `ContractData` entry takes the following form:
+// The asset info in `ContractData` entry takes the following form:
+//
+//   - Instance storage - it's part of contract instance data storage
 //
 //   - Key: a vector with one element, which is the symbol "AssetInfo"
 //
@@ -52,7 +63,7 @@ var (
 //   - Value: a map with two key-value pairs: code and issuer
 //
 //     ScVal{ Map: ScMap(
-//     { ScVal{ Sym: ScSymbol("asset_code") } -> ScVal{ Bytes: ScBytes(...) } },
+//     { ScVal{ Sym: ScSymbol("asset_code") } -> ScVal{ Str: ScString(...) } },
 //     { ScVal{ Sym: ScSymbol("issuer") } -> ScVal{ Bytes: ScBytes(...) } }
 //     )}
 func AssetFromContractData(ledgerEntry xdr.LedgerEntry, passphrase string) *xdr.Asset {
@@ -60,18 +71,32 @@ func AssetFromContractData(ledgerEntry xdr.LedgerEntry, passphrase string) *xdr.
 	if !ok {
 		return nil
 	}
+	if contractData.Key.Type != xdr.ScValTypeScvLedgerKeyContractInstance ||
+		contractData.Body.BodyType != xdr.ContractEntryBodyTypeDataEntry ||
+		contractData.Body.Data.Val.Instance.Storage == nil {
+		return nil
+	}
 
+	// fmt.Printf("ContractData Asset Info:\n\n%# +v\n\n", pretty.Formatter(contractData))
 	// we don't support asset stats for lumens
 	nativeAssetContractID, err := xdr.MustNewNativeAsset().ContractID(passphrase)
 	if err != nil || (contractData.Contract.ContractId != nil && (*contractData.Contract.ContractId) == nativeAssetContractID) {
 		return nil
 	}
 
-	if !contractData.Key.Equals(assetInfoKey) {
+	var assetInfo *xdr.ScVal
+	for _, mapEntry := range *contractData.Body.Data.Val.Instance.Storage {
+		if mapEntry.Key.Equals(assetInfoKey) {
+			assetInfo = &mapEntry.Val
+			break
+		}
+	}
+
+	if assetInfo == nil {
 		return nil
 	}
 
-	vecPtr, ok := contractData.Body.Data.Val.GetVec()
+	vecPtr, ok := assetInfo.GetVec()
 	if !ok || vecPtr == nil || len(*vecPtr) != 2 {
 		return nil
 	}
@@ -96,23 +121,25 @@ func AssetFromContractData(ledgerEntry xdr.LedgerEntry, passphrase string) *xdr.
 	assetMap := *assetMapPtr
 
 	assetCodeEntry, assetIssuerEntry := assetMap[0], assetMap[1]
-	if sym, ok = assetCodeEntry.Key.GetSym(); !ok || sym != "asset_code" {
+	if sym, ok = assetCodeEntry.Key.GetSym(); !ok || sym != assetCodeSym {
 		return nil
 	}
-	bin, ok := assetCodeEntry.Val.GetBytes()
-	if !ok || bin == nil {
+	assetCodeSc, ok := assetCodeEntry.Val.GetStr()
+	if !ok {
 		return nil
 	}
-	assetCode = string(bin)
+	if assetCode = string(assetCodeSc); assetCode == "" {
+		return nil
+	}
 
-	if sym, ok = assetIssuerEntry.Key.GetSym(); !ok || sym != "issuer" {
+	if sym, ok = assetIssuerEntry.Key.GetSym(); !ok || sym != issuerSym {
 		return nil
 	}
-	bin, ok = assetIssuerEntry.Val.GetBytes()
-	if !ok || bin == nil {
+	assetIssuerSc, ok := assetIssuerEntry.Val.GetBytes()
+	if !ok {
 		return nil
 	}
-	assetIssuer, err = strkey.Encode(strkey.VersionByteAccountID, bin)
+	assetIssuer, err = strkey.Encode(strkey.VersionByteAccountID, assetIssuerSc)
 	if err != nil {
 		return nil
 	}
@@ -212,69 +239,161 @@ func ContractBalanceFromContractData(ledgerEntry xdr.LedgerEntry, passphrase str
 	return holder, amt, true
 }
 
-func metadataObjFromAsset(isNative bool, code, issuer string) (*xdr.ScVec, error) {
+func metadataObjFromAsset(isNative bool, code, issuer string) (*xdr.ScMap, error) {
+	assetInfoVecKey := &xdr.ScVec{
+		xdr.ScVal{
+			Type: xdr.ScValTypeScvSymbol,
+			Sym:  &assetInfoSym,
+		},
+	}
+
 	if isNative {
-		return &xdr.ScVec{
+		nativeVec := &xdr.ScVec{
 			xdr.ScVal{
 				Type: xdr.ScValTypeScvSymbol,
 				Sym:  &nativeAssetSym,
 			},
+		}
+		return &xdr.ScMap{
+			xdr.ScMapEntry{
+				Key: xdr.ScVal{
+					Type: xdr.ScValTypeScvVec,
+					Vec:  &assetInfoVecKey,
+				},
+				Val: xdr.ScVal{
+					Type: xdr.ScValTypeScvVec,
+					Vec:  &nativeVec,
+				},
+			},
 		}, nil
 	}
 
-	var assetCodeLength int
-	var symbol xdr.ScSymbol
-	if len(code) <= 4 {
-		symbol = "AlphaNum4"
-		assetCodeLength = 4
-	} else {
-		symbol = "AlphaNum12"
-		assetCodeLength = 12
+	decimalVal := xdr.Uint32(7)
+	nameVal := xdr.ScString(code + ":" + issuer)
+
+	symbolVal := xdr.ScString(code)
+	metaDataMap := &xdr.ScMap{
+		xdr.ScMapEntry{
+			Key: xdr.ScVal{
+				Type: xdr.ScValTypeScvSymbol,
+				Sym:  &decimalSym,
+			},
+			Val: xdr.ScVal{
+				Type: xdr.ScValTypeScvU32,
+				U32:  &decimalVal,
+			},
+		},
+		xdr.ScMapEntry{
+			Key: xdr.ScVal{
+				Type: xdr.ScValTypeScvSymbol,
+				Sym:  &metadataNameSym,
+			},
+			Val: xdr.ScVal{
+				Type: xdr.ScValTypeScvString,
+				Str:  &nameVal,
+			},
+		},
+		xdr.ScMapEntry{
+			Key: xdr.ScVal{
+				Type: xdr.ScValTypeScvSymbol,
+				Sym:  &metadataSymbolSym,
+			},
+			Val: xdr.ScVal{
+				Type: xdr.ScValTypeScvString,
+				Str:  &symbolVal,
+			},
+		},
 	}
 
-	assetCodeSymbol := xdr.ScSymbol("asset_code")
-	assetCodeBytes := make([]byte, assetCodeLength)
-	copy(assetCodeBytes, code)
+	adminVec := &xdr.ScVec{
+		xdr.ScVal{
+			Type: xdr.ScValTypeScvSymbol,
+			Sym:  &adminSym,
+		},
+	}
 
-	issuerSymbol := xdr.ScSymbol("issuer")
+	adminAccountId := xdr.MustAddress(issuer)
+	assetCodeVal := xdr.ScString(code)
 	issuerBytes, err := strkey.Decode(strkey.VersionByteAccountID, issuer)
 	if err != nil {
 		return nil, err
 	}
 
-	mapObj := &xdr.ScMap{
+	assetIssuerBytes := xdr.ScBytes(issuerBytes)
+	assetInfoMap := &xdr.ScMap{
 		xdr.ScMapEntry{
 			Key: xdr.ScVal{
 				Type: xdr.ScValTypeScvSymbol,
-				Sym:  &assetCodeSymbol,
+				Sym:  &assetCodeSym,
 			},
 			Val: xdr.ScVal{
-				Type:  xdr.ScValTypeScvBytes,
-				Bytes: (*xdr.ScBytes)(&assetCodeBytes),
+				Type: xdr.ScValTypeScvString,
+				Str:  &assetCodeVal,
 			},
 		},
 		xdr.ScMapEntry{
 			Key: xdr.ScVal{
 				Type: xdr.ScValTypeScvSymbol,
-				Sym:  &issuerSymbol,
+				Sym:  &issuerSym,
 			},
 			Val: xdr.ScVal{
 				Type:  xdr.ScValTypeScvBytes,
-				Bytes: (*xdr.ScBytes)(&issuerBytes),
+				Bytes: &assetIssuerBytes,
 			},
 		},
 	}
 
-	return &xdr.ScVec{
+	alphaNumSym := alphaNum4Sym
+	if len(code) > 4 {
+		alphaNumSym = alphaNum12Sym
+	}
+	assetInfoVecVal := &xdr.ScVec{
 		xdr.ScVal{
 			Type: xdr.ScValTypeScvSymbol,
-			Sym:  &symbol,
+			Sym:  &alphaNumSym,
 		},
 		xdr.ScVal{
 			Type: xdr.ScValTypeScvMap,
-			Map:  &mapObj,
+			Map:  &assetInfoMap,
 		},
-	}, nil
+	}
+
+	storageMap := &xdr.ScMap{
+		xdr.ScMapEntry{
+			Key: xdr.ScVal{
+				Type: xdr.ScValTypeScvSymbol,
+				Sym:  &metadataSym,
+			},
+			Val: xdr.ScVal{
+				Type: xdr.ScValTypeScvMap,
+				Map:  &metaDataMap,
+			},
+		},
+		xdr.ScMapEntry{
+			Key: xdr.ScVal{
+				Type: xdr.ScValTypeScvVec,
+				Vec:  &adminVec,
+			},
+			Val: xdr.ScVal{
+				Type: xdr.ScValTypeScvAddress,
+				Address: &xdr.ScAddress{
+					AccountId: &adminAccountId,
+				},
+			},
+		},
+		xdr.ScMapEntry{
+			Key: xdr.ScVal{
+				Type: xdr.ScValTypeScvVec,
+				Vec:  &assetInfoVecKey,
+			},
+			Val: xdr.ScVal{
+				Type: xdr.ScValTypeScvVec,
+				Vec:  &assetInfoVecVal,
+			},
+		},
+	}
+
+	return storageMap, nil
 }
 
 // AssetToContractData is the inverse of AssetFromContractData. It creates a
@@ -283,11 +402,12 @@ func metadataObjFromAsset(isNative bool, code, issuer string) (*xdr.ScVec, error
 //
 // Warning: Only for use in tests. This does not set a realistic expirationLedgerSeq
 func AssetToContractData(isNative bool, code, issuer string, contractID [32]byte) (xdr.LedgerEntryData, error) {
-	vec, err := metadataObjFromAsset(isNative, code, issuer)
+	storageMap, err := metadataObjFromAsset(isNative, code, issuer)
 	if err != nil {
 		return xdr.LedgerEntryData{}, err
 	}
 	var ContractIDHash xdr.Hash = contractID
+
 	return xdr.LedgerEntryData{
 		Type: xdr.LedgerEntryTypeContractData,
 		ContractData: &xdr.ContractDataEntry{
@@ -296,14 +416,18 @@ func AssetToContractData(isNative bool, code, issuer string, contractID [32]byte
 				AccountId:  nil,
 				ContractId: &ContractIDHash,
 			},
-			Key:        assetInfoKey,
+			Key: xdr.ScVal{
+				Type: xdr.ScValTypeScvLedgerKeyContractInstance,
+			},
 			Durability: xdr.ContractDataDurabilityPersistent,
 			Body: xdr.ContractDataEntryBody{
 				BodyType: xdr.ContractEntryBodyTypeDataEntry,
 				Data: &xdr.ContractDataEntryData{
 					Val: xdr.ScVal{
-						Type: xdr.ScValTypeScvVec,
-						Vec:  &vec,
+						Type: xdr.ScValTypeScvContractInstance,
+						Instance: &xdr.ScContractInstance{
+							Storage: storageMap,
+						},
 					},
 					// No flags written by the contract:
 					// https://github.com/stellar/rs-soroban-env/blob/c43bbd47959dde2e39eeeb5b7207868a44e96c7d/soroban-env-host/src/native_contract/token/asset_info.rs#L12

--- a/services/horizon/internal/ingest/processors/operations_processor.go
+++ b/services/horizon/internal/ingest/processors/operations_processor.go
@@ -640,7 +640,6 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 		switch op.HostFunction.Type {
 		case xdr.HostFunctionTypeHostFunctionTypeInvokeContract:
 			args := op.HostFunction.MustInvokeContract()
-			details["type"] = "invoke_contract"
 			params := make([]map[string]string, 0, len(args))
 
 			for _, param := range args {
@@ -666,7 +665,6 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 
 		case xdr.HostFunctionTypeHostFunctionTypeCreateContract:
 			args := op.HostFunction.MustCreateContract()
-			details["type"] = "create_contract"
 			switch args.ContractIdPreimage.Type {
 			case xdr.ContractIdPreimageTypeContractIdPreimageFromAddress:
 				fromAddress := args.ContractIdPreimage.MustFromAddress()
@@ -684,7 +682,6 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 				panic(fmt.Errorf("unknown contract id type: %s", args.ContractIdPreimage.Type))
 			}
 		case xdr.HostFunctionTypeHostFunctionTypeUploadContractWasm:
-			details["type"] = "upload_wasm"
 		default:
 			panic(fmt.Errorf("unknown host function type: %s", op.HostFunction.Type))
 		}

--- a/services/horizon/internal/ingest/processors/operations_processor_test.go
+++ b/services/horizon/internal/ingest/processors/operations_processor_test.go
@@ -158,35 +158,6 @@ func (s *OperationsProcessorTestSuiteLedger) TestOperationTypeInvokeHostFunction
 								},
 							},
 						},
-						Auth: []xdr.SorobanAuthorizationEntry{
-							{
-								Credentials: xdr.SorobanCredentials{
-									Type: xdr.SorobanCredentialsTypeSorobanCredentialsAddress,
-									Address: &xdr.SorobanAddressCredentials{
-										Address: xdr.ScAddress{
-											Type:      xdr.ScAddressTypeScAddressTypeAccount,
-											AccountId: &accountId,
-										},
-										Nonce:         0,
-										SignatureArgs: nil,
-									},
-								},
-								RootInvocation: xdr.SorobanAuthorizedInvocation{
-									Function: xdr.SorobanAuthorizedFunction{
-										Type: xdr.SorobanAuthorizedFunctionTypeSorobanAuthorizedFunctionTypeContractFn,
-										ContractFn: &xdr.SorobanAuthorizedContractFunction{
-											ContractAddress: xdr.ScAddress{
-												Type:      xdr.ScAddressTypeScAddressTypeAccount,
-												AccountId: &accountId,
-											},
-											FunctionName: "foo",
-											Args:         nil,
-										},
-									},
-									SubInvocations: nil,
-								},
-							},
-						},
 					},
 				},
 			},
@@ -197,7 +168,7 @@ func (s *OperationsProcessorTestSuiteLedger) TestOperationTypeInvokeHostFunction
 
 		var hostFnArgs []xdr.ScVal = *(wrapper.operation.Body.InvokeHostFunctionOp.HostFunction.InvokeContract)
 		detailsFunctionParams := details["parameters"].([]map[string]string)
-		s.Assert().Equal(details["type"], "invoke_contract")
+		s.Assert().Equal(details["function"], "HostFunctionTypeHostFunctionTypeInvokeContract")
 		s.assertInvokeHostFunctionParameter(detailsFunctionParams, 0, "Sym", hostFnArgs[0])
 		s.assertInvokeHostFunctionParameter(detailsFunctionParams, 1, "I32", hostFnArgs[1])
 		s.assertInvokeHostFunctionParameter(detailsFunctionParams, 2, "U32", hostFnArgs[2])
@@ -233,35 +204,6 @@ func (s *OperationsProcessorTestSuiteLedger) TestOperationTypeInvokeHostFunction
 								},
 							},
 						},
-						Auth: []xdr.SorobanAuthorizationEntry{
-							{
-								Credentials: xdr.SorobanCredentials{
-									Type: xdr.SorobanCredentialsTypeSorobanCredentialsAddress,
-									Address: &xdr.SorobanAddressCredentials{
-										Address: xdr.ScAddress{
-											Type:      xdr.ScAddressTypeScAddressTypeAccount,
-											AccountId: &accountId,
-										},
-										Nonce:         0,
-										SignatureArgs: nil,
-									},
-								},
-								RootInvocation: xdr.SorobanAuthorizedInvocation{
-									Function: xdr.SorobanAuthorizedFunction{
-										Type: xdr.SorobanAuthorizedFunctionTypeSorobanAuthorizedFunctionTypeContractFn,
-										ContractFn: &xdr.SorobanAuthorizedContractFunction{
-											ContractAddress: xdr.ScAddress{
-												Type:      xdr.ScAddressTypeScAddressTypeAccount,
-												AccountId: &accountId,
-											},
-											FunctionName: "foo",
-											Args:         nil,
-										},
-									},
-									SubInvocations: nil,
-								},
-							},
-						},
 					},
 				},
 			},
@@ -270,7 +212,7 @@ func (s *OperationsProcessorTestSuiteLedger) TestOperationTypeInvokeHostFunction
 		details, err := wrapper.Details()
 		s.Assert().NoError(err)
 
-		s.Assert().Equal(details["type"], "create_contract")
+		s.Assert().Equal(details["function"], "HostFunctionTypeHostFunctionTypeCreateContract")
 		s.Assert().Equal(details["from"], "asset")
 		s.Assert().Equal(details["asset"], "ARS:GCXI6Q73J7F6EUSBZTPW4G4OUGVDHABPYF2U4KO7MVEX52OH5VMVUCRF")
 	})
@@ -299,35 +241,6 @@ func (s *OperationsProcessorTestSuiteLedger) TestOperationTypeInvokeHostFunction
 								Executable: xdr.ContractExecutable{},
 							},
 						},
-						Auth: []xdr.SorobanAuthorizationEntry{
-							{
-								Credentials: xdr.SorobanCredentials{
-									Type: xdr.SorobanCredentialsTypeSorobanCredentialsAddress,
-									Address: &xdr.SorobanAddressCredentials{
-										Address: xdr.ScAddress{
-											Type:      xdr.ScAddressTypeScAddressTypeAccount,
-											AccountId: &accountId,
-										},
-										Nonce:         0,
-										SignatureArgs: nil,
-									},
-								},
-								RootInvocation: xdr.SorobanAuthorizedInvocation{
-									Function: xdr.SorobanAuthorizedFunction{
-										Type: xdr.SorobanAuthorizedFunctionTypeSorobanAuthorizedFunctionTypeContractFn,
-										ContractFn: &xdr.SorobanAuthorizedContractFunction{
-											ContractAddress: xdr.ScAddress{
-												Type:      xdr.ScAddressTypeScAddressTypeAccount,
-												AccountId: &accountId,
-											},
-											FunctionName: "foo",
-											Args:         nil,
-										},
-									},
-									SubInvocations: nil,
-								},
-							},
-						},
 					},
 				},
 			},
@@ -336,7 +249,7 @@ func (s *OperationsProcessorTestSuiteLedger) TestOperationTypeInvokeHostFunction
 		details, err := wrapper.Details()
 		s.Assert().NoError(err)
 
-		s.Assert().Equal(details["type"], "create_contract")
+		s.Assert().Equal(details["function"], "HostFunctionTypeHostFunctionTypeCreateContract")
 		s.Assert().Equal(details["from"], "address")
 		s.Assert().Equal(details["address"], "GB7BDSZU2Y27LYNLALKKALB52WS2IZWYBDGY6EQBLEED3TJOCVMZRH7H")
 		s.Assert().Equal(details["salt"], xdr.Uint256{1}.String())
@@ -354,35 +267,6 @@ func (s *OperationsProcessorTestSuiteLedger) TestOperationTypeInvokeHostFunction
 							Type: xdr.HostFunctionTypeHostFunctionTypeUploadContractWasm,
 							Wasm: &wasm,
 						},
-						Auth: []xdr.SorobanAuthorizationEntry{
-							{
-								Credentials: xdr.SorobanCredentials{
-									Type: xdr.SorobanCredentialsTypeSorobanCredentialsAddress,
-									Address: &xdr.SorobanAddressCredentials{
-										Address: xdr.ScAddress{
-											Type:      xdr.ScAddressTypeScAddressTypeAccount,
-											AccountId: &accountId,
-										},
-										Nonce:         0,
-										SignatureArgs: nil,
-									},
-								},
-								RootInvocation: xdr.SorobanAuthorizedInvocation{
-									Function: xdr.SorobanAuthorizedFunction{
-										Type: xdr.SorobanAuthorizedFunctionTypeSorobanAuthorizedFunctionTypeContractFn,
-										ContractFn: &xdr.SorobanAuthorizedContractFunction{
-											ContractAddress: xdr.ScAddress{
-												Type:      xdr.ScAddressTypeScAddressTypeAccount,
-												AccountId: &accountId,
-											},
-											FunctionName: "foo",
-											Args:         nil,
-										},
-									},
-									SubInvocations: nil,
-								},
-							},
-						},
 					},
 				},
 			},
@@ -390,8 +274,7 @@ func (s *OperationsProcessorTestSuiteLedger) TestOperationTypeInvokeHostFunction
 
 		details, err := wrapper.Details()
 		s.Assert().NoError(err)
-
-		s.Assert().Equal(details["type"], "upload_wasm")
+		s.Assert().Equal(details["function"], "HostFunctionTypeHostFunctionTypeUploadContractWasm")
 	})
 
 	s.T().Run("InvokeContractWithSACEventsInDetails", func(t *testing.T) {
@@ -433,35 +316,6 @@ func (s *OperationsProcessorTestSuiteLedger) TestOperationTypeInvokeHostFunction
 						HostFunction: xdr.HostFunction{
 							Type:           xdr.HostFunctionTypeHostFunctionTypeInvokeContract,
 							InvokeContract: &xdr.ScVec{},
-						},
-						Auth: []xdr.SorobanAuthorizationEntry{
-							{
-								Credentials: xdr.SorobanCredentials{
-									Type: xdr.SorobanCredentialsTypeSorobanCredentialsAddress,
-									Address: &xdr.SorobanAddressCredentials{
-										Address: xdr.ScAddress{
-											Type:      xdr.ScAddressTypeScAddressTypeAccount,
-											AccountId: &accountId,
-										},
-										Nonce:         0,
-										SignatureArgs: nil,
-									},
-								},
-								RootInvocation: xdr.SorobanAuthorizedInvocation{
-									Function: xdr.SorobanAuthorizedFunction{
-										Type: xdr.SorobanAuthorizedFunctionTypeSorobanAuthorizedFunctionTypeContractFn,
-										ContractFn: &xdr.SorobanAuthorizedContractFunction{
-											ContractAddress: xdr.ScAddress{
-												Type:      xdr.ScAddressTypeScAddressTypeAccount,
-												AccountId: &accountId,
-											},
-											FunctionName: "foo",
-											Args:         nil,
-										},
-									},
-									SubInvocations: nil,
-								},
-							},
 						},
 					},
 				},

--- a/services/horizon/internal/ingest/verify_test.go
+++ b/services/horizon/internal/ingest/verify_test.go
@@ -159,20 +159,6 @@ func genClaimableBalance(tt *test.T, gen randxdr.Generator) xdr.LedgerEntryChang
 	return change
 }
 
-func genContractData(tt *test.T, gen randxdr.Generator) xdr.LedgerEntryChange {
-	change := xdr.LedgerEntryChange{}
-	shape := &gxdr.LedgerEntryChange{}
-	gen.Next(
-		shape,
-		[]randxdr.Preset{
-			{randxdr.FieldEquals("type"), randxdr.SetU32(gxdr.LEDGER_ENTRY_CREATED.GetU32())},
-			{randxdr.FieldEquals("created.data.type"), randxdr.SetU32(gxdr.CONTRACT_DATA.GetU32())},
-		},
-	)
-	tt.Assert.NoError(gxdr.Convert(shape, &change))
-	return change
-}
-
 func genContractCode(tt *test.T, gen randxdr.Generator) xdr.LedgerEntryChange {
 	change := xdr.LedgerEntryChange{}
 	shape := &gxdr.LedgerEntryChange{}
@@ -181,6 +167,7 @@ func genContractCode(tt *test.T, gen randxdr.Generator) xdr.LedgerEntryChange {
 		[]randxdr.Preset{
 			{randxdr.FieldEquals("type"), randxdr.SetU32(gxdr.LEDGER_ENTRY_CREATED.GetU32())},
 			{randxdr.FieldEquals("created.data.type"), randxdr.SetU32(gxdr.CONTRACT_CODE.GetU32())},
+			//{randxdr.FieldEquals("created.data.contractcode.body.bodytype"), randxdr.SetU32(xdr.Body)},
 		},
 	)
 	tt.Assert.NoError(gxdr.Convert(shape, &change))
@@ -337,7 +324,6 @@ func TestStateVerifier(t *testing.T) {
 			genTrustLine(tt, gen),
 			genAccount(tt, gen),
 			genAccountData(tt, gen),
-			genContractData(tt, gen),
 			genContractCode(tt, gen),
 			genConfigSetting(tt, gen),
 		)

--- a/services/horizon/internal/integration/invokehostfunction_test.go
+++ b/services/horizon/internal/integration/invokehostfunction_test.go
@@ -69,7 +69,7 @@ func TestContractInvokeHostFunctionInstallContract(t *testing.T) {
 
 	invokeHostFunctionOpJson, ok := clientInvokeOp.Embedded.Records[0].(operations.InvokeHostFunction)
 	assert.True(t, ok)
-	assert.Equal(t, invokeHostFunctionOpJson.Type, "upload_wasm")
+	assert.Equal(t, invokeHostFunctionOpJson.Function, "HostFunctionTypeHostFunctionTypeUploadContractWasm")
 
 }
 
@@ -122,7 +122,6 @@ func TestContractInvokeHostFunctionCreateContractByAddress(t *testing.T) {
 	invokeHostFunctionOpJson, ok := clientInvokeOp.Embedded.Records[0].(operations.InvokeHostFunction)
 	assert.True(t, ok)
 	assert.Equal(t, invokeHostFunctionOpJson.Function, "HostFunctionTypeHostFunctionTypeCreateContract")
-	assert.Equal(t, invokeHostFunctionOpJson.Type, "create_contract")
 	assert.Equal(t, invokeHostFunctionOpJson.Address, sourceAccount.AccountID)
 	assert.Equal(t, invokeHostFunctionOpJson.Salt, "110986164698320180327942133831752629430491002266485370052238869825166557303060")
 }
@@ -230,7 +229,6 @@ func TestContractInvokeHostFunctionInvokeStatelessContractFn(t *testing.T) {
 	assert.True(t, ok)
 	assert.Len(t, invokeHostFunctionOpJson.Parameters, 4)
 	assert.Equal(t, invokeHostFunctionOpJson.Function, "HostFunctionTypeHostFunctionTypeInvokeContract")
-	assert.Equal(t, invokeHostFunctionOpJson.Type, "invoke_contract")
 	addressParam, err := xdr.MarshalBase64(contractIdParameter)
 	require.NoError(t, err)
 	assert.Equal(t, invokeHostFunctionOpJson.Parameters[0].Value, addressParam)
@@ -334,7 +332,6 @@ func TestContractInvokeHostFunctionInvokeStatefulContractFn(t *testing.T) {
 	assert.True(t, ok)
 	assert.Len(t, invokeHostFunctionOpJson.Parameters, 2)
 	assert.Equal(t, invokeHostFunctionOpJson.Function, "HostFunctionTypeHostFunctionTypeInvokeContract")
-	assert.Equal(t, invokeHostFunctionOpJson.Type, "invoke_contract")
 	addressParam, err := xdr.MarshalBase64(contractIdParameter)
 	require.NoError(t, err)
 	assert.Equal(t, invokeHostFunctionOpJson.Parameters[0].Value, addressParam)

--- a/services/horizon/internal/integration/sac_test.go
+++ b/services/horizon/internal/integration/sac_test.go
@@ -33,7 +33,7 @@ func TestContractMintToAccount(t *testing.T) {
 
 	itest := integration.NewTest(t, integration.Config{
 		ProtocolVersion:    20,
-		HorizonEnvironment: map[string]string{"INGEST_DISABLE_STATE_VERIFICATION": "true"},
+		HorizonEnvironment: map[string]string{"INGEST_DISABLE_STATE_VERIFICATION": "true", "CONNECTION_TIMEOUT": "360000"},
 	})
 
 	issuer := itest.Master().Address()
@@ -823,6 +823,7 @@ func assertEventPayments(itest *integration.Test, txHash string, asset xdr.Asset
 	assert.Equal(itest.CurrentTest(), ops.Embedded.Records[0].GetType(), operations.TypeNames[xdr.OperationTypeInvokeHostFunction])
 
 	invokeHostFn := ops.Embedded.Records[0].(operations.InvokeHostFunction)
+	assert.Equal(itest.CurrentTest(), invokeHostFn.Function, "HostFunctionTypeHostFunctionTypeInvokeContract")
 	assert.Equal(itest.CurrentTest(), 1, len(invokeHostFn.AssetBalanceChanges))
 	assetBalanceChange := invokeHostFn.AssetBalanceChanges[0]
 	assert.Equal(itest.CurrentTest(), assetBalanceChange.Amount, amount)
@@ -1052,7 +1053,7 @@ func assertInvokeHostFnSucceeds(itest *integration.Test, signer *keypair.Full, o
 	acc := itest.MustGetAccount(signer)
 
 	preFlightOp, minFee := itest.PreflightHostFunctions(&acc, *op)
-	tx, err := itest.SubmitOperationsWithFee(&acc, signer, minFee, &preFlightOp)
+	tx, err := itest.SubmitOperationsWithFee(&acc, signer, minFee+1000, &preFlightOp)
 	require.NoError(itest.CurrentTest(), err)
 
 	clientTx, err := itest.Client().TransactionDetail(tx.Hash)

--- a/support/contractevents/generate.go
+++ b/support/contractevents/generate.go
@@ -174,38 +174,24 @@ func makeAsset(asset xdr.Asset) xdr.ScVal {
 		if err != nil {
 			panic(err)
 		}
-		pubkey, ok := asset.AlphaNum4.Issuer.GetEd25519()
-		if !ok {
-			panic("issuer not a public key")
-		}
 		buffer.WriteString(":")
-		_, err = xdr.Marshal(buffer, pubkey)
-		if err != nil {
-			panic(err)
-		}
+		buffer.WriteString(asset.AlphaNum4.Issuer.Address())
 
 	case xdr.AssetTypeAssetTypeCreditAlphanum12:
 		_, err := xdr.Marshal(buffer, asset.AlphaNum12.AssetCode)
 		if err != nil {
 			panic(err)
 		}
-		pubkey, ok := asset.AlphaNum12.Issuer.GetEd25519()
-		if !ok {
-			panic("issuer not a public key")
-		}
 		buffer.WriteString(":")
-		_, err = xdr.Marshal(buffer, pubkey)
-		if err != nil {
-			panic(err)
-		}
+		buffer.WriteString(asset.AlphaNum12.Issuer.Address())
 
 	default:
 		panic("unexpected asset type")
 	}
 
-	slice := xdr.ScBytes(buffer.Bytes())
+	assetScStr := xdr.ScString(buffer.String())
 	return xdr.ScVal{
-		Type:  xdr.ScValTypeScvBytes,
-		Bytes: &slice,
+		Type: xdr.ScValTypeScvString,
+		Str:  &assetScStr,
 	}
 }


### PR DESCRIPTION
This is part #2 of updates for preview 10 data model on horizon:

part #1 focused on non-sac test fixing and has merged - https://github.com/stellar/go/pull/4938

this is focused on fixing the sac tests:

* asset stats 
* effects(contract events parsing) 
* contract events

all these areas were affected by changes in different vec/map layout and instance vs. persistent contract data paths in ContractDataEntry and ScString usage in sac event topics and contract ledger entry asset issuer value.

Closes #4896 

