### PR TITLE
ingest: Extract ledger entry changes from Tx Meta in a deterministic order

### DIFF
--- a/ingest/change.go
+++ b/ingest/change.go
@@ -72,7 +72,8 @@ func GetChangesFromLedgerEntryChanges(ledgerEntryChanges xdr.LedgerEntryChanges)
 		}
 	}
 
-	return sortChanges(changes)
+	sortChanges(changes)
+	return changes
 }
 
 type sortableChanges struct {
@@ -118,9 +119,8 @@ func (s sortableChanges) Swap(i, j int) {
 // multiple changes with the same ledger key in a LedgerEntryChanges group,
 // but if that is the case, we fall back to the original ordering of the changes
 // by using a stable sorting algorithm.
-func sortChanges(changes []Change) []Change {
+func sortChanges(changes []Change) {
 	sort.Stable(newSortableChanges(changes))
-	return changes
 }
 
 // LedgerEntryChangeType returns type in terms of LedgerEntryChangeType.

--- a/ingest/change.go
+++ b/ingest/change.go
@@ -2,6 +2,7 @@ package ingest
 
 import (
 	"bytes"
+	"sort"
 
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
@@ -18,6 +19,13 @@ type Change struct {
 	Type xdr.LedgerEntryType
 	Pre  *xdr.LedgerEntry
 	Post *xdr.LedgerEntry
+}
+
+func (c *Change) ledgerKey() (xdr.LedgerKey, error) {
+	if c.Pre != nil {
+		return c.Pre.LedgerKey()
+	}
+	return c.Post.LedgerKey()
 }
 
 // GetChangesFromLedgerEntryChanges transforms LedgerEntryChanges to []Change.
@@ -64,6 +72,54 @@ func GetChangesFromLedgerEntryChanges(ledgerEntryChanges xdr.LedgerEntryChanges)
 		}
 	}
 
+	return sortChanges(changes)
+}
+
+type sortableChanges struct {
+	changes    []Change
+	ledgerKeys [][]byte
+}
+
+func newSortableChanges(changes []Change) sortableChanges {
+	ledgerKeys := make([][]byte, len(changes))
+	for i, c := range changes {
+		lk, err := c.ledgerKey()
+		if err != nil {
+			panic(err)
+		}
+		lkBytes, err := lk.MarshalBinary()
+		if err != nil {
+			panic(err)
+		}
+		ledgerKeys[i] = lkBytes
+	}
+	return sortableChanges{
+		changes:    changes,
+		ledgerKeys: ledgerKeys,
+	}
+}
+
+func (s sortableChanges) Len() int {
+	return len(s.changes)
+}
+
+func (s sortableChanges) Less(i, j int) bool {
+	return bytes.Compare(s.ledgerKeys[i], s.ledgerKeys[j]) < 0
+}
+
+func (s sortableChanges) Swap(i, j int) {
+	s.changes[i], s.changes[j] = s.changes[j], s.changes[i]
+	s.ledgerKeys[i], s.ledgerKeys[j] = s.ledgerKeys[j], s.ledgerKeys[i]
+}
+
+// sortChanges is applied on a list of changes to ensure that LedgerEntryChanges
+// from Tx Meta are ingested in a deterministic order.
+// The changes are sorted by ledger key. It is unexpected for there to be
+// multiple changes with the same ledger key in a LedgerEntryChanges group,
+// but if that is the case, we fall back to the original ordering of the changes
+// by using a stable sorting algorithm.
+func sortChanges(changes []Change) []Change {
+	sort.Stable(newSortableChanges(changes))
 	return changes
 }
 

--- a/ingest/change_test.go
+++ b/ingest/change_test.go
@@ -1,0 +1,215 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/go/xdr"
+)
+
+func assertChangesAreEqual(t *testing.T, a, b Change) {
+	assert.Equal(t, a.Type, b.Type)
+	if a.Pre == nil {
+		assert.Nil(t, b.Pre)
+	} else {
+		aBytes, err := a.Pre.MarshalBinary()
+		assert.NoError(t, err)
+		bBytes, err := b.Pre.MarshalBinary()
+		assert.NoError(t, err)
+		assert.Equal(t, aBytes, bBytes)
+	}
+	if a.Post == nil {
+		assert.Nil(t, b.Post)
+	} else {
+		aBytes, err := a.Post.MarshalBinary()
+		assert.NoError(t, err)
+		bBytes, err := b.Post.MarshalBinary()
+		assert.NoError(t, err)
+		assert.Equal(t, aBytes, bBytes)
+	}
+}
+
+func TestSortChanges(t *testing.T) {
+	for _, testCase := range []struct {
+		input    []Change
+		expected []Change
+	}{
+		{[]Change{}, []Change{}},
+		{
+			[]Change{
+				{
+					Type: xdr.LedgerEntryTypeAccount,
+					Pre:  nil,
+					Post: &xdr.LedgerEntry{
+						LastModifiedLedgerSeq: 11,
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeAccount,
+							Account: &xdr.AccountEntry{
+								AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+							},
+						},
+					},
+				},
+			},
+			[]Change{
+				{
+					Type: xdr.LedgerEntryTypeAccount,
+					Pre:  nil,
+					Post: &xdr.LedgerEntry{
+						LastModifiedLedgerSeq: 11,
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeAccount,
+							Account: &xdr.AccountEntry{
+								AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			[]Change{
+				{
+					Type: xdr.LedgerEntryTypeAccount,
+					Pre:  nil,
+					Post: &xdr.LedgerEntry{
+						LastModifiedLedgerSeq: 11,
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeAccount,
+							Account: &xdr.AccountEntry{
+								AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+								Balance:   25,
+							},
+						},
+					},
+				},
+				{
+					Type: xdr.LedgerEntryTypeAccount,
+					Pre: &xdr.LedgerEntry{
+						LastModifiedLedgerSeq: 11,
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeAccount,
+							Account: &xdr.AccountEntry{
+								AccountId: xdr.MustAddress("GCMNSW2UZMSH3ZFRLWP6TW2TG4UX4HLSYO5HNIKUSFMLN2KFSF26JKWF"),
+								Balance:   20,
+							},
+						},
+					},
+					Post: nil,
+				},
+				{
+					Type: xdr.LedgerEntryTypeExpiration,
+					Pre: &xdr.LedgerEntry{
+						LastModifiedLedgerSeq: 11,
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeExpiration,
+							Expiration: &xdr.ExpirationEntry{
+								KeyHash:             xdr.Hash{1},
+								ExpirationLedgerSeq: 50,
+							},
+						},
+					},
+					Post: &xdr.LedgerEntry{
+						LastModifiedLedgerSeq: 11,
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeExpiration,
+							Expiration: &xdr.ExpirationEntry{
+								KeyHash:             xdr.Hash{1},
+								ExpirationLedgerSeq: 100,
+							},
+						},
+					},
+				},
+				{
+					Type: xdr.LedgerEntryTypeAccount,
+					Pre: &xdr.LedgerEntry{
+						LastModifiedLedgerSeq: 11,
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeAccount,
+							Account: &xdr.AccountEntry{
+								AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+								Balance:   25,
+							},
+						},
+					},
+					Post: nil,
+				},
+			},
+			[]Change{
+				{
+					Type: xdr.LedgerEntryTypeAccount,
+					Pre: &xdr.LedgerEntry{
+						LastModifiedLedgerSeq: 11,
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeAccount,
+							Account: &xdr.AccountEntry{
+								AccountId: xdr.MustAddress("GCMNSW2UZMSH3ZFRLWP6TW2TG4UX4HLSYO5HNIKUSFMLN2KFSF26JKWF"),
+								Balance:   20,
+							},
+						},
+					},
+					Post: nil,
+				},
+				{
+					Type: xdr.LedgerEntryTypeAccount,
+					Pre:  nil,
+					Post: &xdr.LedgerEntry{
+						LastModifiedLedgerSeq: 11,
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeAccount,
+							Account: &xdr.AccountEntry{
+								AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+								Balance:   25,
+							},
+						},
+					},
+				},
+				{
+					Type: xdr.LedgerEntryTypeAccount,
+					Pre: &xdr.LedgerEntry{
+						LastModifiedLedgerSeq: 11,
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeAccount,
+							Account: &xdr.AccountEntry{
+								AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+								Balance:   25,
+							},
+						},
+					},
+					Post: nil,
+				},
+
+				{
+					Type: xdr.LedgerEntryTypeExpiration,
+					Pre: &xdr.LedgerEntry{
+						LastModifiedLedgerSeq: 11,
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeExpiration,
+							Expiration: &xdr.ExpirationEntry{
+								KeyHash:             xdr.Hash{1},
+								ExpirationLedgerSeq: 50,
+							},
+						},
+					},
+					Post: &xdr.LedgerEntry{
+						LastModifiedLedgerSeq: 11,
+						Data: xdr.LedgerEntryData{
+							Type: xdr.LedgerEntryTypeExpiration,
+							Expiration: &xdr.ExpirationEntry{
+								KeyHash:             xdr.Hash{1},
+								ExpirationLedgerSeq: 100,
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		sortChanges(testCase.input)
+		assert.Equal(t, len(testCase.input), len(testCase.expected))
+		for i := range testCase.input {
+			assertChangesAreEqual(t, testCase.input[i], testCase.expected[i])
+		}
+	}
+}

--- a/ingest/ledger_change_reader.go
+++ b/ingest/ledger_change_reader.go
@@ -139,6 +139,7 @@ func (r *LedgerChangeReader) Read() (Change, error) {
 				Post: nil,
 			}
 		}
