### PR TITLE
services/horizon: Use COPY to speed up ClaimableBalanceChangeProcessor

### DIFF
--- a/services/horizon/internal/actions/claimable_balance_test.go
+++ b/services/horizon/internal/actions/claimable_balance_test.go
@@ -22,7 +22,9 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 	q := &history.Q{tt.HorizonSession()}
 
 	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
-	defer q.SessionInterface.Rollback()
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
@@ -155,7 +157,9 @@ func TestGetClaimableBalances(t *testing.T) {
 	q := &history.Q{tt.HorizonSession()}
 
 	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
-	defer q.SessionInterface.Rollback()
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	entriesMeta := []struct {
 		id        xdr.Hash

--- a/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
@@ -36,11 +36,12 @@ func (i *claimableBalanceBatchInsertBuilder) Add(claimableBalance ClaimableBalan
 	return i.builder.RowStruct(claimableBalance)
 }
 
-// Exec inserts claimable balance rows to the database
+// Exec writes the batch of claimable balances to the database.
 func (i *claimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
 	return i.builder.Exec(ctx, session, i.table)
 }
 
+// Reset clears out the current batch of claimable balances
 func (i *claimableBalanceBatchInsertBuilder) Reset() error {
 	i.builder.Reset()
 	return nil

--- a/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
@@ -12,7 +12,7 @@ import (
 type ClaimableBalanceBatchInsertBuilder interface {
 	Add(claimableBalance ClaimableBalance) error
 	Exec(ctx context.Context, session db.SessionInterface) error
-	Reset() error
+	Reset()
 }
 
 // ClaimableBalanceBatchInsertBuilder is a simple wrapper around db.FastBatchInsertBuilder
@@ -42,7 +42,6 @@ func (i *claimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session d
 }
 
 // Reset clears out the current batch of claimable balances
-func (i *claimableBalanceBatchInsertBuilder) Reset() error {
+func (i *claimableBalanceBatchInsertBuilder) Reset() {
 	i.builder.Reset()
-	return nil
 }

--- a/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
@@ -1,0 +1,47 @@
+package history
+
+import (
+	"context"
+
+	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/xdr"
+)
+
+// ClaimableBalanceBatchInsertBuilder is used to insert claimable balance into the
+// claimable_balances table
+type ClaimableBalanceBatchInsertBuilder interface {
+	Add(claimableBalance ClaimableBalance) error
+	Exec(ctx context.Context, session db.SessionInterface) error
+	Reset() error
+}
+
+// ClaimableBalanceBatchInsertBuilder is a simple wrapper around db.FastBatchInsertBuilder
+type claimableBalanceBatchInsertBuilder struct {
+	encodingBuffer *xdr.EncodingBuffer
+	builder        db.FastBatchInsertBuilder
+	table          string
+}
+
+// NewClaimableBalanceBatchInsertBuilder constructs a new ClaimableBalanceBatchInsertBuilder instance
+func (q *Q) NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder {
+	return &claimableBalanceBatchInsertBuilder{
+		encodingBuffer: xdr.NewEncodingBuffer(),
+		builder:        db.FastBatchInsertBuilder{},
+		table:          "claimable_balances",
+	}
+}
+
+// Add adds a new claimable balance to the batch
+func (i *claimableBalanceBatchInsertBuilder) Add(claimableBalance ClaimableBalance) error {
+	return i.builder.RowStruct(claimableBalance)
+}
+
+// Exec inserts claimable balance rows to the database
+func (i *claimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
+	return i.builder.Exec(ctx, session, i.table)
+}
+
+func (i *claimableBalanceBatchInsertBuilder) Reset() error{
+	i.builder.Reset()
+	return nil
+}

--- a/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
@@ -41,7 +41,7 @@ func (i *claimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session d
 	return i.builder.Exec(ctx, session, i.table)
 }
 
-func (i *claimableBalanceBatchInsertBuilder) Reset() error{
+func (i *claimableBalanceBatchInsertBuilder) Reset() error {
 	i.builder.Reset()
 	return nil
 }

--- a/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-// ClaimableBalanceClaimantBatchInsertBuilder is used to insert transactions into the
-// history_transactions table
+// ClaimableBalanceClaimantBatchInsertBuilder is used to insert claimants into the
+// claimable_balance_claimants table
 type ClaimableBalanceClaimantBatchInsertBuilder interface {
 	Add(claimableBalanceClaimant ClaimableBalanceClaimant) error
 	Exec(ctx context.Context, session db.SessionInterface) error
@@ -31,16 +31,17 @@ func (q *Q) NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClai
 	}
 }
 
-// Add adds a new claimant for a claimable Balance to the batch
+// Add adds a new claimant to the batch
 func (i *claimableBalanceClaimantBatchInsertBuilder) Add(claimableBalanceClaimant ClaimableBalanceClaimant) error {
 	return i.builder.RowStruct(claimableBalanceClaimant)
 }
 
-// Exec flushes the entire batch into the database
+// Exec writes the batch of claimants to the database.
 func (i *claimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
 	return i.builder.Exec(ctx, session, i.table)
 }
 
+// Reset clears out the current batch of claimants
 func (i *claimableBalanceClaimantBatchInsertBuilder) Reset() error {
 	i.builder.Reset()
 	return nil

--- a/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
@@ -12,7 +12,7 @@ import (
 type ClaimableBalanceClaimantBatchInsertBuilder interface {
 	Add(claimableBalanceClaimant ClaimableBalanceClaimant) error
 	Exec(ctx context.Context, session db.SessionInterface) error
-	Reset() error
+	Reset()
 }
 
 // ClaimableBalanceClaimantBatchInsertBuilder is a simple wrapper around db.FastBatchInsertBuilder
@@ -42,7 +42,6 @@ func (i *claimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context, s
 }
 
 // Reset clears out the current batch of claimants
-func (i *claimableBalanceClaimantBatchInsertBuilder) Reset() error {
+func (i *claimableBalanceClaimantBatchInsertBuilder) Reset() {
 	i.builder.Reset()
-	return nil
 }

--- a/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
@@ -10,33 +10,38 @@ import (
 // ClaimableBalanceClaimantBatchInsertBuilder is used to insert transactions into the
 // history_transactions table
 type ClaimableBalanceClaimantBatchInsertBuilder interface {
-	Add(ctx context.Context, claimableBalanceClaimant ClaimableBalanceClaimant) error
-	Exec(ctx context.Context) error
+	Add(claimableBalanceClaimant ClaimableBalanceClaimant) error
+	Exec(ctx context.Context, session db.SessionInterface) error
+	Reset() error
 }
 
-// ClaimableBalanceClaimantBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
+// ClaimableBalanceClaimantBatchInsertBuilder is a simple wrapper around db.FastBatchInsertBuilder
 type claimableBalanceClaimantBatchInsertBuilder struct {
 	encodingBuffer *xdr.EncodingBuffer
-	builder        db.BatchInsertBuilder
+	builder        db.FastBatchInsertBuilder
+	table          string
 }
 
 // NewClaimableBalanceClaimantBatchInsertBuilder constructs a new ClaimableBalanceClaimantBatchInsertBuilder instance
-func (q *Q) NewClaimableBalanceClaimantBatchInsertBuilder(maxBatchSize int) ClaimableBalanceClaimantBatchInsertBuilder {
+func (q *Q) NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder {
 	return &claimableBalanceClaimantBatchInsertBuilder{
 		encodingBuffer: xdr.NewEncodingBuffer(),
-		builder: db.BatchInsertBuilder{
-			Table:        q.GetTable("claimable_balance_claimants"),
-			MaxBatchSize: maxBatchSize,
-			Suffix:       "ON CONFLICT (id, destination) DO UPDATE SET last_modified_ledger=EXCLUDED.last_modified_ledger",
-		},
+		builder:        db.FastBatchInsertBuilder{},
+		table:          "claimable_balance_claimants",
 	}
 }
 
-// Add adds a new transaction to the batch
-func (i *claimableBalanceClaimantBatchInsertBuilder) Add(ctx context.Context, claimableBalanceClaimant ClaimableBalanceClaimant) error {
-	return i.builder.RowStruct(ctx, claimableBalanceClaimant)
+// Add adds a new claimant for a claimable Balance to the batch
+func (i *claimableBalanceClaimantBatchInsertBuilder) Add(claimableBalanceClaimant ClaimableBalanceClaimant) error {
+	return i.builder.RowStruct(claimableBalanceClaimant)
 }
 
-func (i *claimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context) error {
-	return i.builder.Exec(ctx)
+// Exec flushes the entire batch into the database
+func (i *claimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
+	return i.builder.Exec(ctx, session, i.table)
+}
+
+func (i *claimableBalanceClaimantBatchInsertBuilder) Reset() error {
+	i.builder.Reset()
+	return nil
 }

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -107,7 +107,8 @@ type ClaimableBalance struct {
 type Claimants []Claimant
 
 func (c Claimants) Value() (driver.Value, error) {
-	return json.Marshal(c)
+	val, err := json.Marshal(c)
+	return string(val), err
 }
 
 func (c *Claimants) Scan(value interface{}) error {

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -126,12 +126,12 @@ type Claimant struct {
 
 // QClaimableBalances defines claimable-balance-related related queries.
 type QClaimableBalances interface {
-	UpsertClaimableBalances(ctx context.Context, cb []ClaimableBalance) error
 	RemoveClaimableBalances(ctx context.Context, ids []string) (int64, error)
 	RemoveClaimableBalanceClaimants(ctx context.Context, ids []string) (int64, error)
 	GetClaimableBalancesByID(ctx context.Context, ids []string) ([]ClaimableBalance, error)
 	CountClaimableBalances(ctx context.Context) (int, error)
-	NewClaimableBalanceClaimantBatchInsertBuilder(maxBatchSize int) ClaimableBalanceClaimantBatchInsertBuilder
+	NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder
+	NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder
 	GetClaimantsByClaimableBalances(ctx context.Context, ids []string) (map[string][]ClaimableBalanceClaimant, error)
 }
 
@@ -169,36 +169,6 @@ func (q *Q) GetClaimantsByClaimableBalances(ctx context.Context, ids []string) (
 		claimantsMap[claimant.BalanceID] = append(claimantsMap[claimant.BalanceID], claimant)
 	}
 	return claimantsMap, err
-}
-
-// UpsertClaimableBalances upserts a batch of claimable balances in the claimable_balances table.
-// There's currently no limit of the number of offers this method can
-// accept other than 2GB limit of the query string length what should be enough
-// for each ledger with the current limits.
-func (q *Q) UpsertClaimableBalances(ctx context.Context, cbs []ClaimableBalance) error {
-	var id, claimants, asset, amount, sponsor, lastModifiedLedger, flags []interface{}
-
-	for _, cb := range cbs {
-		id = append(id, cb.BalanceID)
-		claimants = append(claimants, cb.Claimants)
-		asset = append(asset, cb.Asset)
-		amount = append(amount, cb.Amount)
-		sponsor = append(sponsor, cb.Sponsor)
-		lastModifiedLedger = append(lastModifiedLedger, cb.LastModifiedLedger)
-		flags = append(flags, cb.Flags)
-	}
-
-	upsertFields := []upsertField{
-		{"id", "text", id},
-		{"claimants", "jsonb", claimants},
-		{"asset", "text", asset},
-		{"amount", "bigint", amount},
-		{"sponsor", "text", sponsor},
-		{"last_modified_ledger", "integer", lastModifiedLedger},
-		{"flags", "int", flags},
-	}
-
-	return q.upsertRows(ctx, "claimable_balances", "id", upsertFields)
 }
 
 // RemoveClaimableBalances deletes claimable balances table.

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -107,6 +107,11 @@ type ClaimableBalance struct {
 type Claimants []Claimant
 
 func (c Claimants) Value() (driver.Value, error) {
+	// Convert the byte array into a string as a workaround to bypass buggy encoding in the pq driver
+	// (More info about this bug here https://github.com/stellar/go/issues/5086#issuecomment-1773215436).
+	// By doing so, the data will be written as a string rather than hex encoded bytes.
+	// According to this https://www.postgresql.org/docs/current/datatype-json.html
+	// this may even improve write performance due to reduced conversion overhead.
 	val, err := json.Marshal(c)
 	return string(val), err
 }

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -110,8 +110,6 @@ func (c Claimants) Value() (driver.Value, error) {
 	// Convert the byte array into a string as a workaround to bypass buggy encoding in the pq driver
 	// (More info about this bug here https://github.com/stellar/go/issues/5086#issuecomment-1773215436).
 	// By doing so, the data will be written as a string rather than hex encoded bytes.
-	// According to this https://www.postgresql.org/docs/current/datatype-json.html
-	// this may even improve write performance due to reduced conversion overhead.
 	val, err := json.Marshal(c)
 	return string(val), err
 }

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"database/sql"
 	"fmt"
 	"testing"
 
@@ -15,6 +16,8 @@ func TestRemoveClaimableBalance(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
@@ -39,8 +42,9 @@ func TestRemoveClaimableBalance(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	balanceBatchInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	tt.Assert.NoError(balanceBatchInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(balanceBatchInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	r, err := q.FindClaimableBalanceByID(tt.Ctx, id)
 	tt.Assert.NoError(err)
@@ -63,6 +67,8 @@ func TestRemoveClaimableBalanceClaimants(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
@@ -87,20 +93,9 @@ func TestRemoveClaimableBalanceClaimants(t *testing.T) {
 		Amount:             10,
 	}
 
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(10)
-
-	for _, claimant := range cBalance.Claimants {
-		claimant := ClaimableBalanceClaimant{
-			BalanceID:          cBalance.BalanceID,
-			Destination:        claimant.Destination,
-			LastModifiedLedger: cBalance.LastModifiedLedger,
-		}
-		err = claimantsInsertBuilder.Add(tt.Ctx, claimant)
-		tt.Assert.NoError(err)
-	}
-
-	err = claimantsInsertBuilder.Exec(tt.Ctx)
-	tt.Assert.NoError(err)
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance))
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	removed, err := q.RemoveClaimableBalanceClaimants(tt.Ctx, []string{id})
 	tt.Assert.NoError(err)
@@ -112,6 +107,9 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
+
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.Rollback()
 
 	dest1 := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	dest2 := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
@@ -138,19 +136,11 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
 
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(10)
-	for _, claimant := range cBalance.Claimants {
-		claimant := ClaimableBalanceClaimant{
-			BalanceID:          cBalance.BalanceID,
-			Destination:        claimant.Destination,
-			LastModifiedLedger: cBalance.LastModifiedLedger,
-		}
-		err = claimantsInsertBuilder.Add(tt.Ctx, claimant)
-		tt.Assert.NoError(err)
-	}
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance))
 
 	balanceID = xdr.ClaimableBalanceId{
 		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
@@ -179,21 +169,11 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance))
 
-	for _, claimant := range cBalance.Claimants {
-		claimant := ClaimableBalanceClaimant{
-			BalanceID:          cBalance.BalanceID,
-			Destination:        claimant.Destination,
-			LastModifiedLedger: cBalance.LastModifiedLedger,
-		}
-		err = claimantsInsertBuilder.Add(tt.Ctx, claimant)
-		tt.Assert.NoError(err)
-	}
-
-	err = claimantsInsertBuilder.Exec(tt.Ctx)
-	tt.Assert.NoError(err)
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	query := ClaimableBalancesQuery{
 		PageQuery: db2.MustPageQuery("", false, "", 10),
@@ -233,65 +213,188 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 	tt.Assert.Len(cbs, 1)
 }
 
-func TestUpdateClaimableBalance(t *testing.T) {
+func insertClaimants(claimantsInsertBuilder ClaimableBalanceClaimantBatchInsertBuilder, cBalance ClaimableBalance) error {
+	for _, claimant := range cBalance.Claimants {
+		claimant := ClaimableBalanceClaimant{
+			BalanceID:          cBalance.BalanceID,
+			Destination:        claimant.Destination,
+			LastModifiedLedger: cBalance.LastModifiedLedger,
+		}
+		err := claimantsInsertBuilder.Add(claimant)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type claimableBalanceQueryResult struct {
+	Claimants []string
+	Asset     string
+	Sponsor   string
+}
+
+func validateClaimableBalanceQuery(t *test.T, q *Q, query ClaimableBalancesQuery, expectedQueryResult []claimableBalanceQueryResult) {
+	cbs, err := q.GetClaimableBalances(t.Ctx, query)
+	t.Assert.NoError(err)
+	for i, expected := range expectedQueryResult {
+		for j, claimant := range expected.Claimants {
+			t.Assert.Equal(claimant, cbs[i].Claimants[j].Destination)
+		}
+		if expected.Asset != "" {
+			t.Assert.Equal(expected.Asset, cbs[i].Asset.String())
+		}
+		if expected.Sponsor != "" {
+			t.Assert.Equal(expected.Sponsor, cbs[i].Sponsor.String)
+		}
+	}
+}
+
+// TestFindClaimableBalancesByDestinationWithLimit tests querying claimable balances by destination and asset
+func TestFindClaimableBalancesByDestinationWithLimit(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
+
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
-	lastModifiedLedgerSeq := xdr.Uint32(123)
-	asset := xdr.MustNewCreditAsset("USD", accountID)
-	balanceID := xdr.ClaimableBalanceId{
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.Rollback()
+
+	assetIssuer := "GA25GQLHJU3LPEJXEIAXK23AWEA5GWDUGRSHTQHDFT6HXHVMRULSQJUJ"
+	asset1 := xdr.MustNewCreditAsset("ASSET1", assetIssuer)
+	asset2 := xdr.MustNewCreditAsset("ASSET2", assetIssuer)
+
+	sponsor1 := "GA25GQLHJU3LPEJXEIAXK23AWEA5GWDUGRSHTQHDFT6HXHVMRULSQJUJ"
+	sponsor2 := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
+
+	dest1 := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
+	dest2 := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
+
+	claimants := []Claimant{
+		{
+			Destination: dest1,
+			Predicate: xdr.ClaimPredicate{
+				Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+			},
+		},
+		{
+			Destination: dest2,
+			Predicate: xdr.ClaimPredicate{
+				Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
+			},
+		},
+	}
+
+	balanceID1 := xdr.ClaimableBalanceId{
 		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
 		V0:   &xdr.Hash{1, 2, 3},
 	}
-	id, err := xdr.MarshalHex(balanceID)
+	id, err := xdr.MarshalHex(balanceID1)
 	tt.Assert.NoError(err)
-	cBalance := ClaimableBalance{
-		BalanceID: id,
-		Claimants: []Claimant{
-			{
-				Destination: accountID,
-				Predicate: xdr.ClaimPredicate{
-					Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
-				},
-			},
-		},
-		Asset:              asset,
+	cBalance1 := ClaimableBalance{
+		BalanceID:          id,
+		Claimants:          claimants,
+		Asset:              asset1,
+		Sponsor:            null.StringFrom(sponsor1),
 		LastModifiedLedger: 123,
 		Amount:             10,
 	}
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance1))
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance1))
 
-	// add sponsor
-	cBalance2 := ClaimableBalance{
-		BalanceID: id,
-		Claimants: []Claimant{
-			{
-				Destination: accountID,
-				Predicate: xdr.ClaimPredicate{
-					Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
-				},
+	claimants2 := []Claimant{
+		{
+			Destination: dest2,
+			Predicate: xdr.ClaimPredicate{
+				Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
 			},
 		},
-		Asset:              asset,
-		LastModifiedLedger: 123 + 1,
-		Amount:             10,
-		Sponsor:            null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance2})
+	balanceID2 := xdr.ClaimableBalanceId{
+		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
+		V0:   &xdr.Hash{4, 5, 6},
+	}
+	id, err = xdr.MarshalHex(balanceID2)
 	tt.Assert.NoError(err)
+	cBalance2 := ClaimableBalance{
+		BalanceID: id,
+		Claimants: claimants2,
+		Asset:     asset2,
+		Sponsor:   null.StringFrom(sponsor2),
 
-	cbs := []ClaimableBalance{}
-	err = q.Select(tt.Ctx, &cbs, selectClaimableBalances)
-	tt.Assert.NoError(err)
-	tt.Assert.Len(cbs, 1)
-	tt.Assert.Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", cbs[0].Sponsor.String)
-	tt.Assert.Equal(uint32(lastModifiedLedgerSeq+1), cbs[0].LastModifiedLedger)
+		LastModifiedLedger: 456,
+		Amount:             10,
+	}
+
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance2))
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance2))
+
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+
+	pageQuery := db2.MustPageQuery("", false, "", 1)
+
+	// no claimant parameter, no filters
+	query := ClaimableBalancesQuery{
+		PageQuery: pageQuery,
+	}
+	validateClaimableBalanceQuery(tt, q, query, []claimableBalanceQueryResult{
+		{Claimants: []string{dest1, dest2}},
+	})
+
+	// invalid claimant parameter
+	query = ClaimableBalancesQuery{
+		PageQuery: pageQuery,
+		Claimant:  xdr.MustAddressPtr("GA25GQLHJU3LPEJXEIAXK23AWEA5GWDUGRSHTQHDFT6HXHVMRULSQJUJ"),
+		Asset:     &asset2,
+		Sponsor:   xdr.MustAddressPtr(sponsor1),
+	}
+	validateClaimableBalanceQuery(tt, q, query, []claimableBalanceQueryResult{})
+
+	// claimant parameter, no filters
+	query = ClaimableBalancesQuery{
+		PageQuery: pageQuery,
+		Claimant:  xdr.MustAddressPtr(dest1),
+	}
+	validateClaimableBalanceQuery(tt, q, query, []claimableBalanceQueryResult{
+		{Claimants: []string{dest1, dest2}},
+	})
+
+	// claimant parameter, asset filter
+	query = ClaimableBalancesQuery{
+		PageQuery: pageQuery,
+		Claimant:  xdr.MustAddressPtr(dest2),
+		Asset:     &asset1,
+	}
+	validateClaimableBalanceQuery(tt, q, query, []claimableBalanceQueryResult{
+		{Claimants: []string{dest1, dest2}, Asset: asset1.String()},
+	})
+
+	// claimant parameter, sponsor filter
+	query = ClaimableBalancesQuery{
+		PageQuery: pageQuery,
+		Claimant:  xdr.MustAddressPtr(dest2),
+		Sponsor:   xdr.MustAddressPtr(sponsor1),
+	}
+	validateClaimableBalanceQuery(tt, q, query, []claimableBalanceQueryResult{
+		{Claimants: []string{dest1, dest2}, Sponsor: sponsor1},
+	})
+
+	//claimant parameter, asset filter, sponsor filter
+	query = ClaimableBalancesQuery{
+		PageQuery: pageQuery,
+		Claimant:  xdr.MustAddressPtr(dest2),
+		Asset:     &asset2,
+		Sponsor:   xdr.MustAddressPtr(sponsor2),
+	}
+	validateClaimableBalanceQuery(tt, q, query, []claimableBalanceQueryResult{
+		{Claimants: []string{dest2}, Asset: asset2.String(), Sponsor: sponsor2},
+	})
 }
 
 func TestFindClaimableBalance(t *testing.T) {
@@ -300,6 +403,9 @@ func TestFindClaimableBalance(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
+
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
 	balanceID := xdr.ClaimableBalanceId{
@@ -323,11 +429,11 @@ func TestFindClaimableBalance(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	cb, err := q.FindClaimableBalanceByID(tt.Ctx, id)
-	tt.Assert.NoError(err)
 
 	tt.Assert.Equal(cBalance.BalanceID, cb.BalanceID)
 	tt.Assert.Equal(cBalance.Asset, cb.Asset)
@@ -344,6 +450,9 @@ func TestGetClaimableBalancesByID(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
+
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
 	balanceID := xdr.ClaimableBalanceId{
@@ -367,8 +476,9 @@ func TestGetClaimableBalancesByID(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	r, err := q.GetClaimableBalancesByID(tt.Ctx, []string{id})
 	tt.Assert.NoError(err)

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -16,7 +16,9 @@ func TestRemoveClaimableBalance(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
-	defer q.SessionInterface.Rollback()
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
@@ -67,7 +69,9 @@ func TestRemoveClaimableBalanceClaimants(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
-	defer q.SessionInterface.Rollback()
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
@@ -119,7 +123,9 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
-	defer q.SessionInterface.Rollback()
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	dest1 := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	dest2 := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
@@ -250,7 +256,9 @@ func TestFindClaimableBalance(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
-	defer q.SessionInterface.Rollback()
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
@@ -298,7 +306,9 @@ func TestGetClaimableBalancesByID(t *testing.T) {
 	q := &Q{tt.HorizonSession()}
 
 	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
-	defer q.SessionInterface.Rollback()
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)

--- a/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
@@ -1,0 +1,27 @@
+package history
+
+import (
+	"context"
+	"github.com/stellar/go/support/db"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockClaimableBalanceBatchInsertBuilder struct {
+	mock.Mock
+}
+
+func (m *MockClaimableBalanceBatchInsertBuilder) Add(claimableBalance ClaimableBalance) error {
+	a := m.Called(claimableBalance)
+	return a.Error(0)
+}
+
+func (m *MockClaimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
+	a := m.Called(ctx, session)
+	return a.Error(0)
+}
+
+func (m *MockClaimableBalanceBatchInsertBuilder) Reset() error {
+	a := m.Called()
+	return a.Error(0)
+}

--- a/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
@@ -21,7 +21,6 @@ func (m *MockClaimableBalanceBatchInsertBuilder) Exec(ctx context.Context, sessi
 	return a.Error(0)
 }
 
-func (m *MockClaimableBalanceBatchInsertBuilder) Reset() error {
-	a := m.Called()
-	return a.Error(0)
+func (m *MockClaimableBalanceBatchInsertBuilder) Reset() {
+	m.Called()
 }

--- a/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
@@ -2,8 +2,8 @@ package history
 
 import (
 	"context"
-	"github.com/stellar/go/support/db"
 
+	"github.com/stellar/go/support/db"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/services/horizon/internal/db2/history/mock_claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_claimant_batch_insert_builder.go
@@ -21,7 +21,6 @@ func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Contex
 	return a.Error(0)
 }
 
-func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Reset() error {
-	a := m.Called()
-	return a.Error(0)
+func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Reset() {
+	m.Called()
 }

--- a/services/horizon/internal/db2/history/mock_claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_claimant_batch_insert_builder.go
@@ -2,6 +2,7 @@ package history
 
 import (
 	"context"
+	"github.com/stellar/go/support/db"
 
 	"github.com/stretchr/testify/mock"
 )
@@ -10,12 +11,17 @@ type MockClaimableBalanceClaimantBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Add(ctx context.Context, claimableBalanceClaimant ClaimableBalanceClaimant) error {
-	a := m.Called(ctx, claimableBalanceClaimant)
+func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Add(claimableBalanceClaimant ClaimableBalanceClaimant) error {
+	a := m.Called(claimableBalanceClaimant)
 	return a.Error(0)
 }
 
-func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context) error {
-	a := m.Called(ctx)
+func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
+	a := m.Called(ctx, session)
+	return a.Error(0)
+}
+
+func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Reset() error {
+	a := m.Called()
 	return a.Error(0)
 }

--- a/services/horizon/internal/db2/history/mock_claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_claimant_batch_insert_builder.go
@@ -2,8 +2,8 @@ package history
 
 import (
 	"context"
-	"github.com/stellar/go/support/db"
 
+	"github.com/stellar/go/support/db"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/services/horizon/internal/db2/history/mock_q_claimable_balances.go
+++ b/services/horizon/internal/db2/history/mock_q_claimable_balances.go
@@ -21,11 +21,6 @@ func (m *MockQClaimableBalances) GetClaimableBalancesByID(ctx context.Context, i
 	return a.Get(0).([]ClaimableBalance), a.Error(1)
 }
 
-func (m *MockQClaimableBalances) UpsertClaimableBalances(ctx context.Context, cbs []ClaimableBalance) error {
-	a := m.Called(ctx, cbs)
-	return a.Error(0)
-}
-
 func (m *MockQClaimableBalances) RemoveClaimableBalances(ctx context.Context, ids []string) (int64, error) {
 	a := m.Called(ctx, ids)
 	return a.Get(0).(int64), a.Error(1)
@@ -36,9 +31,14 @@ func (m *MockQClaimableBalances) RemoveClaimableBalanceClaimants(ctx context.Con
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQClaimableBalances) NewClaimableBalanceClaimantBatchInsertBuilder(maxBatchSize int) ClaimableBalanceClaimantBatchInsertBuilder {
-	a := m.Called(maxBatchSize)
+func (m *MockQClaimableBalances) NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder {
+	a := m.Called()
 	return a.Get(0).(ClaimableBalanceClaimantBatchInsertBuilder)
+}
+
+func (m *MockQClaimableBalances) NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder {
+	a := m.Called()
+	return a.Get(0).(ClaimableBalanceBatchInsertBuilder)
 }
 
 func (m *MockQClaimableBalances) GetClaimantsByClaimableBalances(ctx context.Context, ids []string) (map[string][]ClaimableBalanceClaimant, error) {

--- a/services/horizon/internal/ingest/processor_runner.go
+++ b/services/horizon/internal/ingest/processor_runner.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/stellar/go/support/db"
 	"time"
 
 	"github.com/stellar/go/ingest"
@@ -244,7 +243,6 @@ func (s *ProcessorRunner) RunHistoryArchiveIngestion(
 		&changeStats,
 		historyArchiveSource,
 		checkpointLedger,
-		s.config.NetworkPassphrase,
 	)
 
 	if checkpointLedger == 1 {
@@ -410,7 +408,6 @@ func (s *ProcessorRunner) RunAllProcessorsOnLedger(ledger xdr.LedgerCloseMeta) (
 		&changeStatsProcessor,
 		ledgerSource,
 		ledger.LedgerSequence(),
-		s.config.NetworkPassphrase,
 	)
 	err = s.runChangeProcessorOnLedger(groupChangeProcessors, ledger)
 	if err != nil {

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -200,7 +200,7 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 	}
 
 	stats := &ingest.StatsChangeProcessor{}
-	processor := buildChangeProcessor(runner.historyQ, &db.MockSession{}, stats, ledgerSource, 123, "")
+	processor := buildChangeProcessor(runner.historyQ, &db.MockSession{}, stats, ledgerSource, 123)
 	assert.IsType(t, &groupChangeProcessors{}, processor)
 
 	assert.IsType(t, &statsChangeProcessor{}, processor.processors[0])
@@ -221,7 +221,7 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 		filters:  &MockFilters{},
 	}
 
-	processor = buildChangeProcessor(runner.historyQ, &db.MockSession{}, stats, historyArchiveSource, 456, "")
+	processor = buildChangeProcessor(runner.historyQ, &db.MockSession{}, stats, historyArchiveSource, 456)
 	assert.IsType(t, &groupChangeProcessors{}, processor)
 
 	assert.IsType(t, &statsChangeProcessor{}, processor.processors[0])

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"github.com/guregu/null"
-	"github.com/stretchr/testify/suite"
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/suite"
 )
 
 func TestClaimableBalancesChangeProcessorTestSuiteState(t *testing.T) {

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/xdr"
 )
 
@@ -20,21 +21,32 @@ func TestClaimableBalancesChangeProcessorTestSuiteState(t *testing.T) {
 
 type ClaimableBalancesChangeProcessorTestSuiteState struct {
 	suite.Suite
-	ctx                    context.Context
-	processor              *ClaimableBalancesChangeProcessor
-	mockQ                  *history.MockQClaimableBalances
-	mockBatchInsertBuilder *history.MockClaimableBalanceClaimantBatchInsertBuilder
+	ctx                                    context.Context
+	processor                              *ClaimableBalancesChangeProcessor
+	mockQ                                  *history.MockQClaimableBalances
+	mockClaimantsBatchInsertBuilder        *history.MockClaimableBalanceClaimantBatchInsertBuilder
+	mockClaimableBalanceBatchInsertBuilder *history.MockClaimableBalanceBatchInsertBuilder
+	session                                db.SessionInterface
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteState) SetupTest() {
 	s.ctx = context.Background()
-	s.mockBatchInsertBuilder = &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
-	s.mockQ = &history.MockQClaimableBalances{}
-	s.mockQ.
-		On("NewClaimableBalanceClaimantBatchInsertBuilder", maxBatchSize).
-		Return(s.mockBatchInsertBuilder).Once()
+	s.mockClaimantsBatchInsertBuilder = &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	s.mockClaimableBalanceBatchInsertBuilder = &history.MockClaimableBalanceBatchInsertBuilder{}
 
-	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ)
+	s.mockQ = &history.MockQClaimableBalances{}
+	s.session = &db.MockSession{}
+	s.mockQ.
+		On("NewClaimableBalanceClaimantBatchInsertBuilder").
+		Return(s.mockClaimantsBatchInsertBuilder).Once()
+	s.mockQ.
+		On("NewClaimableBalanceBatchInsertBuilder").
+		Return(s.mockClaimableBalanceBatchInsertBuilder).Once()
+
+	s.mockClaimantsBatchInsertBuilder.On("Reset").Return(nil).Once()
+	s.mockClaimableBalanceBatchInsertBuilder.On("Reset").Return(nil).Once()
+
+	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ, s.session)
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteState) TearDownTest() {
@@ -67,27 +79,27 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteState) TestCreatesClaimableBal
 	}
 	id, err := xdr.MarshalHex(balanceID)
 	s.Assert().NoError(err)
-	s.mockQ.On("UpsertClaimableBalances", s.ctx, []history.ClaimableBalance{
-		{
-			BalanceID: id,
-			Claimants: []history.Claimant{
-				{
-					Destination: "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-				},
+	s.mockClaimableBalanceBatchInsertBuilder.On("Add", history.ClaimableBalance{
+		BalanceID: id,
+		Claimants: []history.Claimant{
+			{
+				Destination: "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 			},
-			Asset:              cBalance.Asset,
-			Amount:             cBalance.Amount,
-			LastModifiedLedger: uint32(lastModifiedLedgerSeq),
 		},
+		Asset:              cBalance.Asset,
+		Amount:             cBalance.Amount,
+		LastModifiedLedger: uint32(lastModifiedLedgerSeq),
 	}).Return(nil).Once()
 
-	s.mockBatchInsertBuilder.On("Add", s.ctx, history.ClaimableBalanceClaimant{
+	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
+
+	s.mockClaimantsBatchInsertBuilder.On("Add", history.ClaimableBalanceClaimant{
 		BalanceID:          id,
 		Destination:        "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 		LastModifiedLedger: uint32(lastModifiedLedgerSeq),
 	}).Return(nil).Once()
 
-	s.mockBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
+	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
 
 	err = s.processor.ProcessChange(s.ctx, ingest.Change{
 		Type: xdr.LedgerEntryTypeClaimableBalance,
@@ -109,25 +121,39 @@ func TestClaimableBalancesChangeProcessorTestSuiteLedger(t *testing.T) {
 
 type ClaimableBalancesChangeProcessorTestSuiteLedger struct {
 	suite.Suite
-	ctx                    context.Context
-	processor              *ClaimableBalancesChangeProcessor
-	mockQ                  *history.MockQClaimableBalances
-	mockBatchInsertBuilder *history.MockClaimableBalanceClaimantBatchInsertBuilder
+	ctx                                    context.Context
+	processor                              *ClaimableBalancesChangeProcessor
+	mockQ                                  *history.MockQClaimableBalances
+	mockClaimantsBatchInsertBuilder        *history.MockClaimableBalanceClaimantBatchInsertBuilder
+	mockClaimableBalanceBatchInsertBuilder *history.MockClaimableBalanceBatchInsertBuilder
+	session                                db.SessionInterface
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) SetupTest() {
 	s.ctx = context.Background()
-	s.mockBatchInsertBuilder = &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	s.mockClaimantsBatchInsertBuilder = &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	s.mockClaimableBalanceBatchInsertBuilder = &history.MockClaimableBalanceBatchInsertBuilder{}
 	s.mockQ = &history.MockQClaimableBalances{}
+	s.session = &db.MockSession{}
 	s.mockQ.
-		On("NewClaimableBalanceClaimantBatchInsertBuilder", maxBatchSize).
-		Return(s.mockBatchInsertBuilder).Once()
+		On("NewClaimableBalanceClaimantBatchInsertBuilder").
+		Return(s.mockClaimantsBatchInsertBuilder).Twice()
+	s.mockQ.
+		On("NewClaimableBalanceBatchInsertBuilder").
+		Return(s.mockClaimableBalanceBatchInsertBuilder).Twice()
 
-	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ)
+	s.mockClaimantsBatchInsertBuilder.On("Reset").Return(nil).Once()
+	s.mockClaimableBalanceBatchInsertBuilder.On("Reset").Return(nil).Once()
+
+	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
+	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
+
+	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ, s.session)
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TearDownTest() {
 	s.Assert().NoError(s.processor.Commit(s.ctx))
+	s.processor.reset()
 	s.mockQ.AssertExpectations(s.T())
 }
 
@@ -160,9 +186,23 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TestNewClaimableBalanc
 			},
 		},
 	}
-	s.mockBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
 
-	err := s.processor.ProcessChange(s.ctx, ingest.Change{
+	id, err := xdr.MarshalHex(balanceID)
+	s.Assert().NoError(err)
+
+	// We use LedgerEntryChangesCache so all changes are squashed
+	s.mockClaimableBalanceBatchInsertBuilder.On(
+		"Add",
+		history.ClaimableBalance{
+			BalanceID:          id,
+			Claimants:          []history.Claimant{},
+			Asset:              cBalance.Asset,
+			Amount:             cBalance.Amount,
+			LastModifiedLedger: uint32(lastModifiedLedgerSeq),
+		},
+	).Return(nil).Once()
+
+	err = s.processor.ProcessChange(s.ctx, ingest.Change{
 		Type: xdr.LedgerEntryTypeClaimableBalance,
 		Pre:  nil,
 		Post: &entry,
@@ -192,89 +232,16 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TestNewClaimableBalanc
 	})
 	s.Assert().NoError(err)
 
-	id, err := xdr.MarshalHex(balanceID)
-	s.Assert().NoError(err)
 	// We use LedgerEntryChangesCache so all changes are squashed
-	s.mockQ.On(
-		"UpsertClaimableBalances",
-		s.ctx,
-		[]history.ClaimableBalance{
-			{
-				BalanceID:          id,
-				Claimants:          []history.Claimant{},
-				Asset:              cBalance.Asset,
-				Amount:             cBalance.Amount,
-				LastModifiedLedger: uint32(lastModifiedLedgerSeq),
-				Sponsor:            null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-			},
-		},
-	).Return(nil).Once()
-}
-
-func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TestUpdateClaimableBalance() {
-	balanceID := xdr.ClaimableBalanceId{
-		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
-		V0:   &xdr.Hash{1, 2, 3},
-	}
-	cBalance := xdr.ClaimableBalanceEntry{
-		BalanceId: balanceID,
-		Claimants: []xdr.Claimant{},
-		Asset:     xdr.MustNewCreditAsset("USD", "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-		Amount:    10,
-	}
-	lastModifiedLedgerSeq := xdr.Uint32(123)
-
-	pre := xdr.LedgerEntry{
-		Data: xdr.LedgerEntryData{
-			Type:             xdr.LedgerEntryTypeClaimableBalance,
-			ClaimableBalance: &cBalance,
-		},
-		LastModifiedLedgerSeq: lastModifiedLedgerSeq - 1,
-		Ext: xdr.LedgerEntryExt{
-			V: 1,
-			V1: &xdr.LedgerEntryExtensionV1{
-				SponsoringId: nil,
-			},
-		},
-	}
-
-	// add sponsor
-	updated := xdr.LedgerEntry{
-		Data: xdr.LedgerEntryData{
-			Type:             xdr.LedgerEntryTypeClaimableBalance,
-			ClaimableBalance: &cBalance,
-		},
-		LastModifiedLedgerSeq: lastModifiedLedgerSeq,
-		Ext: xdr.LedgerEntryExt{
-			V: 1,
-			V1: &xdr.LedgerEntryExtensionV1{
-				SponsoringId: xdr.MustAddressPtr("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-			},
-		},
-	}
-	s.mockBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
-
-	err := s.processor.ProcessChange(s.ctx, ingest.Change{
-		Type: xdr.LedgerEntryTypeClaimableBalance,
-		Pre:  &pre,
-		Post: &updated,
-	})
-	s.Assert().NoError(err)
-
-	id, err := xdr.MarshalHex(balanceID)
-	s.Assert().NoError(err)
-	s.mockQ.On(
-		"UpsertClaimableBalances",
-		s.ctx,
-		[]history.ClaimableBalance{
-			{
-				BalanceID:          id,
-				Claimants:          []history.Claimant{},
-				Asset:              cBalance.Asset,
-				Amount:             cBalance.Amount,
-				LastModifiedLedger: uint32(lastModifiedLedgerSeq),
-				Sponsor:            null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-			},
+	s.mockClaimableBalanceBatchInsertBuilder.On(
+		"Add",
+		history.ClaimableBalance{
+			BalanceID:          id,
+			Claimants:          []history.Claimant{},
+			Asset:              cBalance.Asset,
+			Amount:             cBalance.Amount,
+			LastModifiedLedger: uint32(lastModifiedLedgerSeq),
+			Sponsor:            null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 		},
 	).Return(nil).Once()
 }

--- a/services/horizon/internal/ingest/verify_test.go
+++ b/services/horizon/internal/ingest/verify_test.go
@@ -165,11 +165,11 @@ func TestStateVerifierLockBusy(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
-	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
 	defer q.SessionInterface.Rollback()
 
 	checkpointLedger := uint32(63)
-	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
+	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger)
 
 	gen := randxdr.NewGenerator()
 	var changes []xdr.LedgerEntryChange
@@ -187,6 +187,8 @@ func TestStateVerifierLockBusy(t *testing.T) {
 		tt.Assert.NoError(changeProcessor.ProcessChange(tt.Ctx, change))
 	}
 	tt.Assert.NoError(changeProcessor.Commit(tt.Ctx))
+
+	tt.Assert.NoError(q.SessionInterface.Commit())
 
 	q.UpdateLastLedgerIngest(tt.Ctx, checkpointLedger)
 
@@ -221,11 +223,11 @@ func TestStateVerifier(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
-	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
 	defer q.SessionInterface.Rollback()
 
 	checkpointLedger := uint32(63)
-	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
+	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger)
 	mockChangeReader := &ingest.MockChangeReader{}
 
 	gen := randxdr.NewGenerator()
@@ -246,7 +248,7 @@ func TestStateVerifier(t *testing.T) {
 	}
 	tt.Assert.NoError(changeProcessor.Commit(tt.Ctx))
 
-	q.SessionInterface.Commit()
+	tt.Assert.NoError(q.SessionInterface.Commit())
 
 	q.UpdateLastLedgerIngest(tt.Ctx, checkpointLedger)
 

--- a/services/horizon/internal/ingest/verify_test.go
+++ b/services/horizon/internal/ingest/verify_test.go
@@ -166,7 +166,9 @@ func TestStateVerifierLockBusy(t *testing.T) {
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
 	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
-	defer q.SessionInterface.Rollback()
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	checkpointLedger := uint32(63)
 	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger)
@@ -224,7 +226,9 @@ func TestStateVerifier(t *testing.T) {
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
 	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
-	defer q.SessionInterface.Rollback()
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	checkpointLedger := uint32(63)
 	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Use [FastBatchInsertBuilder](https://github.com/stellar/go/blob/9ce82de12cbade47de862ad5e9d0684029558564/support/db/fast_batch_insert_builder.go) for writing to `claimable_balances` and `claimable_balance_claimants` tables. FastBatchInsertBuilder uses ‘COPY' to insert into the db which is faster than using 'INSERT'.

### Why

#5086 

### Known limitations

[TODO or N/A]
