### PR TITLE
horizon: fix comment following updated XDR

### DIFF
--- a/services/horizon/internal/ingest/processors/contract_data.go
+++ b/services/horizon/internal/ingest/processors/contract_data.go
@@ -413,7 +413,7 @@ func metadataObjFromAsset(isNative bool, code, issuer string) (*xdr.ScMap, error
 // ledger entry containing the asset info entry written to contract storage by the
 // Stellar Asset Contract.
 //
-// Warning: Only for use in tests. This does not set a realistic expirationLedgerSeq
+// Warning: Only for use in tests. This does not create the accompanied TTLEntry which would typically be created by core.
 func AssetToContractData(isNative bool, code, issuer string, contractID [32]byte) (xdr.LedgerEntryData, error) {
 	storageMap, err := metadataObjFromAsset(isNative, code, issuer)
 	if err != nil {
@@ -450,7 +450,7 @@ func AssetToContractData(isNative bool, code, issuer string, contractID [32]byte
 // creates a ledger entry containing the asset balance of a contract holder
 // written to contract storage by the Stellar Asset Contract.
 //
-// Warning: Only for use in tests. This does not set a realistic expirationLedgerSeq
+// Warning: Only for use in tests. This does not create the accompanied TTLEntry which would typically be created by core.
 func BalanceToContractData(assetContractId, holderID [32]byte, amt uint64) xdr.LedgerEntryData {
 	return balanceToContractData(assetContractId, holderID, xdr.Int128Parts{
 		Lo: xdr.Uint64(amt),


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

fix comment following updated XDR

### Why

comment became irrelevant and would only create additional confusion.

### Known limitations

n/a
