### PR TITLE
services/horizon add horizon binary building Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ ticker:
 friendbot:
 	$(MAKE) -C services/friendbot/ docker-build
 
+horizon:
+	$(MAKE) -C services/horizon/ binary-build
+
 webauth:
 	$(MAKE) -C exp/services/webauth/ docker-build
 

--- a/services/horizon/Makefile
+++ b/services/horizon/Makefile
@@ -1,0 +1,16 @@
+SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
+
+ifndef VERSION_STRING
+        $(error VERSION_STRING environment variable must be set. For example "2.26.0-d2d01d39759f2f315f4af59e4b95700a4def44eb")
+endif
+
+binary-build:
+	$(SUDO) docker run --rm $(DOCKER_OPTS) -v $(shell pwd)/../../:/go/src/github.com/stellar/go \
+		--pull always \
+		--env CGO_ENABLED=0 \
+		--env GOFLAGS="-ldflags=-X=github.com/stellar/go/support/app.version=$(VERSION_STRING)" \
+		golang:1.20-bullseye \
+		/bin/bash -c '\
+			git config --global --add safe.directory /go/src/github.com/stellar/go && \
+			cd /go/src/github.com/stellar/go && \
+			go build -o horizon -trimpath -v ./services/horizon'

--- a/services/horizon/Makefile
+++ b/services/horizon/Makefile
@@ -4,8 +4,10 @@ ifndef VERSION_STRING
         $(error VERSION_STRING environment variable must be set. For example "2.26.0-d2d01d39759f2f315f4af59e4b95700a4def44eb")
 endif
 
+DOCKER_PLATFORM := $(shell docker system info --format '{{.OSType}}/{{.Architecture}}')
+
 binary-build:
-	$(SUDO) docker run --rm $(DOCKER_OPTS) -v $(shell pwd)/../../:/go/src/github.com/stellar/go \
+	$(SUDO) docker run --platform $(DOCKER_PLATFORM) --rm $(DOCKER_OPTS) -v $(shell pwd)/../../:/go/src/github.com/stellar/go \
 		--pull always \
 		--env CGO_ENABLED=0 \
 		--env GOFLAGS="-ldflags=-X=github.com/stellar/go/support/app.version=$(VERSION_STRING)" \

--- a/services/horizon/Makefile
+++ b/services/horizon/Makefile
@@ -15,4 +15,4 @@ binary-build:
 		/bin/bash -c '\
 			git config --global --add safe.directory /go/src/github.com/stellar/go && \
 			cd /go/src/github.com/stellar/go && \
-			go build -o horizon -trimpath -v ./services/horizon'
+			go build -o stellar-horizon -trimpath -v ./services/horizon'


### PR DESCRIPTION
### What

This PR adds Makefile entries to allow us to build horizon in an isolated, docker based, environment.

### Why

This will make build process more transparent and it will simplify build systems where horizon is built.