### PR TITLE
services/horizon: Add more validations for the NETWORK parameter

### DIFF
--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -769,14 +769,6 @@ func setCaptiveCoreConfiguration(config *Config) error {
 	}
 
 	if config.Network != "" {
-		// Make sure stellar-core binary is installed and is available in the OS $PATH
-		cmd := exec.Command("stellar-core")
-		_ = cmd.Run()
-		if cmd.Err != nil {
-			return errors.Wrap(cmd.Err, "error executing stellar-core."+
-				" Please ensure that stellar-core binary to be installed and available in the OS PATH.")
-		}
-
 		err := createCaptiveCoreConfigFromNetwork(config)
 		if err != nil {
 			return errors.Wrap(err, "error generating default captive core config.")

--- a/services/horizon/internal/flags_test.go
+++ b/services/horizon/internal/flags_test.go
@@ -8,15 +8,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_createCaptiveCoreDefaultConfig(t *testing.T) {
+func TestCreateCaptiveCoreConfigFromNetwork(t *testing.T) {
 
-	var errorMsgDefaultConfig = "invalid config: %s not allowed with %s network"
 	tests := []struct {
-		name               string
-		config             Config
-		networkPassphrase  string
-		historyArchiveURLs []string
-		errStr             string
+		name                  string
+		config                Config
+		networkPassphrase     string
+		historyArchiveURLs    []string
+		stellarCoreBinaryPath string
+		errStr                string
 	}{
 		{
 			name:               "testnet default config",
@@ -29,36 +29,6 @@ func Test_createCaptiveCoreDefaultConfig(t *testing.T) {
 			config:             Config{Network: StellarPubnet},
 			networkPassphrase:  pubnetConf.networkPassphrase,
 			historyArchiveURLs: pubnetConf.historyArchiveURLs,
-		},
-		{
-			name: "testnet validation; history archive urls supplied",
-			config: Config{Network: StellarTestnet,
-				HistoryArchiveURLs: []string{"network history archive urls supplied"},
-			},
-			errStr: fmt.Sprintf(errorMsgDefaultConfig, HistoryArchiveURLsFlagName, StellarTestnet),
-		},
-		{
-			name: "pubnet validation; history archive urls supplied",
-			config: Config{Network: StellarPubnet,
-				HistoryArchiveURLs: []string{"network history archive urls supplied"},
-			},
-			errStr: fmt.Sprintf(errorMsgDefaultConfig, HistoryArchiveURLsFlagName, StellarPubnet),
-		},
-		{
-			name: "testnet validation; network passphrase supplied",
-			config: Config{Network: StellarTestnet,
-				NetworkPassphrase:  "network passphrase supplied",
-				HistoryArchiveURLs: []string{},
-			},
-			errStr: fmt.Sprintf(errorMsgDefaultConfig, NetworkPassphraseFlagName, StellarTestnet),
-		},
-		{
-			name: "pubnet validation; network passphrase supplied",
-			config: Config{Network: StellarPubnet,
-				NetworkPassphrase:  "pubnet network passphrase supplied",
-				HistoryArchiveURLs: []string{},
-			},
-			errStr: fmt.Sprintf(errorMsgDefaultConfig, NetworkPassphraseFlagName, StellarPubnet),
 		},
 		{
 			name: "unknown network specified",
@@ -83,8 +53,7 @@ func Test_createCaptiveCoreDefaultConfig(t *testing.T) {
 	}
 }
 
-func Test_createCaptiveCoreConfig(t *testing.T) {
-
+func TestCreateCaptiveCoreConfigFromParameters(t *testing.T) {
 	var errorMsgConfig = "%s must be set"
 	tests := []struct {
 		name               string
@@ -95,6 +64,16 @@ func Test_createCaptiveCoreConfig(t *testing.T) {
 	}{
 		{
 			name: "no network specified",
+			config: Config{
+				NetworkPassphrase:     "NetworkPassphrase",
+				HistoryArchiveURLs:    []string{"HistoryArchiveURLs"},
+				CaptiveCoreBinaryPath: "stellarCoreBinaryPath",
+			},
+			networkPassphrase:  "NetworkPassphrase",
+			historyArchiveURLs: []string{"HistoryArchiveURLs"},
+		},
+		{
+			name: "no network specified, stellar-core binary path not specified",
 			config: Config{
 				NetworkPassphrase:  "NetworkPassphrase",
 				HistoryArchiveURLs: []string{"HistoryArchiveURLs"},
@@ -124,6 +103,162 @@ func Test_createCaptiveCoreConfig(t *testing.T) {
 				assert.NoError(t, e)
 				assert.Equal(t, tt.networkPassphrase, tt.config.NetworkPassphrase)
 				assert.Equal(t, tt.historyArchiveURLs, tt.config.HistoryArchiveURLs)
+			} else {
+				require.Error(t, e)
+				assert.Equal(t, tt.errStr, e.Error())
+			}
+		})
+	}
+}
+
+func TestValidateNetworkConfigParameter(t *testing.T) {
+	var invalidConfigErrMsg = "invalid configuration: You cannot specify --%s with the '%s' network parameter"
+	var invalidConfigErrMsgIngestion = invalidConfigErrMsg + ". By default, --%s is true when the network parameter is specified"
+	tests := []struct {
+		name   string
+		config Config
+		errStr string
+	}{
+		{
+			name: "testnet validation; ingest false",
+			config: Config{
+				Ingest:                     false,
+				EnableCaptiveCoreIngestion: true,
+				Network:                    StellarTestnet,
+			},
+			errStr: fmt.Sprintf(invalidConfigErrMsgIngestion, IngestFlagName, StellarTestnet, IngestFlagName),
+		},
+		{
+			name: "pubnet validation; ingest false",
+			config: Config{
+				Ingest:                     false,
+				EnableCaptiveCoreIngestion: true,
+				Network:                    StellarPubnet,
+			},
+			errStr: fmt.Sprintf(invalidConfigErrMsgIngestion, IngestFlagName, StellarPubnet, IngestFlagName),
+		},
+		{
+			name: "testnet validation; enable-captive-core-ingestion false",
+			config: Config{
+				Ingest:                     true,
+				EnableCaptiveCoreIngestion: false,
+				Network:                    StellarTestnet,
+			},
+			errStr: fmt.Sprintf(invalidConfigErrMsgIngestion, EnableCaptiveCoreIngestionFlagName,
+				StellarTestnet, EnableCaptiveCoreIngestionFlagName),
+		},
+		{
+			name: "pubnet validation; enable-captive-core-ingestion false",
+			config: Config{
+				Ingest:                     true,
+				EnableCaptiveCoreIngestion: false,
+				Network:                    StellarPubnet,
+			},
+			errStr: fmt.Sprintf(invalidConfigErrMsgIngestion, EnableCaptiveCoreIngestionFlagName,
+				StellarPubnet, EnableCaptiveCoreIngestionFlagName),
+		},
+		{
+			name: "testnet validation; history archive urls supplied",
+			config: Config{
+				Ingest:                     true,
+				EnableCaptiveCoreIngestion: true,
+				Network:                    StellarTestnet,
+				HistoryArchiveURLs:         []string{"network history archive urls supplied"},
+			},
+			errStr: fmt.Sprintf(invalidConfigErrMsg, HistoryArchiveURLsFlagName, StellarTestnet),
+		},
+		{
+			name: "pubnet validation; history archive urls supplied",
+			config: Config{
+				Ingest:                     true,
+				EnableCaptiveCoreIngestion: true,
+				Network:                    StellarPubnet,
+				HistoryArchiveURLs:         []string{"network history archive urls supplied"},
+			},
+			errStr: fmt.Sprintf(invalidConfigErrMsg, HistoryArchiveURLsFlagName, StellarPubnet),
+		},
+		{
+			name: "testnet validation; network passphrase supplied",
+			config: Config{
+				Ingest:                     true,
+				EnableCaptiveCoreIngestion: true,
+				Network:                    StellarTestnet,
+				NetworkPassphrase:          "network passphrase supplied",
+			},
+			errStr: fmt.Sprintf(invalidConfigErrMsg, NetworkPassphraseFlagName, StellarTestnet),
+		},
+		{
+			name: "pubnet validation; network passphrase supplied",
+			config: Config{
+				Ingest:                     true,
+				EnableCaptiveCoreIngestion: true,
+				Network:                    StellarPubnet,
+				NetworkPassphrase:          "pubnet network passphrase supplied",
+			},
+			errStr: fmt.Sprintf(invalidConfigErrMsg, NetworkPassphraseFlagName, StellarPubnet),
+		},
+		{
+			name: "testnet validation; captive-core-config-path-name supplied",
+			config: Config{
+				Ingest:                     true,
+				EnableCaptiveCoreIngestion: true,
+				Network:                    StellarTestnet,
+				CaptiveCoreConfigPath:      "CaptiveCoreConfigPath",
+			},
+			errStr: fmt.Sprintf(invalidConfigErrMsg, CaptiveCoreConfigPathName, StellarTestnet),
+		},
+		{
+			name: "pubnet validation; captive-core-config-path-name supplied",
+			config: Config{
+				Ingest:                     true,
+				EnableCaptiveCoreIngestion: true,
+				Network:                    StellarPubnet,
+				CaptiveCoreConfigPath:      "CaptiveCoreConfigPath",
+			},
+			errStr: fmt.Sprintf(invalidConfigErrMsg, CaptiveCoreConfigPathName, StellarPubnet),
+		},
+		{
+			name: "testnet validation; stellar-core-binary-path supplied",
+			config: Config{
+				Ingest:                     true,
+				EnableCaptiveCoreIngestion: true,
+				Network:                    StellarTestnet,
+				CaptiveCoreBinaryPath:      "StellarCoreBinaryPathName",
+			},
+			errStr: fmt.Sprintf(invalidConfigErrMsg, StellarCoreBinaryPathName, StellarTestnet),
+		},
+		{
+			name: "pubnet validation; stellar-core-binary-path supplied",
+			config: Config{
+				Ingest:                     true,
+				EnableCaptiveCoreIngestion: true,
+				Network:                    StellarPubnet,
+				CaptiveCoreBinaryPath:      "StellarCoreBinaryPathName",
+			},
+			errStr: fmt.Sprintf(invalidConfigErrMsg, StellarCoreBinaryPathName, StellarPubnet),
+		},
+		{
+			name: "testnet validation success",
+			config: Config{
+				Ingest:                     true,
+				EnableCaptiveCoreIngestion: true,
+				Network:                    StellarTestnet,
+			},
+		},
+		{
+			name: "pubnet validation success",
+			config: Config{
+				Ingest:                     true,
+				EnableCaptiveCoreIngestion: true,
+				Network:                    StellarPubnet,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := validateNetworkConfigParameter(&tt.config)
+			if tt.errStr == "" {
+				assert.NoError(t, e)
 			} else {
 				require.Error(t, e)
 				assert.Equal(t, tt.errStr, e.Error())


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Show an error message if the `NETWORK` parameter is provided, but `ENABLE_CAPTIVE_CORE_INGESTION` is set to false.

### Why
The `NETWORK` parameter is intended to simplify captive core configuration, and it has no effect if captive-core is disabled.

### Known limitations

[TODO or N/A]
