### PR TITLE
Ingestion fastbatch cbp

### DIFF
--- a/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
@@ -1,0 +1,47 @@
+package history
+
+import (
+	"context"
+
+	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/xdr"
+)
+
+// ClaimableBalanceBatchInsertBuilder is used to insert claimable balance into the
+// claimable_balances table
+type ClaimableBalanceBatchInsertBuilder interface {
+	Add(claimableBalance ClaimableBalance) error
+	Exec(ctx context.Context, session db.SessionInterface) error
+	Reset() error
+}
+
+// ClaimableBalanceBatchInsertBuilder is a simple wrapper around db.FastBatchInsertBuilder
+type claimableBalanceBatchInsertBuilder struct {
+	encodingBuffer *xdr.EncodingBuffer
+	builder        db.FastBatchInsertBuilder
+	table          string
+}
+
+// NewClaimableBalanceBatchInsertBuilder constructs a new ClaimableBalanceBatchInsertBuilder instance
+func (q *Q) NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder {
+	return &claimableBalanceBatchInsertBuilder{
+		encodingBuffer: xdr.NewEncodingBuffer(),
+		builder:        db.FastBatchInsertBuilder{},
+		table:          "claimable_balances",
+	}
+}
+
+// Add adds a new claimable balance to the batch
+func (i *claimableBalanceBatchInsertBuilder) Add(claimableBalance ClaimableBalance) error {
+	return i.builder.RowStruct(claimableBalance)
+}
+
+// Exec inserts claimable balance rows to the database
+func (i *claimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
+	return i.builder.Exec(ctx, session, i.table)
+}
+
+func (i *claimableBalanceBatchInsertBuilder) Reset() error{
+	i.builder.Reset()
+	return nil
+}

--- a/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
@@ -41,7 +41,7 @@ func (i *claimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session d
 	return i.builder.Exec(ctx, session, i.table)
 }
 
