### PR TITLE
horizon/integration/contracts: readme docs on rpc usage for contract integration tests

### DIFF
--- a/services/horizon/internal/integration/contracts/README.md
+++ b/services/horizon/internal/integration/contracts/README.md
@@ -1,3 +1,18 @@
+### Contract integration tests use rpc preflight
+The contract integration tests depend on soroban rpc for preflight requests, two additional environment variables must be set to enable soroban rpc server to be launced in a separate docker container:
+```
+HORIZON_INTEGRATION_TESTS_SOROBAN_RPC_DOCKER_IMG=stellar/soroban-rpc
+HORIZON_INTEGRATION_TESTS_ENABLE_SOROBAN_RPC=true
+```
+
+The `stellar/soroban-rpc` refers to an image built from soroban-tools/cmd/soroban-rpc/docker/Dockerfile and published on public `docker.io` so it is referrable in any build environment. Images are published to `docker.io/stellar/soroban-rpc` on a release basis, if you need more recent build, can build interim images from soroban-tools/cmd/soroban-rpc/docker/Dockerfile, example:
+
+```
+docker build --platform linux/amd64 --build-arg STELLAR_CORE_VERSION=19.11.1-1373.875f47e24.focal~soroban -t stellar-soroban-rpc:test -f cmd/soroban-rpc/docker/Dockerfile .
+```
+
+`STELLAR_CORE_VERSION` should be set to a debian package version for `stellar-core`.
+
 ### Contract test fixture source code
 
 The existing integeration tests refer to .wasm files from the `testdata/` directory location.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
added documentation explaining configuration of soroban rpc for preflight usage in horizon/internal/integration/contracts tests.

### Why
the contract integration tests require soroban rpc to perform preflight before submitting transactions, needed to include documentation on how to update the settings for which version of soroban rpc docker image to use.

### Known limitations

