### PR TITLE
services/horizon: Fix Horizon connectivity to core in standalone docker

### DIFF
--- a/services/horizon/docker/docker-compose.standalone.yml
+++ b/services/horizon/docker/docker-compose.standalone.yml
@@ -37,6 +37,7 @@ services:
       - HISTORY_ARCHIVE_URLS=http://host.docker.internal:1570
       - NETWORK_PASSPHRASE=Standalone Network ; February 2017
       - CAPTIVE_CORE_CONFIG_APPEND_PATH=/captive-core-standalone.cfg
+      - STELLAR_CORE_URL=http://host.docker.internal:11626
     volumes:
       - ./captive-core-standalone.cfg:/captive-core-standalone.cfg
 


### PR DESCRIPTION


<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Set `STELLAR_CORE_URL` to `http://host.docker.internal:11626`.

### Why

The default value of STELLAR_CORE_URL (localhost:11626) in standalone network mode doesn't work. We need to explicitly set STELLAR_CORE_URL to http://host.docker.internal:11626, to allow Horizon to access the host container's port to connect with the core container.

### Known limitations

[TODO or N/A]
