### PR TITLE
xdr: Add function to obtain the type of a binary-compressed key 

### DIFF
--- a/xdr/main.go
+++ b/xdr/main.go
@@ -232,8 +232,15 @@ func (e *EncodingBuffer) LedgerKeyUnsafeMarshalBinaryCompress(key LedgerKey) ([]
 }
 
 // GetBinaryCompressedLedgerKeyType gets the key type from the result of LedgerKeyUnsafeMarshalBinaryCompress
-func GetBinaryCompressedLedgerKeyType(compressedKey []byte) LedgerEntryType {
-	return LedgerEntryType(compressedKey[0])
+func GetBinaryCompressedLedgerKeyType(compressedKey []byte) (LedgerEntryType, error) {
+	if len(compressedKey) < 1 {
+		return 0, errors.New("empty compressed ledger key")
+	}
+	result := LedgerEntryType(compressedKey[0])
+	if int(result) > len(ledgerEntryTypeMap)-1 {
+		return 0, fmt.Errorf("incorrect key type %d", result)
+	}
+	return result, nil
 }
 
 func (e *EncodingBuffer) MarshalBase64(encodable EncoderTo) (string, error) {

--- a/xdr/main.go
+++ b/xdr/main.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	xdr "github.com/stellar/go-xdr/xdr3"
+
 	"github.com/stellar/go/support/errors"
 )
 
@@ -228,6 +229,11 @@ func (e *EncodingBuffer) LedgerKeyUnsafeMarshalBinaryCompress(key LedgerKey) ([]
 		return nil, err
 	}
 	return e.xdrEncoderBuf.Bytes(), nil
+}
+
+// GetBinaryCompressedLedgerKeyType gets the key type from the result of LedgerKeyUnsafeMarshalBinaryCompress
+func GetBinaryCompressedLedgerKeyType(compressedKey []byte) LedgerEntryType {
+	return LedgerEntryType(compressedKey[0])
 }
 
 func (e *EncodingBuffer) MarshalBase64(encodable EncoderTo) (string, error) {

--- a/xdr/main_test.go
+++ b/xdr/main_test.go
@@ -219,7 +219,9 @@ func TestLedgerKeyBinaryCompressCoverage(t *testing.T) {
 
 		compressed, err := e.LedgerKeyUnsafeMarshalBinaryCompress(ledgerKey)
 		assert.NoError(t, err)
-		assert.Equal(t, ledgerKey.Type, GetBinaryCompressedLedgerKeyType(compressed))
+		keyType, err := GetBinaryCompressedLedgerKeyType(compressed)
+		assert.NoError(t, err)
+		assert.Equal(t, ledgerKey.Type, keyType)
 	}
 }
 

--- a/xdr/main_test.go
+++ b/xdr/main_test.go
@@ -217,8 +217,9 @@ func TestLedgerKeyBinaryCompressCoverage(t *testing.T) {
 		)
 		assert.NoError(t, gxdr.Convert(shape, &ledgerKey))
 
-		_, err := e.LedgerKeyUnsafeMarshalBinaryCompress(ledgerKey)
+		compressed, err := e.LedgerKeyUnsafeMarshalBinaryCompress(ledgerKey)
 		assert.NoError(t, err)
+		assert.Equal(t, ledgerKey.Type, GetBinaryCompressedLedgerKeyType(compressed))
 	}
 }
 


### PR DESCRIPTION
I need it for soroban-tools