### PR TITLE
Resolve Horizon CI failures caused by the failure to install the right version of libc++ 

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -76,7 +76,7 @@ jobs:
         # Workaround for https://github.com/actions/virtual-environments/issues/5245,
         # libc++1-8 won't be installed if another version is installed (but apt won't give you a helpul
         # message about why the installation fails)
-        sudo apt-get remove -y libc++1-10 libc++abi1-10 || true
+        sudo apt-get remove -y libc++1-12 libc++abi1-12 || true
 
         sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
         sudo bash -c 'echo "deb https://apt.stellar.org focal unstable" > /etc/apt/sources.list.d/SDF-unstable.list'

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -76,7 +76,7 @@ jobs:
         # Workaround for https://github.com/actions/virtual-environments/issues/5245,
         # libc++1-8 won't be installed if another version is installed (but apt won't give you a helpul
         # message about why the installation fails)
-        #sudo apt-get remove -y libc++1-12 libc++abi1-12 || true
+        sudo apt-get remove -y libc++1-14 libc++abi1-14 || true
 
         sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
         sudo bash -c 'echo "deb https://apt.stellar.org focal unstable" > /etc/apt/sources.list.d/SDF-unstable.list'

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -76,7 +76,8 @@ jobs:
         # Workaround for https://github.com/actions/virtual-environments/issues/5245,
         # libc++1-8 won't be installed if another version is installed (but apt won't give you a helpul
         # message about why the installation fails)
-        sudo apt-get remove -y libc++1-14 libc++abi1-14 || true
+        sudo apt list --installed | grep libc++
+        sudo apt-get remove -y libc++1-* libc++abi1-* || true
 
         sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
         sudo bash -c 'echo "deb https://apt.stellar.org focal unstable" > /etc/apt/sources.list.d/SDF-unstable.list'

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -76,7 +76,7 @@ jobs:
         # Workaround for https://github.com/actions/virtual-environments/issues/5245,
         # libc++1-8 won't be installed if another version is installed (but apt won't give you a helpul
         # message about why the installation fails)
-        sudo apt-get remove -y libc++1-12 libc++abi1-12 || true
+        #sudo apt-get remove -y libc++1-12 libc++abi1-12 || true
 
         sudo wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true sudo apt-key add -
         sudo bash -c 'echo "deb https://apt.stellar.org focal unstable" > /etc/apt/sources.list.d/SDF-unstable.list'


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update this [fix](https://github.com/stellar/go/pull/4292) to handle all versions of libc++ 

### Why

Horizon CI is failing with errors while running integration test. The error occurs because the apt package manager is unable to install the required version of libc++ (`libc++1-12`) when there is already an existing version installed.

```
2023-07-27T17:08:37.2546428Z Reading package lists...
2023-07-27T17:08:37.4156798Z Building dependency tree...
2023-07-27T17:08:37.4169264Z Reading state information...
2023-07-27T17:08:37.4714457Z Some packages could not be installed. This may mean that you have
2023-07-27T17:08:37.4715476Z requested an impossible situation or if you are using the unstable
2023-07-27T17:08:37.4716439Z distribution that some required packages have not yet been created
2023-07-27T17:08:37.4716842Z or been moved out of Incoming.
2023-07-27T17:08:37.4717193Z The following information may help to resolve the situation:
2023-07-27T17:08:37.4717408Z 
2023-07-27T17:08:37.4717574Z The following packages have unmet dependencies:
2023-07-27T17:08:37.5522389Z  libc++1-12 : Conflicts: libc++-x.y
2023-07-27T17:08:37.5523382Z  libc++1-14 : Conflicts: libc++-x.y
2023-07-27T17:08:37.5526307Z  libc++abi1-12 : Conflicts: libc++abi-x.y
2023-07-27T17:08:37.5529085Z  libc++abi1-14 : Conflicts: libc++abi-x.y
2023-07-27T17:08:37.5531166Z  libunwind-12 : Conflicts: libunwind-x.y
2023-07-27T17:08:37.5531937Z  libunwind-14 : Conflicts: libunwind-x.y
2023-07-27T17:08:37.5559422Z E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
2023-07-27T17:08:37.5590668Z ##[error]Process completed with exit code 100.
```

### Known limitations

[TODO or N/A]
