### PR TITLE
build: update integration testing to use the updated sdk ( rc2 )

### DIFF
--- a/services/horizon/internal/integration/contracts/Cargo.toml
+++ b/services/horizon/internal/integration/contracts/Cargo.toml
@@ -22,6 +22,6 @@ codegen-units = 1
 lto = true
 
 [workspace.dependencies.soroban-sdk]
-version = "20.0.0-rc1"
+version = "20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-sdk"
-rev = "f743d6f9e49caa08924318907cd0588b60d7f187"
+rev = "0992413f9b05e5bfb1f872bce99e89d9129b2e61"


### PR DESCRIPTION
### What

We're going to release horizon based on the new 20.0.0-rc2 soroban sdk.
This PR updates the sdk dependency.

### Why

Align with the release.

### Known limitations

n/a