### PR TITLE
horizon: fix EffectRestoreFootprint enum

### DIFF
--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -327,6 +327,14 @@ type ContractDebited struct {
 	Amount   string `json:"amount"`
 }
 
+type BumpFootprintExpiration struct {
+	Base
+}
+
+type RestoreFootprint struct {
+	Base
+}
+
 type AccountThresholdsUpdated struct {
 	Base
 	LowThreshold  int32 `json:"low_threshold"`

--- a/protocols/horizon/effects/main.go
+++ b/protocols/horizon/effects/main.go
@@ -209,6 +209,14 @@ const (
 	// from SAC events involving transfers, mints, and burns.
 	// https://github.com/stellar/rs-soroban-env/blob/5695440da452837555d8f7f259cc33341fdf07b0/soroban-env-host/src/native_contract/token/contract.rs#L51-L63
 	EffectContractDebited EffectType = 97
+
+	// EffectBumpFootprintExpiration effects occur when a user bumps the
+	// expiration_ledger_seq of some ledger entries via the BumpFootprintExpiration.
+	EffectBumpFootprintExpiration EffectType = 98
+
+	// EffectRestoreFootprint effects occur when a user attempts to restore a ledger entry
+	// via the RestoreFootprint.
+	EffectRestoreFootprint EffectType = 99
 )
 
 // Peter 30-04-2019: this is copied from the resourcadapter package
@@ -271,6 +279,8 @@ var EffectTypeNames = map[EffectType]string{
 	EffectLiquidityPoolRevoked:               "liquidity_pool_revoked",
 	EffectContractCredited:                   "contract_credited",
 	EffectContractDebited:                    "contract_debited",
+	EffectBumpFootprintExpiration:            "bump_footprint_expiration",
+	EffectRestoreFootprint:                   "restore_footprint",
 }
 
 // Base provides the common structure for any effect resource effect.

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -238,7 +238,7 @@ const (
 
 	// EffectRestoreFootprint effects occur when a user attempts to restore a ledger entry
 	// via the RestoreFootprint.
-	EffectRestoreFootprint EffectType = 98
+	EffectRestoreFootprint EffectType = 99
 )
 
 // Account is a row of data from the `history_accounts` table

--- a/services/horizon/internal/resourceadapter/effects.go
+++ b/services/horizon/internal/resourceadapter/effects.go
@@ -67,7 +67,7 @@ var EffectTypeNames = map[history.EffectType]string{
 	history.EffectContractCredited:                   "contract_credited",
 	history.EffectContractDebited:                    "contract_debited",
 	history.EffectBumpFootprintExpiration:            "bump_footprint_expiration",
-	history.EffectRestoreFootprint:                   "restore_footprint_expiration",
+	history.EffectRestoreFootprint:                   "restore_footprint",
 }
 
 // NewEffect creates a new effect resource from the provided database representation

--- a/services/horizon/internal/resourceadapter/effects.go
+++ b/services/horizon/internal/resourceadapter/effects.go
@@ -66,6 +66,8 @@ var EffectTypeNames = map[history.EffectType]string{
 	history.EffectLiquidityPoolRevoked:               "liquidity_pool_revoked",
 	history.EffectContractCredited:                   "contract_credited",
 	history.EffectContractDebited:                    "contract_debited",
+	history.EffectBumpFootprintExpiration:            "bump_footprint_expiration",
+	history.EffectRestoreFootprint:                   "restore_footprint_expiration",
 }
 
 // NewEffect creates a new effect resource from the provided database representation
@@ -289,6 +291,14 @@ func NewEffect(
 		result = e
 	case history.EffectContractDebited:
 		e := effects.ContractDebited{Base: basev}
+		err = row.UnmarshalDetails(&e)
+		result = e
+	case history.EffectBumpFootprintExpiration:
+		e := effects.BumpFootprintExpiration{Base: basev}
+		err = row.UnmarshalDetails(&e)
+		result = e
+	case history.EffectRestoreFootprint:
+		e := effects.RestoreFootprint{Base: basev}
 		err = row.UnmarshalDetails(&e)
 		result = e
 	case history.EffectAccountRemoved:

--- a/services/horizon/internal/resourceadapter/effects_test.go
+++ b/services/horizon/internal/resourceadapter/effects_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stellar/go/support/render/hal"
 	"github.com/stellar/go/support/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewEffectAllEffectsCovered(t *testing.T) {
@@ -42,13 +43,13 @@ func TestNewEffectAllEffectsCovered(t *testing.T) {
 func TestEffectTypeNamesAreConsistentWithAdapterTypeNames(t *testing.T) {
 	for typ, s := range EffectTypeNames {
 		s2, ok := effects.EffectTypeNames[effects.EffectType(typ)]
-		assert.True(t, ok, s)
-		assert.Equal(t, s, s2)
+		require.True(t, ok, s)
+		require.Equal(t, s, s2)
 	}
 	for typ, s := range effects.EffectTypeNames {
 		s2, ok := EffectTypeNames[history.EffectType(typ)]
-		assert.True(t, ok, s)
-		assert.Equal(t, s, s2)
+		require.True(t, ok, s)
+		require.Equal(t, s, s2)
 	}
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The EffectRestoreFootprint had the same value as EffectBumpFootprintExpiration, which would generate uncertainties when processing effects.

### Why

Trivial

### Known limitations

n/a
