### PR TITLE
services/horizon/internal: Fix configuration of captive core in reingest command

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -8,6 +8,7 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking Changes
 - The command line flag `--remote-captive-core-url` has been removed, as remote captive core functionality is now deprecated ([4940](https://github.com/stellar/go/pull/4940)).
+- The functionality of generating default captive core configuration based on the --network-passphrase is now deprecated. Use the --network command instead ([4949](https://github.com/stellar/go/pull/4949)).
 
 ### Added
 - Added new command-line flag `--network` to specify the Stellar network (pubnet or testnet), aiming at simplifying the configuration process by automatically configuring the following parameters based on the chosen network: `--history-archive-urls`, `--network-passphrase`, and `--captive-core-config-path` ([4949](https://github.com/stellar/go/pull/4949)).

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -779,6 +779,10 @@ func createCaptiveCoreConfigFromParameters(config *Config) error {
 	if config.CaptiveCoreConfigPath != "" {
 		return loadCaptiveCoreTomlFromFile(config)
 	} else {
+		config.CaptiveCoreTomlParams.CoreBinaryPath = config.CaptiveCoreBinaryPath
+		config.CaptiveCoreTomlParams.HistoryArchiveURLs = config.HistoryArchiveURLs
+		config.CaptiveCoreTomlParams.NetworkPassphrase = config.NetworkPassphrase
+
 		var err error
 		config.CaptiveCoreToml, err = ledgerbackend.NewCaptiveCoreToml(config.CaptiveCoreTomlParams)
 		if err != nil {

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -766,7 +766,7 @@ func createCaptiveCoreConfigFromNetwork(config *Config) error {
 
 // createCaptiveCoreConfigFromParameters generates the Captive Core configuration.
 // validates the configuration settings, sets necessary values, and loads the Captive Core TOML file.
-func createCaptiveCoreConfigFromParameters(config *Config) error {
+func createCaptiveCoreConfigFromParameters(config *Config, options ApplyOptions) error {
 
 	if config.NetworkPassphrase == "" {
 		return fmt.Errorf("%s must be set", NetworkPassphraseFlagName)
@@ -778,6 +778,9 @@ func createCaptiveCoreConfigFromParameters(config *Config) error {
 
 	if config.CaptiveCoreConfigPath != "" {
 		return loadCaptiveCoreTomlFromFile(config)
+	} else if options.RequireCaptiveCoreConfig {
+		return fmt.Errorf(
+			"invalid config: captive core requires that --%s is set", CaptiveCoreConfigPathName)
 	} else {
 		config.CaptiveCoreTomlParams.CoreBinaryPath = config.CaptiveCoreBinaryPath
 		config.CaptiveCoreTomlParams.HistoryArchiveURLs = config.HistoryArchiveURLs
@@ -794,7 +797,7 @@ func createCaptiveCoreConfigFromParameters(config *Config) error {
 }
 
 // setCaptiveCoreConfiguration prepares configuration for the Captive Core
-func setCaptiveCoreConfiguration(config *Config) error {
+func setCaptiveCoreConfiguration(config *Config, options ApplyOptions) error {
 	stdLog.Println("Preparing captive core...")
 
 	// If the user didn't specify a Stellar Core binary, we can check the
@@ -812,7 +815,7 @@ func setCaptiveCoreConfiguration(config *Config) error {
 			return err
 		}
 	} else {
-		err := createCaptiveCoreConfigFromParameters(config)
+		err := createCaptiveCoreConfigFromParameters(config, options)
 		if err != nil {
 			return err
 		}
@@ -862,7 +865,7 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 		}
 
 		if config.EnableCaptiveCoreIngestion {
-			err := setCaptiveCoreConfiguration(config)
+			err := setCaptiveCoreConfiguration(config, options)
 			if err != nil {
 				return errors.Wrap(err, "error generating captive core configuration")
 			}

--- a/services/horizon/internal/flags_test.go
+++ b/services/horizon/internal/flags_test.go
@@ -128,7 +128,8 @@ func Test_createCaptiveCoreConfig(t *testing.T) {
 				NetworkPassphrase:  PubnetConf.NetworkPassphrase,
 				HistoryArchiveURLs: PubnetConf.HistoryArchiveURLs,
 			},
-			errStr: fmt.Sprintf("invalid config: captive core requires that --captive-core-config-path is set"),
+			errStr: fmt.Sprintf("invalid config: captive core requires that --%s is set",
+				CaptiveCoreConfigPathName),
 		},
 		{
 			name:                     "no network specified; captive-core-config-path invalid file",
@@ -138,8 +139,8 @@ func Test_createCaptiveCoreConfig(t *testing.T) {
 				HistoryArchiveURLs:    PubnetConf.HistoryArchiveURLs,
 				CaptiveCoreConfigPath: "xyz.cfg",
 			},
-			errStr: fmt.Sprintf("invalid captive core toml file: could not load toml path:" +
-				" open xyz.cfg: no such file or directory"),
+			errStr: "invalid captive core toml file: could not load toml path:" +
+				" open xyz.cfg: no such file or directory",
 		},
 		{
 			name:                     "no network specified; captive-core-config-path incorrect config",
@@ -149,9 +150,9 @@ func Test_createCaptiveCoreConfig(t *testing.T) {
 				HistoryArchiveURLs:    PubnetConf.HistoryArchiveURLs,
 				CaptiveCoreConfigPath: "configs/captive-core-testnet.cfg",
 			},
-			errStr: fmt.Sprintf("invalid captive core toml file: invalid captive core toml: " +
-				"NETWORK_PASSPHRASE in captive core config file: Test SDF Network ; September 2015 " +
-				"does not match Horizon network-passphrase flag: Public Global Stellar Network ; September 2015"),
+			errStr: fmt.Sprintf("invalid captive core toml file: invalid captive core toml: "+
+				"NETWORK_PASSPHRASE in captive core config file: %s does not match Horizon "+
+				"network-passphrase flag: %s", TestnetConf.NetworkPassphrase, PubnetConf.NetworkPassphrase),
 		},
 		{
 			name:                     "no network specified; captive-core-config not required",

--- a/services/horizon/internal/flags_test.go
+++ b/services/horizon/internal/flags_test.go
@@ -87,43 +87,91 @@ func Test_createCaptiveCoreConfig(t *testing.T) {
 
 	var errorMsgConfig = "%s must be set"
 	tests := []struct {
-		name               string
-		config             Config
-		networkPassphrase  string
-		historyArchiveURLs []string
-		errStr             string
+		name                     string
+		requireCaptiveCoreConfig bool
+		config                   Config
+		networkPassphrase        string
+		historyArchiveURLs       []string
+		errStr                   string
 	}{
 		{
-			name: "no network specified",
+			name:                     "no network specified; valid parameters",
+			requireCaptiveCoreConfig: true,
 			config: Config{
-				NetworkPassphrase:  "NetworkPassphrase",
-				HistoryArchiveURLs: []string{"HistoryArchiveURLs"},
+				NetworkPassphrase:     PubnetConf.NetworkPassphrase,
+				HistoryArchiveURLs:    PubnetConf.HistoryArchiveURLs,
+				CaptiveCoreConfigPath: "configs/captive-core-pubnet.cfg",
 			},
-			networkPassphrase:  "NetworkPassphrase",
-			historyArchiveURLs: []string{"HistoryArchiveURLs"},
+			networkPassphrase:  PubnetConf.NetworkPassphrase,
+			historyArchiveURLs: PubnetConf.HistoryArchiveURLs,
 		},
 		{
-			name: "no network specified; passphrase not supplied",
+			name:                     "no network specified; passphrase not supplied",
+			requireCaptiveCoreConfig: true,
 			config: Config{
 				HistoryArchiveURLs: []string{"HistoryArchiveURLs"},
 			},
 			errStr: fmt.Sprintf(errorMsgConfig, NetworkPassphraseFlagName),
 		},
 		{
-			name: "no network specified; history archive urls not supplied",
+			name:                     "no network specified; history archive urls not supplied",
+			requireCaptiveCoreConfig: true,
 			config: Config{
 				NetworkPassphrase: "NetworkPassphrase",
 			},
 			errStr: fmt.Sprintf(errorMsgConfig, HistoryArchiveURLsFlagName),
 		},
+		{
+			name:                     "no network specified; captive-core-config-path not supplied",
+			requireCaptiveCoreConfig: true,
+			config: Config{
+				NetworkPassphrase:  PubnetConf.NetworkPassphrase,
+				HistoryArchiveURLs: PubnetConf.HistoryArchiveURLs,
+			},
+			errStr: fmt.Sprintf("invalid config: captive core requires that --captive-core-config-path is set"),
+		},
+		{
+			name:                     "no network specified; captive-core-config-path invalid file",
+			requireCaptiveCoreConfig: true,
+			config: Config{
+				NetworkPassphrase:     PubnetConf.NetworkPassphrase,
+				HistoryArchiveURLs:    PubnetConf.HistoryArchiveURLs,
+				CaptiveCoreConfigPath: "xyz.cfg",
+			},
+			errStr: fmt.Sprintf("invalid captive core toml file: could not load toml path:" +
+				" open xyz.cfg: no such file or directory"),
+		},
+		{
+			name:                     "no network specified; captive-core-config-path incorrect config",
+			requireCaptiveCoreConfig: true,
+			config: Config{
+				NetworkPassphrase:     PubnetConf.NetworkPassphrase,
+				HistoryArchiveURLs:    PubnetConf.HistoryArchiveURLs,
+				CaptiveCoreConfigPath: "configs/captive-core-testnet.cfg",
+			},
+			errStr: fmt.Sprintf("invalid captive core toml file: invalid captive core toml: " +
+				"NETWORK_PASSPHRASE in captive core config file: Test SDF Network ; September 2015 " +
+				"does not match Horizon network-passphrase flag: Public Global Stellar Network ; September 2015"),
+		},
+		{
+			name:                     "no network specified; captive-core-config not required",
+			requireCaptiveCoreConfig: false,
+			config: Config{
+				NetworkPassphrase:  PubnetConf.NetworkPassphrase,
+				HistoryArchiveURLs: PubnetConf.HistoryArchiveURLs,
+			},
+			networkPassphrase:  PubnetConf.NetworkPassphrase,
+			historyArchiveURLs: PubnetConf.HistoryArchiveURLs,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := createCaptiveCoreConfigFromParameters(&tt.config)
+			e := createCaptiveCoreConfigFromParameters(&tt.config,
+				ApplyOptions{RequireCaptiveCoreConfig: tt.requireCaptiveCoreConfig})
 			if tt.errStr == "" {
 				assert.NoError(t, e)
-				assert.Equal(t, tt.networkPassphrase, tt.config.NetworkPassphrase)
-				assert.Equal(t, tt.historyArchiveURLs, tt.config.HistoryArchiveURLs)
+				assert.Equal(t, tt.networkPassphrase, tt.config.CaptiveCoreTomlParams.NetworkPassphrase)
+				assert.Equal(t, tt.historyArchiveURLs, tt.config.CaptiveCoreTomlParams.HistoryArchiveURLs)
 			} else {
 				require.Error(t, e)
 				assert.Equal(t, tt.errStr, e.Error())


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What


When running `horizon --db-url postgres://postgres@localhost:5432?sslmode=disable --apply-migrations db reingest range 48263265 48263265` with the following environment variables:

```
HISTORY_ARCHIVE_URLS=https://history.stellar.org/prd/core-live/core_live_001;INGEST=true
NETWORK_PASSPHRASE=Public Global Stellar Network \; September 2015
STELLAR_CORE_BINARY_PATH=/usr/local/bin/stellar-core
```


I encountered the error listed below:

```
2023/09/27 12:51:23 Applying DB migrations...
2023/09/27 12:51:24 successfully applied 66 horizon migrations
2023/09/27 12:51:24 Checking DB migrations...
2023/09/27 12:51:24 Preparing captive core...
INFO[2023-09-27T12:51:24.383+01:00] Ingestion system initial state                current_state="reingestHistoryRange(fromLedger=48263265, toLedger=48263265, force=false)" pid=65279 service=ingest
INFO[2023-09-27T12:51:24.385+01:00] Preparing ledger backend to retrieve range    from=48263265 pid=65279 service=ingest to=48263265
INFO[2023-09-27T12:51:25.212+01:00] Warning: soroban-env-host-curr is running a pre-release version 20.0.0-rc1  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.215+01:00] default: Config from /Users/tamir/work/gopath/src/github.com/stellar/go/captive-core-09ac164f/stellar-core.conf  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.215+01:00] default: 'RUN_STANDALONE' enabled in configuration file - node will not function properly with most networks  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.216+01:00] default: Using QUORUM_SET: {                  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.216+01:00] "t" : 1,                                      pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.216+01:00] "v" : [ "GCZBO" ]                             pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.216+01:00] }                                             pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.217+01:00] Database: Connecting to: sqlite3://stellar.db  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.221+01:00] SCP: LocalNode::LocalNode@GA4HX qSet: 1dcacc  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.224+01:00] default: *                                    pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.224+01:00] default: * The database has been initialized  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.224+01:00] default: *                                    pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.225+01:00] Database: Applying DB schema upgrade to version 14  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.225+01:00] Database: Applying DB schema upgrade to version 15  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.225+01:00] Database: Applying DB schema upgrade to version 16  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.225+01:00] Database: Applying DB schema upgrade to version 17  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.225+01:00] Database: Applying DB schema upgrade to version 18  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.225+01:00] Database: Applying DB schema upgrade to version 19  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.226+01:00] Database: Applying DB schema upgrade to version 20  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.226+01:00] Database: Applying DB schema upgrade to version 21  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.226+01:00] Database: DB schema is in current version     pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.226+01:00] default: Dropping accounts                    pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.226+01:00] default: Dropping trustlines                  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.226+01:00] default: Dropping offers                      pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.226+01:00] default: Dropping accountdata                 pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.232+01:00] default: Dropping claimablebalances           pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.232+01:00] default: Dropping liquiditypools              pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.232+01:00] default: Dropping contractdata                pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.232+01:00] default: Dropping contractcode                pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.232+01:00] default: Dropping configsettings              pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.232+01:00] default: Dropping expiration                  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.233+01:00] Ledger: Established genesis ledger, closing   pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.233+01:00] Ledger: Root account: GC7JA62LVSCP5ZOORAI5WLPPZG7QWKRKFO6D2VGYUISX5TLQIQMWEIY3  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.233+01:00] Ledger: Root account seed: SDR3BRCCTD6BYFE27P2MRGLPXESCPLSB4RSJXE2MUSKZSG3YKK4FL6HO  pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.235+01:00] default: Application destructing              pid=65279 service=ingest subservice=stellar-core
INFO[2023-09-27T12:51:25.235+01:00] default: Application destroyed                pid=65279 service=ingest subservice=stellar-core
ERRO[2023-09-27T12:51:25.237+01:00] default: Got an exception: NETWORK_PASSPHRASE not configured  pid=65279 service=ingest subservice=stellar-core
ERRO[2023-09-27T12:51:25.237+01:00] default: Please report this bug along with this log file if this was not expected  pid=65279 service=ingest subservice=stellar-core
ERRO[2023-09-27T12:51:25.241+01:00] Error in ingestion state machine              current_state="reingestHistoryRange(fromLedger=48263265, toLedger=48263265, force=false)" error="error preparing range: error starting prepare range: opening subprocess: error running stellar-core: error initializing core db: exit status 1" next_state=stop pid=65279 service=ingest
INFO[2023-09-27T12:51:25.241+01:00] Shut down                                     pid=65279 service=ingest
INFO[2023-09-27T12:51:25.241+01:00] Shutting down ingestion system...             pid=65279 service=ingest
error preparing range: error starting prepare range: opening subprocess: error running stellar-core: error initializing core db: exit status 1
Exiting.
```

It looks like this regression was introduced in https://github.com/stellar/go/pull/4949/files . Prior to https://github.com/stellar/go/pull/4949 we were overriding `config.CaptiveCoreTomlParams.CoreBinaryPath` , `config.CaptiveCoreTomlParams.HistoryArchiveURLs`, and `config.CaptiveCoreTomlParams.NetworkPassphrase` before constructing the captive core toml. But, it seems like we missed one of the cases in 
It looks like this regression was introduced in https