-func (i *claimableBalanceBatchInsertBuilder) Reset() error{
+func (i *claimableBalanceBatchInsertBuilder) Reset() error {
 	i.builder.Reset()
 	return nil
 }

--- a/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
@@ -10,33 +10,38 @@ import (
 // ClaimableBalanceClaimantBatchInsertBuilder is used to insert transactions into the
 // history_transactions table
 type ClaimableBalanceClaimantBatchInsertBuilder interface {
-	Add(ctx context.Context, claimableBalanceClaimant ClaimableBalanceClaimant) error
-	Exec(ctx context.Context) error
+	Add(claimableBalanceClaimant ClaimableBalanceClaimant) error
+	Exec(ctx context.Context, session db.SessionInterface) error
+	Reset() error
 }
 
-// ClaimableBalanceClaimantBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
+// ClaimableBalanceClaimantBatchInsertBuilder is a simple wrapper around db.FastBatchInsertBuilder
 type claimableBalanceClaimantBatchInsertBuilder struct {
 	encodingBuffer *xdr.EncodingBuffer
-	builder        db.BatchInsertBuilder
+	builder        db.FastBatchInsertBuilder
+	table          string
 }
 
 // NewClaimableBalanceClaimantBatchInsertBuilder constructs a new ClaimableBalanceClaimantBatchInsertBuilder instance
-func (q *Q) NewClaimableBalanceClaimantBatchInsertBuilder(maxBatchSize int) ClaimableBalanceClaimantBatchInsertBuilder {
+func (q *Q) NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder {
 	return &claimableBalanceClaimantBatchInsertBuilder{
 		encodingBuffer: xdr.NewEncodingBuffer(),
-		builder: db.BatchInsertBuilder{
-			Table:        q.GetTable("claimable_balance_claimants"),
-			MaxBatchSize: maxBatchSize,
-			Suffix:       "ON CONFLICT (id, destination) DO UPDATE SET last_modified_ledger=EXCLUDED.last_modified_ledger",
-		},
+		builder:        db.FastBatchInsertBuilder{},
+		table:          "claimable_balance_claimants",
 	}
 }
 
-// Add adds a new transaction to the batch
-func (i *claimableBalanceClaimantBatchInsertBuilder) Add(ctx context.Context, claimableBalanceClaimant ClaimableBalanceClaimant) error {
-	return i.builder.RowStruct(ctx, claimableBalanceClaimant)
+// Add adds a new claimant for a claimable Balance to the batch
+func (i *claimableBalanceClaimantBatchInsertBuilder) Add(claimableBalanceClaimant ClaimableBalanceClaimant) error {
+	return i.builder.RowStruct(claimableBalanceClaimant)
 }
 
-func (i *claimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context) error {
-	return i.builder.Exec(ctx)
+// Exec flushes the entire batch into the database
+func (i *claimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
+	return i.builder.Exec(ctx, session, i.table)
+}
+
+func (i *claimableBalanceClaimantBatchInsertBuilder) Reset() error {
+	i.builder.Reset()
+	return nil
 }

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -107,7 +107,8 @@ type ClaimableBalance struct {
 type Claimants []Claimant
 
 func (c Claimants) Value() (driver.Value, error) {
-	return json.Marshal(c)
+	val, err := json.Marshal(c)
+	return string(val), err
 }
 
 func (c *Claimants) Scan(value interface{}) error {

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -126,12 +126,12 @@ type Claimant struct {
 
 // QClaimableBalances defines claimable-balance-related related queries.
 type QClaimableBalances interface {
-	UpsertClaimableBalances(ctx context.Context, cb []ClaimableBalance) error
 	RemoveClaimableBalances(ctx context.Context, ids []string) (int64, error)
 	RemoveClaimableBalanceClaimants(ctx context.Context, ids []string) (int64, error)
 	GetClaimableBalancesByID(ctx context.Context, ids []string) ([]ClaimableBalance, error)
 	CountClaimableBalances(ctx context.Context) (int, error)
-	NewClaimableBalanceClaimantBatchInsertBuilder(maxBatchSize int) ClaimableBalanceClaimantBatchInsertBuilder
+	NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder
+	NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder
 	GetClaimantsByClaimableBalances(ctx context.Context, ids []string) (map[string][]ClaimableBalanceClaimant, error)
 }
 
@@ -169,36 +169,6 @@ func (q *Q) GetClaimantsByClaimableBalances(ctx context.Context, ids []string) (
 		claimantsMap[claimant.BalanceID] = append(claimantsMap[claimant.BalanceID], claimant)
 	}
 	return claimantsMap, err
-}
-
-// UpsertClaimableBalances upserts a batch of claimable balances in the claimable_balances table.
-// There's currently no limit of the number of offers this method can
-// accept other than 2GB limit of the query string length what should be enough
-// for each ledger with the current limits.
-func (q *Q) UpsertClaimableBalances(ctx context.Context, cbs []ClaimableBalance) error {
-	var id, claimants, asset, amount, sponsor, lastModifiedLedger, flags []interface{}
-
-	for _, cb := range cbs {
-		id = append(id, cb.BalanceID)
-		claimants = append(claimants, cb.Claimants)
-		asset = append(asset, cb.Asset)
-		amount = append(amount, cb.Amount)
-		sponsor = append(sponsor, cb.Sponsor)
-		lastModifiedLedger = append(lastModifiedLedger, cb.LastModifiedLedger)
-		flags = append(flags, cb.Flags)
-	}
-
-	upsertFields := []upsertField{
-		{"id", "text", id},
-		{"claimants", "jsonb", claimants},
-		{"asset", "text", asset},
-		{"amount", "bigint", amount},
-		{"sponsor", "text", sponsor},
-		{"last_modified_ledger", "integer", lastModifiedLedger},
-		{"flags", "int", flags},
-	}
-
-	return q.upsertRows(ctx, "claimable_balances", "id", upsertFields)
 }
 
 // RemoveClaimableBalances deletes claimable balances table.

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -107,6 +107,11 @@ type ClaimableBalance struct {
 type Claimants []Claimant
 
 func (c Claimants) Value() (driver.Value, error) {
+	// Convert the byte array into a string as a workaround to bypass buggy encoding in the pq driver
+	// (More info about this bug here https://github.com/stellar/go/issues/5086#issuecomment-1773215436).
+	// By doing so, the data will be written as a string rather than hex encoded bytes.
+	// According to this https://www.postgresql.org/docs/current/datatype-json.html
+	// this may even improve write performance due to reduced conversion overhead.
 	val, err := json.Marshal(c)
 	return string(val), err
 }

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"database/sql"
 	"fmt"
 	"testing"
 
@@ -15,6 +16,8 @@ func TestRemoveClaimableBalance(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
@@ -39,8 +42,9 @@ func TestRemoveClaimableBalance(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	balanceBatchInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	tt.Assert.NoError(balanceBatchInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(balanceBatchInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	r, err := q.FindClaimableBalanceByID(tt.Ctx, id)
 	tt.Assert.NoError(err)
@@ -63,6 +67,8 @@ func TestRemoveClaimableBalanceClaimants(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
@@ -87,20 +93,9 @@ func TestRemoveClaimableBalanceClaimants(t *testing.T) {
 		Amount:             10,
 	}
 
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(10)
-
-	for _, claimant := range cBalance.Claimants {
-		claimant := ClaimableBalanceClaimant{
-			BalanceID:          cBalance.BalanceID,
-			Destination:        claimant.Destination,
-			LastModifiedLedger: cBalance.LastModifiedLedger,
-		}
-		err = claimantsInsertBuilder.Add(tt.Ctx, claimant)
-		tt.Assert.NoError(err)
-	}
-
-	err = claimantsInsertBuilder.Exec(tt.Ctx)
-	tt.Assert.NoError(err)
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance))
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	removed, err := q.RemoveClaimableBalanceClaimants(tt.Ctx, []string{id})
 	tt.Assert.NoError(err)
@@ -112,6 +107,9 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
+
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.Rollback()
 
 	dest1 := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	dest2 := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
@@ -138,19 +136,11 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
 
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(10)
-	for _, claimant := range cBalance.Claimants {
-		claimant := ClaimableBalanceClaimant{
-			BalanceID:          cBalance.BalanceID,
-			Destination:        claimant.Destination,
-			LastModifiedLedger: cBalance.LastModifiedLedger,
-		}
-		err = claimantsInsertBuilder.Add(tt.Ctx, claimant)
-		tt.Assert.NoError(err)
-	}
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance))
 
 	balanceID = xdr.ClaimableBalanceId{
 		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
@@ -179,21 +169,11 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance))
 
-	for _, claimant := range cBalance.Claimants {
-		claimant := ClaimableBalanceClaimant{
-			BalanceID:          cBalance.BalanceID,
-			Destination:        claimant.Destination,
-			LastModifiedLedger: cBalance.LastModifiedLedger,
-		}
-		err = claimantsInsertBuilder.Add(tt.Ctx, claimant)
-		tt.Assert.NoError(err)
-	}
-
-	err = claimantsInsertBuilder.Exec(tt.Ctx)
-	tt.Assert.NoError(err)
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	query := ClaimableBalancesQuery{
 		PageQuery: db2.MustPageQuery("", false, "", 10),
@@ -233,20 +213,19 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 	tt.Assert.Len(cbs, 1)
 }
 
-func insertClaimants(q *Q, tt *test.T, cBalance ClaimableBalance) error {
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(10)
+func insertClaimants(claimantsInsertBuilder ClaimableBalanceClaimantBatchInsertBuilder, cBalance ClaimableBalance) error {
 	for _, claimant := range cBalance.Claimants {
 		claimant := ClaimableBalanceClaimant{
 			BalanceID:          cBalance.BalanceID,
 			Destination:        claimant.Destination,
 			LastModifiedLedger: cBalance.LastModifiedLedger,
 		}
-		err := claimantsInsertBuilder.Add(tt.Ctx, claimant)
+		err := claimantsInsertBuilder.Add(claimant)
 		if err != nil {
 			return err
 		}
 	}
-	return claimantsInsertBuilder.Exec(tt.Ctx)
+	return nil
 }
 
 type claimableBalanceQueryResult struct {
@@ -278,6 +257,9 @@ func TestFindClaimableBalancesByDestinationWithLimit(t *testing.T) {
 
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
+
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.Rollback()
 
 	assetIssuer := "GA25GQLHJU3LPEJXEIAXK23AWEA5GWDUGRSHTQHDFT6HXHVMRULSQJUJ"
 	asset1 := xdr.MustNewCreditAsset("ASSET1", assetIssuer)
@@ -318,8 +300,11 @@ func TestFindClaimableBalancesByDestinationWithLimit(t *testing.T) {
 		LastModifiedLedger: 123,
 		Amount:             10,
 	}
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance1})
-	tt.Assert.NoError(err)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
+
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance1))
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance1))
 
 	claimants2 := []Claimant{
 		{
@@ -345,14 +330,12 @@ func TestFindClaimableBalancesByDestinationWithLimit(t *testing.T) {
 		LastModifiedLedger: 456,
 		Amount:             10,
 	}
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance2})
-	tt.Assert.NoError(err)
 
-	err = insertClaimants(q, tt, cBalance1)
-	tt.Assert.NoError(err)
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance2))
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance2))
 
-	err = insertClaimants(q, tt, cBalance2)
-	tt.Assert.NoError(err)
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	pageQuery := db2.MustPageQuery("", false, "", 1)
 
@@ -414,73 +397,15 @@ func TestFindClaimableBalancesByDestinationWithLimit(t *testing.T) {
 	})
 }
 
