### PR TITLE
services/horizon: Explicitly supply objectives in Prometheus SummaryOpts to fix metrics dashboards

### DIFF
--- a/ingest/ledgerbackend/metrics.go
+++ b/ingest/ledgerbackend/metrics.go
@@ -17,7 +17,8 @@ func WithMetrics(base LedgerBackend, registry *prometheus.Registry, namespace st
 	summary := prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Namespace: namespace, Subsystem: "ingest", Name: "ledger_fetch_duration_seconds",
-			Help: "duration of fetching ledgers from ledger backend, sliding window = 10m",
+			Help:       "duration of fetching ledgers from ledger backend, sliding window = 10m",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
 	)
 	registry.MustRegister(summary)

--- a/services/horizon/internal/httpx/server.go
+++ b/services/horizon/internal/httpx/server.go
@@ -66,7 +66,8 @@ func NewServer(serverConfig ServerConfig, routerConfig RouterConfig, ledgerState
 		RequestDurationSummary: prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{
 				Namespace: "horizon", Subsystem: "http", Name: "requests_duration_seconds",
-				Help: "HTTP requests durations, sliding window = 10m",
+				Help:       "HTTP requests durations, sliding window = 10m",
+				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 			},
 			[]string{"status", "route", "streaming", "method"},
 		),

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -336,22 +336,26 @@ func (s *system) initMetrics() {
 
 	s.metrics.LedgerIngestionDuration = prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: "horizon", Subsystem: "ingest", Name: "ledger_ingestion_duration_seconds",
-		Help: "ledger ingestion durations, sliding window = 10m",
+		Help:       "ledger ingestion durations, sliding window = 10m",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	})
 
 	s.metrics.LedgerIngestionTradeAggregationDuration = prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: "horizon", Subsystem: "ingest", Name: "ledger_ingestion_trade_aggregation_duration_seconds",
-		Help: "ledger ingestion trade aggregation rebuild durations, sliding window = 10m",
+		Help:       "ledger ingestion trade aggregation rebuild durations, sliding window = 10m",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	})
 
 	s.metrics.LedgerIngestionReapLookupTablesDuration = prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: "horizon", Subsystem: "ingest", Name: "ledger_ingestion_reap_lookup_tables_duration_seconds",
-		Help: "ledger ingestion reap lookup tables durations, sliding window = 10m",
+		Help:       "ledger ingestion reap lookup tables durations, sliding window = 10m",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	})
 
 	s.metrics.StateVerifyDuration = prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: "horizon", Subsystem: "ingest", Name: "state_verify_duration_seconds",
-		Help: "state verification durations, sliding window = 10m",
+		Help:       "state verification durations, sliding window = 10m",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	})
 
 	s.metrics.StateInvalidGauge = prometheus.NewGaugeFunc(
@@ -400,7 +404,8 @@ func (s *system) initMetrics() {
 	s.metrics.ProcessorsRunDurationSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Namespace: "horizon", Subsystem: "ingest", Name: "processor_run_duration_seconds",
-			Help: "run durations of ingestion processors, sliding window = 10m",
+			Help:       "run durations of ingestion processors, sliding window = 10m",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
 		[]string{"name"},
 	)

--- a/services/horizon/internal/txsub/system.go
+++ b/services/horizon/internal/txsub/system.go
@@ -353,7 +353,8 @@ func (sys *System) Init() {
 
 		sys.Metrics.SubmissionDuration = prometheus.NewSummary(prometheus.SummaryOpts{
 			Namespace: "horizon", Subsystem: "txsub", Name: "submission_duration_seconds",
-			Help: "submission durations to Stellar-Core, sliding window = 10m",
+			Help:       "submission durations to Stellar-Core, sliding window = 10m",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		})
 		sys.Metrics.FailedSubmissionsCounter = prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: "horizon", Subsystem: "txsub", Name: "failed",

--- a/support/db/metrics.go
+++ b/support/db/metrics.go
@@ -82,6 +82,7 @@ func RegisterMetrics(base *Session, namespace string, sub Subservice, registry *
 			Namespace: namespace, Subsystem: "db",
 			Name:        "query_duration_seconds",
 			ConstLabels: prometheus.Labels{"subservice": string(sub)},
+			Objectives:  map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
 		[]string{"query_type", "error", "route"},
 	)
@@ -232,6 +233,7 @@ func RegisterMetrics(base *Session, namespace string, sub Subservice, registry *
 			Name:        "round_trip_time_seconds",
 			Help:        "time required to run `select 1` query in a DB - effectively measures round trip time, if time exceeds 1s it will be recorded as 1",
 			ConstLabels: prometheus.Labels{"subservice": string(sub)},
+			Objectives:  map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
 	)
 	registry.MustRegister(s.roundTripTimeSummary)


### PR DESCRIPTION


<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR explicitly supplies objectives in `Prometheus.SummaryOpts` because the new version of the Prometheus go client no longer provides the default value.

### Why

In previous versions of the Prometheus go client, default objectives were automatically provided in `prometheus.SummaryOpts`. However, this was [deprecated](
https://github.com/prometheus/client_golang/pull/262/files
) in [version 1.0.0.](https://github.com/prometheus/client_golang/blob/main/CHANGELOG.md#100--2019-06-15). As a result, when we [updated](https://github.com/stellar/go/commit/d50c63e68acca8e2c59e2a8c53d167665d18e7e9#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L35-L36) the dependencies in our repo, certain dashboards, such as the "Top 20 slowest routes" and "Occurrences of DB query taking longer than 5 seconds", stopped showing any data. This is because Horizon was unable to post "summary" metrics type without objectives.

This PR addresses this issue by explicitly supplying objectives for all summary metrics.

### Known limitations
N/A
