### PR TITLE
Remove LIMIT_TX_QUEUE_SOURCE_ACCOUNT core config

### DIFF
--- a/ingest/ledgerbackend/toml.go
+++ b/ingest/ledgerbackend/toml.go
@@ -70,12 +70,11 @@ type captiveCoreTomlValues struct {
 	BucketDirPath string `toml:"BUCKET_DIR_PATH,omitempty"`
 	// we cannot omitempty because 0 is a valid configuration for HTTP_PORT
 	// and the default is 11626
-	HTTPPort                  uint     `toml:"HTTP_PORT"`
-	PublicHTTPPort            bool     `toml:"PUBLIC_HTTP_PORT,omitempty"`
-	NodeNames                 []string `toml:"NODE_NAMES,omitempty"`
-	NetworkPassphrase         string   `toml:"NETWORK_PASSPHRASE,omitempty"`
-	PeerPort                  uint     `toml:"PEER_PORT,omitempty"`
-	LimitTxQueueSourceAccount bool     `toml:"LIMIT_TX_QUEUE_SOURCE_ACCOUNT,omitempty"`
+	HTTPPort          uint     `toml:"HTTP_PORT"`
+	PublicHTTPPort    bool     `toml:"PUBLIC_HTTP_PORT,omitempty"`
+	NodeNames         []string `toml:"NODE_NAMES,omitempty"`
+	NetworkPassphrase string   `toml:"NETWORK_PASSPHRASE,omitempty"`
+	PeerPort          uint     `toml:"PEER_PORT,omitempty"`
 	// we cannot omitempty because 0 is a valid configuration for FAILURE_SAFETY
 	// and the default is -1
 	FailureSafety                         int                  `toml:"FAILURE_SAFETY"`


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Remove this config that enables/disables the 1 tx/account/ledger limit. 

### Why

This flag is defunct now that we're on protocol 20 (see https://github.com/stellar/stellar-core/issues/3933) since it's always enabled. We aren't specifying this field anywhere anymore (https://github.com/stellar/puppet-v4/pull/3464, https://github.com/stellar/quickstart/pull/485) and we've never published it externally in Horizon release notes or documentation, so doubtful any Horizon users are using it.

### Known limitations

N/A