-func TestUpdateClaimableBalance(t *testing.T) {
-	tt := test.Start(t)
-	defer tt.Finish()
-	test.ResetHorizonDB(t, tt.HorizonDB)
-	q := &Q{tt.HorizonSession()}
-
-	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
-	lastModifiedLedgerSeq := xdr.Uint32(123)
-	asset := xdr.MustNewCreditAsset("USD", accountID)
-	balanceID := xdr.ClaimableBalanceId{
-		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
-		V0:   &xdr.Hash{1, 2, 3},
-	}
-	id, err := xdr.MarshalHex(balanceID)
-	tt.Assert.NoError(err)
-	cBalance := ClaimableBalance{
-		BalanceID: id,
-		Claimants: []Claimant{
-			{
-				Destination: accountID,
-				Predicate: xdr.ClaimPredicate{
-					Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
-				},
-			},
-		},
-		Asset:              asset,
-		LastModifiedLedger: 123,
-		Amount:             10,
-	}
-
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
-
-	// add sponsor
-	cBalance2 := ClaimableBalance{
-		BalanceID: id,
-		Claimants: []Claimant{
-			{
-				Destination: accountID,
-				Predicate: xdr.ClaimPredicate{
-					Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
-				},
-			},
-		},
-		Asset:              asset,
-		LastModifiedLedger: 123 + 1,
-		Amount:             10,
-		Sponsor:            null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-	}
-
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance2})
-	tt.Assert.NoError(err)
-
-	cbs := []ClaimableBalance{}
-	err = q.Select(tt.Ctx, &cbs, selectClaimableBalances)
-	tt.Assert.NoError(err)
-	tt.Assert.Len(cbs, 1)
-	tt.Assert.Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", cbs[0].Sponsor.String)
-	tt.Assert.Equal(uint32(lastModifiedLedgerSeq+1), cbs[0].LastModifiedLedger)
-}
-
 func TestFindClaimableBalance(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
+
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
 	balanceID := xdr.ClaimableBalanceId{
@@ -504,11 +429,11 @@ func TestFindClaimableBalance(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	cb, err := q.FindClaimableBalanceByID(tt.Ctx, id)
-	tt.Assert.NoError(err)
 
 	tt.Assert.Equal(cBalance.BalanceID, cb.BalanceID)
 	tt.Assert.Equal(cBalance.Asset, cb.Asset)
@@ -525,6 +450,9 @@ func TestGetClaimableBalancesByID(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
+
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
 	balanceID := xdr.ClaimableBalanceId{
@@ -548,8 +476,9 @@ func TestGetClaimableBalancesByID(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	r, err := q.GetClaimableBalancesByID(tt.Ctx, []string{id})
 	tt.Assert.NoError(err)

--- a/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
@@ -1,0 +1,27 @@
+package history
+
+import (
+	"context"
+	"github.com/stellar/go/support/db"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockClaimableBalanceBatchInsertBuilder struct {
+	mock.Mock
+}
+
+func (m *MockClaimableBalanceBatchInsertBuilder) Add(claimableBalance ClaimableBalance) error {
+	a := m.Called(claimableBalance)
+	return a.Error(0)
+}
+
+func (m *MockClaimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
+	a := m.Called(ctx, session)
+	return a.Error(0)
+}
+
+func (m *MockClaimableBalanceBatchInsertBuilder) Reset() error {
+	a := m.Called()
+	return a.Error(0)
+}

--- a/services/horizon/internal/db2/history/mock_claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_claimant_batch_insert_builder.go
@@ -2,6 +2,7 @@ package history
 
 import (
 	"context"
+	"github.com/stellar/go/support/db"
 
 	"github.com/stretchr/testify/mock"
 )
@@ -10,12 +11,17 @@ type MockClaimableBalanceClaimantBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Add(ctx context.Context, claimableBalanceClaimant ClaimableBalanceClaimant) error {
-	a := m.Called(ctx, claimableBalanceClaimant)
+func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Add(claimableBalanceClaimant ClaimableBalanceClaimant) error {
+	a := m.Called(claimableBalanceClaimant)
 	return a.Error(0)
 }
 
-func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context) error {
-	a := m.Called(ctx)
+func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
+	a := m.Called(ctx, session)
+	return a.Error(0)
+}
+
+func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Reset() error {
+	a := m.Called()
 	return a.Error(0)
 }

--- a/services/horizon/internal/db2/history/mock_q_claimable_balances.go
+++ b/services/horizon/internal/db2/history/mock_q_claimable_balances.go
@@ -21,11 +21,6 @@ func (m *MockQClaimableBalances) GetClaimableBalancesByID(ctx context.Context, i
 	return a.Get(0).([]ClaimableBalance), a.Error(1)
 }
 
-func (m *MockQClaimableBalances) UpsertClaimableBalances(ctx context.Context, cbs []ClaimableBalance) error {
-	a := m.Called(ctx, cbs)
-	return a.Error(0)
-}
-
 func (m *MockQClaimableBalances) RemoveClaimableBalances(ctx context.Context, ids []string) (int64, error) {
 	a := m.Called(ctx, ids)
 	return a.Get(0).(int64), a.Error(1)
@@ -36,9 +31,14 @@ func (m *MockQClaimableBalances) RemoveClaimableBalanceClaimants(ctx context.Con
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQClaimableBalances) NewClaimableBalanceClaimantBatchInsertBuilder(maxBatchSize int) ClaimableBalanceClaimantBatchInsertBuilder {
-	a := m.Called(maxBatchSize)
+func (m *MockQClaimableBalances) NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder {
+	a := m.Called()
 	return a.Get(0).(ClaimableBalanceClaimantBatchInsertBuilder)
+}
+
+func (m *MockQClaimableBalances) NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder {
+	a := m.Called()
+	return a.Get(0).(ClaimableBalanceBatchInsertBuilder)
 }
 
 func (m *MockQClaimableBalances) GetClaimantsByClaimableBalances(ctx context.Context, ids []string) (map[string][]ClaimableBalanceClaimant, error) {

--- a/services/horizon/internal/db2/history/operation.go
+++ b/services/horizon/internal/db2/history/operation.go
@@ -8,6 +8,7 @@ import (
 	"text/template"
 
 	sq "github.com/Masterminds/squirrel"
+
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/toid"
@@ -394,7 +395,7 @@ var selectOperation = sq.Select(
 		"hop.details, " +
 		"hop.source_account, " +
 		"hop.source_account_muxed, " +
-		"hop.is_payment, " +
+		"COALESCE(hop.is_payment, false) as is_payment, " +
 		"ht.transaction_hash, " +
 		"ht.tx_result, " +
 		"COALESCE(ht.successful, true) as transaction_successful").

--- a/services/horizon/internal/db2/history/operation_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/operation_batch_insert_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/guregu/null"
+
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/xdr"
 )
@@ -52,7 +53,7 @@ func (i *operationBatchInsertBuilder) Add(
 	sourceAccountMuxed null.String,
 	isPayment bool,
 ) error {
-	return i.builder.Row(ctx, map[string]interface{}{
+	row := map[string]interface{}{
 		"id":                   id,
 		"transaction_id":       transactionID,
 		"application_order":    applicationOrder,
@@ -60,8 +61,12 @@ func (i *operationBatchInsertBuilder) Add(
 		"details":              details,
 		"source_account":       sourceAccount,
 		"source_account_muxed": sourceAccountMuxed,
-		"is_payment":           isPayment,
-	})
+		"is_payment":           nil,
+	}
+	if isPayment {
+		row["is_payment"] = true
+	}
+	return i.builder.Row(ctx, row)
 
 }
 

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -299,6 +299,7 @@ func NewSystem(config Config) (System, error) {
 			ctx:            ctx,
 			config:         config,
 			historyQ:       historyQ,
+			session:        historyQ,
 			historyAdapter: historyAdapter,
 			filters:        filters,
 		},

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/xdr"
 )
 
@@ -20,21 +21,32 @@ func TestClaimableBalancesChangeProcessorTestSuiteState(t *testing.T) {
 
 type ClaimableBalancesChangeProcessorTestSuiteState struct {
 	suite.Suite
-	ctx                    context.Context
-	processor              *ClaimableBalancesChangeProcessor
-	mockQ                  *history.MockQClaimableBalances
-	mockBatchInsertBuilder *history.MockClaimableBalanceClaimantBatchInsertBuilder
+	ctx                                    context.Context
+	processor                              *ClaimableBalancesChangeProcessor
+	mockQ                                  *history.MockQClaimableBalances
+	mockClaimantsBatchInsertBuilder        *history.MockClaimableBalanceClaimantBatchInsertBuilder
+	mockClaimableBalanceBatchInsertBuilder *history.MockClaimableBalanceBatchInsertBuilder
+	session                                db.SessionInterface
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteState) SetupTest() {
 	s.ctx = context.Background()
-	s.mockBatchInsertBuilder = &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
-	s.mockQ = &history.MockQClaimableBalances{}
-	s.mockQ.
-		On("NewClaimableBalanceClaimantBatchInsertBuilder", maxBatchSize).
-		Return(s.mockBatchInsertBuilder).Once()
+	s.mockClaimantsBatchInsertBuilder = &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	s.mockClaimableBalanceBatchInsertBuilder = &history.MockClaimableBalanceBatchInsertBuilder{}
 
-	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ)
+	s.mockQ = &history.MockQClaimableBalances{}
+	s.session = &db.MockSession{}
+	s.mockQ.
+		On("NewClaimableBalanceClaimantBatchInsertBuilder").
+		Return(s.mockClaimantsBatchInsertBuilder).Once()
+	s.mockQ.
+		On("NewClaimableBalanceBatchInsertBuilder").
+		Return(s.mockClaimableBalanceBatchInsertBuilder).Once()
+
+	s.mockClaimantsBatchInsertBuilder.On("Reset").Return(nil).Once()
+	s.mockClaimableBalanceBatchInsertBuilder.On("Reset").Return(nil).Once()
+
+	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ, s.session)
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteState) TearDownTest() {
@@ -67,27 +79,27 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteState) TestCreatesClaimableBal
 	}
 	id, err := xdr.MarshalHex(balanceID)
 	s.Assert().NoError(err)
-	s.mockQ.On("UpsertClaimableBalances", s.ctx, []history.ClaimableBalance{
-		{
-			BalanceID: id,
-			Claimants: []history.Claimant{
-				{
-					Destination: "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-				},
+	s.mockClaimableBalanceBatchInsertBuilder.On("Add", history.ClaimableBalance{
+		BalanceID: id,
+		Claimants: []history.Claimant{
+			{
+				Destination: "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 			},
-			Asset:              cBalance.Asset,
-			Amount:             cBalance.Amount,
-			LastModifiedLedger: uint32(lastModifiedLedgerSeq),
 		},
+		Asset:              cBalance.Asset,
+		Amount:             cBalance.Amount,
+		LastModifiedLedger: uint32(lastModifiedLedgerSeq),
 	}).Return(nil).Once()
 
-	s.mockBatchInsertBuilder.On("Add", s.ctx, history.ClaimableBalanceClaimant{
+	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
+
+	s.mockClaimantsBatchInsertBuilder.On("Add", history.ClaimableBalanceClaimant{
 		BalanceID:          id,
 		Destination:        "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 		LastModifiedLedger: uint32(lastModifiedLedgerSeq),
 	}).Return(nil).Once()
 
-	s.mockBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
+	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
 
 	err = s.processor.ProcessChange(s.ctx, ingest.Change{
 		Type: xdr.LedgerEntryTypeClaimableBalance,
@@ -109,25 +121,39 @@ func TestClaimableBalancesChangeProcessorTestSuiteLedger(t *testing.T) {
 
 type ClaimableBalancesChangeProcessorTestSuiteLedger struct {
 	suite.Suite
-	ctx                    context.Context
-	processor              *ClaimableBalancesChangeProcessor
-	mockQ                  *history.MockQClaimableBalances
-	mockBatchInsertBuilder *history.MockClaimableBalanceClaimantBatchInsertBuilder
+	ctx                                    context.Context
+	processor                              *ClaimableBalancesChangeProcessor
+	mockQ                                  *history.MockQClaimableBalances
+	mockClaimantsBatchInsertBuilder        *history.MockClaimableBalanceClaimantBatchInsertBuilder
+	mockClaimableBalanceBatchInsertBuilder *history.MockClaimableBalanceBatchInsertBuilder
+	session                                db.SessionInterface
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) SetupTest() {
 	s.ctx = context.Background()
-	s.mockBatchInsertBuilder = &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	s.mockClaimantsBatchInsertBuilder = &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	s.mockClaimableBalanceBatchInsertBuilder = &history.MockClaimableBalanceBatchInsertBuilder{}
 	s.mockQ = &history.MockQClaimableBalances{}
+	s.session = &db.MockSession{}
 	s.mockQ.
-		On("NewClaimableBalanceClaimantBatchInsertBuilder", maxBatchSize).
-		Return(s.mockBatchInsertBuilder).Once()
+		On("NewClaimableBalanceClaimantBatchInsertBuilder").
+		Return(s.mockClaimantsBatchInsertBuilder).Twice()
+	s.mockQ.
+		On("NewClaimableBalanceBatchInsertBuilder").
+		Return(s.mockClaimableBalanceBatchInsertBuilder).Twice()
 
-	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ)
+	s.mockClaimantsBatchInsertBuilder.On("Reset").Return(nil).Once()
+	s.mockClaimableBalanceBatchInsertBuilder.On("Reset").Return(nil).Once()
+
+	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
+	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
+
+	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ, s.session)
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TearDownTest() {
 	s.Assert().NoError(s.processor.Commit(s.ctx))
+	s.processor.reset()
 	s.mockQ.AssertExpectations(s.T())
 }
 
@@ -160,9 +186,23 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TestNewClaimableBalanc
 			},
 		},
 	}
-	s.mockBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
 
-	err := s.processor.ProcessChange(s.ctx, ingest.Change{
+	id, err := xdr.MarshalHex(balanceID)
+	s.Assert().NoError(err)
+
+	// We use LedgerEntryChangesCache so all changes are squashed
+	s.mockClaimableBalanceBatchInsertBuilder.On(
+		"Add",
+		history.ClaimableBalance{
+			BalanceID:          id,
+			Claimants:          []history.Claimant{},
+			Asset:              cBalance.Asset,
+			Amount:             cBalance.Amount,
+			LastModifiedLedger: uint32(lastModifiedLedgerSeq),
+		},
+	).Return(nil).Once()
+
+	err = s.processor.ProcessChange(s.ctx, ingest.Change{
 		Type: xdr.LedgerEntryTypeClaimableBalance,
 		Pre:  nil,
 		Post: &entry,
@@ -192,89 +232,16 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TestNewClaimableBalanc
 	})
 	s.Assert().NoError(err)
 
-	id, err := xdr.MarshalHex(balanceID)
-	s.Assert().NoError(err)
 	// We use LedgerEntryChangesCache so all changes are squashed
-	s.mockQ.On(
-		"UpsertClaimableBalances",
-		s.ctx,
-		[]history.ClaimableBalance{
-			{
-				BalanceID:          id,
-				Claimants:          []history.Claimant{},
-				Asset:              cBalance.Asset,
-				Amount:             cBalance.Amount,
-				LastModifiedLedger: uint32(lastModifiedLedgerSeq),
-				Sponsor:            null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-			},
-		},
-	).Return(nil).Once()
-}
-
-func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TestUpdateClaimableBalance() {
-	balanceID := xdr.ClaimableBalanceId{
-		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
-		V0:   &xdr.Hash{1, 2, 3},
-	}
-	cBalance := xdr.ClaimableBalanceEntry{
-		BalanceId: balanceID,
-		Claimants: []xdr.Claimant{},
-		Asset:     xdr.MustNewCreditAsset("USD", "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-		Amount:    10,
-	}
-	lastModifiedLedgerSeq := xdr.Uint32(123)
-
-	pre := xdr.LedgerEntry{
-		Data: xdr.LedgerEntryData{
-			Type:             xdr.LedgerEntryTypeClaimableBalance,
-			ClaimableBalance: &cBalance,
-		},
-		LastModifiedLedgerSeq: lastModifiedLedgerSeq - 1,
-		Ext: xdr.LedgerEntryExt{
-			V: 1,
-			V1: &xdr.LedgerEntryExtensionV1{
-				SponsoringId: nil,
-			},
-		},
-	}
-
-	// add sponsor
-	updated := xdr.LedgerEntry{
-		Data: xdr.LedgerEntryData{
-			Type:             xdr.LedgerEntryTypeClaimableBalance,
-			ClaimableBalance: &cBalance,
-		},
-		LastModifiedLedgerSeq: lastModifiedLedgerSeq,
-		Ext: xdr.LedgerEntryExt{
-			V: 1,
-			V1: &xdr.LedgerEntryExtensionV1{
-				SponsoringId: xdr.MustAddressPtr("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-			},
-		},
-	}
-	s.mockBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
-
-	err := s.processor.ProcessChange(s.ctx, ingest.Change{
-		Type: xdr.LedgerEntryTypeClaimableBalance,
-		Pre:  &pre,
-		Post: &updated,
-	})
-	s.Assert().NoError(err)
-
-	id, err := xdr.MarshalHex(balanceID)
-	s.Assert().NoError(err)
-	s.mockQ.On(
-		"UpsertClaimableBalances",
-		s.ctx,
-		[]history.ClaimableBalance{
-			{
-				BalanceID:          id,
-				Claimants:          []history.Claimant{},
-				Asset:              cBalance.Asset,
-				Amount:             cBalance.Amount,
-				LastModifiedLedger: uint32(lastModifiedLedgerSeq),
-				Sponsor:            null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-			},
+	s.mockClaimableBalanceBatchInsertBuilder.On(
+		"Add",
+		history.ClaimableBalance{
+			BalanceID:          id,
+			Claimants:          []history.Claimant{},
+			Asset:              cBalance.Asset,
+			Amount:             cBalance.Amount,
+			LastModifiedLedger: uint32(lastModifiedLedgerSeq),
+			Sponsor:            null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 		},
 	).Return(nil).Once()
 }

--- a/services/horizon/internal/ingest/verify_test.go
+++ b/services/horizon/internal/ingest/verify_test.go
@@ -271,8 +271,11 @@ func TestStateVerifierLockBusy(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
+
 	checkpointLedger := uint32(63)
-	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
+	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
 
 	gen := randxdr.NewGenerator()
 	var changes []xdr.LedgerEntryChange
@@ -324,8 +327,11 @@ func TestStateVerifier(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
+
 	checkpointLedger := uint32(63)
-	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
+	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
 	mockChangeReader := &ingest.MockChangeReader{}
 
 	gen := randxdr.NewGenerator()
@@ -353,6 +359,8 @@ func TestStateVerifier(t *testing.T) {
 	}
 	tt.Assert.NoError(changeProcessor.Commit(tt.Ctx))
 	tt.Assert.Equal(len(xdr.LedgerEntryTypeMap), len(coverage))
+
+	q.SessionInterface.Commit()
 
 	q.UpdateLastLedgerIngest(tt.Ctx, checkpointLedger)
 

--- a/support/db/fast_batch_insert_builder.go
+++ b/support/db/fast_batch_insert_builder.go
@@ -1,0 +1,150 @@
+package db
+
+import (
+	"context"
+	"reflect"
+	"sort"
+
+	"github.com/lib/pq"
+
+	"github.com/stellar/go/support/errors"
+)
+
+// ErrSealed is returned when trying to add rows to the FastBatchInsertBuilder after Exec() is called.
+// Once Exec() is called no more rows can be added to the FastBatchInsertBuilder unless you call Reset()
+// which clears out the old rows from the FastBatchInsertBuilder.
+var ErrSealed = errors.New("cannot add more rows after Exec() without calling Reset() first")
+
+// ErrNoTx is returned when Exec() is called outside of a transaction.
+var ErrNoTx = errors.New("cannot call Exec() outside of a transaction")
+
+// FastBatchInsertBuilder works like sq.InsertBuilder but has a better support for batching
+// large number of rows.
+// It is NOT safe for concurrent use.
+// It does NOT support updating existing rows.
+type FastBatchInsertBuilder struct {
+	columns       []string
+	rows          [][]interface{}
+	rowStructType reflect.Type
+	sealed        bool
+}
+
+// Row adds a new row to the batch. All rows must have exactly the same columns
+// (map keys). Otherwise, error will be returned. Please note that rows are not
+// added one by one but in batches when `Exec` is called.
+func (b *FastBatchInsertBuilder) Row(row map[string]interface{}) error {
+	if b.sealed {
+		return ErrSealed
+	}
+
+	if b.columns == nil {
+		b.columns = make([]string, 0, len(row))
+		b.rows = make([][]interface{}, 0)
+
+		for column := range row {
+			b.columns = append(b.columns, column)
+		}
+
+		sort.Strings(b.columns)
+	}
+
+	if len(b.columns) != len(row) {
+		return errors.Errorf("invalid number of columns (expected=%d, actual=%d)", len(b.columns), len(row))
+	}
+
+	rowSlice := make([]interface{}, 0, len(b.columns))
+	for _, column := range b.columns {
+		val, ok := row[column]
+		if !ok {
+			return errors.Errorf(`column "%s" does not exist`, column)
+		}
+		rowSlice = append(rowSlice, val)
+	}
+	b.rows = append(b.rows, rowSlice)
+
+	return nil
+}
+
+// RowStruct adds a new row to the batch. All rows must have exactly the same columns
+// (map keys). Otherwise, error will be returned. Please note that rows are not
+// added one by one but in batches when `Exec` is called.
+func (b *FastBatchInsertBuilder) RowStruct(row interface{}) error {
+	if b.sealed {
+		return ErrSealed
+	}
+
+	if b.columns == nil {
+		b.columns = ColumnsForStruct(row)
+		b.rows = make([][]interface{}, 0)
+	}
+
+	rowType := reflect.TypeOf(row)
+	if b.rowStructType == nil {
+		b.rowStructType = rowType
+	} else if b.rowStructType != rowType {
+		return errors.Errorf(`expected value of type "%s" but got "%s" value`, b.rowStructType.String(), rowType.String())
+	}
+
+	rrow := reflect.ValueOf(row)
+	rvals := mapper.FieldsByName(rrow, b.columns)
+
+	// convert fields values to interface{}
+	columnValues := make([]interface{}, len(b.columns))
+	for i, rval := range rvals {
+		columnValues[i] = rval.Interface()
+	}
+
+	b.rows = append(b.rows, columnValues)
+
+	return nil
+}
+
+// Len returns the number of rows held in memory by the FastBatchInsertBuilder.
+func (b *FastBatchInsertBuilder) Len() int {
+	return len(b.rows)
+}
+
+// Exec inserts rows in a single COPY statement. Once Exec is called no more rows
+// can be added to the FastBatchInsertBuilder unless Reset is called.
+// Exec must be called within a transaction.
+func (b *FastBatchInsertBuilder) Exec(ctx context.Context, session SessionInterface, tableName string) error {
+	b.sealed = true
+	if session.GetTx() == nil {
+		return ErrNoTx
+	}
+
+	if len(b.rows) == 0 {
+		return nil
+	}
+
+	tx := session.GetTx()
+	stmt, err := tx.PrepareContext(ctx, pq.CopyIn(tableName, b.columns...))
+	if err != nil {
+		return err
+	}
+
+	for _, row := range b.rows {
+		if _, err = stmt.ExecContext(ctx, row...); err != nil {
+			// we need to close the statement otherwise the session
+			// will always return bad connection errors when executing
+			// any other sql statements,
+			// see https://github.com/stellar/go/pull/316#issuecomment-368990324
+			stmt.Close()
+			return err
+		}
+	}
+
+	if err = stmt.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Reset clears out all the rows contained in the FastBatchInsertBuilder.
+// After Reset is called new rows can be added to the FastBatchInsertBuilder.
+func (b *FastBatchInsertBuilder) Reset() {
+	b.sealed = false
+	b.columns = nil
+	b.rows = nil
+	b.rowStructType = nil
+}

--- a/support/db/fast_batch_insert_builder_test.go
+++ b/support/db/fast_batch_insert_builder_test.go
@@ -1,0 +1,127 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/go/support/db/dbtest"
+)
+
+func TestFastBatchInsertBuilder(t *testing.T) {
+	db := dbtest.Postgres(t).Load(testSchema)
+	defer db.Close()
+	sess := &Session{DB: db.Open()}
+	defer sess.DB.Close()
+
+	insertBuilder := &FastBatchInsertBuilder{}
+
+	assert.NoError(t,
+		insertBuilder.Row(map[string]interface{}{
+			"name":         "bubba",
+			"hunger_level": "1",
+		}),
+	)
+
+	assert.EqualError(t,
+		insertBuilder.Row(map[string]interface{}{
+			"name": "bubba",
+		}),
+		"invalid number of columns (expected=2, actual=1)",
+	)
+
+	assert.EqualError(t,
+		insertBuilder.Row(map[string]interface{}{
+			"name": "bubba",
+			"city": "London",
+		}),
+		"column \"hunger_level\" does not exist",
+	)
+
+	assert.NoError(t,
+		insertBuilder.RowStruct(hungerRow{
+			Name:        "bubba2",
+			HungerLevel: "9",
+		}),
+	)
+
+	assert.EqualError(t,
+		insertBuilder.RowStruct(invalidHungerRow{
+			Name:        "bubba",
+			HungerLevel: "2",
+			LastName:    "b",
+		}),
+		"expected value of type \"db.hungerRow\" but got \"db.invalidHungerRow\" value",
+	)
+	assert.Equal(t, 2, insertBuilder.Len())
+	assert.Equal(t, false, insertBuilder.sealed)
+
+	assert.EqualError(t,
+		insertBuilder.Exec(context.Background(), sess, "people"),
+		"cannot call Exec() outside of a transaction",
+	)
+	assert.Equal(t, true, insertBuilder.sealed)
+
+	assert.NoError(t, sess.Begin())
+	assert.NoError(t, insertBuilder.Exec(context.Background(), sess, "people"))
+	assert.Equal(t, 2, insertBuilder.Len())
+	assert.Equal(t, true, insertBuilder.sealed)
+
+	var found []person
+	assert.NoError(t, sess.SelectRaw(context.Background(), &found, `SELECT * FROM people WHERE name like 'bubba%'`))
+	assert.Equal(
+		t,
+		found,
+		[]person{
+			{Name: "bubba", HungerLevel: "1"},
+			{Name: "bubba2", HungerLevel: "9"},
+		},
+	)
+
+	assert.EqualError(t,
+		insertBuilder.Row(map[string]interface{}{
+			"name":         "bubba3",
+			"hunger_level": "100",
+		}),
+		"cannot add more rows after Exec() without calling Reset() first",
+	)
+	assert.Equal(t, 2, insertBuilder.Len())
+	assert.Equal(t, true, insertBuilder.sealed)
+
+	insertBuilder.Reset()
+	assert.Equal(t, 0, insertBuilder.Len())
+	assert.Equal(t, false, insertBuilder.sealed)
+
+	assert.NoError(t,
+		insertBuilder.Row(map[string]interface{}{
+			"name":         "bubba3",
+			"hunger_level": "3",
+		}),
+	)
+	assert.Equal(t, 1, insertBuilder.Len())
+	assert.Equal(t, false, insertBuilder.sealed)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.EqualError(t,
+		insertBuilder.Exec(ctx, sess, "people"),
+		"context canceled",
+	)
+	assert.Equal(t, 1, insertBuilder.Len())
+	assert.Equal(t, true, insertBuilder.sealed)
+
+	assert.NoError(t, sess.SelectRaw(context.Background(), &found, `SELECT * FROM people WHERE name like 'bubba%'`))
+	assert.Equal(
+		t,
+		found,
+		[]person{
+			{Name: "bubba", HungerLevel: "1"},
+			{Name: "bubba2", HungerLevel: "9"},
+		},
+	)
+	assert.NoError(t, sess.Rollback())
+
+	assert.NoError(t, sess.SelectRaw(context.Background(), &found, `SELECT * FROM people WHERE name like 'bubba%'`))
+	assert.Empty(t, found)
+}

--- a/support/db/fast_batch_insert_builder_test.go
+++ b/support/db/fast_batch_insert_builder_test.go
@@ -63,7 +63,7 @@ func TestFastBatchInsertBuilder(t *testing.T) {
 	)
 	assert.Equal(t, true, insertBuilder.sealed)
 
-	assert.NoError(t, sess.Begin())
+	assert.NoError(t, sess.Begin(context.Background()))
 	assert.NoError(t, insertBuilder.Exec(context.Background(), sess, "people"))
 	assert.Equal(t, 2, insertBuilder.Len())
 	assert.Equal(t, true, insertBuilder.sealed)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Use [FastBatchInsertBuilder](https://github.com/stellar/go/blob/9ce82de12cbade47de862ad5e9d0684029558564/support/db/fast_batch_insert_builder.go) for writing to `claimable_balances` and `claimable_balance_claimants` tables.  FastBatchInsertBuilder uses ‘COPY' to insert into the db which is faster than using 'INSERT'.

### Why
#5086 

### Known limitations
