### PR TITLE
Update Postgres version used in integration tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,7 +57,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         go: ["1.19", "1.20"]
-        pg: [9.6.5, 10]
+        pg: [12]
     runs-on: ${{ matrix.os }}
     services:
       postgres:

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
         go: ["1.20", "1.21"]
-        pg: [9.6.5]
+        pg: [12]
         ingestion-backend: [db, captive-core, captive-core-remote-storage]
         protocol-version: [19, 20]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Upgrade the Postgres versions that we use for integration tests.

### Why

Since Horizon requires Postgres version 12 or higher ([as per new docs](https://github.com/stellar/stellar-docs/pull/249/files#diff-55398e93ceb3417fe250daeca353620a9ced43dc94e1610691214bc7b86e7f62R31)) and our production environment uses Postgres version 12,  updating integration tests to reflect that. 


### Known limitations

