### PR TITLE
services/horizon: Use COPY to speed up ClaimableBalanceChangeProcessor

### DIFF
--- a/services/horizon/internal/actions/claimable_balance_test.go
+++ b/services/horizon/internal/actions/claimable_balance_test.go
@@ -21,8 +21,10 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{tt.HorizonSession()}
 
-	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
-	defer q.SessionInterface.Rollback()
+	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
@@ -154,8 +156,15 @@ func TestGetClaimableBalances(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{tt.HorizonSession()}
 
+<<<<<<< HEAD
 	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
 	defer q.SessionInterface.Rollback()
+=======
+	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
+>>>>>>> c7bd7ac1 (Fix linter errors)
 
 	entriesMeta := []struct {
 		id        xdr.Hash

--- a/services/horizon/internal/actions/claimable_balance_test.go
+++ b/services/horizon/internal/actions/claimable_balance_test.go
@@ -49,10 +49,10 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 		LastModifiedLedger: 123,
 	}
 
-	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
 	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
 
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(q.SessionInterface)
 	for _, claimant := range cBalance.Claimants {
 		claimant := history.ClaimableBalanceClaimant{
 			BalanceID:          cBalance.BalanceID,
@@ -62,8 +62,8 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 		tt.Assert.NoError(claimantsInsertBuilder.Add(claimant))
 	}
 
-	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
-	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx))
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx))
 
 	handler := GetClaimableBalanceByIDHandler{}
 	response, err := handler.GetResource(httptest.NewRecorder(), makeRequest(
@@ -200,9 +200,9 @@ func TestGetClaimableBalances(t *testing.T) {
 		hCBs = append(hCBs, cb)
 	}
 
-	balanceInsertbuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	balanceInsertbuilder := q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
 
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(q.SessionInterface)
 
 	for _, cBalance := range hCBs {
 		tt.Assert.NoError(balanceInsertbuilder.Add(cBalance))
@@ -217,8 +217,8 @@ func TestGetClaimableBalances(t *testing.T) {
 		}
 	}
 
-	tt.Assert.NoError(balanceInsertbuilder.Exec(tt.Ctx, q.SessionInterface))
-	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(balanceInsertbuilder.Exec(tt.Ctx))
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx))
 
 	handler := GetClaimableBalancesHandler{}
 	response, err := handler.GetResourcePage(httptest.NewRecorder(), makeRequest(
@@ -298,8 +298,8 @@ func TestGetClaimableBalances(t *testing.T) {
 	tt.Assert.Len(response, 0)
 
 	// new claimable balances are ingested, they should appear in the next pages
-	balanceInsertbuilder = q.NewClaimableBalanceBatchInsertBuilder()
-	claimantsInsertBuilder = q.NewClaimableBalanceClaimantBatchInsertBuilder()
+	balanceInsertbuilder = q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
+	claimantsInsertBuilder = q.NewClaimableBalanceClaimantBatchInsertBuilder(q.SessionInterface)
 
 	entriesMeta = []struct {
 		id        xdr.Hash
@@ -339,8 +339,8 @@ func TestGetClaimableBalances(t *testing.T) {
 		}
 	}
 
-	tt.Assert.NoError(balanceInsertbuilder.Exec(tt.Ctx, q.SessionInterface))
-	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(balanceInsertbuilder.Exec(tt.Ctx))
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx))
 
 	response, err = handler.GetResourcePage(httptest.NewRecorder(), makeRequest(
 		t,

--- a/services/horizon/internal/actions/claimable_balance_test.go
+++ b/services/horizon/internal/actions/claimable_balance_test.go
@@ -21,7 +21,7 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{tt.HorizonSession()}
 
-	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
 		_ = q.SessionInterface.Rollback()
 	}()
@@ -156,15 +156,10 @@ func TestGetClaimableBalances(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{tt.HorizonSession()}
 
-<<<<<<< HEAD
-	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
-	defer q.SessionInterface.Rollback()
-=======
-	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
 		_ = q.SessionInterface.Rollback()
 	}()
->>>>>>> c7bd7ac1 (Fix linter errors)
 
 	entriesMeta := []struct {
 		id        xdr.Hash
@@ -206,6 +201,7 @@ func TestGetClaimableBalances(t *testing.T) {
 	}
 
 	balanceInsertbuilder := q.NewClaimableBalanceBatchInsertBuilder()
+
 	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
 
 	for _, cBalance := range hCBs {
@@ -301,6 +297,7 @@ func TestGetClaimableBalances(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Len(response, 0)
 
+	// new claimable balances are ingested, they should appear in the next pages
 	balanceInsertbuilder = q.NewClaimableBalanceBatchInsertBuilder()
 	claimantsInsertBuilder = q.NewClaimableBalanceClaimantBatchInsertBuilder()
 
@@ -324,13 +321,12 @@ func TestGetClaimableBalances(t *testing.T) {
 		},
 	}
 
-	hCBs = nil
 	for _, e := range entriesMeta {
 		entry := buildClaimableBalance(tt, e.id, e.accountID, e.ledger, e.asset)
 		hCBs = append(hCBs, entry)
 	}
 
-	for _, cBalance := range hCBs {
+	for _, cBalance := range hCBs[4:] {
 		tt.Assert.NoError(balanceInsertbuilder.Add(cBalance))
 
 		for _, claimant := range cBalance.Claimants {
@@ -370,7 +366,7 @@ func TestGetClaimableBalances(t *testing.T) {
 	tt.Assert.Len(response, 2)
 
 	// response should be the first 2 elements of entries
-	for i, entry := range hCBs {
+	for i, entry := range hCBs[4:] {
 		tt.Assert.Equal(entry.BalanceID, response[i].(protocol.ClaimableBalance).BalanceID)
 	}
 
@@ -401,7 +397,9 @@ func TestGetClaimableBalances(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Len(response, 2)
 
-	tt.Assert.Equal(hCBs[1].BalanceID, response[0].(protocol.ClaimableBalance).BalanceID)
+	tt.Assert.Equal(hCBs[5].BalanceID, response[0].(protocol.ClaimableBalance).BalanceID)
+
+	tt.Assert.Equal(hCBs[4].BalanceID, response[1].(protocol.ClaimableBalance).BalanceID)
 
 	response, err = handler.GetResourcePage(httptest.NewRecorder(), makeRequest(
 		t,
@@ -416,6 +414,8 @@ func TestGetClaimableBalances(t *testing.T) {
 
 	tt.Assert.NoError(err)
 	tt.Assert.Len(response, 1)
+
+	tt.Assert.Equal(hCBs[0].BalanceID, response[0].(protocol.ClaimableBalance).BalanceID)
 
 	// filter by asset
 	response, err = handler.GetResourcePage(httptest.NewRecorder(), makeRequest(

--- a/services/horizon/internal/actions/claimable_balance_test.go
+++ b/services/horizon/internal/actions/claimable_balance_test.go
@@ -19,11 +19,11 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
-	q := &history.Q{tt.HorizonSession()}
+	q := &history.Q{SessionInterface: tt.HorizonSession()}
 
-	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
+	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
-		_ = q.SessionInterface.Rollback()
+		_ = q.Rollback()
 	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
@@ -49,10 +49,10 @@ func TestGetClaimableBalanceByID(t *testing.T) {
 		LastModifiedLedger: 123,
 	}
 
-	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
 	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
 
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(q.SessionInterface)
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
 	for _, claimant := range cBalance.Claimants {
 		claimant := history.ClaimableBalanceClaimant{
 			BalanceID:          cBalance.BalanceID,
@@ -156,7 +156,7 @@ func TestGetClaimableBalances(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{tt.HorizonSession()}
 
-	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
+	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
 		_ = q.SessionInterface.Rollback()
 	}()
@@ -200,9 +200,9 @@ func TestGetClaimableBalances(t *testing.T) {
 		hCBs = append(hCBs, cb)
 	}
 
-	balanceInsertbuilder := q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
+	balanceInsertbuilder := q.NewClaimableBalanceBatchInsertBuilder()
 
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(q.SessionInterface)
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
 
 	for _, cBalance := range hCBs {
 		tt.Assert.NoError(balanceInsertbuilder.Add(cBalance))
@@ -298,8 +298,8 @@ func TestGetClaimableBalances(t *testing.T) {
 	tt.Assert.Len(response, 0)
 
 	// new claimable balances are ingested, they should appear in the next pages
-	balanceInsertbuilder = q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
-	claimantsInsertBuilder = q.NewClaimableBalanceClaimantBatchInsertBuilder(q.SessionInterface)
+	balanceInsertbuilder = q.NewClaimableBalanceBatchInsertBuilder()
+	claimantsInsertBuilder = q.NewClaimableBalanceClaimantBatchInsertBuilder()
 
 	entriesMeta = []struct {
 		id        xdr.Hash

--- a/services/horizon/internal/actions/claimable_balance_test.go
+++ b/services/horizon/internal/actions/claimable_balance_test.go
@@ -158,7 +158,7 @@ func TestGetClaimableBalances(t *testing.T) {
 
 	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
-		_ = q.SessionInterface.Rollback()
+		_ = q.Rollback()
 	}()
 
 	entriesMeta := []struct {

--- a/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
@@ -1,0 +1,47 @@
+package history
+
+import (
+	"context"
+
+	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/xdr"
+)
+
+// ClaimableBalanceBatchInsertBuilder is used to insert claimable balance into the
+// claimable_balances table
+type ClaimableBalanceBatchInsertBuilder interface {
+	Add(claimableBalance ClaimableBalance) error
+	Exec(ctx context.Context, session db.SessionInterface) error
+	Reset() error
+}
+
+// ClaimableBalanceBatchInsertBuilder is a simple wrapper around db.FastBatchInsertBuilder
+type claimableBalanceBatchInsertBuilder struct {
+	encodingBuffer *xdr.EncodingBuffer
+	builder        db.FastBatchInsertBuilder
+	table          string
+}
+
+// NewClaimableBalanceBatchInsertBuilder constructs a new ClaimableBalanceBatchInsertBuilder instance
+func (q *Q) NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder {
+	return &claimableBalanceBatchInsertBuilder{
+		encodingBuffer: xdr.NewEncodingBuffer(),
+		builder:        db.FastBatchInsertBuilder{},
+		table:          "claimable_balances",
+	}
+}
+
+// Add adds a new claimable balance to the batch
+func (i *claimableBalanceBatchInsertBuilder) Add(claimableBalance ClaimableBalance) error {
+	return i.builder.RowStruct(claimableBalance)
+}
+
+// Exec inserts claimable balance rows to the database
+func (i *claimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
+	return i.builder.Exec(ctx, session, i.table)
+}
+
+func (i *claimableBalanceBatchInsertBuilder) Reset() error{
+	i.builder.Reset()
+	return nil
+}

--- a/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
@@ -41,7 +41,7 @@ func (i *claimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session d
 	return i.builder.Exec(ctx, session, i.table)
 }
 
-func (i *claimableBalanceBatchInsertBuilder) Reset() error{
+func (i *claimableBalanceBatchInsertBuilder) Reset() error {
 	i.builder.Reset()
 	return nil
 }

--- a/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
@@ -36,7 +36,7 @@ func (i *claimableBalanceBatchInsertBuilder) Add(claimableBalance ClaimableBalan
 	return i.builder.RowStruct(claimableBalance)
 }
 
-// Exec inserts claimable balance rows to the database
+// Exec writes the batch of claimable balances to the database.
 func (i *claimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
 	return i.builder.Exec(ctx, session, i.table)
 }

--- a/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
@@ -4,30 +4,28 @@ import (
 	"context"
 
 	"github.com/stellar/go/support/db"
-	"github.com/stellar/go/xdr"
 )
 
 // ClaimableBalanceBatchInsertBuilder is used to insert claimable balance into the
 // claimable_balances table
 type ClaimableBalanceBatchInsertBuilder interface {
 	Add(claimableBalance ClaimableBalance) error
-	Exec(ctx context.Context, session db.SessionInterface) error
-	Reset()
+	Exec(ctx context.Context) error
 }
 
 // ClaimableBalanceBatchInsertBuilder is a simple wrapper around db.FastBatchInsertBuilder
 type claimableBalanceBatchInsertBuilder struct {
-	encodingBuffer *xdr.EncodingBuffer
-	builder        db.FastBatchInsertBuilder
-	table          string
+	session db.SessionInterface
+	builder db.FastBatchInsertBuilder
+	table   string
 }
 
 // NewClaimableBalanceBatchInsertBuilder constructs a new ClaimableBalanceBatchInsertBuilder instance
-func (q *Q) NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder {
+func (q *Q) NewClaimableBalanceBatchInsertBuilder(session db.SessionInterface) ClaimableBalanceBatchInsertBuilder {
 	return &claimableBalanceBatchInsertBuilder{
-		encodingBuffer: xdr.NewEncodingBuffer(),
-		builder:        db.FastBatchInsertBuilder{},
-		table:          "claimable_balances",
+		session: session,
+		builder: db.FastBatchInsertBuilder{},
+		table:   "claimable_balances",
 	}
 }
 
@@ -37,11 +35,6 @@ func (i *claimableBalanceBatchInsertBuilder) Add(claimableBalance ClaimableBalan
 }
 
 // Exec writes the batch of claimable balances to the database.
-func (i *claimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
-	return i.builder.Exec(ctx, session, i.table)
-}
-
-// Reset clears out the current batch of claimable balances
-func (i *claimableBalanceBatchInsertBuilder) Reset() {
-	i.builder.Reset()
+func (i *claimableBalanceBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx, i.session, i.table)
 }

--- a/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
@@ -12,7 +12,7 @@ import (
 type ClaimableBalanceBatchInsertBuilder interface {
 	Add(claimableBalance ClaimableBalance) error
 	Exec(ctx context.Context, session db.SessionInterface) error
-	Reset() error
+	Reset()
 }
 
 // ClaimableBalanceBatchInsertBuilder is a simple wrapper around db.FastBatchInsertBuilder
@@ -41,7 +41,7 @@ func (i *claimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session d
 	return i.builder.Exec(ctx, session, i.table)
 }
 
-func (i *claimableBalanceBatchInsertBuilder) Reset() error {
+// Reset clears out the current batch of claimable balances
+func (i *claimableBalanceBatchInsertBuilder) Reset() {
 	i.builder.Reset()
-	return nil
 }

--- a/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_batch_insert_builder.go
@@ -21,9 +21,9 @@ type claimableBalanceBatchInsertBuilder struct {
 }
 
 // NewClaimableBalanceBatchInsertBuilder constructs a new ClaimableBalanceBatchInsertBuilder instance
-func (q *Q) NewClaimableBalanceBatchInsertBuilder(session db.SessionInterface) ClaimableBalanceBatchInsertBuilder {
+func (q *Q) NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder {
 	return &claimableBalanceBatchInsertBuilder{
-		session: session,
+		session: q,
 		builder: db.FastBatchInsertBuilder{},
 		table:   "claimable_balances",
 	}

--- a/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
@@ -10,33 +10,38 @@ import (
 // ClaimableBalanceClaimantBatchInsertBuilder is used to insert transactions into the
 // history_transactions table
 type ClaimableBalanceClaimantBatchInsertBuilder interface {
-	Add(ctx context.Context, claimableBalanceClaimant ClaimableBalanceClaimant) error
-	Exec(ctx context.Context) error
+	Add(claimableBalanceClaimant ClaimableBalanceClaimant) error
+	Exec(ctx context.Context, session db.SessionInterface) error
+	Reset() error
 }
 
-// ClaimableBalanceClaimantBatchInsertBuilder is a simple wrapper around db.BatchInsertBuilder
+// ClaimableBalanceClaimantBatchInsertBuilder is a simple wrapper around db.FastBatchInsertBuilder
 type claimableBalanceClaimantBatchInsertBuilder struct {
 	encodingBuffer *xdr.EncodingBuffer
-	builder        db.BatchInsertBuilder
+	builder        db.FastBatchInsertBuilder
+	table          string
 }
 
 // NewClaimableBalanceClaimantBatchInsertBuilder constructs a new ClaimableBalanceClaimantBatchInsertBuilder instance
-func (q *Q) NewClaimableBalanceClaimantBatchInsertBuilder(maxBatchSize int) ClaimableBalanceClaimantBatchInsertBuilder {
+func (q *Q) NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder {
 	return &claimableBalanceClaimantBatchInsertBuilder{
 		encodingBuffer: xdr.NewEncodingBuffer(),
-		builder: db.BatchInsertBuilder{
-			Table:        q.GetTable("claimable_balance_claimants"),
-			MaxBatchSize: maxBatchSize,
-			Suffix:       "ON CONFLICT (id, destination) DO UPDATE SET last_modified_ledger=EXCLUDED.last_modified_ledger",
-		},
+		builder:        db.FastBatchInsertBuilder{},
+		table:          "claimable_balance_claimants",
 	}
 }
 
-// Add adds a new transaction to the batch
-func (i *claimableBalanceClaimantBatchInsertBuilder) Add(ctx context.Context, claimableBalanceClaimant ClaimableBalanceClaimant) error {
-	return i.builder.RowStruct(ctx, claimableBalanceClaimant)
+// Add adds a new claimant for a claimable Balance to the batch
+func (i *claimableBalanceClaimantBatchInsertBuilder) Add(claimableBalanceClaimant ClaimableBalanceClaimant) error {
+	return i.builder.RowStruct(claimableBalanceClaimant)
 }
 
-func (i *claimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context) error {
-	return i.builder.Exec(ctx)
+// Exec flushes the entire batch into the database
+func (i *claimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
+	return i.builder.Exec(ctx, session, i.table)
+}
+
+func (i *claimableBalanceClaimantBatchInsertBuilder) Reset() error {
+	i.builder.Reset()
+	return nil
 }

--- a/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
@@ -21,9 +21,9 @@ type claimableBalanceClaimantBatchInsertBuilder struct {
 }
 
 // NewClaimableBalanceClaimantBatchInsertBuilder constructs a new ClaimableBalanceClaimantBatchInsertBuilder instance
-func (q *Q) NewClaimableBalanceClaimantBatchInsertBuilder(session db.SessionInterface) ClaimableBalanceClaimantBatchInsertBuilder {
+func (q *Q) NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder {
 	return &claimableBalanceClaimantBatchInsertBuilder{
-		session: session,
+		session: q,
 		builder: db.FastBatchInsertBuilder{},
 		table:   "claimable_balance_claimants",
 	}

--- a/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
@@ -12,7 +12,7 @@ import (
 type ClaimableBalanceClaimantBatchInsertBuilder interface {
 	Add(claimableBalanceClaimant ClaimableBalanceClaimant) error
 	Exec(ctx context.Context, session db.SessionInterface) error
-	Reset() error
+	Reset()
 }
 
 // ClaimableBalanceClaimantBatchInsertBuilder is a simple wrapper around db.FastBatchInsertBuilder
@@ -41,7 +41,7 @@ func (i *claimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context, s
 	return i.builder.Exec(ctx, session, i.table)
 }
 
-func (i *claimableBalanceClaimantBatchInsertBuilder) Reset() error {
+// Reset clears out the current batch of claimants
+func (i *claimableBalanceClaimantBatchInsertBuilder) Reset() {
 	i.builder.Reset()
-	return nil
 }

--- a/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-// ClaimableBalanceClaimantBatchInsertBuilder is used to insert transactions into the
-// history_transactions table
+// ClaimableBalanceClaimantBatchInsertBuilder is used to insert claimants into the
+// claimable_balance_claimants table
 type ClaimableBalanceClaimantBatchInsertBuilder interface {
 	Add(claimableBalanceClaimant ClaimableBalanceClaimant) error
 	Exec(ctx context.Context, session db.SessionInterface) error
@@ -31,12 +31,12 @@ func (q *Q) NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClai
 	}
 }
 
-// Add adds a new claimant for a claimable Balance to the batch
+// Add adds a new claimant to the batch
 func (i *claimableBalanceClaimantBatchInsertBuilder) Add(claimableBalanceClaimant ClaimableBalanceClaimant) error {
 	return i.builder.RowStruct(claimableBalanceClaimant)
 }
 
-// Exec flushes the entire batch into the database
+// Exec writes the batch of claimants to the database.
 func (i *claimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
 	return i.builder.Exec(ctx, session, i.table)
 }

--- a/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/claimable_balance_claimant_batch_insert_builder.go
@@ -4,30 +4,28 @@ import (
 	"context"
 
 	"github.com/stellar/go/support/db"
-	"github.com/stellar/go/xdr"
 )
 
 // ClaimableBalanceClaimantBatchInsertBuilder is used to insert claimants into the
 // claimable_balance_claimants table
 type ClaimableBalanceClaimantBatchInsertBuilder interface {
 	Add(claimableBalanceClaimant ClaimableBalanceClaimant) error
-	Exec(ctx context.Context, session db.SessionInterface) error
-	Reset()
+	Exec(ctx context.Context) error
 }
 
 // ClaimableBalanceClaimantBatchInsertBuilder is a simple wrapper around db.FastBatchInsertBuilder
 type claimableBalanceClaimantBatchInsertBuilder struct {
-	encodingBuffer *xdr.EncodingBuffer
-	builder        db.FastBatchInsertBuilder
-	table          string
+	session db.SessionInterface
+	builder db.FastBatchInsertBuilder
+	table   string
 }
 
 // NewClaimableBalanceClaimantBatchInsertBuilder constructs a new ClaimableBalanceClaimantBatchInsertBuilder instance
-func (q *Q) NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder {
+func (q *Q) NewClaimableBalanceClaimantBatchInsertBuilder(session db.SessionInterface) ClaimableBalanceClaimantBatchInsertBuilder {
 	return &claimableBalanceClaimantBatchInsertBuilder{
-		encodingBuffer: xdr.NewEncodingBuffer(),
-		builder:        db.FastBatchInsertBuilder{},
-		table:          "claimable_balance_claimants",
+		session: session,
+		builder: db.FastBatchInsertBuilder{},
+		table:   "claimable_balance_claimants",
 	}
 }
 
@@ -37,11 +35,6 @@ func (i *claimableBalanceClaimantBatchInsertBuilder) Add(claimableBalanceClaiman
 }
 
 // Exec writes the batch of claimants to the database.
-func (i *claimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
-	return i.builder.Exec(ctx, session, i.table)
-}
-
-// Reset clears out the current batch of claimants
-func (i *claimableBalanceClaimantBatchInsertBuilder) Reset() {
-	i.builder.Reset()
+func (i *claimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx, i.session, i.table)
 }

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -107,7 +107,8 @@ type ClaimableBalance struct {
 type Claimants []Claimant
 
 func (c Claimants) Value() (driver.Value, error) {
-	return json.Marshal(c)
+	val, err := json.Marshal(c)
+	return string(val), err
 }
 
 func (c *Claimants) Scan(value interface{}) error {

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -126,12 +126,12 @@ type Claimant struct {
 
 // QClaimableBalances defines claimable-balance-related related queries.
 type QClaimableBalances interface {
-	UpsertClaimableBalances(ctx context.Context, cb []ClaimableBalance) error
 	RemoveClaimableBalances(ctx context.Context, ids []string) (int64, error)
 	RemoveClaimableBalanceClaimants(ctx context.Context, ids []string) (int64, error)
 	GetClaimableBalancesByID(ctx context.Context, ids []string) ([]ClaimableBalance, error)
 	CountClaimableBalances(ctx context.Context) (int, error)
-	NewClaimableBalanceClaimantBatchInsertBuilder(maxBatchSize int) ClaimableBalanceClaimantBatchInsertBuilder
+	NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder
+	NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder
 	GetClaimantsByClaimableBalances(ctx context.Context, ids []string) (map[string][]ClaimableBalanceClaimant, error)
 }
 
@@ -169,36 +169,6 @@ func (q *Q) GetClaimantsByClaimableBalances(ctx context.Context, ids []string) (
 		claimantsMap[claimant.BalanceID] = append(claimantsMap[claimant.BalanceID], claimant)
 	}
 	return claimantsMap, err
-}
-
-// UpsertClaimableBalances upserts a batch of claimable balances in the claimable_balances table.
-// There's currently no limit of the number of offers this method can
-// accept other than 2GB limit of the query string length what should be enough
-// for each ledger with the current limits.
-func (q *Q) UpsertClaimableBalances(ctx context.Context, cbs []ClaimableBalance) error {
-	var id, claimants, asset, amount, sponsor, lastModifiedLedger, flags []interface{}
-
-	for _, cb := range cbs {
-		id = append(id, cb.BalanceID)
-		claimants = append(claimants, cb.Claimants)
-		asset = append(asset, cb.Asset)
-		amount = append(amount, cb.Amount)
-		sponsor = append(sponsor, cb.Sponsor)
-		lastModifiedLedger = append(lastModifiedLedger, cb.LastModifiedLedger)
-		flags = append(flags, cb.Flags)
-	}
-
-	upsertFields := []upsertField{
-		{"id", "text", id},
-		{"claimants", "jsonb", claimants},
-		{"asset", "text", asset},
-		{"amount", "bigint", amount},
-		{"sponsor", "text", sponsor},
-		{"last_modified_ledger", "integer", lastModifiedLedger},
-		{"flags", "int", flags},
-	}
-
-	return q.upsertRows(ctx, "claimable_balances", "id", upsertFields)
 }
 
 // RemoveClaimableBalances deletes claimable balances table.

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -107,6 +107,11 @@ type ClaimableBalance struct {
 type Claimants []Claimant
 
 func (c Claimants) Value() (driver.Value, error) {
+	// Convert the byte array into a string as a workaround to bypass buggy encoding in the pq driver
+	// (More info about this bug here https://github.com/stellar/go/issues/5086#issuecomment-1773215436).
+	// By doing so, the data will be written as a string rather than hex encoded bytes.
+	// According to this https://www.postgresql.org/docs/current/datatype-json.html
+	// this may even improve write performance due to reduced conversion overhead.
 	val, err := json.Marshal(c)
 	return string(val), err
 }

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -110,8 +110,6 @@ func (c Claimants) Value() (driver.Value, error) {
 	// Convert the byte array into a string as a workaround to bypass buggy encoding in the pq driver
 	// (More info about this bug here https://github.com/stellar/go/issues/5086#issuecomment-1773215436).
 	// By doing so, the data will be written as a string rather than hex encoded bytes.
-	// According to this https://www.postgresql.org/docs/current/datatype-json.html
-	// this may even improve write performance due to reduced conversion overhead.
 	val, err := json.Marshal(c)
 	return string(val), err
 }

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -11,7 +11,6 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/guregu/null"
 	"github.com/stellar/go/services/horizon/internal/db2"
-	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -135,8 +134,8 @@ type QClaimableBalances interface {
 	RemoveClaimableBalanceClaimants(ctx context.Context, ids []string) (int64, error)
 	GetClaimableBalancesByID(ctx context.Context, ids []string) ([]ClaimableBalance, error)
 	CountClaimableBalances(ctx context.Context) (int, error)
-	NewClaimableBalanceClaimantBatchInsertBuilder(session db.SessionInterface) ClaimableBalanceClaimantBatchInsertBuilder
-	NewClaimableBalanceBatchInsertBuilder(session db.SessionInterface) ClaimableBalanceBatchInsertBuilder
+	NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder
+	NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder
 	GetClaimantsByClaimableBalances(ctx context.Context, ids []string) (map[string][]ClaimableBalanceClaimant, error)
 }
 

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -11,6 +11,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/guregu/null"
 	"github.com/stellar/go/services/horizon/internal/db2"
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -134,8 +135,8 @@ type QClaimableBalances interface {
 	RemoveClaimableBalanceClaimants(ctx context.Context, ids []string) (int64, error)
 	GetClaimableBalancesByID(ctx context.Context, ids []string) ([]ClaimableBalance, error)
 	CountClaimableBalances(ctx context.Context) (int, error)
-	NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder
-	NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder
+	NewClaimableBalanceClaimantBatchInsertBuilder(session db.SessionInterface) ClaimableBalanceClaimantBatchInsertBuilder
+	NewClaimableBalanceBatchInsertBuilder(session db.SessionInterface) ClaimableBalanceBatchInsertBuilder
 	GetClaimantsByClaimableBalances(ctx context.Context, ids []string) (map[string][]ClaimableBalanceClaimant, error)
 }
 

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"database/sql"
 	"fmt"
 	"testing"
 
@@ -15,6 +16,8 @@ func TestRemoveClaimableBalance(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
@@ -39,8 +42,9 @@ func TestRemoveClaimableBalance(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	balanceBatchInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	tt.Assert.NoError(balanceBatchInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(balanceBatchInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	r, err := q.FindClaimableBalanceByID(tt.Ctx, id)
 	tt.Assert.NoError(err)
@@ -63,6 +67,8 @@ func TestRemoveClaimableBalanceClaimants(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
@@ -87,20 +93,9 @@ func TestRemoveClaimableBalanceClaimants(t *testing.T) {
 		Amount:             10,
 	}
 
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(10)
-
-	for _, claimant := range cBalance.Claimants {
-		claimant := ClaimableBalanceClaimant{
-			BalanceID:          cBalance.BalanceID,
-			Destination:        claimant.Destination,
-			LastModifiedLedger: cBalance.LastModifiedLedger,
-		}
-		err = claimantsInsertBuilder.Add(tt.Ctx, claimant)
-		tt.Assert.NoError(err)
-	}
-
-	err = claimantsInsertBuilder.Exec(tt.Ctx)
-	tt.Assert.NoError(err)
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance))
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	removed, err := q.RemoveClaimableBalanceClaimants(tt.Ctx, []string{id})
 	tt.Assert.NoError(err)
@@ -112,6 +107,9 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
+
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.Rollback()
 
 	dest1 := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	dest2 := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
@@ -138,19 +136,11 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
 
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(10)
-	for _, claimant := range cBalance.Claimants {
-		claimant := ClaimableBalanceClaimant{
-			BalanceID:          cBalance.BalanceID,
-			Destination:        claimant.Destination,
-			LastModifiedLedger: cBalance.LastModifiedLedger,
-		}
-		err = claimantsInsertBuilder.Add(tt.Ctx, claimant)
-		tt.Assert.NoError(err)
-	}
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance))
 
 	balanceID = xdr.ClaimableBalanceId{
 		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
@@ -179,21 +169,11 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance))
 
-	for _, claimant := range cBalance.Claimants {
-		claimant := ClaimableBalanceClaimant{
-			BalanceID:          cBalance.BalanceID,
-			Destination:        claimant.Destination,
-			LastModifiedLedger: cBalance.LastModifiedLedger,
-		}
-		err = claimantsInsertBuilder.Add(tt.Ctx, claimant)
-		tt.Assert.NoError(err)
-	}
-
-	err = claimantsInsertBuilder.Exec(tt.Ctx)
-	tt.Assert.NoError(err)
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	query := ClaimableBalancesQuery{
 		PageQuery: db2.MustPageQuery("", false, "", 10),
@@ -233,20 +213,19 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 	tt.Assert.Len(cbs, 1)
 }
 
-func insertClaimants(q *Q, tt *test.T, cBalance ClaimableBalance) error {
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(10)
+func insertClaimants(claimantsInsertBuilder ClaimableBalanceClaimantBatchInsertBuilder, cBalance ClaimableBalance) error {
 	for _, claimant := range cBalance.Claimants {
 		claimant := ClaimableBalanceClaimant{
 			BalanceID:          cBalance.BalanceID,
 			Destination:        claimant.Destination,
 			LastModifiedLedger: cBalance.LastModifiedLedger,
 		}
-		err := claimantsInsertBuilder.Add(tt.Ctx, claimant)
+		err := claimantsInsertBuilder.Add(claimant)
 		if err != nil {
 			return err
 		}
 	}
-	return claimantsInsertBuilder.Exec(tt.Ctx)
+	return nil
 }
 
 type claimableBalanceQueryResult struct {
@@ -278,6 +257,9 @@ func TestFindClaimableBalancesByDestinationWithLimit(t *testing.T) {
 
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
+
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.Rollback()
 
 	assetIssuer := "GA25GQLHJU3LPEJXEIAXK23AWEA5GWDUGRSHTQHDFT6HXHVMRULSQJUJ"
 	asset1 := xdr.MustNewCreditAsset("ASSET1", assetIssuer)
@@ -318,8 +300,11 @@ func TestFindClaimableBalancesByDestinationWithLimit(t *testing.T) {
 		LastModifiedLedger: 123,
 		Amount:             10,
 	}
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance1})
-	tt.Assert.NoError(err)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
+
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance1))
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance1))
 
 	claimants2 := []Claimant{
 		{
@@ -345,14 +330,12 @@ func TestFindClaimableBalancesByDestinationWithLimit(t *testing.T) {
 		LastModifiedLedger: 456,
 		Amount:             10,
 	}
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance2})
-	tt.Assert.NoError(err)
 
-	err = insertClaimants(q, tt, cBalance1)
-	tt.Assert.NoError(err)
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance2))
+	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance2))
 
-	err = insertClaimants(q, tt, cBalance2)
-	tt.Assert.NoError(err)
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	pageQuery := db2.MustPageQuery("", false, "", 1)
 
@@ -414,73 +397,15 @@ func TestFindClaimableBalancesByDestinationWithLimit(t *testing.T) {
 	})
 }
 
-func TestUpdateClaimableBalance(t *testing.T) {
-	tt := test.Start(t)
-	defer tt.Finish()
-	test.ResetHorizonDB(t, tt.HorizonDB)
-	q := &Q{tt.HorizonSession()}
-
-	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
-	lastModifiedLedgerSeq := xdr.Uint32(123)
-	asset := xdr.MustNewCreditAsset("USD", accountID)
-	balanceID := xdr.ClaimableBalanceId{
-		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
-		V0:   &xdr.Hash{1, 2, 3},
-	}
-	id, err := xdr.MarshalHex(balanceID)
-	tt.Assert.NoError(err)
-	cBalance := ClaimableBalance{
-		BalanceID: id,
-		Claimants: []Claimant{
-			{
-				Destination: accountID,
-				Predicate: xdr.ClaimPredicate{
-					Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
-				},
-			},
-		},
-		Asset:              asset,
-		LastModifiedLedger: 123,
-		Amount:             10,
-	}
-
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
-
-	// add sponsor
-	cBalance2 := ClaimableBalance{
-		BalanceID: id,
-		Claimants: []Claimant{
-			{
-				Destination: accountID,
-				Predicate: xdr.ClaimPredicate{
-					Type: xdr.ClaimPredicateTypeClaimPredicateUnconditional,
-				},
-			},
-		},
-		Asset:              asset,
-		LastModifiedLedger: 123 + 1,
-		Amount:             10,
-		Sponsor:            null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-	}
-
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance2})
-	tt.Assert.NoError(err)
-
-	cbs := []ClaimableBalance{}
-	err = q.Select(tt.Ctx, &cbs, selectClaimableBalances)
-	tt.Assert.NoError(err)
-	tt.Assert.Len(cbs, 1)
-	tt.Assert.Equal("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", cbs[0].Sponsor.String)
-	tt.Assert.Equal(uint32(lastModifiedLedgerSeq+1), cbs[0].LastModifiedLedger)
-}
-
 func TestFindClaimableBalance(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
+
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
 	balanceID := xdr.ClaimableBalanceId{
@@ -504,11 +429,11 @@ func TestFindClaimableBalance(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	cb, err := q.FindClaimableBalanceByID(tt.Ctx, id)
-	tt.Assert.NoError(err)
 
 	tt.Assert.Equal(cBalance.BalanceID, cb.BalanceID)
 	tt.Assert.Equal(cBalance.Asset, cb.Asset)
@@ -525,6 +450,9 @@ func TestGetClaimableBalancesByID(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
+
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
 	balanceID := xdr.ClaimableBalanceId{
@@ -548,8 +476,9 @@ func TestGetClaimableBalancesByID(t *testing.T) {
 		Amount:             10,
 	}
 
-	err = q.UpsertClaimableBalances(tt.Ctx, []ClaimableBalance{cBalance})
-	tt.Assert.NoError(err)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
 
 	r, err := q.GetClaimableBalancesByID(tt.Ctx, []string{id})
 	tt.Assert.NoError(err)

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -44,9 +44,9 @@ func TestRemoveClaimableBalance(t *testing.T) {
 		Amount:             10,
 	}
 
-	balanceBatchInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	balanceBatchInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
 	tt.Assert.NoError(balanceBatchInsertBuilder.Add(cBalance))
-	tt.Assert.NoError(balanceBatchInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(balanceBatchInsertBuilder.Exec(tt.Ctx))
 
 	r, err := q.FindClaimableBalanceByID(tt.Ctx, id)
 	tt.Assert.NoError(err)
@@ -97,9 +97,9 @@ func TestRemoveClaimableBalanceClaimants(t *testing.T) {
 		Amount:             10,
 	}
 
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(q.SessionInterface)
 	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance))
-	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx))
 
 	removed, err := q.RemoveClaimableBalanceClaimants(tt.Ctx, []string{id})
 	tt.Assert.NoError(err)
@@ -142,8 +142,8 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 		Amount:             10,
 	}
 
-	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(q.SessionInterface)
 
 	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
 	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance))
@@ -178,8 +178,8 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
 	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance))
 
-	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
-	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx))
 
 	query := ClaimableBalancesQuery{
 		PageQuery: db2.MustPageQuery("", false, "", 10),
@@ -308,8 +308,8 @@ func TestFindClaimableBalancesByDestinationWithLimit(t *testing.T) {
 		LastModifiedLedger: 123,
 		Amount:             10,
 	}
-	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(q.SessionInterface)
 
 	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance1))
 	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance1))
@@ -342,8 +342,8 @@ func TestFindClaimableBalancesByDestinationWithLimit(t *testing.T) {
 	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance2))
 	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance2))
 
-	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
-	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx))
 
 	pageQuery := db2.MustPageQuery("", false, "", 1)
 
@@ -439,9 +439,9 @@ func TestFindClaimableBalance(t *testing.T) {
 		Amount:             10,
 	}
 
-	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
 	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
-	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx))
 
 	cb, err := q.FindClaimableBalanceByID(tt.Ctx, id)
 
@@ -488,9 +488,9 @@ func TestGetClaimableBalancesByID(t *testing.T) {
 		Amount:             10,
 	}
 
-	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
 	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
-	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx, q.SessionInterface))
+	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx))
 
 	r, err := q.GetClaimableBalancesByID(tt.Ctx, []string{id})
 	tt.Assert.NoError(err)

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -16,9 +16,9 @@ func TestRemoveClaimableBalance(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
-	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
+	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
-		_ = q.SessionInterface.Rollback()
+		_ = q.Rollback()
 	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
@@ -69,9 +69,9 @@ func TestRemoveClaimableBalanceClaimants(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
-	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
+	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
-		_ = q.SessionInterface.Rollback()
+		_ = q.Rollback()
 	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
@@ -264,9 +264,9 @@ func TestFindClaimableBalancesByDestinationWithLimit(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
+	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
-		_ = q.SessionInterface.Rollback()
+		_ = q.Rollback()
 	}()
 
 	assetIssuer := "GA25GQLHJU3LPEJXEIAXK23AWEA5GWDUGRSHTQHDFT6HXHVMRULSQJUJ"
@@ -411,9 +411,9 @@ func TestFindClaimableBalance(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
+	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
-		_ = q.SessionInterface.Rollback()
+		_ = q.Rollback()
 	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
@@ -460,9 +460,9 @@ func TestGetClaimableBalancesByID(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
+	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
-		_ = q.SessionInterface.Rollback()
+		_ = q.Rollback()
 	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -16,8 +16,10 @@ func TestRemoveClaimableBalance(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
-	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
-	defer q.SessionInterface.Rollback()
+	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
@@ -67,8 +69,10 @@ func TestRemoveClaimableBalanceClaimants(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
-	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
-	defer q.SessionInterface.Rollback()
+	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
@@ -108,8 +112,10 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
-	defer q.Rollback()
+	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	dest1 := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	dest2 := "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"
@@ -405,6 +411,10 @@ func TestFindClaimableBalance(t *testing.T) {
 
 	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
 	defer q.SessionInterface.Rollback()
+	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)
@@ -452,6 +462,10 @@ func TestGetClaimableBalancesByID(t *testing.T) {
 
 	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
 	defer q.SessionInterface.Rollback()
+	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	accountID := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
 	asset := xdr.MustNewCreditAsset("USD", accountID)

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -44,7 +44,7 @@ func TestRemoveClaimableBalance(t *testing.T) {
 		Amount:             10,
 	}
 
-	balanceBatchInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
+	balanceBatchInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
 	tt.Assert.NoError(balanceBatchInsertBuilder.Add(cBalance))
 	tt.Assert.NoError(balanceBatchInsertBuilder.Exec(tt.Ctx))
 
@@ -97,7 +97,7 @@ func TestRemoveClaimableBalanceClaimants(t *testing.T) {
 		Amount:             10,
 	}
 
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(q.SessionInterface)
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
 	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance))
 	tt.Assert.NoError(claimantsInsertBuilder.Exec(tt.Ctx))
 
@@ -112,9 +112,9 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
+	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
-		_ = q.SessionInterface.Rollback()
+		_ = q.Rollback()
 	}()
 
 	dest1 := "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"
@@ -142,8 +142,8 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 		Amount:             10,
 	}
 
-	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(q.SessionInterface)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
 
 	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
 	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance))
@@ -308,8 +308,8 @@ func TestFindClaimableBalancesByDestinationWithLimit(t *testing.T) {
 		LastModifiedLedger: 123,
 		Amount:             10,
 	}
-	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
-	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder(q.SessionInterface)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
+	claimantsInsertBuilder := q.NewClaimableBalanceClaimantBatchInsertBuilder()
 
 	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance1))
 	tt.Assert.NoError(insertClaimants(claimantsInsertBuilder, cBalance1))
@@ -439,7 +439,7 @@ func TestFindClaimableBalance(t *testing.T) {
 		Amount:             10,
 	}
 
-	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
 	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
 	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx))
 
@@ -488,7 +488,7 @@ func TestGetClaimableBalancesByID(t *testing.T) {
 		Amount:             10,
 	}
 
-	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder(q.SessionInterface)
+	balanceInsertBuilder := q.NewClaimableBalanceBatchInsertBuilder()
 	tt.Assert.NoError(balanceInsertBuilder.Add(cBalance))
 	tt.Assert.NoError(balanceInsertBuilder.Exec(tt.Ctx))
 

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -3,9 +3,9 @@ package history
 import (
 	"database/sql"
 	"fmt"
+	"github.com/guregu/null"
 	"testing"
 
-	"github.com/guregu/null"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/xdr"
@@ -16,7 +16,7 @@ func TestRemoveClaimableBalance(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
-	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
 		_ = q.SessionInterface.Rollback()
 	}()
@@ -69,7 +69,7 @@ func TestRemoveClaimableBalanceClaimants(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
-	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
 		_ = q.SessionInterface.Rollback()
 	}()
@@ -112,7 +112,7 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
 		_ = q.SessionInterface.Rollback()
 	}()
@@ -409,9 +409,7 @@ func TestFindClaimableBalance(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
-	defer q.SessionInterface.Rollback()
-	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
 		_ = q.SessionInterface.Rollback()
 	}()
@@ -460,9 +458,7 @@ func TestGetClaimableBalancesByID(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
-	defer q.SessionInterface.Rollback()
-	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
 		_ = q.SessionInterface.Rollback()
 	}()

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -3,9 +3,9 @@ package history
 import (
 	"database/sql"
 	"fmt"
-	"github.com/guregu/null"
 	"testing"
 
+	"github.com/guregu/null"
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/xdr"
@@ -264,8 +264,10 @@ func TestFindClaimableBalancesByDestinationWithLimit(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
-	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
-	defer q.Rollback()
+	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	assetIssuer := "GA25GQLHJU3LPEJXEIAXK23AWEA5GWDUGRSHTQHDFT6HXHVMRULSQJUJ"
 	asset1 := xdr.MustNewCreditAsset("ASSET1", assetIssuer)

--- a/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
@@ -1,0 +1,27 @@
+package history
+
+import (
+	"context"
+	"github.com/stellar/go/support/db"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockClaimableBalanceBatchInsertBuilder struct {
+	mock.Mock
+}
+
+func (m *MockClaimableBalanceBatchInsertBuilder) Add(claimableBalance ClaimableBalance) error {
+	a := m.Called(claimableBalance)
+	return a.Error(0)
+}
+
+func (m *MockClaimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
+	a := m.Called(ctx, session)
+	return a.Error(0)
+}
+
+func (m *MockClaimableBalanceBatchInsertBuilder) Reset() error {
+	a := m.Called()
+	return a.Error(0)
+}

--- a/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
@@ -21,7 +21,6 @@ func (m *MockClaimableBalanceBatchInsertBuilder) Exec(ctx context.Context, sessi
 	return a.Error(0)
 }
 
-func (m *MockClaimableBalanceBatchInsertBuilder) Reset() error {
-	a := m.Called()
-	return a.Error(0)
+func (m *MockClaimableBalanceBatchInsertBuilder) Reset() {
+	m.Called()
 }

--- a/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
@@ -2,8 +2,8 @@ package history
 
 import (
 	"context"
-	"github.com/stellar/go/support/db"
 
+	"github.com/stellar/go/support/db"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_batch_insert_builder.go
@@ -3,7 +3,6 @@ package history
 import (
 	"context"
 
-	"github.com/stellar/go/support/db"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -16,11 +15,7 @@ func (m *MockClaimableBalanceBatchInsertBuilder) Add(claimableBalance ClaimableB
 	return a.Error(0)
 }
 
-func (m *MockClaimableBalanceBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
-	a := m.Called(ctx, session)
+func (m *MockClaimableBalanceBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
 	return a.Error(0)
-}
-
-func (m *MockClaimableBalanceBatchInsertBuilder) Reset() {
-	m.Called()
 }

--- a/services/horizon/internal/db2/history/mock_claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_claimant_batch_insert_builder.go
@@ -21,7 +21,6 @@ func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Contex
 	return a.Error(0)
 }
 
-func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Reset() error {
-	a := m.Called()
-	return a.Error(0)
+func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Reset() {
+	m.Called()
 }

--- a/services/horizon/internal/db2/history/mock_claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_claimant_batch_insert_builder.go
@@ -2,6 +2,7 @@ package history
 
 import (
 	"context"
+	"github.com/stellar/go/support/db"
 
 	"github.com/stretchr/testify/mock"
 )
@@ -10,12 +11,17 @@ type MockClaimableBalanceClaimantBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Add(ctx context.Context, claimableBalanceClaimant ClaimableBalanceClaimant) error {
-	a := m.Called(ctx, claimableBalanceClaimant)
+func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Add(claimableBalanceClaimant ClaimableBalanceClaimant) error {
+	a := m.Called(claimableBalanceClaimant)
 	return a.Error(0)
 }
 
-func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context) error {
-	a := m.Called(ctx)
+func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
+	a := m.Called(ctx, session)
+	return a.Error(0)
+}
+
+func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Reset() error {
+	a := m.Called()
 	return a.Error(0)
 }

--- a/services/horizon/internal/db2/history/mock_claimable_balance_claimant_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_claimable_balance_claimant_batch_insert_builder.go
@@ -2,8 +2,6 @@ package history
 
 import (
 	"context"
-	"github.com/stellar/go/support/db"
-
 	"github.com/stretchr/testify/mock"
 )
 
@@ -16,11 +14,7 @@ func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Add(claimableBalanceCla
 	return a.Error(0)
 }
 
-func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context, session db.SessionInterface) error {
-	a := m.Called(ctx, session)
+func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
 	return a.Error(0)
-}
-
-func (m *MockClaimableBalanceClaimantBatchInsertBuilder) Reset() {
-	m.Called()
 }

--- a/services/horizon/internal/db2/history/mock_q_claimable_balances.go
+++ b/services/horizon/internal/db2/history/mock_q_claimable_balances.go
@@ -21,11 +21,6 @@ func (m *MockQClaimableBalances) GetClaimableBalancesByID(ctx context.Context, i
 	return a.Get(0).([]ClaimableBalance), a.Error(1)
 }
 
-func (m *MockQClaimableBalances) UpsertClaimableBalances(ctx context.Context, cbs []ClaimableBalance) error {
-	a := m.Called(ctx, cbs)
-	return a.Error(0)
-}
-
 func (m *MockQClaimableBalances) RemoveClaimableBalances(ctx context.Context, ids []string) (int64, error) {
 	a := m.Called(ctx, ids)
 	return a.Get(0).(int64), a.Error(1)
@@ -36,9 +31,14 @@ func (m *MockQClaimableBalances) RemoveClaimableBalanceClaimants(ctx context.Con
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQClaimableBalances) NewClaimableBalanceClaimantBatchInsertBuilder(maxBatchSize int) ClaimableBalanceClaimantBatchInsertBuilder {
-	a := m.Called(maxBatchSize)
+func (m *MockQClaimableBalances) NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder {
+	a := m.Called()
 	return a.Get(0).(ClaimableBalanceClaimantBatchInsertBuilder)
+}
+
+func (m *MockQClaimableBalances) NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder {
+	a := m.Called()
+	return a.Get(0).(ClaimableBalanceBatchInsertBuilder)
 }
 
 func (m *MockQClaimableBalances) GetClaimantsByClaimableBalances(ctx context.Context, ids []string) (map[string][]ClaimableBalanceClaimant, error) {

--- a/services/horizon/internal/db2/history/mock_q_claimable_balances.go
+++ b/services/horizon/internal/db2/history/mock_q_claimable_balances.go
@@ -3,7 +3,6 @@ package history
 import (
 	"context"
 
-	"github.com/stellar/go/support/db"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -32,13 +31,13 @@ func (m *MockQClaimableBalances) RemoveClaimableBalanceClaimants(ctx context.Con
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQClaimableBalances) NewClaimableBalanceClaimantBatchInsertBuilder(session db.SessionInterface) ClaimableBalanceClaimantBatchInsertBuilder {
-	a := m.Called(session)
+func (m *MockQClaimableBalances) NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder {
+	a := m.Called()
 	return a.Get(0).(ClaimableBalanceClaimantBatchInsertBuilder)
 }
 
-func (m *MockQClaimableBalances) NewClaimableBalanceBatchInsertBuilder(session db.SessionInterface) ClaimableBalanceBatchInsertBuilder {
-	a := m.Called(session)
+func (m *MockQClaimableBalances) NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder {
+	a := m.Called()
 	return a.Get(0).(ClaimableBalanceBatchInsertBuilder)
 }
 

--- a/services/horizon/internal/db2/history/mock_q_claimable_balances.go
+++ b/services/horizon/internal/db2/history/mock_q_claimable_balances.go
@@ -3,6 +3,7 @@ package history
 import (
 	"context"
 
+	"github.com/stellar/go/support/db"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -31,13 +32,13 @@ func (m *MockQClaimableBalances) RemoveClaimableBalanceClaimants(ctx context.Con
 	return a.Get(0).(int64), a.Error(1)
 }
 
-func (m *MockQClaimableBalances) NewClaimableBalanceClaimantBatchInsertBuilder() ClaimableBalanceClaimantBatchInsertBuilder {
-	a := m.Called()
+func (m *MockQClaimableBalances) NewClaimableBalanceClaimantBatchInsertBuilder(session db.SessionInterface) ClaimableBalanceClaimantBatchInsertBuilder {
+	a := m.Called(session)
 	return a.Get(0).(ClaimableBalanceClaimantBatchInsertBuilder)
 }
 
-func (m *MockQClaimableBalances) NewClaimableBalanceBatchInsertBuilder() ClaimableBalanceBatchInsertBuilder {
-	a := m.Called()
+func (m *MockQClaimableBalances) NewClaimableBalanceBatchInsertBuilder(session db.SessionInterface) ClaimableBalanceBatchInsertBuilder {
+	a := m.Called(session)
 	return a.Get(0).(ClaimableBalanceBatchInsertBuilder)
 }
 

--- a/services/horizon/internal/ingest/processor_runner.go
+++ b/services/horizon/internal/ingest/processor_runner.go
@@ -109,7 +109,6 @@ func (s *ProcessorRunner) DisableMemoryStatsLogging() {
 
 func buildChangeProcessor(
 	historyQ history.IngestionQ,
-	session db.SessionInterface,
 	changeStats *ingest.StatsChangeProcessor,
 	source ingestionSource,
 	ledgerSequence uint32,
@@ -240,7 +239,6 @@ func (s *ProcessorRunner) RunHistoryArchiveIngestion(
 	changeStats := ingest.StatsChangeProcessor{}
 	changeProcessor := buildChangeProcessor(
 		s.historyQ,
-		s.session,
 		&changeStats,
 		historyArchiveSource,
 		checkpointLedger,
@@ -406,7 +404,6 @@ func (s *ProcessorRunner) RunAllProcessorsOnLedger(ledger xdr.LedgerCloseMeta) (
 
 	groupChangeProcessors := buildChangeProcessor(
 		s.historyQ,
-		s.session,
 		&changeStatsProcessor,
 		ledgerSource,
 		ledger.LedgerSequence(),

--- a/services/horizon/internal/ingest/processor_runner.go
+++ b/services/horizon/internal/ingest/processor_runner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/stellar/go/support/db"
 	"time"
 
 	"github.com/stellar/go/ingest"
@@ -109,6 +110,7 @@ func (s *ProcessorRunner) DisableMemoryStatsLogging() {
 
 func buildChangeProcessor(
 	historyQ history.IngestionQ,
+	session db.SessionInterface,
 	changeStats *ingest.StatsChangeProcessor,
 	source ingestionSource,
 	ledgerSequence uint32,
@@ -127,7 +129,7 @@ func buildChangeProcessor(
 		processors.NewAssetStatsProcessor(historyQ, networkPassphrase, useLedgerCache),
 		processors.NewSignersProcessor(historyQ, useLedgerCache),
 		processors.NewTrustLinesProcessor(historyQ),
-		processors.NewClaimableBalancesChangeProcessor(historyQ),
+		processors.NewClaimableBalancesChangeProcessor(historyQ, session),
 		processors.NewLiquidityPoolsChangeProcessor(historyQ, ledgerSequence),
 	})
 }
@@ -239,6 +241,7 @@ func (s *ProcessorRunner) RunHistoryArchiveIngestion(
 	changeStats := ingest.StatsChangeProcessor{}
 	changeProcessor := buildChangeProcessor(
 		s.historyQ,
+		s.session,
 		&changeStats,
 		historyArchiveSource,
 		checkpointLedger,
@@ -404,6 +407,10 @@ func (s *ProcessorRunner) RunAllProcessorsOnLedger(ledger xdr.LedgerCloseMeta) (
 
 	groupChangeProcessors := buildChangeProcessor(
 		s.historyQ,
+<<<<<<< HEAD
+=======
+		s.session,
+>>>>>>> 8f1836b1 (Use FastBatchInsertBuilder to insert to insert into claimable_balances and claimable_balance_claimants tables)
 		&changeStatsProcessor,
 		ledgerSource,
 		ledger.LedgerSequence(),

--- a/services/horizon/internal/ingest/processor_runner.go
+++ b/services/horizon/internal/ingest/processor_runner.go
@@ -128,7 +128,7 @@ func buildChangeProcessor(
 		processors.NewAssetStatsProcessor(historyQ, networkPassphrase, useLedgerCache),
 		processors.NewSignersProcessor(historyQ, useLedgerCache),
 		processors.NewTrustLinesProcessor(historyQ),
-		processors.NewClaimableBalancesChangeProcessor(historyQ, session),
+		processors.NewClaimableBalancesChangeProcessor(historyQ),
 		processors.NewLiquidityPoolsChangeProcessor(historyQ, ledgerSequence),
 	})
 }

--- a/services/horizon/internal/ingest/processor_runner.go
+++ b/services/horizon/internal/ingest/processor_runner.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/stellar/go/support/db"
 	"time"
 
 	"github.com/stellar/go/ingest"
@@ -407,10 +406,7 @@ func (s *ProcessorRunner) RunAllProcessorsOnLedger(ledger xdr.LedgerCloseMeta) (
 
 	groupChangeProcessors := buildChangeProcessor(
 		s.historyQ,
-<<<<<<< HEAD
-=======
 		s.session,
->>>>>>> 8f1836b1 (Use FastBatchInsertBuilder to insert to insert into claimable_balances and claimable_balance_claimants tables)
 		&changeStatsProcessor,
 		ledgerSource,
 		ledger.LedgerSequence(),

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -235,7 +235,7 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 	}
 
 	stats := &ingest.StatsChangeProcessor{}
-	processor := buildChangeProcessor(runner.historyQ, &db.MockSession{}, stats, ledgerSource, 123, "")
+	processor := buildChangeProcessor(runner.historyQ, stats, ledgerSource, 123, "")
 	assert.IsType(t, &groupChangeProcessors{}, processor)
 
 	assert.IsType(t, &statsChangeProcessor{}, processor.processors[0])
@@ -256,7 +256,7 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 		filters:  &MockFilters{},
 	}
 
-	processor = buildChangeProcessor(runner.historyQ, &db.MockSession{}, stats, historyArchiveSource, 456, "")
+	processor = buildChangeProcessor(runner.historyQ, stats, historyArchiveSource, 456, "")
 	assert.IsType(t, &groupChangeProcessors{}, processor)
 
 	assert.IsType(t, &statsChangeProcessor{}, processor.processors[0])

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -52,11 +52,11 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 		Return(mockAccountSignersBatchInsertBuilder).Once()
 
 	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
-	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
 		Return(mockClaimableBalanceBatchInsertBuilder).Twice()
 
 	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
 		Return(mockClaimantsBatchInsertBuilder).Twice()
 
 	mockClaimantsBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
@@ -130,11 +130,11 @@ func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 		Return(mockAccountSignersBatchInsertBuilder).Once()
 
 	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
-	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
 		Return(mockClaimableBalanceBatchInsertBuilder).Twice()
 
 	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
 		Return(mockClaimantsBatchInsertBuilder).Twice()
 
 	mockClaimantsBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
@@ -178,11 +178,11 @@ func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t 
 		Return(mockAccountSignersBatchInsertBuilder).Once()
 
 	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
-	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
 		Return(mockClaimableBalanceBatchInsertBuilder).Once()
 
 	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
 		Return(mockClaimantsBatchInsertBuilder).Once()
 
 	mockClaimantsBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
@@ -213,7 +213,6 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 	ctx := context.Background()
 	maxBatchSize := 100000
 
-	mockSession := &db.MockSession{}
 	q := &mockDBQ{}
 	defer mock.AssertExpectationsForObjects(t, q)
 
@@ -222,11 +221,11 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 		Return(&history.MockAccountSignersBatchInsertBuilder{}).Twice()
 
 	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
-	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
 		Return(mockClaimableBalanceBatchInsertBuilder).Twice()
 
 	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
 		Return(mockClaimantsBatchInsertBuilder).Twice()
 
 	runner := ProcessorRunner{
@@ -355,11 +354,11 @@ func TestProcessorRunnerWithFilterEnabled(t *testing.T) {
 		Return(mockTransactionsFilteredTmpBatchInsertBuilder)
 
 	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
-	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
 		Return(mockClaimableBalanceBatchInsertBuilder).Once()
 
 	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
 		Return(mockClaimantsBatchInsertBuilder).Once()
 
 	mockClaimantsBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
@@ -547,11 +546,11 @@ func mockBatchBuilders(q *mockDBQ, mockSession *db.MockSession, ctx context.Cont
 
 	mockClaimableBalanceClaimantBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
 	mockClaimableBalanceClaimantBatchInsertBuilder.On("Exec", ctx).Return(nil)
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
 		Return(mockClaimableBalanceClaimantBatchInsertBuilder)
 
 	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
-	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
 		Return(mockClaimableBalanceBatchInsertBuilder)
 	mockClaimableBalanceBatchInsertBuilder.On("Exec", ctx).Return(nil)
 

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -53,11 +53,14 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 
 	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
 	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
-		Return(mockClaimableBalanceBatchInsertBuilder).Once()
+		Return(mockClaimableBalanceBatchInsertBuilder).Twice()
 
 	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
 	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
-		Return(mockClaimantsBatchInsertBuilder).Once()
+		Return(mockClaimantsBatchInsertBuilder).Twice()
+
+	mockClaimantsBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
+	mockClaimableBalanceBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 
 	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
@@ -128,11 +131,14 @@ func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 
 	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
 	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
-		Return(mockClaimableBalanceBatchInsertBuilder).Once()
+		Return(mockClaimableBalanceBatchInsertBuilder).Twice()
 
 	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
 	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
-		Return(mockClaimantsBatchInsertBuilder).Once()
+		Return(mockClaimantsBatchInsertBuilder).Twice()
+
+	mockClaimantsBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
+	mockClaimableBalanceBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 
 	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
@@ -178,6 +184,9 @@ func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t 
 	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
 	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
 		Return(mockClaimantsBatchInsertBuilder).Once()
+
+	mockClaimantsBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
+	mockClaimableBalanceBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 
 	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
@@ -353,6 +362,9 @@ func TestProcessorRunnerWithFilterEnabled(t *testing.T) {
 	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
 		Return(mockClaimantsBatchInsertBuilder).Once()
 
+	mockClaimantsBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
+	mockClaimableBalanceBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
+
 	q.On("DeleteTransactionsFilteredTmpOlderThan", ctx, mock.AnythingOfType("uint64")).
 		Return(int64(0), nil)
 
@@ -416,14 +428,6 @@ func TestProcessorRunnerRunAllProcessorsOnLedger(t *testing.T) {
 		ctx,
 		mockSession,
 	).Return(nil)
-
-	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
-	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
-		Return(mockClaimableBalanceBatchInsertBuilder).Once()
-
-	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
-		Return(mockClaimantsBatchInsertBuilder).Once()
 
 	runner := ProcessorRunner{
 		ctx:      ctx,
@@ -541,8 +545,15 @@ func mockBatchBuilders(q *mockDBQ, mockSession *db.MockSession, ctx context.Cont
 	q.MockQHistoryLiquidityPools.On("NewOperationLiquidityPoolBatchInsertBuilder").
 		Return(mockOperationLiquidityPoolBatchInsertBuilder)
 
+	mockClaimableBalanceClaimantBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	mockClaimableBalanceClaimantBatchInsertBuilder.On("Exec", ctx).Return(nil)
 	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
-		Return(&history.MockClaimableBalanceClaimantBatchInsertBuilder{}).Once()
+		Return(mockClaimableBalanceClaimantBatchInsertBuilder)
+
+	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
+		Return(mockClaimableBalanceBatchInsertBuilder)
+	mockClaimableBalanceBatchInsertBuilder.On("Exec", ctx).Return(nil)
 
 	q.On("NewTradeBatchInsertBuilder").Return(&history.MockTradeBatchInsertBuilder{})
 

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -49,9 +49,10 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
 		Return(mockAccountSignersBatchInsertBuilder).Once()
 
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", maxBatchSize).
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
 		Return(&history.MockClaimableBalanceClaimantBatchInsertBuilder{}).Once()
-
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
+		Return(&history.MockClaimableBalanceBatchInsertBuilder{}).Once()
 	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
 
@@ -116,9 +117,10 @@ func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 	mockAccountSignersBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
 		Return(mockAccountSignersBatchInsertBuilder).Once()
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", maxBatchSize).
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
 		Return(&history.MockClaimableBalanceClaimantBatchInsertBuilder{}).Once()
-
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
+		Return(&history.MockClaimableBalanceBatchInsertBuilder{}).Once()
 	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
 
@@ -153,9 +155,10 @@ func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t 
 	defer mock.AssertExpectationsForObjects(t, mockAccountSignersBatchInsertBuilder)
 	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
 		Return(mockAccountSignersBatchInsertBuilder).Once()
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", maxBatchSize).
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
 		Return(&history.MockClaimableBalanceClaimantBatchInsertBuilder{}).Once()
-
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
+		Return(&history.MockClaimableBalanceBatchInsertBuilder{}).Once()
 	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
 
@@ -186,8 +189,10 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 	// Twice = checking ledgerSource and historyArchiveSource
 	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
 		Return(&history.MockAccountSignersBatchInsertBuilder{}).Twice()
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", maxBatchSize).
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
 		Return(&history.MockClaimableBalanceClaimantBatchInsertBuilder{}).Twice()
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
+		Return(&history.MockClaimableBalanceBatchInsertBuilder{}).Twice()
 	runner := ProcessorRunner{
 		ctx:      ctx,
 		historyQ: q,
@@ -216,7 +221,11 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 		filters:  &MockFilters{},
 	}
 
+<<<<<<< HEAD
 	processor = buildChangeProcessor(runner.historyQ, stats, historyArchiveSource, 456, "")
+=======
+	processor = buildChangeProcessor(runner.historyQ, &db.MockSession{}, stats, historyArchiveSource, 456, "")
+>>>>>>> 8f1836b1 (Use FastBatchInsertBuilder to insert to insert into claimable_balances and claimable_balance_claimants tables)
 	assert.IsType(t, &groupChangeProcessors{}, processor)
 
 	assert.IsType(t, &statsChangeProcessor{}, processor.processors[0])
@@ -313,6 +322,12 @@ func TestProcessorRunnerWithFilterEnabled(t *testing.T) {
 	q.MockQTransactions.On("NewTransactionFilteredTmpBatchInsertBuilder").
 		Return(mockTransactionsFilteredTmpBatchInsertBuilder)
 
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
+		Return(&history.MockClaimableBalanceClaimantBatchInsertBuilder{}).Once()
+
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
+		Return(&history.MockClaimableBalanceBatchInsertBuilder{}).Once()
+
 	q.On("DeleteTransactionsFilteredTmpOlderThan", ctx, mock.AnythingOfType("uint64")).
 		Return(int64(0), nil)
 
@@ -376,6 +391,12 @@ func TestProcessorRunnerRunAllProcessorsOnLedger(t *testing.T) {
 		ctx,
 		mockSession,
 	).Return(nil)
+
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
+		Return(&history.MockClaimableBalanceClaimantBatchInsertBuilder{}).Once()
+
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
+		Return(&history.MockClaimableBalanceBatchInsertBuilder{}).Once()
 
 	runner := ProcessorRunner{
 		ctx:      ctx,

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -200,7 +200,7 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 	}
 
 	stats := &ingest.StatsChangeProcessor{}
-	processor := buildChangeProcessor(runner.historyQ, stats, ledgerSource, 123, "")
+	processor := buildChangeProcessor(runner.historyQ, &db.MockSession{}, stats, ledgerSource, 123, "")
 	assert.IsType(t, &groupChangeProcessors{}, processor)
 
 	assert.IsType(t, &statsChangeProcessor{}, processor.processors[0])
@@ -221,11 +221,7 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 		filters:  &MockFilters{},
 	}
 
-<<<<<<< HEAD
-	processor = buildChangeProcessor(runner.historyQ, stats, historyArchiveSource, 456, "")
-=======
 	processor = buildChangeProcessor(runner.historyQ, &db.MockSession{}, stats, historyArchiveSource, 456, "")
->>>>>>> 8f1836b1 (Use FastBatchInsertBuilder to insert to insert into claimable_balances and claimable_balance_claimants tables)
 	assert.IsType(t, &groupChangeProcessors{}, processor)
 
 	assert.IsType(t, &statsChangeProcessor{}, processor.processors[0])

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -24,6 +24,8 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 	ctx := context.Background()
 	maxBatchSize := 100000
 
+	mockSession := &db.MockSession{}
+
 	q := &mockDBQ{}
 
 	q.MockQAccounts.On("UpsertAccounts", ctx, []history.AccountEntry{
@@ -49,10 +51,14 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
 		Return(mockAccountSignersBatchInsertBuilder).Once()
 
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
-		Return(&history.MockClaimableBalanceClaimantBatchInsertBuilder{}).Once()
-	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
-		Return(&history.MockClaimableBalanceBatchInsertBuilder{}).Once()
+	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
+		Return(mockClaimableBalanceBatchInsertBuilder).Once()
+
+	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
+		Return(mockClaimantsBatchInsertBuilder).Once()
+
 	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
 
@@ -63,6 +69,7 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 		},
 		historyQ: q,
 		filters:  &MockFilters{},
+		session:  mockSession,
 	}
 
 	_, err := runner.RunGenesisStateIngestion()
@@ -77,6 +84,7 @@ func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 		NetworkPassphrase: network.PublicNetworkPassphrase,
 	}
 
+	mockSession := &db.MockSession{}
 	q := &mockDBQ{}
 	defer mock.AssertExpectationsForObjects(t, q)
 	historyAdapter := &mockHistoryArchiveAdapter{}
@@ -117,10 +125,15 @@ func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 	mockAccountSignersBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
 		Return(mockAccountSignersBatchInsertBuilder).Once()
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
-		Return(&history.MockClaimableBalanceClaimantBatchInsertBuilder{}).Once()
-	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
-		Return(&history.MockClaimableBalanceBatchInsertBuilder{}).Once()
+
+	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
+		Return(mockClaimableBalanceBatchInsertBuilder).Once()
+
+	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
+		Return(mockClaimantsBatchInsertBuilder).Once()
+
 	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
 
@@ -130,6 +143,7 @@ func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 		historyQ:       q,
 		historyAdapter: historyAdapter,
 		filters:        &MockFilters{},
+		session:        mockSession,
 	}
 
 	_, err := runner.RunHistoryArchiveIngestion(63, false, MaxSupportedProtocolVersion, bucketListHash)
@@ -144,6 +158,7 @@ func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t 
 		NetworkPassphrase: network.PublicNetworkPassphrase,
 	}
 
+	mockSession := &db.MockSession{}
 	q := &mockDBQ{}
 	defer mock.AssertExpectationsForObjects(t, q)
 	historyAdapter := &mockHistoryArchiveAdapter{}
@@ -155,10 +170,15 @@ func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t 
 	defer mock.AssertExpectationsForObjects(t, mockAccountSignersBatchInsertBuilder)
 	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
 		Return(mockAccountSignersBatchInsertBuilder).Once()
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
-		Return(&history.MockClaimableBalanceClaimantBatchInsertBuilder{}).Once()
-	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
-		Return(&history.MockClaimableBalanceBatchInsertBuilder{}).Once()
+
+	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
+		Return(mockClaimableBalanceBatchInsertBuilder).Once()
+
+	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
+		Return(mockClaimantsBatchInsertBuilder).Once()
+
 	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
 
@@ -168,6 +188,7 @@ func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t 
 		historyQ:       q,
 		historyAdapter: historyAdapter,
 		filters:        &MockFilters{},
+		session:        mockSession,
 	}
 
 	_, err := runner.RunHistoryArchiveIngestion(100, false, 200, xdr.Hash{})
@@ -183,16 +204,22 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 	ctx := context.Background()
 	maxBatchSize := 100000
 
+	mockSession := &db.MockSession{}
 	q := &mockDBQ{}
 	defer mock.AssertExpectationsForObjects(t, q)
 
 	// Twice = checking ledgerSource and historyArchiveSource
 	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
 		Return(&history.MockAccountSignersBatchInsertBuilder{}).Twice()
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
-		Return(&history.MockClaimableBalanceClaimantBatchInsertBuilder{}).Twice()
-	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
-		Return(&history.MockClaimableBalanceBatchInsertBuilder{}).Twice()
+
+	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
+		Return(mockClaimableBalanceBatchInsertBuilder).Twice()
+
+	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
+		Return(mockClaimantsBatchInsertBuilder).Twice()
+
 	runner := ProcessorRunner{
 		ctx:      ctx,
 		historyQ: q,
@@ -318,11 +345,13 @@ func TestProcessorRunnerWithFilterEnabled(t *testing.T) {
 	q.MockQTransactions.On("NewTransactionFilteredTmpBatchInsertBuilder").
 		Return(mockTransactionsFilteredTmpBatchInsertBuilder)
 
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
-		Return(&history.MockClaimableBalanceClaimantBatchInsertBuilder{}).Once()
+	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
+		Return(mockClaimableBalanceBatchInsertBuilder).Once()
 
-	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
-		Return(&history.MockClaimableBalanceBatchInsertBuilder{}).Once()
+	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
+		Return(mockClaimantsBatchInsertBuilder).Once()
 
 	q.On("DeleteTransactionsFilteredTmpOlderThan", ctx, mock.AnythingOfType("uint64")).
 		Return(int64(0), nil)
@@ -388,11 +417,13 @@ func TestProcessorRunnerRunAllProcessorsOnLedger(t *testing.T) {
 		mockSession,
 	).Return(nil)
 
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
-		Return(&history.MockClaimableBalanceClaimantBatchInsertBuilder{}).Once()
+	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
+	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder", mockSession).
+		Return(mockClaimableBalanceBatchInsertBuilder).Once()
 
-	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
-		Return(&history.MockClaimableBalanceBatchInsertBuilder{}).Once()
+	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
+		Return(mockClaimantsBatchInsertBuilder).Once()
 
 	runner := ProcessorRunner{
 		ctx:      ctx,
@@ -510,7 +541,7 @@ func mockBatchBuilders(q *mockDBQ, mockSession *db.MockSession, ctx context.Cont
 	q.MockQHistoryLiquidityPools.On("NewOperationLiquidityPoolBatchInsertBuilder").
 		Return(mockOperationLiquidityPoolBatchInsertBuilder)
 
-	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", maxBatchSize).
+	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder", mockSession).
 		Return(&history.MockClaimableBalanceClaimantBatchInsertBuilder{}).Once()
 
 	q.On("NewTradeBatchInsertBuilder").Return(&history.MockTradeBatchInsertBuilder{})

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/db"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
 

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -17,14 +16,12 @@ type ClaimableBalancesChangeProcessor struct {
 	cache                         *ingest.ChangeCompactor
 	claimantsInsertBuilder        history.ClaimableBalanceClaimantBatchInsertBuilder
 	claimableBalanceInsertBuilder history.ClaimableBalanceBatchInsertBuilder
-	session                       db.SessionInterface
 }
 
-func NewClaimableBalancesChangeProcessor(Q history.QClaimableBalances, session db.SessionInterface) *ClaimableBalancesChangeProcessor {
+func NewClaimableBalancesChangeProcessor(Q history.QClaimableBalances) *ClaimableBalancesChangeProcessor {
 	p := &ClaimableBalancesChangeProcessor{
 		encodingBuffer:     xdr.NewEncodingBuffer(),
 		qClaimableBalances: Q,
-		session:            session,
 	}
 	p.reset()
 	return p

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
@@ -2,6 +2,7 @@ package processors
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -50,27 +51,43 @@ func (p *ClaimableBalancesChangeProcessor) ProcessChange(ctx context.Context, ch
 		if err != nil {
 			return errors.Wrap(err, "error in Commit")
 		}
-		p.reset()
 	}
 
 	return nil
 }
 
 func (p *ClaimableBalancesChangeProcessor) Commit(ctx context.Context) error {
+	defer p.reset()
 	var (
-		cbsToInsert   []history.ClaimableBalance
 		cbIDsToDelete []string
 	)
 	changes := p.cache.GetChanges()
 	for _, change := range changes {
-		if change.Post != nil {
+		switch {
+		case change.Pre == nil && change.Post != nil:
 			// Created
-			row, err := p.ledgerEntryToRow(change.Post)
+			cb, err := p.ledgerEntryToRow(change.Post)
 			if err != nil {
 				return err
 			}
-			cbsToInsert = append(cbsToInsert, row)
-		} else {
+			// Add claimable balance
+			if err := p.claimableBalanceInsertBuilder.Add(cb); err != nil {
+				return errors.Wrap(err, "error adding to ClaimableBalanceBatchInsertBuilder")
+			}
+
+			// Add claimants
+			for _, claimant := range cb.Claimants {
+				claimant := history.ClaimableBalanceClaimant{
+					BalanceID:          cb.BalanceID,
+					Destination:        claimant.Destination,
+					LastModifiedLedger: cb.LastModifiedLedger,
+				}
+
+				if err := p.claimantsInsertBuilder.Add(claimant); err != nil {
+					return errors.Wrap(err, "error adding to ClaimableBalanceClaimantBatchInsertBuilder")
+				}
+			}
+		case change.Pre != nil && change.Post == nil:
 			// Removed
 			cBalance := change.Pre.Data.MustClaimableBalance()
 			id, err := p.encodingBuffer.MarshalHex(cBalance.BalanceId)
@@ -78,13 +95,20 @@ func (p *ClaimableBalancesChangeProcessor) Commit(ctx context.Context) error {
 				return err
 			}
 			cbIDsToDelete = append(cbIDsToDelete, id)
+		default:
+			// claimable balance can only be created or removed
+			return fmt.Errorf("invalid change entry for a claimable balance was detected")
 		}
 	}
 
-	if len(cbsToInsert) > 0 {
-		if err := p.insertClaimableBalancesAndClaimants(ctx, cbsToInsert); err != nil {
-			return errors.Wrap(err, "error inserting claimable balance")
-		}
+	err := p.claimantsInsertBuilder.Exec(ctx)
+	if err != nil {
+		return errors.Wrap(err, "error executing ClaimableBalanceClaimantBatchInsertBuilder")
+	}
+
+	err = p.claimableBalanceInsertBuilder.Exec(ctx)
+	if err != nil {
+		return errors.Wrap(err, "error executing ClaimableBalanceBatchInsertBuilder")
 	}
 
 	if len(cbIDsToDelete) > 0 {
@@ -107,42 +131,6 @@ func (p *ClaimableBalancesChangeProcessor) Commit(ctx context.Context) error {
 		}
 	}
 
-	return nil
-}
-
-func (p *ClaimableBalancesChangeProcessor) insertClaimableBalancesAndClaimants(ctx context.Context,
-	claimableBalances []history.ClaimableBalance) error {
-
-	for _, cb := range claimableBalances {
-
-		// Add claimable balance
-		if err := p.claimableBalanceInsertBuilder.Add(cb); err != nil {
-			return errors.Wrap(err, "error adding to ClaimableBalanceBatchInsertBuilder")
-		}
-
-		// Add claimants
-		for _, claimant := range cb.Claimants {
-			claimant := history.ClaimableBalanceClaimant{
-				BalanceID:          cb.BalanceID,
-				Destination:        claimant.Destination,
-				LastModifiedLedger: cb.LastModifiedLedger,
-			}
-
-			if err := p.claimantsInsertBuilder.Add(claimant); err != nil {
-				return errors.Wrap(err, "error adding to ClaimableBalanceClaimantBatchInsertBuilder")
-			}
-		}
-	}
-
-	err := p.claimantsInsertBuilder.Exec(ctx)
-	if err != nil {
-		return errors.Wrap(err, "error executing ClaimableBalanceClaimantBatchInsertBuilder")
-	}
-
-	err = p.claimableBalanceInsertBuilder.Exec(ctx)
-	if err != nil {
-		return errors.Wrap(err, "error executing ClaimableBalanceBatchInsertBuilder")
-	}
 	return nil
 }
 

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
@@ -31,8 +31,8 @@ func NewClaimableBalancesChangeProcessor(Q history.QClaimableBalances, session d
 
 func (p *ClaimableBalancesChangeProcessor) reset() {
 	p.cache = ingest.NewChangeCompactor()
-	p.claimantsInsertBuilder = p.qClaimableBalances.NewClaimableBalanceClaimantBatchInsertBuilder()
-	p.claimableBalanceInsertBuilder = p.qClaimableBalances.NewClaimableBalanceBatchInsertBuilder()
+	p.claimantsInsertBuilder = p.qClaimableBalances.NewClaimableBalanceClaimantBatchInsertBuilder(p.session)
+	p.claimableBalanceInsertBuilder = p.qClaimableBalances.NewClaimableBalanceBatchInsertBuilder(p.session)
 }
 
 func (p *ClaimableBalancesChangeProcessor) ProcessChange(ctx context.Context, change ingest.Change) error {
@@ -112,8 +112,6 @@ func (p *ClaimableBalancesChangeProcessor) Commit(ctx context.Context) error {
 
 func (p *ClaimableBalancesChangeProcessor) insertClaimableBalancesAndClaimants(ctx context.Context,
 	claimableBalances []history.ClaimableBalance) error {
-	defer p.claimantsInsertBuilder.Reset()
-	defer p.claimableBalanceInsertBuilder.Reset()
 
 	for _, cb := range claimableBalances {
 
@@ -136,12 +134,12 @@ func (p *ClaimableBalancesChangeProcessor) insertClaimableBalancesAndClaimants(c
 		}
 	}
 
-	err := p.claimantsInsertBuilder.Exec(ctx, p.session)
+	err := p.claimantsInsertBuilder.Exec(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error executing ClaimableBalanceClaimantBatchInsertBuilder")
 	}
 
-	err = p.claimableBalanceInsertBuilder.Exec(ctx, p.session)
+	err = p.claimableBalanceInsertBuilder.Exec(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error executing ClaimableBalanceBatchInsertBuilder")
 	}

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor.go
@@ -32,8 +32,8 @@ func NewClaimableBalancesChangeProcessor(Q history.QClaimableBalances, session d
 
 func (p *ClaimableBalancesChangeProcessor) reset() {
 	p.cache = ingest.NewChangeCompactor()
-	p.claimantsInsertBuilder = p.qClaimableBalances.NewClaimableBalanceClaimantBatchInsertBuilder(p.session)
-	p.claimableBalanceInsertBuilder = p.qClaimableBalances.NewClaimableBalanceBatchInsertBuilder(p.session)
+	p.claimantsInsertBuilder = p.qClaimableBalances.NewClaimableBalanceClaimantBatchInsertBuilder()
+	p.claimableBalanceInsertBuilder = p.qClaimableBalances.NewClaimableBalanceBatchInsertBuilder()
 }
 
 func (p *ClaimableBalancesChangeProcessor) ProcessChange(ctx context.Context, change ingest.Change) error {

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/xdr"
 )
 
@@ -20,21 +21,32 @@ func TestClaimableBalancesChangeProcessorTestSuiteState(t *testing.T) {
 
 type ClaimableBalancesChangeProcessorTestSuiteState struct {
 	suite.Suite
-	ctx                    context.Context
-	processor              *ClaimableBalancesChangeProcessor
-	mockQ                  *history.MockQClaimableBalances
-	mockBatchInsertBuilder *history.MockClaimableBalanceClaimantBatchInsertBuilder
+	ctx                                    context.Context
+	processor                              *ClaimableBalancesChangeProcessor
+	mockQ                                  *history.MockQClaimableBalances
+	mockClaimantsBatchInsertBuilder        *history.MockClaimableBalanceClaimantBatchInsertBuilder
+	mockClaimableBalanceBatchInsertBuilder *history.MockClaimableBalanceBatchInsertBuilder
+	session                                db.SessionInterface
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteState) SetupTest() {
 	s.ctx = context.Background()
-	s.mockBatchInsertBuilder = &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
-	s.mockQ = &history.MockQClaimableBalances{}
-	s.mockQ.
-		On("NewClaimableBalanceClaimantBatchInsertBuilder", maxBatchSize).
-		Return(s.mockBatchInsertBuilder).Once()
+	s.mockClaimantsBatchInsertBuilder = &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	s.mockClaimableBalanceBatchInsertBuilder = &history.MockClaimableBalanceBatchInsertBuilder{}
 
-	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ)
+	s.mockQ = &history.MockQClaimableBalances{}
+	s.session = &db.MockSession{}
+	s.mockQ.
+		On("NewClaimableBalanceClaimantBatchInsertBuilder").
+		Return(s.mockClaimantsBatchInsertBuilder).Once()
+	s.mockQ.
+		On("NewClaimableBalanceBatchInsertBuilder").
+		Return(s.mockClaimableBalanceBatchInsertBuilder).Once()
+
+	s.mockClaimantsBatchInsertBuilder.On("Reset").Return(nil).Once()
+	s.mockClaimableBalanceBatchInsertBuilder.On("Reset").Return(nil).Once()
+
+	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ, s.session)
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteState) TearDownTest() {
@@ -67,27 +79,27 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteState) TestCreatesClaimableBal
 	}
 	id, err := xdr.MarshalHex(balanceID)
 	s.Assert().NoError(err)
-	s.mockQ.On("UpsertClaimableBalances", s.ctx, []history.ClaimableBalance{
-		{
-			BalanceID: id,
-			Claimants: []history.Claimant{
-				{
-					Destination: "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-				},
+	s.mockClaimableBalanceBatchInsertBuilder.On("Add", history.ClaimableBalance{
+		BalanceID: id,
+		Claimants: []history.Claimant{
+			{
+				Destination: "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 			},
-			Asset:              cBalance.Asset,
-			Amount:             cBalance.Amount,
-			LastModifiedLedger: uint32(lastModifiedLedgerSeq),
 		},
+		Asset:              cBalance.Asset,
+		Amount:             cBalance.Amount,
+		LastModifiedLedger: uint32(lastModifiedLedgerSeq),
 	}).Return(nil).Once()
 
-	s.mockBatchInsertBuilder.On("Add", s.ctx, history.ClaimableBalanceClaimant{
+	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
+
+	s.mockClaimantsBatchInsertBuilder.On("Add", history.ClaimableBalanceClaimant{
 		BalanceID:          id,
 		Destination:        "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 		LastModifiedLedger: uint32(lastModifiedLedgerSeq),
 	}).Return(nil).Once()
 
-	s.mockBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
+	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
 
 	err = s.processor.ProcessChange(s.ctx, ingest.Change{
 		Type: xdr.LedgerEntryTypeClaimableBalance,
@@ -109,25 +121,39 @@ func TestClaimableBalancesChangeProcessorTestSuiteLedger(t *testing.T) {
 
 type ClaimableBalancesChangeProcessorTestSuiteLedger struct {
 	suite.Suite
-	ctx                    context.Context
-	processor              *ClaimableBalancesChangeProcessor
-	mockQ                  *history.MockQClaimableBalances
-	mockBatchInsertBuilder *history.MockClaimableBalanceClaimantBatchInsertBuilder
+	ctx                                    context.Context
+	processor                              *ClaimableBalancesChangeProcessor
+	mockQ                                  *history.MockQClaimableBalances
+	mockClaimantsBatchInsertBuilder        *history.MockClaimableBalanceClaimantBatchInsertBuilder
+	mockClaimableBalanceBatchInsertBuilder *history.MockClaimableBalanceBatchInsertBuilder
+	session                                db.SessionInterface
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) SetupTest() {
 	s.ctx = context.Background()
-	s.mockBatchInsertBuilder = &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	s.mockClaimantsBatchInsertBuilder = &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
+	s.mockClaimableBalanceBatchInsertBuilder = &history.MockClaimableBalanceBatchInsertBuilder{}
 	s.mockQ = &history.MockQClaimableBalances{}
+	s.session = &db.MockSession{}
 	s.mockQ.
-		On("NewClaimableBalanceClaimantBatchInsertBuilder", maxBatchSize).
-		Return(s.mockBatchInsertBuilder).Once()
+		On("NewClaimableBalanceClaimantBatchInsertBuilder").
+		Return(s.mockClaimantsBatchInsertBuilder).Twice()
+	s.mockQ.
+		On("NewClaimableBalanceBatchInsertBuilder").
+		Return(s.mockClaimableBalanceBatchInsertBuilder).Twice()
 
-	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ)
+	s.mockClaimantsBatchInsertBuilder.On("Reset").Return(nil).Once()
+	s.mockClaimableBalanceBatchInsertBuilder.On("Reset").Return(nil).Once()
+
+	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
+	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
+
+	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ, s.session)
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TearDownTest() {
 	s.Assert().NoError(s.processor.Commit(s.ctx))
+	s.processor.reset()
 	s.mockQ.AssertExpectations(s.T())
 }
 
@@ -160,9 +186,23 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TestNewClaimableBalanc
 			},
 		},
 	}
-	s.mockBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
 
-	err := s.processor.ProcessChange(s.ctx, ingest.Change{
+	id, err := xdr.MarshalHex(balanceID)
+	s.Assert().NoError(err)
+
+	// We use LedgerEntryChangesCache so all changes are squashed
+	s.mockClaimableBalanceBatchInsertBuilder.On(
+		"Add",
+		history.ClaimableBalance{
+			BalanceID:          id,
+			Claimants:          []history.Claimant{},
+			Asset:              cBalance.Asset,
+			Amount:             cBalance.Amount,
+			LastModifiedLedger: uint32(lastModifiedLedgerSeq),
+		},
+	).Return(nil).Once()
+
+	err = s.processor.ProcessChange(s.ctx, ingest.Change{
 		Type: xdr.LedgerEntryTypeClaimableBalance,
 		Pre:  nil,
 		Post: &entry,
@@ -192,89 +232,16 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TestNewClaimableBalanc
 	})
 	s.Assert().NoError(err)
 
-	id, err := xdr.MarshalHex(balanceID)
-	s.Assert().NoError(err)
 	// We use LedgerEntryChangesCache so all changes are squashed
-	s.mockQ.On(
-		"UpsertClaimableBalances",
-		s.ctx,
-		[]history.ClaimableBalance{
-			{
-				BalanceID:          id,
-				Claimants:          []history.Claimant{},
-				Asset:              cBalance.Asset,
-				Amount:             cBalance.Amount,
-				LastModifiedLedger: uint32(lastModifiedLedgerSeq),
-				Sponsor:            null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-			},
-		},
-	).Return(nil).Once()
-}
-
-func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TestUpdateClaimableBalance() {
-	balanceID := xdr.ClaimableBalanceId{
-		Type: xdr.ClaimableBalanceIdTypeClaimableBalanceIdTypeV0,
-		V0:   &xdr.Hash{1, 2, 3},
-	}
-	cBalance := xdr.ClaimableBalanceEntry{
-		BalanceId: balanceID,
-		Claimants: []xdr.Claimant{},
-		Asset:     xdr.MustNewCreditAsset("USD", "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-		Amount:    10,
-	}
-	lastModifiedLedgerSeq := xdr.Uint32(123)
-
-	pre := xdr.LedgerEntry{
-		Data: xdr.LedgerEntryData{
-			Type:             xdr.LedgerEntryTypeClaimableBalance,
-			ClaimableBalance: &cBalance,
-		},
-		LastModifiedLedgerSeq: lastModifiedLedgerSeq - 1,
-		Ext: xdr.LedgerEntryExt{
-			V: 1,
-			V1: &xdr.LedgerEntryExtensionV1{
-				SponsoringId: nil,
-			},
-		},
-	}
-
-	// add sponsor
-	updated := xdr.LedgerEntry{
-		Data: xdr.LedgerEntryData{
-			Type:             xdr.LedgerEntryTypeClaimableBalance,
-			ClaimableBalance: &cBalance,
-		},
-		LastModifiedLedgerSeq: lastModifiedLedgerSeq,
-		Ext: xdr.LedgerEntryExt{
-			V: 1,
-			V1: &xdr.LedgerEntryExtensionV1{
-				SponsoringId: xdr.MustAddressPtr("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-			},
-		},
-	}
-	s.mockBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
-
-	err := s.processor.ProcessChange(s.ctx, ingest.Change{
-		Type: xdr.LedgerEntryTypeClaimableBalance,
-		Pre:  &pre,
-		Post: &updated,
-	})
-	s.Assert().NoError(err)
-
-	id, err := xdr.MarshalHex(balanceID)
-	s.Assert().NoError(err)
-	s.mockQ.On(
-		"UpsertClaimableBalances",
-		s.ctx,
-		[]history.ClaimableBalance{
-			{
-				BalanceID:          id,
-				Claimants:          []history.Claimant{},
-				Asset:              cBalance.Asset,
-				Amount:             cBalance.Amount,
-				LastModifiedLedger: uint32(lastModifiedLedgerSeq),
-				Sponsor:            null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-			},
+	s.mockClaimableBalanceBatchInsertBuilder.On(
+		"Add",
+		history.ClaimableBalance{
+			BalanceID:          id,
+			Claimants:          []history.Claimant{},
+			Asset:              cBalance.Asset,
+			Amount:             cBalance.Amount,
+			LastModifiedLedger: uint32(lastModifiedLedgerSeq),
+			Sponsor:            null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 		},
 	).Return(nil).Once()
 }

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/suite"
 )
@@ -26,7 +25,6 @@ type ClaimableBalancesChangeProcessorTestSuiteState struct {
 	mockQ                                  *history.MockQClaimableBalances
 	mockClaimantsBatchInsertBuilder        *history.MockClaimableBalanceClaimantBatchInsertBuilder
 	mockClaimableBalanceBatchInsertBuilder *history.MockClaimableBalanceBatchInsertBuilder
-	session                                db.SessionInterface
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteState) SetupTest() {
@@ -125,7 +123,6 @@ type ClaimableBalancesChangeProcessorTestSuiteLedger struct {
 	mockQ                                  *history.MockQClaimableBalances
 	mockClaimantsBatchInsertBuilder        *history.MockClaimableBalanceClaimantBatchInsertBuilder
 	mockClaimableBalanceBatchInsertBuilder *history.MockClaimableBalanceBatchInsertBuilder
-	session                                db.SessionInterface
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) SetupTest() {

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/suite"
 )
 
 func TestClaimableBalancesChangeProcessorTestSuiteState(t *testing.T) {

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
@@ -37,15 +37,11 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteState) SetupTest() {
 	s.mockQ = &history.MockQClaimableBalances{}
 	s.session = &db.MockSession{}
 	s.mockQ.
-		On("NewClaimableBalanceClaimantBatchInsertBuilder").
+		On("NewClaimableBalanceClaimantBatchInsertBuilder", s.session).
 		Return(s.mockClaimantsBatchInsertBuilder).Once()
 	s.mockQ.
-		On("NewClaimableBalanceBatchInsertBuilder").
+		On("NewClaimableBalanceBatchInsertBuilder", s.session).
 		Return(s.mockClaimableBalanceBatchInsertBuilder).Once()
-
-	s.mockClaimantsBatchInsertBuilder.On("Reset").Return(nil).Once()
-	s.mockClaimableBalanceBatchInsertBuilder.On("Reset").Return(nil).Once()
-
 	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ, s.session)
 }
 
@@ -91,7 +87,7 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteState) TestCreatesClaimableBal
 		LastModifiedLedger: uint32(lastModifiedLedgerSeq),
 	}).Return(nil).Once()
 
-	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
+	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
 
 	s.mockClaimantsBatchInsertBuilder.On("Add", history.ClaimableBalanceClaimant{
 		BalanceID:          id,
@@ -99,7 +95,7 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteState) TestCreatesClaimableBal
 		LastModifiedLedger: uint32(lastModifiedLedgerSeq),
 	}).Return(nil).Once()
 
-	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
+	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
 
 	err = s.processor.ProcessChange(s.ctx, ingest.Change{
 		Type: xdr.LedgerEntryTypeClaimableBalance,
@@ -136,17 +132,14 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) SetupTest() {
 	s.mockQ = &history.MockQClaimableBalances{}
 	s.session = &db.MockSession{}
 	s.mockQ.
-		On("NewClaimableBalanceClaimantBatchInsertBuilder").
+		On("NewClaimableBalanceClaimantBatchInsertBuilder", &db.MockSession{}).
 		Return(s.mockClaimantsBatchInsertBuilder).Twice()
 	s.mockQ.
-		On("NewClaimableBalanceBatchInsertBuilder").
+		On("NewClaimableBalanceBatchInsertBuilder", &db.MockSession{}).
 		Return(s.mockClaimableBalanceBatchInsertBuilder).Twice()
 
-	s.mockClaimantsBatchInsertBuilder.On("Reset").Return(nil).Once()
-	s.mockClaimableBalanceBatchInsertBuilder.On("Reset").Return(nil).Once()
-
-	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
-	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx, s.session).Return(nil).Once()
+	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
+	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
 
 	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ, s.session)
 }

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
@@ -35,12 +35,11 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteState) SetupTest() {
 	s.mockClaimableBalanceBatchInsertBuilder = &history.MockClaimableBalanceBatchInsertBuilder{}
 
 	s.mockQ = &history.MockQClaimableBalances{}
-	s.session = &db.MockSession{}
 	s.mockQ.
-		On("NewClaimableBalanceClaimantBatchInsertBuilder", s.session).
+		On("NewClaimableBalanceClaimantBatchInsertBuilder").
 		Return(s.mockClaimantsBatchInsertBuilder)
 	s.mockQ.
-		On("NewClaimableBalanceBatchInsertBuilder", s.session).
+		On("NewClaimableBalanceBatchInsertBuilder").
 		Return(s.mockClaimableBalanceBatchInsertBuilder)
 
 	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx).Return(nil)
@@ -134,12 +133,11 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) SetupTest() {
 	s.mockClaimantsBatchInsertBuilder = &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
 	s.mockClaimableBalanceBatchInsertBuilder = &history.MockClaimableBalanceBatchInsertBuilder{}
 	s.mockQ = &history.MockQClaimableBalances{}
-	s.session = &db.MockSession{}
 	s.mockQ.
-		On("NewClaimableBalanceClaimantBatchInsertBuilder", &db.MockSession{}).
+		On("NewClaimableBalanceClaimantBatchInsertBuilder").
 		Return(s.mockClaimantsBatchInsertBuilder)
 	s.mockQ.
-		On("NewClaimableBalanceBatchInsertBuilder", &db.MockSession{}).
+		On("NewClaimableBalanceBatchInsertBuilder").
 		Return(s.mockClaimableBalanceBatchInsertBuilder)
 
 	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx).Return(nil)

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
@@ -45,7 +45,7 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteState) SetupTest() {
 	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx).Return(nil)
 	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx).Return(nil)
 
-	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ, s.session)
+	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ)
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteState) TearDownTest() {
@@ -143,7 +143,7 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) SetupTest() {
 	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx).Return(nil)
 	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx).Return(nil)
 
-	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ, s.session)
+	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ)
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TearDownTest() {

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
@@ -38,10 +38,14 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteState) SetupTest() {
 	s.session = &db.MockSession{}
 	s.mockQ.
 		On("NewClaimableBalanceClaimantBatchInsertBuilder", s.session).
-		Return(s.mockClaimantsBatchInsertBuilder).Once()
+		Return(s.mockClaimantsBatchInsertBuilder)
 	s.mockQ.
 		On("NewClaimableBalanceBatchInsertBuilder", s.session).
-		Return(s.mockClaimableBalanceBatchInsertBuilder).Once()
+		Return(s.mockClaimableBalanceBatchInsertBuilder)
+
+	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx).Return(nil)
+	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx).Return(nil)
+
 	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ, s.session)
 }
 
@@ -133,13 +137,13 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) SetupTest() {
 	s.session = &db.MockSession{}
 	s.mockQ.
 		On("NewClaimableBalanceClaimantBatchInsertBuilder", &db.MockSession{}).
-		Return(s.mockClaimantsBatchInsertBuilder).Twice()
+		Return(s.mockClaimantsBatchInsertBuilder)
 	s.mockQ.
 		On("NewClaimableBalanceBatchInsertBuilder", &db.MockSession{}).
-		Return(s.mockClaimableBalanceBatchInsertBuilder).Twice()
+		Return(s.mockClaimableBalanceBatchInsertBuilder)
 
-	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
-	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
+	s.mockClaimantsBatchInsertBuilder.On("Exec", s.ctx).Return(nil)
+	s.mockClaimableBalanceBatchInsertBuilder.On("Exec", s.ctx).Return(nil)
 
 	s.processor = NewClaimableBalancesChangeProcessor(s.mockQ, s.session)
 }

--- a/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_change_processor_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/guregu/null"
-	"github.com/stretchr/testify/suite"
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -183,7 +182,7 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TestNewClaimableBalanc
 		Ext: xdr.LedgerEntryExt{
 			V: 1,
 			V1: &xdr.LedgerEntryExtensionV1{
-				SponsoringId: nil,
+				SponsoringId: xdr.MustAddressPtr("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 			},
 		},
 	}
@@ -200,6 +199,7 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TestNewClaimableBalanc
 			Asset:              cBalance.Asset,
 			Amount:             cBalance.Amount,
 			LastModifiedLedger: uint32(lastModifiedLedgerSeq),
+			Sponsor:            null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
 		},
 	).Return(nil).Once()
 
@@ -209,42 +209,6 @@ func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TestNewClaimableBalanc
 		Post: &entry,
 	})
 	s.Assert().NoError(err)
-
-	// add sponsor
-	updated := xdr.LedgerEntry{
-		Data: xdr.LedgerEntryData{
-			Type:             xdr.LedgerEntryTypeClaimableBalance,
-			ClaimableBalance: &cBalance,
-		},
-		LastModifiedLedgerSeq: lastModifiedLedgerSeq,
-		Ext: xdr.LedgerEntryExt{
-			V: 1,
-			V1: &xdr.LedgerEntryExtensionV1{
-				SponsoringId: xdr.MustAddressPtr("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-			},
-		},
-	}
-
-	entry.LastModifiedLedgerSeq = entry.LastModifiedLedgerSeq - 1
-	err = s.processor.ProcessChange(s.ctx, ingest.Change{
-		Type: xdr.LedgerEntryTypeClaimableBalance,
-		Pre:  &entry,
-		Post: &updated,
-	})
-	s.Assert().NoError(err)
-
-	// We use LedgerEntryChangesCache so all changes are squashed
-	s.mockClaimableBalanceBatchInsertBuilder.On(
-		"Add",
-		history.ClaimableBalance{
-			BalanceID:          id,
-			Claimants:          []history.Claimant{},
-			Asset:              cBalance.Asset,
-			Amount:             cBalance.Amount,
-			LastModifiedLedger: uint32(lastModifiedLedgerSeq),
-			Sponsor:            null.StringFrom("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-		},
-	).Return(nil).Once()
 }
 
 func (s *ClaimableBalancesChangeProcessorTestSuiteLedger) TestRemoveClaimableBalance() {

--- a/services/horizon/internal/ingest/verify_test.go
+++ b/services/horizon/internal/ingest/verify_test.go
@@ -271,10 +271,10 @@ func TestStateVerifierLockBusy(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
-	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
+	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 
 	checkpointLedger := uint32(63)
-	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
+	changeProcessor := buildChangeProcessor(q, q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
 
 	gen := randxdr.NewGenerator()
 	var changes []xdr.LedgerEntryChange
@@ -293,7 +293,7 @@ func TestStateVerifierLockBusy(t *testing.T) {
 	}
 	tt.Assert.NoError(changeProcessor.Commit(tt.Ctx))
 
-	tt.Assert.NoError(q.SessionInterface.Commit())
+	tt.Assert.NoError(q.Commit())
 
 	q.UpdateLastLedgerIngest(tt.Ctx, checkpointLedger)
 
@@ -328,10 +328,10 @@ func TestStateVerifier(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
-	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
+	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 
 	checkpointLedger := uint32(63)
-	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
+	changeProcessor := buildChangeProcessor(q, q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
 	mockChangeReader := &ingest.MockChangeReader{}
 
 	gen := randxdr.NewGenerator()
@@ -360,7 +360,7 @@ func TestStateVerifier(t *testing.T) {
 	tt.Assert.NoError(changeProcessor.Commit(tt.Ctx))
 	tt.Assert.Equal(len(xdr.LedgerEntryTypeMap), len(coverage))
 
-	tt.Assert.NoError(q.SessionInterface.Commit())
+	tt.Assert.NoError(q.Commit())
 
 	q.UpdateLastLedgerIngest(tt.Ctx, checkpointLedger)
 

--- a/services/horizon/internal/ingest/verify_test.go
+++ b/services/horizon/internal/ingest/verify_test.go
@@ -271,6 +271,9 @@ func TestStateVerifierLockBusy(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
+
 	checkpointLedger := uint32(63)
 	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
 
@@ -324,8 +327,15 @@ func TestStateVerifier(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
+	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
+	defer q.SessionInterface.Rollback()
+
 	checkpointLedger := uint32(63)
+<<<<<<< HEAD
 	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
+=======
+	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
+>>>>>>> 8f1836b1 (Use FastBatchInsertBuilder to insert to insert into claimable_balances and claimable_balance_claimants tables)
 	mockChangeReader := &ingest.MockChangeReader{}
 
 	gen := randxdr.NewGenerator()
@@ -353,6 +363,8 @@ func TestStateVerifier(t *testing.T) {
 	}
 	tt.Assert.NoError(changeProcessor.Commit(tt.Ctx))
 	tt.Assert.Equal(len(xdr.LedgerEntryTypeMap), len(coverage))
+
+	q.SessionInterface.Commit()
 
 	q.UpdateLastLedgerIngest(tt.Ctx, checkpointLedger)
 

--- a/services/horizon/internal/ingest/verify_test.go
+++ b/services/horizon/internal/ingest/verify_test.go
@@ -271,13 +271,13 @@ func TestStateVerifierLockBusy(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
-	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
 		_ = q.SessionInterface.Rollback()
 	}()
 
 	checkpointLedger := uint32(63)
-	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
+	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
 
 	gen := randxdr.NewGenerator()
 	var changes []xdr.LedgerEntryChange
@@ -295,6 +295,8 @@ func TestStateVerifierLockBusy(t *testing.T) {
 		tt.Assert.NoError(changeProcessor.ProcessChange(tt.Ctx, change))
 	}
 	tt.Assert.NoError(changeProcessor.Commit(tt.Ctx))
+
+	tt.Assert.NoError(q.SessionInterface.Commit())
 
 	q.UpdateLastLedgerIngest(tt.Ctx, checkpointLedger)
 
@@ -329,7 +331,7 @@ func TestStateVerifier(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
-	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	defer func() {
 		_ = q.SessionInterface.Rollback()
 	}()

--- a/services/horizon/internal/ingest/verify_test.go
+++ b/services/horizon/internal/ingest/verify_test.go
@@ -272,9 +272,6 @@ func TestStateVerifierLockBusy(t *testing.T) {
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
 	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
-	defer func() {
-		_ = q.SessionInterface.Rollback()
-	}()
 
 	checkpointLedger := uint32(63)
 	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
@@ -332,9 +329,6 @@ func TestStateVerifier(t *testing.T) {
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
 	tt.Assert.NoError(q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{}))
-	defer func() {
-		_ = q.SessionInterface.Rollback()
-	}()
 
 	checkpointLedger := uint32(63)
 	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")

--- a/services/horizon/internal/ingest/verify_test.go
+++ b/services/horizon/internal/ingest/verify_test.go
@@ -271,8 +271,10 @@ func TestStateVerifierLockBusy(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
-	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
-	defer q.SessionInterface.Rollback()
+	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	checkpointLedger := uint32(63)
 	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
@@ -327,15 +329,13 @@ func TestStateVerifier(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{&db.Session{DB: tt.HorizonDB}}
 
-	q.SessionInterface.BeginTx(tt.Ctx, &sql.TxOptions{})
-	defer q.SessionInterface.Rollback()
+	tt.Assert.NoError(q.SessionInterface.BeginTx(&sql.TxOptions{}))
+	defer func() {
+		_ = q.SessionInterface.Rollback()
+	}()
 
 	checkpointLedger := uint32(63)
-<<<<<<< HEAD
-	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
-=======
 	changeProcessor := buildChangeProcessor(q, q.SessionInterface, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
->>>>>>> 8f1836b1 (Use FastBatchInsertBuilder to insert to insert into claimable_balances and claimable_balance_claimants tables)
 	mockChangeReader := &ingest.MockChangeReader{}
 
 	gen := randxdr.NewGenerator()

--- a/services/horizon/internal/ingest/verify_test.go
+++ b/services/horizon/internal/ingest/verify_test.go
@@ -366,7 +366,7 @@ func TestStateVerifier(t *testing.T) {
 	tt.Assert.NoError(changeProcessor.Commit(tt.Ctx))
 	tt.Assert.Equal(len(xdr.LedgerEntryTypeMap), len(coverage))
 
-	q.SessionInterface.Commit()
+	tt.Assert.NoError(q.SessionInterface.Commit())
 
 	q.UpdateLastLedgerIngest(tt.Ctx, checkpointLedger)
 

--- a/services/horizon/internal/ingest/verify_test.go
+++ b/services/horizon/internal/ingest/verify_test.go
@@ -274,7 +274,7 @@ func TestStateVerifierLockBusy(t *testing.T) {
 	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 
 	checkpointLedger := uint32(63)
-	changeProcessor := buildChangeProcessor(q, q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
+	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
 
 	gen := randxdr.NewGenerator()
 	var changes []xdr.LedgerEntryChange
@@ -331,7 +331,7 @@ func TestStateVerifier(t *testing.T) {
 	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 
 	checkpointLedger := uint32(63)
-	changeProcessor := buildChangeProcessor(q, q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
+	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
 	mockChangeReader := &ingest.MockChangeReader{}
 
 	gen := randxdr.NewGenerator()


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Use [FastBatchInsertBuilder](https://github.com/stellar/go/blob/9ce82de12cbade47de862ad5e9d0684029558564/support/db/fast_batch_insert_builder.go) for writing to claimable_balances and claimable_balance_claimants tables. FastBatchInsertBuilder uses ‘COPY' to insert into the db which is faster than using 'INSERT'.

### Why
https://github.com/stellar/go/issues/5086

### Known limitations
N/A
