### PR TITLE
ingestion: avoid redundant reallocation during streamBucketContents

### DIFF
--- a/ingest/checkpoint_change_reader.go
+++ b/ingest/checkpoint_change_reader.go
@@ -325,6 +325,8 @@ func (r *CheckpointChangeReader) streamBucketContents(hash historyarchive.Hash, 
 	var batch []xdr.BucketEntry
 	lastBatch := false
 
+	preloadKeys := make([]string, 0, preloadedEntries)
+
 LoopBucketEntry:
 	for {
 		// Preload entries for faster retrieve from temp store.
@@ -332,8 +334,10 @@ LoopBucketEntry:
 			if lastBatch {
 				return true
 			}
+			batch = make([]xdr.BucketEntry, 0, preloadedEntries)
 
-			preloadKeys := []string{}
+			// reset the content of the preloadKeys
+			preloadKeys = preloadKeys[:0]
 
 			for i := 0; i < preloadedEntries; i++ {
 				var entry xdr.BucketEntry


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

avoid redundant reallocation during streamBucketContents

### Why

Existing code was optimized for preloading keys from temp set. However, while this optimization was made, the resizing of the temporary staging buffers was ignored. These could add impactful time and would be easily avoided.

### Known limitations

n/a