+		changes = sortChanges(changes)
 		r.pending = append(r.pending, changes...)
 		r.state++
 		return r.Read()

--- a/ingest/ledger_change_reader.go
+++ b/ingest/ledger_change_reader.go
@@ -139,7 +139,7 @@ func (r *LedgerChangeReader) Read() (Change, error) {
 				Post: nil,
 			}
 		}
-		changes = sortChanges(changes)
+		sortChanges(changes)
 		r.pending = append(r.pending, changes...)
 		r.state++
 		return r.Read()

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this
 file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.27.0
+
+### Fixed
+- Ordering of effects are now deterministic. Previously the order of some Horizon effects could vary upon reingestion but this issue has now been fixed ([5070](https://github.com/stellar/go/pull/5070)).
 
 ## 2.27.0-rc2
 ### Fixed

--- a/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
@@ -5,9 +5,10 @@ package processors
 import (
 	"testing"
 
-	"github.com/stellar/go/protocols/horizon/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/stellar/go/protocols/horizon/base"
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -1521,6 +1522,13 @@ func getSponsoredSandwichWrappers() []*transactionOperationWrapper {
 		{
 			Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
 			Created: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type: xdr.LedgerEntryTypeAccount,
+					Account: &xdr.AccountEntry{
+						AccountId: xdr.MustAddress("GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY"),
+						Balance:   100,
+					},
+				},
 				LastModifiedLedgerSeq: xdr.Uint32(ledgerSeq),
 				Ext: xdr.LedgerEntryExt{
 					V: 1,

--- a/xdr/ledger_close_meta.go
+++ b/xdr/ledger_close_meta.go
@@ -1,6 +1,8 @@
 package xdr
 
-import "fmt"
+import (
+	"fmt"
+)
 
 func (l LedgerCloseMeta) LedgerHeaderHistoryEntry() LedgerHeaderHistoryEntry {
 	switch l.V {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

In https://github.com/stellar/stellar-core/issues/3952 we discovered that the tx meta emitted by captive core can appear in a random order. This is problematic for Horizon because we would like ingestion to always be deterministic and reproducible. For some releases we test our ingestion system by ingesting history twice, once with the release candidate and the second time with the previous stable version and then we assert that content produced by both runs are the same. If tx meta can appear in a random order this can result in horizon effects being produced in a different order.

This commit is an attempt to make the ordering of Tx Meta consistent in Horizon ingestion.
### Known limitations

https://github.com/stellar/stellar-core/pull/3954 is an attempt to fix this issue in core. Once that change is included in a core stable release we can revert this PR. 
