### PR TITLE
RFC: Creating Horizon default config file

### DIFF
--- a/services/horizon/configs/horizon.conf
+++ b/services/horizon/configs/horizon.conf
@@ -1,0 +1,257 @@
+##############################################################################################
+# Horizon Server Configuration
+#
+# docs: https://developers.stellar.org/docs/run-api-server/configuring#parameters
+#
+##############################################################################################
+
+# WARNING: This should not be accessible from the Internet and does not use TLS.
+# TCP port to listen on for admin HTTP requests. Set to 0 to disable the admin server.
+HORIZON_ADMIN_PORT=0
+
+# TCP port to listen on for HTTP requests.
+HORIZON_HTTP_PORT=8000
+
+
+##############################################################################################
+# Stellar Network Configuration.
+#
+# docs: https://developers.stellar.org/docs/run-api-server/configuring#parameters
+#
+##############################################################################################
+
+# Configure either the NETWORK parameter to 'pubnet' or 'testnet',
+# which will automatically set the NETWORK_PASSPHRASE and HISTORY_ARCHIVE_URLS.
+# If the NETWORK parameter is not specified, you must provide the network passphrase
+# and history archive URLs manually.
+NETWORK="testnet"
+#NETWORK="pubnet"
+
+# Override the network passphrase.
+# Mandatory if NETWORK is not specified
+# NETWORK_PASSPHRASE=""
+
+# Comma-separated list of Stellar history archive URLs to connect with.
+# Mandatory if NETWORK is not specified
+# HISTORY_ARCHIVE_URLS=""
+
+
+##############################################################################################
+# Horizon Database Configuration
+#
+# docs: https://developers.stellar.org/docs/run-api-server/configuring#preparing-the-database
+#
+##############################################################################################
+
+# Horizon Postgres database to connect with.
+# Mandatory
+HORIZON_DATABASE_URL=""
+
+# Horizon Postgres read-replica to connect with.
+# When set, it will return a stale history error when the replica is behind the primary.
+# Optional
+# HORIZON_RO_DATABASE_URL=""
+
+# Maximum number of idle connections in the Horizon database pool.
+HORIZON_DB_MAX_IDLE_CONNECTIONS=20
+
+# Maximum number of open connections in the Horizon database pool.
+HORIZON_DB_MAX_OPEN_CONNECTIONS=20
+
+# Maximum number of connections allowed in the Horizon database.
+# When set, it takes priority over HORIZON_DB_MAX_OPEN_CONNECTIONS and HORIZON_DB_MAX_IDLE_CONNECTIONS.
+# optional
+#MAX_DB_CONNECTIONS=0
+
+
+##############################################################################################
+# Captive Core Configuration
+#
+# Captive Core is an embedded Stellar Core process that Horizon can utilize for data ingestion.
+# It provides a lightweight alternative to running a separate persistent Stellar Core database.
+#
+# docs: https://developers.stellar.org/docs/run-api-server/configuring#configuring-captive-core
+#
+##############################################################################################
+
+# Path to the configuration file used by Captive Core.
+# It must include enough details to define a quorum set.
+# Any unsupported fields in the file will be rejected.
+# Mandatory if NETWORK is not specified
+CAPTIVE_CORE_CONFIG_PATH=""
+
+# HTTP port for Captive Core to listen on.
+# Set to 0 to disable the HTTP server.
+# Optional
+CAPTIVE_CORE_HTTP_PORT=0
+
+# Name of the path for Core logs.
+# Leave empty to log with Horizon only.
+# optional
+# CAPTIVE_CORE_LOG_PATH=""
+
+# Port for Captive Core to bind to for connecting to the Stellar swarm.
+# Set to 0 to use Stellar Core's default port.
+CAPTIVE_CORE_PEER_PORT=0
+
+# Storage location for Captive Core bucket data.
+# For stellar-horizon to download buckets locally at specific location.
+# If not enabled, stellar-horizon would download data in the current working directory.
+CAPTIVE_CORE_STORAGE_PATH=""
+
+# When enabled, Horizon ingestion will instruct the Captive Core invocation
+# to use an external database URL for ledger states rather than in-memory (RAM).
+# This results in shifting several GB of space out of RAM and to the external database persistence.
+# he default database is SQLite,and the database file will be stored at a location derived
+# from CAPTIVE_CORE_STORAGE_PATH.
+CAPTIVE_CORE_USE_DB=false
+
+# DEPRECATED: Use CAPTIVE_CORE_CONFIG_PATH instead.
+# CAPTIVE_CORE_CONFIG_APPEND_PATH=""
+
+# Path to the Stellar Core binary.
+# If Captive Core is enabled, it looks for the Stellar Core binary in $PATH by default.
+STELLAR_CORE_BINARY_PATH=""
+
+# DEPRECATED: Stellar-Core Postgres database to connect with.
+# STELLAR_CORE_DATABASE_URL=""
+
+# Stellar-Core to connect with for HTTP commands.
+# If unset and the local Captive Core is enabled, it uses http://localhost:<CAPTIVE_CORE_HTTP_PORT>.
+STELLAR_CORE_URL=""
+
+
+##############################################################################################
+# Horizon Ingestion Configuration
+#
+# https://developers.stellar.org/docs/run-api-server/ingestion
+#
+##############################################################################################
+
+# Flag to enable data ingestion from Stellar Core into Horizon's database.
+ENABLE_INGESTION=true
+
+# Enable ingestion from a Captive Stellar Core process instead of a persistent Stellar Core database.
+ENABLE_CAPTIVE_CORE_INGESTION=true
+
+# Flag to apply pending migrations before starting Horizon.
+# Optional
+HORIZON_DB_APPLY_MIGRATIONS=false
+
+# DEPRECATED: Enable experimental Ingestion Filtering and the ingestion admin HTTP endpoint at /ingestion/filter. 
+# https://developers.stellar.org/docs/run-api-server/ingestion-filtering
+# Optional
+# EXP_ENABLE_INGESTION_FILTERING=false
+
+# Flag to disable state verification during ingestion.
+# The ingestion system runs a verification routine to compare the state in the local database
+# with the history buckets. Disabling this is not recommended.
+# Optional
+INGEST_DISABLE_STATE_VERIFICATION=false
+
+# Enable extended ledger stats in the log (ledger entry changes and operations stats).
+# Optional
+INGEST_ENABLE_EXTENDED_LOG_LEDGER_STATS=false
+
+# Frequency in units per checkpoint for how often state verification is executed.
+# A value of 1 implies running state verification on every checkpoint.
+# A value of 2 implies running state verification on every second checkpoint.
+# Optional
+INGEST_STATE_VERIFICATION_CHECKPOINT_FREQUENCY=1
+
+# Upper bound in minutes for how long state verification is allowed to run.
+# A value of 0 disables the timeout.
+# Optional
+INGEST_STATE_VERIFICATION_TIMEOUT=0
+
+
+############################################################################
+# History Configuration
+#
+# https://developers.stellar.org/docs/run-api-server/ingestion#ingesting-historical-data
+#
+#####################################
+
+# The maximum number of ledgers to maintain within Horizon's history tables.
+# It is recommended to set this parameter to retain ledger data for no more than 30
+# days. This can be achieved by setting the value to 518400, considering that
+# each ledger represents approximately 5 seconds.
+HISTORY_RETENTION_COUNT=518400
+
+# (DEPRECATED:?) The maximum number of ledgers the history database is allowed to be out of date
+# from the connected Stellar Core database before Horizon considers history stale.
+HISTORY_STALE_THRESHOLD=0
+
+
+
+############################################################################
+# Path Finding Configuration
+#
+############################################################################
+
+# Flag to disable path finding endpoints.
+# Optional
+DISABLE_PATH_FINDING=false
+
+# Excludes liquidity pools from consideration in the /paths endpoint.
+# Optional
+DISABLE_POOL_PATH_FINDING=false
+
+# The maximum number of path finding requests per second that Horizon will allow.
+# A value of zero disables the limit.
+# Optional
+MAX_PATH_FINDING_REQUESTS=0
+
+# The maximum number of assets in '/paths/strict-send' and '/paths/strict-receive' endpoints.
+# Optional
+MAX_ASSETS_PER_PATH_REQUEST=15
+
+# The maximum number of assets on the path in /paths endpoint.
+# Warning: Increasing this value will increase /paths response time.
+# Optional
+MAX_PATH_LENGTH=3
+
+############################################################################
+# Logging Configuration
+#
+############################################################################
+
+# Name of the file where logs will be saved.
+# Leave empty to send logs to stdout.
+# Optional
+LOG_FILE=""
+
+# Minimum log severity (debug, info, warn, error) to log.
+# Optional
+LOG_LEVEL="info"
+
+# Tag to be added to every loggly log event.
+# Optional
+LOGGLY_TAG="horizon"
+
+# Loggly token used to configure log forwarding to Loggly.
+# Optional
+LOGGLY_TOKEN=""
+
+# Sentry URL to which panics and errors should be reported.
+# Optional
+SENTRY_DSN=""
+
+
+############################################################################
+# Other Configuration
+#
+############################################################################
+# Flag to skip reporting the last imported ledger state to Stellar Core.
+# Optional
+SKIP_CURSOR_UPDATE=false
+
+# Determines if the Horizon instance is behind AWS load balancers like ELB or ALB.
+# In such a case, the client IP in the logs will be replaced with the last IP in the X-Forwarded-For header.
+# Optional
+BEHIND_AWS_LOAD_BALANCER=false
+
+# Determines if the Horizon instance is behind Cloudflare.
+# In such a case, the client IP in the logs will be replaced with the Cloudflare header.
+# Optional
+BEHIND_CLOUDFLARE=false


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
_This pull request proposal in the RFC stage_

Create a Horizon config file that serves as a single location for managing all configuration parameters easily.
The config file should address the following:
 - Documenting individual parameter
 - Grouping of related parameters
 - Include documentation and official links
 - Rename parameters to be more intuitive (Optional)
 - Identify and remove unnecessary or deprecated parameters for cleaner configuration
- Specify mandatory options for specific Horizon instance types, such as setting `ENABLE_INGEST` to true for ingestion instance

### Why
- It provides a centralized and convenient way to manage all configuration parameters in one place, simplifying the configuration process
- Grouping related parameters improves organization and helps users find and better understand the parameters
- Including official documentation links for each parameter to help users in getting up-to-date information
- Separating default values from the code allows for easier modification of default configuration settings without code changes

### Alternative Recommendation
Instead of a config file, presenting the configuration parameters in a tabular format, grouping parameters by relevance, on the public documentation site to provide a complete reference.

