### PR TITLE
Make ledger sequence numbers be `int64`s natively

### DIFF
--- a/protocols/horizon/operations/main.go
+++ b/protocols/horizon/operations/main.go
@@ -377,7 +377,7 @@ type HostFunctionParameter struct {
 // The model for BumpFootprintExpiration assimilates BumpFootprintExpirationOp, but is simplified.
 type BumpFootprintExpiration struct {
 	Base
-	LedgersToExpire string `json:"ledgers_to_expire"`
+	LedgersToExpire int64 `json:"ledgers_to_expire,string"`
 }
 
 // RestoreFootprint is the json resource representing a single RestoreFootprint.


### PR DESCRIPTION
### What
Modifies `LedgersToExpire` to be an `int64` that encodes to a `string` (for languages that don't have clean 64-bit number abstractions).

### Why
The other ledger sequence numbers are always natively used as numbers, see e.g. [horizon/main.go#L47](https://github.com/stellar/go/blob/master/protocols/horizon/main.go#L47).

### Known limitations
n/a