### PR TITLE
Services/horizon: Integration tests for NETWORK parameter

### DIFF
--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -42,8 +42,8 @@ const (
 	// CaptiveCoreConfigUseDB is the command line flag for enabling captive core runtime to use an external db url
 	// connection rather than RAM for ledger states
 	CaptiveCoreConfigUseDB = "captive-core-use-db"
-	// CaptiveCoreHttpPortFlagName is the commandline flag for specifying captive core HTTP port
-	CaptiveCoreHttpPortFlagName = "captive-core-http-port"
+	// CaptiveCoreHTTPPortFlagName is the commandline flag for specifying captive core HTTP port
+	CaptiveCoreHTTPPortFlagName = "captive-core-http-port"
 	// EnableCaptiveCoreIngestionFlagName is the commandline flag for enabling captive core ingestion
 	EnableCaptiveCoreIngestionFlagName = "enable-captive-core-ingestion"
 	// NetworkPassphraseFlagName is the command line flag for specifying the network passphrase

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -716,11 +716,11 @@ func loadCaptiveCoreTomlFromFile(config *Config) error {
 func createCaptiveCoreConfigFromNetwork(config *Config) error {
 
 	if config.NetworkPassphrase != "" {
-		return fmt.Errorf("invalid config: %s not allowed with %s network", NetworkPassphraseFlagName, config.Network)
+		return fmt.Errorf("invalid config: %s parameter not allowed with the %s parameter", NetworkPassphraseFlagName, NetworkFlagName)
 	}
 
 	if len(config.HistoryArchiveURLs) > 0 {
-		return fmt.Errorf("invalid config: %s not allowed with %s network", HistoryArchiveURLsFlagName, config.Network)
+		return fmt.Errorf("invalid config: %s parameter not allowed with the %s parameter", HistoryArchiveURLsFlagName, NetworkFlagName)
 	}
 
 	var defaultNetworkConfig networkConfig
@@ -783,12 +783,12 @@ func setCaptiveCoreConfiguration(config *Config) error {
 	if config.Network != "" {
 		err := createCaptiveCoreConfigFromNetwork(config)
 		if err != nil {
-			return errors.Wrap(err, "error generating default captive core config.")
+			return err
 		}
 	} else {
 		err := createCaptiveCoreConfigFromParameters(config)
 		if err != nil {
-			return errors.Wrap(err, "error generating captive core config.")
+			return err
 		}
 	}
 

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -647,8 +647,8 @@ type ApplyOptions struct {
 
 type networkConfig struct {
 	defaultConfig      []byte
-	historyArchiveURLs []string
-	networkPassphrase  string
+	HistoryArchiveURLs []string
+	NetworkPassphrase  string
 }
 
 var (
@@ -658,16 +658,16 @@ var (
 	//go:embed configs/captive-core-testnet.cfg
 	TestnetDefaultConfig []byte
 
-	pubnetConf = networkConfig{
+	PubnetConf = networkConfig{
 		defaultConfig:      PubnetDefaultConfig,
-		historyArchiveURLs: network.PublicNetworkhistoryArchiveURLs,
-		networkPassphrase:  network.PublicNetworkPassphrase,
+		HistoryArchiveURLs: network.PublicNetworkhistoryArchiveURLs,
+		NetworkPassphrase:  network.PublicNetworkPassphrase,
 	}
 
-	testnetConf = networkConfig{
+	TestnetConf = networkConfig{
 		defaultConfig:      TestnetDefaultConfig,
-		historyArchiveURLs: network.TestNetworkhistoryArchiveURLs,
-		networkPassphrase:  network.TestNetworkPassphrase,
+		HistoryArchiveURLs: network.TestNetworkhistoryArchiveURLs,
+		NetworkPassphrase:  network.TestNetworkPassphrase,
 	}
 )
 
@@ -726,14 +726,14 @@ func createCaptiveCoreConfigFromNetwork(config *Config) error {
 	var defaultNetworkConfig networkConfig
 	switch config.Network {
 	case StellarPubnet:
-		defaultNetworkConfig = pubnetConf
+		defaultNetworkConfig = PubnetConf
 	case StellarTestnet:
-		defaultNetworkConfig = testnetConf
+		defaultNetworkConfig = TestnetConf
 	default:
 		return fmt.Errorf("no default configuration found for network %s", config.Network)
 	}
-	config.NetworkPassphrase = defaultNetworkConfig.networkPassphrase
-	config.HistoryArchiveURLs = defaultNetworkConfig.historyArchiveURLs
+	config.NetworkPassphrase = defaultNetworkConfig.NetworkPassphrase
+	config.HistoryArchiveURLs = defaultNetworkConfig.HistoryArchiveURLs
 
 	if config.CaptiveCoreConfigPath == "" {
 		return loadDefaultCaptiveCoreToml(config, defaultNetworkConfig.defaultConfig)

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -42,6 +42,10 @@ const (
 	// CaptiveCoreConfigUseDB is the command line flag for enabling captive core runtime to use an external db url
 	// connection rather than RAM for ledger states
 	CaptiveCoreConfigUseDB = "captive-core-use-db"
+	// CaptiveCoreHttpPortFlagName is the commandline flag for specifying captive core HTTP port
+	CaptiveCoreHttpPortFlagName = "captive-core-http-port"
+	// EnableCaptiveCoreIngestionFlagName is the commandline flag for enabling captive core ingestion
+	EnableCaptiveCoreIngestionFlagName = "enable-captive-core-ingestion"
 	// NetworkPassphraseFlagName is the command line flag for specifying the network passphrase
 	NetworkPassphraseFlagName = "network-passphrase"
 	// HistoryArchiveURLsFlagName is the command line flag for specifying the history archive URLs

--- a/services/horizon/internal/flags_test.go
+++ b/services/horizon/internal/flags_test.go
@@ -10,7 +10,7 @@ import (
 
 func Test_createCaptiveCoreDefaultConfig(t *testing.T) {
 
-	var errorMsgDefaultConfig = "invalid config: %s not allowed with %s network"
+	var errorMsgDefaultConfig = "invalid config: %s parameter not allowed with the network parameter"
 	tests := []struct {
 		name               string
 		config             Config
@@ -35,14 +35,14 @@ func Test_createCaptiveCoreDefaultConfig(t *testing.T) {
 			config: Config{Network: StellarTestnet,
 				HistoryArchiveURLs: []string{"network history archive urls supplied"},
 			},
-			errStr: fmt.Sprintf(errorMsgDefaultConfig, HistoryArchiveURLsFlagName, StellarTestnet),
+			errStr: fmt.Sprintf(errorMsgDefaultConfig, HistoryArchiveURLsFlagName),
 		},
 		{
 			name: "pubnet validation; history archive urls supplied",
 			config: Config{Network: StellarPubnet,
 				HistoryArchiveURLs: []string{"network history archive urls supplied"},
 			},
-			errStr: fmt.Sprintf(errorMsgDefaultConfig, HistoryArchiveURLsFlagName, StellarPubnet),
+			errStr: fmt.Sprintf(errorMsgDefaultConfig, HistoryArchiveURLsFlagName),
 		},
 		{
 			name: "testnet validation; network passphrase supplied",
@@ -50,7 +50,7 @@ func Test_createCaptiveCoreDefaultConfig(t *testing.T) {
 				NetworkPassphrase:  "network passphrase supplied",
 				HistoryArchiveURLs: []string{},
 			},
-			errStr: fmt.Sprintf(errorMsgDefaultConfig, NetworkPassphraseFlagName, StellarTestnet),
+			errStr: fmt.Sprintf(errorMsgDefaultConfig, NetworkPassphraseFlagName),
 		},
 		{
 			name: "pubnet validation; network passphrase supplied",
@@ -58,7 +58,7 @@ func Test_createCaptiveCoreDefaultConfig(t *testing.T) {
 				NetworkPassphrase:  "pubnet network passphrase supplied",
 				HistoryArchiveURLs: []string{},
 			},
-			errStr: fmt.Sprintf(errorMsgDefaultConfig, NetworkPassphraseFlagName, StellarPubnet),
+			errStr: fmt.Sprintf(errorMsgDefaultConfig, NetworkPassphraseFlagName),
 		},
 		{
 			name: "unknown network specified",

--- a/services/horizon/internal/flags_test.go
+++ b/services/horizon/internal/flags_test.go
@@ -21,14 +21,14 @@ func Test_createCaptiveCoreDefaultConfig(t *testing.T) {
 		{
 			name:               "testnet default config",
 			config:             Config{Network: StellarTestnet},
-			networkPassphrase:  testnetConf.networkPassphrase,
-			historyArchiveURLs: testnetConf.historyArchiveURLs,
+			networkPassphrase:  TestnetConf.NetworkPassphrase,
+			historyArchiveURLs: TestnetConf.HistoryArchiveURLs,
 		},
 		{
 			name:               "pubnet default config",
 			config:             Config{Network: StellarPubnet},
-			networkPassphrase:  pubnetConf.networkPassphrase,
-			historyArchiveURLs: pubnetConf.historyArchiveURLs,
+			networkPassphrase:  PubnetConf.NetworkPassphrase,
+			historyArchiveURLs: PubnetConf.HistoryArchiveURLs,
 		},
 		{
 			name: "testnet validation; history archive urls supplied",

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -138,148 +138,129 @@ func TestInvalidNetworkParameters(t *testing.T) {
 		t.Skip()
 	}
 
-	errMsg := "history-archive-urls parameter not allowed with the network parameter"
-	t.Run("history archive urls validation", func(t *testing.T) {
-		localParams := integration.MergeMaps(networkParamArgs, map[string]string{
-			horizon.NetworkFlagName:                    horizon.StellarPubnet,
-			horizon.EnableCaptiveCoreIngestionFlagName: "true",
-			horizon.HistoryArchiveURLsFlagName:         "HISTORY_ARCHIVE_URLS",
-		})
-		testConfig := integration.GetTestConfig()
-		testConfig.SkipCoreContainerCreation = true
-		testConfig.HorizonIngestParameters = localParams
-		test := integration.NewTest(t, *testConfig)
-		err := test.StartHorizon()
-		assert.Equal(t, err.Error(), integration.HorizonInitErrStr+
-			": "+CaptiveCoreConfigErrMsg+errMsg)
-		// Adding sleep as a workaround for the race condition in the ingestion system.
-		// https://github.com/stellar/go/issues/5005
-		time.Sleep(2 * time.Second)
-		test.StopHorizon()
-		test.Shutdown()
-	})
+	var captiveCoreConfigErrMsg = integration.HorizonInitErrStr + ": error generating captive " +
+		"core configuration: invalid config: %s parameter not allowed with the %s parameter"
+	testCases := []struct {
+		name         string
+		errMsg       string
+		networkValue string
+		param        string
+	}{
+		{
+			name: "history archive urls validation",
+			errMsg: fmt.Sprintf(captiveCoreConfigErrMsg, horizon.HistoryArchiveURLsFlagName,
+				horizon.NetworkFlagName),
+			networkValue: horizon.StellarPubnet,
+			param:        horizon.HistoryArchiveURLsFlagName,
+		},
+		{
+			name: "network-passphrase validation",
+			errMsg: fmt.Sprintf(captiveCoreConfigErrMsg, horizon.NetworkPassphraseFlagName,
+				horizon.NetworkFlagName),
+			networkValue: horizon.StellarTestnet,
+			param:        horizon.NetworkPassphraseFlagName,
+		},
+	}
 
-	errMsg = "network-passphrase parameter not allowed with the network parameter"
-	t.Run("network-passphrase validation", func(t *testing.T) {
-		localParams := integration.MergeMaps(networkParamArgs, map[string]string{
-			horizon.NetworkFlagName:                    horizon.StellarTestnet,
-			horizon.EnableCaptiveCoreIngestionFlagName: "true",
-			horizon.NetworkPassphraseFlagName:          "NETWORK_PASSPHRASE",
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			localParams := integration.MergeMaps(networkParamArgs, map[string]string{
+				horizon.NetworkFlagName:                    testCase.networkValue,
+				horizon.EnableCaptiveCoreIngestionFlagName: "true",
+				testCase.param:                             "NETWORK_PARAM",
+			})
+			testConfig := integration.GetTestConfig()
+			testConfig.SkipCoreContainerCreation = true
+			testConfig.HorizonIngestParameters = localParams
+			test := integration.NewTest(t, *testConfig)
+			err := test.StartHorizon()
+			// Adding sleep as a workaround for the race condition in the ingestion system.
+			// https://github.com/stellar/go/issues/5005
+			time.Sleep(2 * time.Second)
+			assert.Equal(t, testCase.errMsg, err.Error())
+			test.Shutdown()
 		})
-		testConfig := integration.GetTestConfig()
-		testConfig.SkipCoreContainerCreation = true
-		testConfig.HorizonIngestParameters = localParams
-		test := integration.NewTest(t, *testConfig)
-		err := test.StartHorizon()
-		assert.Equal(t, err.Error(), integration.HorizonInitErrStr+
-			": "+CaptiveCoreConfigErrMsg+errMsg)
-		// Adding sleep as a workaround for the race condition in the ingestion system.
-		// https://github.com/stellar/go/issues/5005
-		time.Sleep(2 * time.Second)
-		test.StopHorizon()
-		test.Shutdown()
-	})
+	}
 }
 
 // TestNetworkParameter Ensure that Horizon successfully starts the captive-core
 // subprocess using the default configuration when --network [testnet|pubnet]
 // commandline parameter.
 //
-// Typically during integration tests, we initiate Horizon in standalone mode and simultaneously start the
-// stellar-core container in standalone mode as well. We wait for Horizon to begin ingesting to verify the test's
-// success. However, in the case of "pubnet" or "testnet," waiting for Horizon to start ingesting is not practical.
-// So we don't start stellar-core containers.
+// In integration tests, we start Horizon and stellar-core containers in standalone mode
+// simultaneously. We usually wait for Horizon to begin ingesting to verify the test's
+// success. However, for "pubnet" or "testnet," we can not wait for Horizon to catch up,
+// so we skip starting stellar-core containers.
 func TestNetworkParameter(t *testing.T) {
 	if !integration.RunWithCaptiveCore {
 		t.Skip()
 	}
 
-	t.Run("network parameter pubnet", func(t *testing.T) {
-		localParams := integration.MergeMaps(networkParamArgs, map[string]string{
-			horizon.NetworkFlagName: horizon.StellarPubnet,
-		})
-		testConfig := integration.GetTestConfig()
-		testConfig.SkipCoreContainerCreation = true
-		testConfig.HorizonIngestParameters = localParams
-		test := integration.NewTest(t, *testConfig)
-		err := test.StartHorizon()
-		// Adding sleep as a workaround for the race condition in the ingestion system.
-		// https://github.com/stellar/go/issues/5005
-		time.Sleep(2 * time.Second)
-		assert.NoError(t, err)
-		test.StopHorizon()
-		test.Shutdown()
-	})
+	testCases := []string{
+		horizon.StellarPubnet,
+		horizon.StellarTestnet,
+	}
 
-	t.Run("network parameter testnet", func(t *testing.T) {
-		localParams := integration.MergeMaps(networkParamArgs, map[string]string{
-			horizon.NetworkFlagName: horizon.StellarTestnet,
+	for _, networkValue := range testCases {
+		t.Run(fmt.Sprintf("NETWORK parameter %s", networkValue), func(t *testing.T) {
+			localParams := integration.MergeMaps(networkParamArgs, map[string]string{
+				horizon.NetworkFlagName: networkValue,
+			})
+			testConfig := integration.GetTestConfig()
+			testConfig.SkipCoreContainerCreation = true
+			testConfig.HorizonIngestParameters = localParams
+			test := integration.NewTest(t, *testConfig)
+			err := test.StartHorizon()
+			// Adding sleep as a workaround for the race condition in the ingestion system.
+			// https://github.com/stellar/go/issues/5005
+			time.Sleep(2 * time.Second)
+			assert.NoError(t, err)
+			test.Shutdown()
 		})
-		testConfig := integration.GetTestConfig()
-		testConfig.SkipCoreContainerCreation = true
-		testConfig.HorizonIngestParameters = localParams
-		test := integration.NewTest(t, *testConfig)
-		err := test.StartHorizon()
-		// Adding sleep as a workaround for the race condition in the ingestion system.
-		// https://github.com/stellar/go/issues/5005
-		time.Sleep(2 * time.Second)
-		assert.NoError(t, err)
-		test.StopHorizon()
-		test.Shutdown()
-	})
+	}
 }
 
 // TestNetworkEnvironmentVariable Ensure that Horizon successfully starts the captive-core
 // subprocess using the default configuration when the NETWORK environment variable is set
 // to either pubnet or testnet.
 //
-// Typically during integration tests, we initiate Horizon in standalone mode and simultaneously start the
-// stellar-core container in standalone mode as well. We wait for Horizon to begin ingesting to verify the test's
-// success. However, in the case of "pubnet" or "testnet," waiting for Horizon to start ingesting is not practical.
-// So we don't start stellar-core containers.
+// In integration tests, we start Horizon and stellar-core containers in standalone mode
+// simultaneously. We usually wait for Horizon to begin ingesting to verify the test's
+// success. However, for "pubnet" or "testnet," we can not wait for Horizon to catch up,
+// so we skip starting stellar-core containers.
 func TestNetworkEnvironmentVariable(t *testing.T) {
 	if !integration.RunWithCaptiveCore {
 		t.Skip()
 	}
+	testCases := []string{
+		horizon.StellarPubnet,
+		horizon.StellarTestnet,
+	}
 
-	value, isSet := os.LookupEnv("NETWORK")
-	defer func() {
-		if isSet {
-			_ = os.Setenv("NETWORK", value)
-		} else {
-			_ = os.Unsetenv("NETWORK")
-		}
-	}()
+	for _, networkValue := range testCases {
+		t.Run(fmt.Sprintf("NETWORK environment variable %s", networkValue), func(t *testing.T) {
+			value, isSet := os.LookupEnv("NETWORK")
+			defer func() {
+				if isSet {
+					_ = os.Setenv("NETWORK", value)
+				} else {
+					_ = os.Unsetenv("NETWORK")
+				}
+			}()
 
-	t.Run("NETWORK environment variable pubnet", func(t *testing.T) {
-		testConfig := integration.GetTestConfig()
-		testConfig.SkipCoreContainerCreation = true
-		testConfig.HorizonIngestParameters = networkParamArgs
-		testConfig.HorizonEnvironment = map[string]string{"NETWORK": horizon.StellarPubnet}
-		test := integration.NewTest(t, *testConfig)
-		err := test.StartHorizon()
-		// Adding sleep here as a workaround for the race condition in the ingestion system.
-		// More details can be found at https://github.com/stellar/go/issues/5005
-		time.Sleep(2 * time.Second)
-		assert.NoError(t, err)
-		test.StopHorizon()
-		test.Shutdown()
-	})
-
-	t.Run("NETWORK environment variable testnet", func(t *testing.T) {
-		testConfig := integration.GetTestConfig()
-		testConfig.SkipCoreContainerCreation = true
-		testConfig.HorizonIngestParameters = networkParamArgs
-		testConfig.HorizonEnvironment = map[string]string{"NETWORK": horizon.StellarTestnet}
-		test := integration.NewTest(t, *testConfig)
-		err := test.StartHorizon()
-		// Adding sleep here as a workaround for the race condition in the ingestion system.
-		// More details can be found at https://github.com/stellar/go/issues/5005
-		time.Sleep(2 * time.Second)
-		assert.NoError(t, err)
-		test.StopHorizon()
-		test.Shutdown()
-	})
+			testConfig := integration.GetTestConfig()
+			testConfig.SkipCoreContainerCreation = true
+			testConfig.HorizonIngestParameters = networkParamArgs
+			testConfig.HorizonEnvironment = map[string]string{"NETWORK": networkValue}
+			test := integration.NewTest(t, *testConfig)
+			err := test.StartHorizon()
+			// Adding sleep here as a workaround for the race condition in the ingestion system.
+			// More details can be found at https://github.com/stellar/go/issues/5005
+			time.Sleep(2 * time.Second)
+			assert.NoError(t, err)
+			test.Shutdown()
+		})
+	}
 }
 
 // Ensures that the filesystem ends up in the correct state with Captive Core.

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -34,7 +34,7 @@ var defaultCaptiveCoreParameters = map[string]string{
 }
 
 var networkParamArgs = map[string]string{
-	horizon.EnableCaptiveCoreIngestionFlagName: "true",
+	horizon.EnableCaptiveCoreIngestionFlagName: "",
 	horizon.CaptiveCoreConfigPathName:          "",
 	horizon.CaptiveCoreHTTPPortFlagName:        "",
 	horizon.StellarCoreBinaryPathName:          "",
@@ -59,34 +59,6 @@ const (
 		QUALITY="MEDIUM"`
 )
 
-func NewParameterTestSkipContainerCreation(t *testing.T, params map[string]string) *integration.Test {
-	return NewParameterTestWithEnvSkipContainerCreation(t, params, map[string]string{})
-}
-
-func NewParameterTestWithEnvSkipContainerCreation(t *testing.T, params, envvars map[string]string) *integration.Test {
-	config := integration.Config{
-		ProtocolVersion:         17,
-		SkipHorizonStart:        true,
-		SkipContainerCreation:   true,
-		HorizonIngestParameters: params,
-		HorizonEnvironment:      envvars}
-	return integration.NewTest(t, config)
-}
-
-func NewParameterTest(t *testing.T, params map[string]string) *integration.Test {
-	return NewParameterTestWithEnv(t, params, map[string]string{})
-}
-
-func NewParameterTestWithEnv(t *testing.T, params, envvars map[string]string) *integration.Test {
-	config := integration.Config{
-		ProtocolVersion:         17,
-		SkipHorizonStart:        true,
-		HorizonIngestParameters: params,
-		HorizonEnvironment:      envvars,
-	}
-	return integration.NewTest(t, config)
-}
-
 func TestFatalScenarios(t *testing.T) {
 	suite.Run(t, new(FatalTestCase))
 }
@@ -107,11 +79,12 @@ func (suite *FatalTestCase) TestBucketDirDisallowed() {
 
 	confName, _, cleanup := createCaptiveCoreConfig(config)
 	defer cleanup()
-
-	test := NewParameterTest(suite.T(), map[string]string{
+	testConfig := integration.GetTestConfig()
+	testConfig.HorizonIngestParameters = map[string]string{
 		horizon.CaptiveCoreConfigPathName: confName,
 		horizon.StellarCoreBinaryPathName: os.Getenv("CAPTIVE_CORE_BIN"),
-	})
+	}
+	test := integration.NewTest(suite.T(), *testConfig)
 
 	suite.Exits(func() { test.StartHorizon() })
 }
@@ -138,9 +111,10 @@ func (suite *FatalTestCase) TestEnvironmentPreserved() {
 
 	confName, _, cleanup := createCaptiveCoreConfig(SIMPLE_CAPTIVE_CORE_TOML)
 	defer cleanup()
-	test := NewParameterTestWithEnv(t, map[string]string{}, map[string]string{
-		"CAPTIVE_CORE_CONFIG_PATH": confName,
-	})
+	testConfig := integration.GetTestConfig()
+	testConfig.HorizonEnvironment = map[string]string{"CAPTIVE_CORE_CONFIG_PATH": confName,
+	}
+	test := integration.NewTest(t, *testConfig)
 
 	err = test.StartHorizon()
 	assert.NoError(t, err)
@@ -176,7 +150,10 @@ func TestNetworkParameter(t *testing.T) {
 		localParams := integration.MergeMaps(networkParamArgs, map[string]string{
 			horizon.NetworkFlagName: horizon.StellarPubnet,
 		})
-		test := NewParameterTestSkipContainerCreation(t, localParams)
+		testConfig := integration.GetTestConfig()
+		testConfig.SkipContainerCreation = true
+		testConfig.HorizonIngestParameters = localParams
+		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
 		time.Sleep(10 * time.Second)
 		assert.NoError(t, err)
@@ -188,7 +165,10 @@ func TestNetworkParameter(t *testing.T) {
 		localParams := integration.MergeMaps(networkParamArgs, map[string]string{
 			horizon.NetworkFlagName: horizon.StellarTestnet,
 		})
-		test := NewParameterTestSkipContainerCreation(t, localParams)
+		testConfig := integration.GetTestConfig()
+		testConfig.SkipContainerCreation = true
+		testConfig.HorizonIngestParameters = localParams
+		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
 		time.Sleep(10 * time.Second)
 		assert.NoError(t, err)
@@ -225,8 +205,11 @@ func TestNetworkEnvironmentVariable(t *testing.T) {
 	}()
 
 	t.Run("NETWORK environment variable pubnet", func(t *testing.T) {
-		test := NewParameterTestWithEnvSkipContainerCreation(t, networkParamArgs,
-			map[string]string{"NETWORK": horizon.StellarPubnet})
+		testConfig := integration.GetTestConfig()
+		testConfig.SkipContainerCreation = true
+		testConfig.HorizonIngestParameters = networkParamArgs
+		testConfig.HorizonEnvironment = map[string]string{"NETWORK": horizon.StellarPubnet}
+		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
 		time.Sleep(10 * time.Second)
 		assert.NoError(t, err)
@@ -235,8 +218,11 @@ func TestNetworkEnvironmentVariable(t *testing.T) {
 	})
 
 	t.Run("NETWORK environment variable testnet", func(t *testing.T) {
-		test := NewParameterTestWithEnvSkipContainerCreation(t, networkParamArgs,
-			map[string]string{"NETWORK": horizon.StellarTestnet})
+		testConfig := integration.GetTestConfig()
+		testConfig.SkipContainerCreation = true
+		testConfig.HorizonIngestParameters = networkParamArgs
+		testConfig.HorizonEnvironment = map[string]string{"NETWORK": horizon.StellarTestnet}
+		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
 		time.Sleep(10 * time.Second)
 		assert.NoError(t, err)
@@ -258,7 +244,9 @@ func TestCaptiveCoreConfigFilesystemState(t *testing.T) {
 		"captive-core-storage-path":       storagePath,
 		horizon.CaptiveCoreConfigPathName: confName,
 	})
-	test := NewParameterTest(t, localParams)
+	testConfig := integration.GetTestConfig()
+	testConfig.HorizonIngestParameters = localParams
+	test := integration.NewTest(t, *testConfig)
 
 	err := test.StartHorizon()
 	assert.NoError(t, err)
@@ -275,7 +263,7 @@ func TestCaptiveCoreConfigFilesystemState(t *testing.T) {
 
 func TestMaxAssetsForPathRequests(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
-		test := NewParameterTest(t, map[string]string{})
+		test := integration.NewTest(t, *integration.GetTestConfig())
 		err := test.StartHorizon()
 		assert.NoError(t, err)
 		test.WaitForHorizon()
@@ -283,7 +271,9 @@ func TestMaxAssetsForPathRequests(t *testing.T) {
 		test.Shutdown()
 	})
 	t.Run("set to 2", func(t *testing.T) {
-		test := NewParameterTest(t, map[string]string{"max-assets-per-path-request": "2"})
+		testConfig := integration.GetTestConfig()
+		testConfig.HorizonIngestParameters = map[string]string{"max-assets-per-path-request": "2"}
+		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
 		assert.NoError(t, err)
 		test.WaitForHorizon()
@@ -294,7 +284,7 @@ func TestMaxAssetsForPathRequests(t *testing.T) {
 
 func TestMaxPathFindingRequests(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
-		test := NewParameterTest(t, map[string]string{})
+		test := integration.NewTest(t, *integration.GetTestConfig())
 		err := test.StartHorizon()
 		assert.NoError(t, err)
 		test.WaitForHorizon()
@@ -304,7 +294,9 @@ func TestMaxPathFindingRequests(t *testing.T) {
 		test.Shutdown()
 	})
 	t.Run("set to 5", func(t *testing.T) {
-		test := NewParameterTest(t, map[string]string{"max-path-finding-requests": "5"})
+		testConfig := integration.GetTestConfig()
+		testConfig.HorizonIngestParameters = map[string]string{"max-path-finding-requests": "5"}
+		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
 		assert.NoError(t, err)
 		test.WaitForHorizon()
@@ -318,7 +310,7 @@ func TestMaxPathFindingRequests(t *testing.T) {
 
 func TestDisablePathFinding(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
-		test := NewParameterTest(t, map[string]string{})
+		test := integration.NewTest(t, *integration.GetTestConfig())
 		err := test.StartHorizon()
 		assert.NoError(t, err)
 		test.WaitForHorizon()
@@ -328,7 +320,9 @@ func TestDisablePathFinding(t *testing.T) {
 		test.Shutdown()
 	})
 	t.Run("set to true", func(t *testing.T) {
-		test := NewParameterTest(t, map[string]string{"disable-path-finding": "true"})
+		testConfig := integration.GetTestConfig()
+		testConfig.HorizonIngestParameters = map[string]string{"disable-path-finding": "true"}
+		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
 		assert.NoError(t, err)
 		test.WaitForHorizon()

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -150,11 +150,11 @@ func TestNetworkParameter(t *testing.T) {
 			horizon.NetworkFlagName: horizon.StellarPubnet,
 		})
 		testConfig := integration.GetTestConfig()
-		testConfig.SkipContainerCreation = true
+		testConfig.SkipCoreContainerCreation = true
 		testConfig.HorizonIngestParameters = localParams
 		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
-		time.Sleep(10 * time.Second)
+		time.Sleep(1 * time.Second)
 		assert.NoError(t, err)
 		test.StopHorizon()
 		test.Shutdown()
@@ -165,11 +165,11 @@ func TestNetworkParameter(t *testing.T) {
 			horizon.NetworkFlagName: horizon.StellarTestnet,
 		})
 		testConfig := integration.GetTestConfig()
-		testConfig.SkipContainerCreation = true
+		testConfig.SkipCoreContainerCreation = true
 		testConfig.HorizonIngestParameters = localParams
 		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
-		time.Sleep(10 * time.Second)
+		time.Sleep(1 * time.Second)
 		assert.NoError(t, err)
 		test.StopHorizon()
 		test.Shutdown()
@@ -205,12 +205,12 @@ func TestNetworkEnvironmentVariable(t *testing.T) {
 
 	t.Run("NETWORK environment variable pubnet", func(t *testing.T) {
 		testConfig := integration.GetTestConfig()
-		testConfig.SkipContainerCreation = true
+		testConfig.SkipCoreContainerCreation = true
 		testConfig.HorizonIngestParameters = networkParamArgs
 		testConfig.HorizonEnvironment = map[string]string{"NETWORK": horizon.StellarPubnet}
 		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
-		time.Sleep(10 * time.Second)
+		time.Sleep(1 * time.Second)
 		assert.NoError(t, err)
 		test.StopHorizon()
 		test.Shutdown()
@@ -218,12 +218,12 @@ func TestNetworkEnvironmentVariable(t *testing.T) {
 
 	t.Run("NETWORK environment variable testnet", func(t *testing.T) {
 		testConfig := integration.GetTestConfig()
-		testConfig.SkipContainerCreation = true
+		testConfig.SkipCoreContainerCreation = true
 		testConfig.HorizonIngestParameters = networkParamArgs
 		testConfig.HorizonEnvironment = map[string]string{"NETWORK": horizon.StellarTestnet}
 		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
-		time.Sleep(10 * time.Second)
+		time.Sleep(1 * time.Second)
 		assert.NoError(t, err)
 		test.StopHorizon()
 		test.Shutdown()

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -154,7 +154,9 @@ func TestNetworkParameter(t *testing.T) {
 		testConfig.HorizonIngestParameters = localParams
 		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
-		time.Sleep(1 * time.Second)
+		// Adding sleep here as a workaround for the race condition in the ingestion system.
+		// More details can be found at https://github.com/stellar/go/issues/5005
+		time.Sleep(2 * time.Second)
 		assert.NoError(t, err)
 		test.StopHorizon()
 		test.Shutdown()
@@ -169,7 +171,9 @@ func TestNetworkParameter(t *testing.T) {
 		testConfig.HorizonIngestParameters = localParams
 		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
-		time.Sleep(1 * time.Second)
+		// Adding sleep here as a workaround for the race condition in the ingestion system.
+		// More details can be found at https://github.com/stellar/go/issues/5005
+		time.Sleep(2 * time.Second)
 		assert.NoError(t, err)
 		test.StopHorizon()
 		test.Shutdown()
@@ -210,7 +214,9 @@ func TestNetworkEnvironmentVariable(t *testing.T) {
 		testConfig.HorizonEnvironment = map[string]string{"NETWORK": horizon.StellarPubnet}
 		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
-		time.Sleep(1 * time.Second)
+		// Adding sleep here as a workaround for the race condition in the ingestion system.
+		// More details can be found at https://github.com/stellar/go/issues/5005
+		time.Sleep(2 * time.Second)
 		assert.NoError(t, err)
 		test.StopHorizon()
 		test.Shutdown()
@@ -223,7 +229,9 @@ func TestNetworkEnvironmentVariable(t *testing.T) {
 		testConfig.HorizonEnvironment = map[string]string{"NETWORK": horizon.StellarTestnet}
 		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
-		time.Sleep(1 * time.Second)
+		// Adding sleep here as a workaround for the race condition in the ingestion system.
+		// More details can be found at https://github.com/stellar/go/issues/5005
+		time.Sleep(2 * time.Second)
 		assert.NoError(t, err)
 		test.StopHorizon()
 		test.Shutdown()

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -167,7 +167,7 @@ func TestInvalidNetworkParameters(t *testing.T) {
 			localParams := integration.MergeMaps(networkParamArgs, map[string]string{
 				horizon.NetworkFlagName:                    testCase.networkValue,
 				horizon.EnableCaptiveCoreIngestionFlagName: "true",
-				testCase.param:                             "NETWORK_PARAM",
+				testCase.param:                             testCase.param, // set any value
 			})
 			testConfig := integration.GetTestConfig()
 			testConfig.SkipCoreContainerCreation = true

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	stdLog "log"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
 	"sync"
@@ -24,7 +23,6 @@ import (
 	"github.com/stellar/go/services/horizon/internal/test/integration"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 )
 
 var defaultCaptiveCoreParameters = map[string]string{
@@ -59,19 +57,19 @@ const (
 		QUALITY="MEDIUM"`
 )
 
-func TestFatalScenarios(t *testing.T) {
-	suite.Run(t, new(FatalTestCase))
-}
+var (
+	CaptiveCoreConfigErrMsg = "error generating captive core configuration: invalid config: "
+)
 
 // Ensures that BUCKET_DIR_PATH is not an allowed value for Captive Core.
-func (suite *FatalTestCase) TestBucketDirDisallowed() {
+func TestBucketDirDisallowed(t *testing.T) {
 	// This is a bit of a hacky workaround.
 	//
 	// In CI, we run our integration tests twice: once with Captive Core
 	// enabled, and once without. *These* tests only run with Captive Core
 	// configured properly (specifically, w/ the CAPTIVE_CORE_BIN envvar set).
 	if !integration.RunWithCaptiveCore {
-		suite.T().Skip()
+		t.Skip()
 	}
 
 	config := `BUCKET_DIR_PATH="/tmp"
@@ -84,17 +82,21 @@ func (suite *FatalTestCase) TestBucketDirDisallowed() {
 		horizon.CaptiveCoreConfigPathName: confName,
 		horizon.StellarCoreBinaryPathName: os.Getenv("CAPTIVE_CORE_BIN"),
 	}
-	test := integration.NewTest(suite.T(), *testConfig)
-
-	suite.Exits(func() { test.StartHorizon() })
+	test := integration.NewTest(t, *testConfig)
+	err := test.StartHorizon()
+	assert.Equal(t, err.Error(), integration.HorizonInitErrStr+": error generating captive core configuration:"+
+		" invalid captive core toml file: could not unmarshal captive core toml: setting BUCKET_DIR_PATH is disallowed"+
+		" for Captive Core, use CAPTIVE_CORE_STORAGE_PATH instead")
+	time.Sleep(1 * time.Second)
+	test.StopHorizon()
+	test.Shutdown()
 }
 
-func (suite *FatalTestCase) TestEnvironmentPreserved() {
+func TestEnvironmentPreserved(t *testing.T) {
 	// Who tests the tests? This test.
 	//
 	// It ensures that the global OS environmental variables are preserved after
 	// running an integration test.
-	t := suite.T()
 
 	// Note that we ALSO need to make sure we don't modify parent env state.
 	value, isSet := os.LookupEnv("CAPTIVE_CORE_CONFIG_PATH")
@@ -128,13 +130,60 @@ func (suite *FatalTestCase) TestEnvironmentPreserved() {
 	assert.Equal(t, "original value", envValue)
 }
 
-// TestNetworkParameter the main objective of this test is to ensure that Horizon successfully starts
-// the captive-core subprocess using the default configuration when --network [testnet|pubnet] parameter
-// is specified The test will fail for scenarios with an invalid static configuration, such as:
-// - The default passphrase in Horizon is different from the one specified in the captive-core config.
-// - History archive URLs are not configured.
-// - The captive-core TOML config file is invalid.
-// The test will also fail if an invalid parameter is specified.
+// TestInvalidNetworkParameters Ensure that Horizon returns an error when
+// using NETWORK environment variables, history archive urls or network passphrase
+// parameters are also set.
+func TestInvalidNetworkParameters(t *testing.T) {
+	if !integration.RunWithCaptiveCore {
+		t.Skip()
+	}
+
+	errMsg := "history-archive-urls parameter not allowed with the network parameter"
+	t.Run("history archive urls validation", func(t *testing.T) {
+		localParams := integration.MergeMaps(networkParamArgs, map[string]string{
+			horizon.NetworkFlagName:                    horizon.StellarPubnet,
+			horizon.EnableCaptiveCoreIngestionFlagName: "true",
+			horizon.HistoryArchiveURLsFlagName:         "HISTORY_ARCHIVE_URLS",
+		})
+		testConfig := integration.GetTestConfig()
+		testConfig.SkipCoreContainerCreation = true
+		testConfig.HorizonIngestParameters = localParams
+		test := integration.NewTest(t, *testConfig)
+		err := test.StartHorizon()
+		assert.Equal(t, err.Error(), integration.HorizonInitErrStr+
+			": "+CaptiveCoreConfigErrMsg+errMsg)
+		// Adding sleep as a workaround for the race condition in the ingestion system.
+		// https://github.com/stellar/go/issues/5005
+		time.Sleep(2 * time.Second)
+		test.StopHorizon()
+		test.Shutdown()
+	})
+
+	errMsg = "network-passphrase parameter not allowed with the network parameter"
+	t.Run("network-passphrase validation", func(t *testing.T) {
+		localParams := integration.MergeMaps(networkParamArgs, map[string]string{
+			horizon.NetworkFlagName:                    horizon.StellarTestnet,
+			horizon.EnableCaptiveCoreIngestionFlagName: "true",
+			horizon.NetworkPassphraseFlagName:          "NETWORK_PASSPHRASE",
+		})
+		testConfig := integration.GetTestConfig()
+		testConfig.SkipCoreContainerCreation = true
+		testConfig.HorizonIngestParameters = localParams
+		test := integration.NewTest(t, *testConfig)
+		err := test.StartHorizon()
+		assert.Equal(t, err.Error(), integration.HorizonInitErrStr+
+			": "+CaptiveCoreConfigErrMsg+errMsg)
+		// Adding sleep as a workaround for the race condition in the ingestion system.
+		// https://github.com/stellar/go/issues/5005
+		time.Sleep(2 * time.Second)
+		test.StopHorizon()
+		test.Shutdown()
+	})
+}
+
+// TestNetworkParameter Ensure that Horizon successfully starts the captive-core
+// subprocess using the default configuration when --network [testnet|pubnet]
+// commandline parameter.
 //
 // Typically during integration tests, we initiate Horizon in standalone mode and simultaneously start the
 // stellar-core container in standalone mode as well. We wait for Horizon to begin ingesting to verify the test's
@@ -154,8 +203,8 @@ func TestNetworkParameter(t *testing.T) {
 		testConfig.HorizonIngestParameters = localParams
 		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
-		// Adding sleep here as a workaround for the race condition in the ingestion system.
-		// More details can be found at https://github.com/stellar/go/issues/5005
+		// Adding sleep as a workaround for the race condition in the ingestion system.
+		// https://github.com/stellar/go/issues/5005
 		time.Sleep(2 * time.Second)
 		assert.NoError(t, err)
 		test.StopHorizon()
@@ -171,8 +220,8 @@ func TestNetworkParameter(t *testing.T) {
 		testConfig.HorizonIngestParameters = localParams
 		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
-		// Adding sleep here as a workaround for the race condition in the ingestion system.
-		// More details can be found at https://github.com/stellar/go/issues/5005
+		// Adding sleep as a workaround for the race condition in the ingestion system.
+		// https://github.com/stellar/go/issues/5005
 		time.Sleep(2 * time.Second)
 		assert.NoError(t, err)
 		test.StopHorizon()
@@ -180,14 +229,9 @@ func TestNetworkParameter(t *testing.T) {
 	})
 }
 
-// TestNetworkEnvironmentVariable the main objective of this test is to ensure that Horizon successfully
-// starts the captive-core subprocess using the default configuration when the NETWORK environment variable
-// is set to either pubnet or testnet.
-// The test will fail for scenarios with an invalid configuration, such as:
-// - The default passphrase in Horizon is different from the one specified in the captive-core config.
-// - History archive URLs are not configured.
-// - The captive-core TOML config file is invalid.
-// The test will also fail if an invalid parameter is specified.
+// TestNetworkEnvironmentVariable Ensure that Horizon successfully starts the captive-core
+// subprocess using the default configuration when the NETWORK environment variable is set
+// to either pubnet or testnet.
 //
 // Typically during integration tests, we initiate Horizon in standalone mode and simultaneously start the
 // stellar-core container in standalone mode as well. We wait for Horizon to begin ingesting to verify the test's
@@ -426,36 +470,6 @@ func TestHelpOutputForNoIngestionFilteringFlag(t *testing.T) {
 
 	output := writer.(*bytes.Buffer).String()
 	assert.NotContains(t, output, "--exp-enable-ingestion-filtering")
-}
-
-// Pattern taken from testify issue:
-// https://github.com/stretchr/testify/issues/858#issuecomment-600491003
-//
-// This lets us run test cases that are *expected* to fail from a fatal error.
-//
-// For our purposes, if you *want* `StartHorizon()` to fail, you should wrap it
-// in a lambda and pass it to `suite.Exits(...)`.
-type FatalTestCase struct {
-	suite.Suite
-}
-
-func (suite *FatalTestCase) Exits(subprocess func()) {
-	testName := suite.T().Name()
-	if os.Getenv("ASSERT_EXISTS_"+testName) == "1" {
-		subprocess()
-		return
-	}
-
-	cmd := exec.Command(os.Args[0], "-test.run="+testName)
-	cmd.Env = append(os.Environ(), "ASSERT_EXISTS_"+testName+"=1")
-	err := cmd.Run()
-
-	suite.T().Log("Result:", err)
-	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
-		return
-	}
-
-	suite.Fail("expecting unsuccessful exit, got", err)
 }
 
 // validateNoBucketDirPath ensures the Stellar Core auto-generated configuration

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -112,8 +112,7 @@ func (suite *FatalTestCase) TestEnvironmentPreserved() {
 	confName, _, cleanup := createCaptiveCoreConfig(SIMPLE_CAPTIVE_CORE_TOML)
 	defer cleanup()
 	testConfig := integration.GetTestConfig()
-	testConfig.HorizonEnvironment = map[string]string{"CAPTIVE_CORE_CONFIG_PATH": confName,
-	}
+	testConfig.HorizonEnvironment = map[string]string{"CAPTIVE_CORE_CONFIG_PATH": confName}
 	test := integration.NewTest(t, *testConfig)
 
 	err = test.StartHorizon()

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -36,7 +36,7 @@ var defaultCaptiveCoreParameters = map[string]string{
 var networkParamArgs = map[string]string{
 	horizon.EnableCaptiveCoreIngestionFlagName: "true",
 	horizon.CaptiveCoreConfigPathName:          "",
-	horizon.CaptiveCoreHttpPortFlagName:        "",
+	horizon.CaptiveCoreHTTPPortFlagName:        "",
 	horizon.StellarCoreBinaryPathName:          "",
 	horizon.StellarCoreURLFlagName:             "",
 	horizon.HistoryArchiveURLsFlagName:         "",

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -59,6 +59,20 @@ const (
 		QUALITY="MEDIUM"`
 )
 
+func NewParameterTestSkipContainerCreation(t *testing.T, params map[string]string) *integration.Test {
+	return NewParameterTestWithEnvSkipContainerCreation(t, params, map[string]string{})
+}
+
+func NewParameterTestWithEnvSkipContainerCreation(t *testing.T, params, envvars map[string]string) *integration.Test {
+	config := integration.Config{
+		ProtocolVersion:         17,
+		SkipHorizonStart:        true,
+		SkipContainerCreation:   true,
+		HorizonIngestParameters: params,
+		HorizonEnvironment:      envvars}
+	return integration.NewTest(t, config)
+}
+
 func NewParameterTest(t *testing.T, params map[string]string) *integration.Test {
 	return NewParameterTestWithEnv(t, params, map[string]string{})
 }
@@ -148,6 +162,11 @@ func (suite *FatalTestCase) TestEnvironmentPreserved() {
 // - History archive URLs are not configured.
 // - The captive-core TOML config file is invalid.
 // The test will also fail if an invalid parameter is specified.
+//
+// Typically during integration tests, we initiate Horizon in standalone mode and simultaneously start the
+// stellar-core container in standalone mode as well. We wait for Horizon to begin ingesting to verify the test's
+// success. However, in the case of "pubnet" or "testnet," waiting for Horizon to start ingesting is not practical.
+// So we don't start stellar-core containers.
 func TestNetworkParameter(t *testing.T) {
 	if !integration.RunWithCaptiveCore {
 		t.Skip()
@@ -157,7 +176,7 @@ func TestNetworkParameter(t *testing.T) {
 		localParams := integration.MergeMaps(networkParamArgs, map[string]string{
 			horizon.NetworkFlagName: horizon.StellarPubnet,
 		})
-		test := NewParameterTest(t, localParams)
+		test := NewParameterTestSkipContainerCreation(t, localParams)
 		err := test.StartHorizon()
 		time.Sleep(10 * time.Second)
 		assert.NoError(t, err)
@@ -169,7 +188,7 @@ func TestNetworkParameter(t *testing.T) {
 		localParams := integration.MergeMaps(networkParamArgs, map[string]string{
 			horizon.NetworkFlagName: horizon.StellarTestnet,
 		})
-		test := NewParameterTest(t, localParams)
+		test := NewParameterTestSkipContainerCreation(t, localParams)
 		err := test.StartHorizon()
 		time.Sleep(10 * time.Second)
 		assert.NoError(t, err)
@@ -186,6 +205,11 @@ func TestNetworkParameter(t *testing.T) {
 // - History archive URLs are not configured.
 // - The captive-core TOML config file is invalid.
 // The test will also fail if an invalid parameter is specified.
+//
+// Typically during integration tests, we initiate Horizon in standalone mode and simultaneously start the
+// stellar-core container in standalone mode as well. We wait for Horizon to begin ingesting to verify the test's
+// success. However, in the case of "pubnet" or "testnet," waiting for Horizon to start ingesting is not practical.
+// So we don't start stellar-core containers.
 func TestNetworkEnvironmentVariable(t *testing.T) {
 	if !integration.RunWithCaptiveCore {
 		t.Skip()
@@ -201,7 +225,7 @@ func TestNetworkEnvironmentVariable(t *testing.T) {
 	}()
 
 	t.Run("NETWORK environment variable pubnet", func(t *testing.T) {
-		test := NewParameterTestWithEnv(t, networkParamArgs,
+		test := NewParameterTestWithEnvSkipContainerCreation(t, networkParamArgs,
 			map[string]string{"NETWORK": horizon.StellarPubnet})
 		err := test.StartHorizon()
 		time.Sleep(10 * time.Second)
@@ -211,7 +235,7 @@ func TestNetworkEnvironmentVariable(t *testing.T) {
 	})
 
 	t.Run("NETWORK environment variable testnet", func(t *testing.T) {
-		test := NewParameterTestWithEnv(t, networkParamArgs,
+		test := NewParameterTestWithEnvSkipContainerCreation(t, networkParamArgs,
 			map[string]string{"NETWORK": horizon.StellarTestnet})
 		err := test.StartHorizon()
 		time.Sleep(10 * time.Second)

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -332,7 +332,7 @@ func TestDisablePathFinding(t *testing.T) {
 
 func TestIngestionFilteringAlwaysDefaultingToTrue(t *testing.T) {
 	t.Run("ingestion filtering flag set to default value", func(t *testing.T) {
-		test := NewParameterTest(t, map[string]string{})
+		test := integration.NewTest(t, *integration.GetTestConfig())
 		err := test.StartHorizon()
 		assert.NoError(t, err)
 		test.WaitForHorizon()
@@ -340,7 +340,9 @@ func TestIngestionFilteringAlwaysDefaultingToTrue(t *testing.T) {
 		test.Shutdown()
 	})
 	t.Run("ingestion filtering flag set to false", func(t *testing.T) {
-		test := NewParameterTest(t, map[string]string{"exp-enable-ingestion-filtering": "false"})
+		testConfig := integration.GetTestConfig()
+		testConfig.HorizonIngestParameters = map[string]string{"exp-enable-ingestion-filtering": "false"}
+		test := integration.NewTest(t, *testConfig)
 		err := test.StartHorizon()
 		assert.NoError(t, err)
 		test.WaitForHorizon()
@@ -355,7 +357,9 @@ func TestDeprecatedOutputForIngestionFilteringFlag(t *testing.T) {
 	os.Stderr = w
 	stdLog.SetOutput(os.Stderr)
 
-	test := NewParameterTest(t, map[string]string{"exp-enable-ingestion-filtering": "false"})
+	testConfig := integration.GetTestConfig()
+	testConfig.HorizonIngestParameters = map[string]string{"exp-enable-ingestion-filtering": "false"}
+	test := integration.NewTest(t, *testConfig)
 	err := test.StartHorizon()
 	assert.NoError(t, err)
 	test.WaitForHorizon()

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -195,16 +195,26 @@ func TestNetworkParameter(t *testing.T) {
 	if !integration.RunWithCaptiveCore {
 		t.Skip()
 	}
-
-	testCases := []string{
-		horizon.StellarPubnet,
-		horizon.StellarTestnet,
+	testCases := []struct {
+		networkValue       string
+		networkPassphrase  string
+		historyArchiveURLs []string
+	}{
+		{
+			networkValue:       horizon.StellarTestnet,
+			networkPassphrase:  horizon.TestnetConf.NetworkPassphrase,
+			historyArchiveURLs: horizon.TestnetConf.HistoryArchiveURLs,
+		},
+		{
+			networkValue:       horizon.StellarPubnet,
+			networkPassphrase:  horizon.PubnetConf.NetworkPassphrase,
+			historyArchiveURLs: horizon.PubnetConf.HistoryArchiveURLs,
+		},
 	}
-
-	for _, networkValue := range testCases {
-		t.Run(fmt.Sprintf("NETWORK parameter %s", networkValue), func(t *testing.T) {
+	for _, tt := range testCases {
+		t.Run(fmt.Sprintf("NETWORK parameter %s", tt.networkValue), func(t *testing.T) {
 			localParams := integration.MergeMaps(networkParamArgs, map[string]string{
-				horizon.NetworkFlagName: networkValue,
+				horizon.NetworkFlagName: tt.networkValue,
 			})
 			testConfig := integration.GetTestConfig()
 			testConfig.SkipCoreContainerCreation = true
@@ -215,6 +225,9 @@ func TestNetworkParameter(t *testing.T) {
 			// https://github.com/stellar/go/issues/5005
 			time.Sleep(2 * time.Second)
 			assert.NoError(t, err)
+			assert.Equal(t, test.GetHorizonIngestConfig().HistoryArchiveURLs, tt.historyArchiveURLs)
+			assert.Equal(t, test.GetHorizonIngestConfig().NetworkPassphrase, tt.networkPassphrase)
+
 			test.Shutdown()
 		})
 	}

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -112,9 +113,9 @@ func (suite *FatalTestCase) TestEnvironmentPreserved() {
 	value, isSet := os.LookupEnv("CAPTIVE_CORE_CONFIG_PATH")
 	defer func() {
 		if isSet {
-			os.Setenv("CAPTIVE_CORE_CONFIG_PATH", value)
+			_ = os.Setenv("CAPTIVE_CORE_CONFIG_PATH", value)
 		} else {
-			os.Unsetenv("CAPTIVE_CORE_CONFIG_PATH")
+			_ = os.Unsetenv("CAPTIVE_CORE_CONFIG_PATH")
 		}
 	}()
 
@@ -148,14 +149,20 @@ func (suite *FatalTestCase) TestEnvironmentPreserved() {
 // - The captive-core TOML config file is invalid.
 // The test will also fail if an invalid parameter is specified.
 func TestNetworkParameter(t *testing.T) {
+	if !integration.RunWithCaptiveCore {
+		t.Skip()
+	}
+
 	t.Run("network parameter pubnet", func(t *testing.T) {
 		localParams := integration.MergeMaps(networkParamArgs, map[string]string{
 			horizon.NetworkFlagName: horizon.StellarPubnet,
 		})
 		test := NewParameterTest(t, localParams)
 		err := test.StartHorizon()
+		time.Sleep(10 * time.Second)
 		assert.NoError(t, err)
 		test.StopHorizon()
+		test.Shutdown()
 	})
 
 	t.Run("network parameter testnet", func(t *testing.T) {
@@ -164,8 +171,10 @@ func TestNetworkParameter(t *testing.T) {
 		})
 		test := NewParameterTest(t, localParams)
 		err := test.StartHorizon()
+		time.Sleep(10 * time.Second)
 		assert.NoError(t, err)
 		test.StopHorizon()
+		test.Shutdown()
 	})
 }
 
@@ -178,12 +187,16 @@ func TestNetworkParameter(t *testing.T) {
 // - The captive-core TOML config file is invalid.
 // The test will also fail if an invalid parameter is specified.
 func TestNetworkEnvironmentVariable(t *testing.T) {
+	if !integration.RunWithCaptiveCore {
+		t.Skip()
+	}
+
 	value, isSet := os.LookupEnv("NETWORK")
 	defer func() {
 		if isSet {
-			os.Setenv("NETWORK", value)
+			_ = os.Setenv("NETWORK", value)
 		} else {
-			os.Unsetenv("NETWORK")
+			_ = os.Unsetenv("NETWORK")
 		}
 	}()
 
@@ -191,16 +204,20 @@ func TestNetworkEnvironmentVariable(t *testing.T) {
 		test := NewParameterTestWithEnv(t, networkParamArgs,
 			map[string]string{"NETWORK": horizon.StellarPubnet})
 		err := test.StartHorizon()
+		time.Sleep(10 * time.Second)
 		assert.NoError(t, err)
 		test.StopHorizon()
+		test.Shutdown()
 	})
 
 	t.Run("NETWORK environment variable testnet", func(t *testing.T) {
 		test := NewParameterTestWithEnv(t, networkParamArgs,
 			map[string]string{"NETWORK": horizon.StellarTestnet})
 		err := test.StartHorizon()
+		time.Sleep(10 * time.Second)
 		assert.NoError(t, err)
 		test.StopHorizon()
+		test.Shutdown()
 	})
 }
 

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -32,6 +32,16 @@ var defaultCaptiveCoreParameters = map[string]string{
 	horizon.StellarCoreDBURLFlagName:  "",
 }
 
+var networkParamArgs = map[string]string{
+	horizon.EnableCaptiveCoreIngestionFlagName: "true",
+	horizon.CaptiveCoreConfigPathName:          "",
+	horizon.CaptiveCoreHttpPortFlagName:        "",
+	horizon.StellarCoreBinaryPathName:          "",
+	horizon.StellarCoreURLFlagName:             "",
+	horizon.HistoryArchiveURLsFlagName:         "",
+	horizon.NetworkPassphraseFlagName:          "",
+}
+
 const (
 	SIMPLE_CAPTIVE_CORE_TOML = `
 		PEER_PORT=11725
@@ -99,11 +109,14 @@ func (suite *FatalTestCase) TestEnvironmentPreserved() {
 	t := suite.T()
 
 	// Note that we ALSO need to make sure we don't modify parent env state.
-	if value, isSet := os.LookupEnv("CAPTIVE_CORE_CONFIG_PATH"); isSet {
-		defer func() {
+	value, isSet := os.LookupEnv("CAPTIVE_CORE_CONFIG_PATH")
+	defer func() {
+		if isSet {
 			os.Setenv("CAPTIVE_CORE_CONFIG_PATH", value)
-		}()
-	}
+		} else {
+			os.Unsetenv("CAPTIVE_CORE_CONFIG_PATH")
+		}
+	}()
 
 	err := os.Setenv("CAPTIVE_CORE_CONFIG_PATH", "original value")
 	assert.NoError(t, err)
@@ -125,6 +138,70 @@ func (suite *FatalTestCase) TestEnvironmentPreserved() {
 
 	envValue = os.Getenv("CAPTIVE_CORE_CONFIG_PATH")
 	assert.Equal(t, "original value", envValue)
+}
+
+// TestNetworkParameter the main objective of this test is to ensure that Horizon successfully starts
+// the captive-core subprocess using the default configuration when --network [testnet|pubnet] parameter
+// is specified The test will fail for scenarios with an invalid static configuration, such as:
+// - The default passphrase in Horizon is different from the one specified in the captive-core config.
+// - History archive URLs are not configured.
+// - The captive-core TOML config file is invalid.
+// The test will also fail if an invalid parameter is specified.
+func TestNetworkParameter(t *testing.T) {
+	t.Run("network parameter pubnet", func(t *testing.T) {
+		localParams := integration.MergeMaps(networkParamArgs, map[string]string{
+			horizon.NetworkFlagName: horizon.StellarPubnet,
+		})
+		test := NewParameterTest(t, localParams)
+		err := test.StartHorizon()
+		assert.NoError(t, err)
+		test.StopHorizon()
+	})
+
+	t.Run("network parameter testnet", func(t *testing.T) {
+		localParams := integration.MergeMaps(networkParamArgs, map[string]string{
+			horizon.NetworkFlagName: horizon.StellarTestnet,
+		})
+		test := NewParameterTest(t, localParams)
+		err := test.StartHorizon()
+		assert.NoError(t, err)
+		test.StopHorizon()
+	})
+}
+
+// TestNetworkEnvironmentVariable the main objective of this test is to ensure that Horizon successfully
+// starts the captive-core subprocess using the default configuration when the NETWORK environment variable
+// is set to either pubnet or testnet.
+// The test will fail for scenarios with an invalid configuration, such as:
+// - The default passphrase in Horizon is different from the one specified in the captive-core config.
+// - History archive URLs are not configured.
+// - The captive-core TOML config file is invalid.
+// The test will also fail if an invalid parameter is specified.
+func TestNetworkEnvironmentVariable(t *testing.T) {
+	value, isSet := os.LookupEnv("NETWORK")
+	defer func() {
+		if isSet {
+			os.Setenv("NETWORK", value)
+		} else {
+			os.Unsetenv("NETWORK")
+		}
+	}()
+
+	t.Run("NETWORK environment variable pubnet", func(t *testing.T) {
+		test := NewParameterTestWithEnv(t, networkParamArgs,
+			map[string]string{"NETWORK": horizon.StellarPubnet})
+		err := test.StartHorizon()
+		assert.NoError(t, err)
+		test.StopHorizon()
+	})
+
+	t.Run("NETWORK environment variable testnet", func(t *testing.T) {
+		test := NewParameterTestWithEnv(t, networkParamArgs,
+			map[string]string{"NETWORK": horizon.StellarTestnet})
+		err := test.StartHorizon()
+		assert.NoError(t, err)
+		test.StopHorizon()
+	})
 }
 
 // Ensures that the filesystem ends up in the correct state with Captive Core.

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -119,23 +119,32 @@ func NewTest(t *testing.T, config Config) *Test {
 			config.ProtocolVersion = maxSupportedCoreProtocolFromEnv
 		}
 	}
-
-	composePath := findDockerComposePath()
-	i := &Test{
-		t:           t,
-		config:      config,
-		composePath: composePath,
-		passPhrase:  StandaloneNetworkPassphrase,
-		environment: NewEnvironmentManager(),
+	var i *Test
+	if !config.SkipContainerCreation {
+		composePath := findDockerComposePath()
+		i = &Test{
+			t:           t,
+			config:      config,
+			composePath: composePath,
+			passPhrase:  StandaloneNetworkPassphrase,
+			environment: NewEnvironmentManager(),
+		}
+		i.configureCaptiveCore()
+		// Only run Stellar Core container and its dependencies.
+		i.runComposeCommand("up", "--detach", "--quiet-pull", "--no-color", "core")
+	} else {
+		i = &Test{
+			t:           t,
+			config:      config,
+			environment: NewEnvironmentManager(),
+		}
 	}
 
-	i.configureCaptiveCore()
-
-	// Only run Stellar Core container and its dependencies.
-	i.runComposeCommand("up", "--detach", "--quiet-pull", "--no-color", "core")
 	i.prepareShutdownHandlers()
 	i.coreClient = &stellarcore.Client{URL: "http://localhost:" + strconv.Itoa(stellarCorePort)}
-	i.waitForCore()
+	if !config.SkipContainerCreation {
+		i.waitForCore()
+	}
 
 	if !config.SkipHorizonStart {
 		if innerErr := i.StartHorizon(); innerErr != nil {
@@ -224,8 +233,10 @@ func (i *Test) prepareShutdownHandlers() {
 			if i.ingestNode != nil {
 				i.ingestNode.Close()
 			}
-			i.runComposeCommand("rm", "-fvs", "core")
-			i.runComposeCommand("rm", "-fvs", "core-postgres")
+			if !i.config.SkipContainerCreation {
+				i.runComposeCommand("rm", "-fvs", "core")
+				i.runComposeCommand("rm", "-fvs", "core-postgres")
+			}
 		},
 		i.environment.Restore,
 	)

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -41,6 +41,7 @@ const (
 )
 
 var (
+	HorizonInitErrStr       = "cannot initialize Horizon"
 	RunWithCaptiveCore      = os.Getenv("HORIZON_INTEGRATION_TESTS_ENABLE_CAPTIVE_CORE") != ""
 	RunWithCaptiveCoreUseDB = os.Getenv("HORIZON_INTEGRATION_TESTS_CAPTIVE_CORE_USE_DB") != ""
 )
@@ -321,14 +322,13 @@ func (i *Test) StartHorizon() error {
 		Use:   "horizon",
 		Short: "Ingest of Stellar network",
 		Long:  "Ingest of Stellar network.",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			i.ingestNode, err = horizon.NewAppFromFlags(ingestConfig, ingestConfigOpts)
 			if err != nil {
-				// Explicitly exit here as that's how these tests are structured for now.
 				fmt.Println(err)
-				os.Exit(1)
 			}
+			return err
 		},
 	}
 
@@ -411,11 +411,11 @@ func (i *Test) StartHorizon() error {
 	}
 
 	if err = ingestCmd.Execute(); err != nil {
-		return errors.Wrap(err, "cannot initialize Horizon")
+		return errors.Wrap(err, HorizonInitErrStr)
 	}
 
 	if err = webCmd.Execute(); err != nil {
-		return errors.Wrap(err, "cannot initialize Horizon")
+		return errors.Wrap(err, HorizonInitErrStr)
 	}
 
 	horizonPort := "8000"
@@ -568,8 +568,9 @@ func (i *Test) StopHorizon() {
 	}
 
 	// Wait for Horizon to shut down completely.
-	i.appStopped.Wait()
-
+	if i.appStopped != nil {
+		i.appStopped.Wait()
+	}
 	i.webNode = nil
 	i.ingestNode = nil
 }

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -98,6 +98,17 @@ type Test struct {
 	passPhrase    string
 }
 
+// GetTestConfig returns the default test Config required to run NewTest.
+func GetTestConfig() *Config {
+	return &Config{
+		ProtocolVersion:         17,
+		SkipHorizonStart:        true,
+		SkipContainerCreation:   false,
+		HorizonIngestParameters: map[string]string{},
+		HorizonEnvironment:      map[string]string{},
+	}
+}
+
 // NewTest starts a new environment for integration test at a given
 // protocol version and blocks until Horizon starts ingesting.
 //

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -46,9 +46,9 @@ var (
 )
 
 type Config struct {
-	ProtocolVersion       uint32
-	SkipContainerCreation bool
-	CoreDockerImage       string
+	ProtocolVersion           uint32
+	SkipCoreContainerCreation bool
+	CoreDockerImage           string
 
 	// Weird naming here because bools default to false, but we want to start
 	// Horizon by default.
@@ -101,11 +101,11 @@ type Test struct {
 // GetTestConfig returns the default test Config required to run NewTest.
 func GetTestConfig() *Config {
 	return &Config{
-		ProtocolVersion:         17,
-		SkipHorizonStart:        true,
-		SkipContainerCreation:   false,
-		HorizonIngestParameters: map[string]string{},
-		HorizonEnvironment:      map[string]string{},
+		ProtocolVersion:           17,
+		SkipHorizonStart:          true,
+		SkipCoreContainerCreation: false,
+		HorizonIngestParameters:   map[string]string{},
+		HorizonEnvironment:        map[string]string{},
 	}
 }
 
@@ -131,7 +131,7 @@ func NewTest(t *testing.T, config Config) *Test {
 		}
 	}
 	var i *Test
-	if !config.SkipContainerCreation {
+	if !config.SkipCoreContainerCreation {
 		composePath := findDockerComposePath()
 		i = &Test{
 			t:           t,
@@ -153,7 +153,7 @@ func NewTest(t *testing.T, config Config) *Test {
 
 	i.prepareShutdownHandlers()
 	i.coreClient = &stellarcore.Client{URL: "http://localhost:" + strconv.Itoa(stellarCorePort)}
-	if !config.SkipContainerCreation {
+	if !config.SkipCoreContainerCreation {
 		i.waitForCore()
 	}
 
@@ -244,7 +244,7 @@ func (i *Test) prepareShutdownHandlers() {
 			if i.ingestNode != nil {
 				i.ingestNode.Close()
 			}
-			if !i.config.SkipContainerCreation {
+			if !i.config.SkipCoreContainerCreation {
 				i.runComposeCommand("rm", "-fvs", "core")
 				i.runComposeCommand("rm", "-fvs", "core-postgres")
 			}

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -360,7 +360,8 @@ func (i *Test) StartHorizon() error {
 	ingestArgs := mapToFlags(mergedIngest)
 
 	// initialize core arguments
-	i.t.Log("Horizon command line:", webArgs)
+	i.t.Log("Horizon command line webArgs:", webArgs)
+	i.t.Log("Horizon command line ingestArgs:", ingestArgs)
 	var env strings.Builder
 	for key, value := range i.config.HorizonEnvironment {
 		env.WriteString(fmt.Sprintf("%s=%s ", key, value))


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Introduce integration tests to verify that Horizon starts successfully with the default configuration when the NETWORK parameter is set to either "pubnet" or "testnet". The tests cover `Network` parameter using both command-line argument and  environment variable. Added support to skip starting core containers for running these tests.

Updated the `StartHorizon()` function to return the error instead of just exiting. Updated the existing test that was affected by it.

Fixed an issue in an existing test where it failed to clean up the environment variable properly.



### Why
closes #4967 

### Known limitations

Typically during integration tests, we initiate Horizon in standalone mode and simultaneously start the stellar-core container in standalone mode as well. We wait for Horizon to begin ingesting to verify the test's success. However, in the case of "pubnet" or "testnet," waiting for Horizon to start ingesting is not practical. As a result, we run only validate that the Horizon successfully starts the captive-core subprocess using the default configuration.