### PR TITLE
services/horizon/internal/db2/history: fix payments query

### DIFF
--- a/services/horizon/internal/db2/history/operation.go
+++ b/services/horizon/internal/db2/history/operation.go
@@ -8,6 +8,7 @@ import (
 	"text/template"
 
 	sq "github.com/Masterminds/squirrel"
+
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/toid"
@@ -394,7 +395,7 @@ var selectOperation = sq.Select(
 		"hop.details, " +
 		"hop.source_account, " +
 		"hop.source_account_muxed, " +
-		"hop.is_payment, " +
+		"COALESCE(hop.is_payment, false) as is_payment, " +
 		"ht.transaction_hash, " +
 		"ht.tx_result, " +
 		"COALESCE(ht.successful, true) as transaction_successful").

--- a/services/horizon/internal/db2/history/operation_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/operation_batch_insert_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/guregu/null"
+
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/xdr"
 )
@@ -52,7 +53,7 @@ func (i *operationBatchInsertBuilder) Add(
 	sourceAccountMuxed null.String,
 	isPayment bool,
 ) error {
-	return i.builder.Row(ctx, map[string]interface{}{
+	row := map[string]interface{}{
 		"id":                   id,
 		"transaction_id":       transactionID,
 		"application_order":    applicationOrder,
@@ -60,8 +61,12 @@ func (i *operationBatchInsertBuilder) Add(
 		"details":              details,
 		"source_account":       sourceAccount,
 		"source_account_muxed": sourceAccountMuxed,
-		"is_payment":           isPayment,
-	})
+		"is_payment":           nil,
+	}
+	if isPayment {
+		row["is_payment"] = true
+	}
+	return i.builder.Row(ctx, row)
 
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The query to select payments from the operations table does not handle the case where is_payments is NULL. The following error occurs in that case:

```
select failed: sql: Scan error on column index 7, name \"is_payment\": sql/driver: couldn't convert <nil> (<nil>) into type bool
```

To fix this issue we need to treat null `is_payment` values as equivalent to false values.
### Known limitations

[N/A]
