### PR TITLE
Update SignersProcessor to use FastBatchInsertBuilder

### DIFF
--- a/services/horizon/internal/db2/history/account_signers.go
+++ b/services/horizon/internal/db2/history/account_signers.go
@@ -53,6 +53,9 @@ func (q *Q) AccountsForSigner(ctx context.Context, signer string, page db2.PageQ
 // CreateAccountSigner creates a row in the accounts_signers table.
 // Returns number of rows affected and error.
 func (q *Q) CreateAccountSigner(ctx context.Context, account, signer string, weight int32, sponsor *string) (int64, error) {
+	// This function is not used in the ingestion code path. SignersProcessor now uses bulk insertion with
+	// FastBatchInsertBuilder, but this function is used in unit tests when only a single row needs to be inserted.
+
 	sql := sq.Insert("accounts_signers").
 		Columns("account_id", "signer", "weight", "sponsor").
 		Values(account, signer, weight, sponsor)

--- a/services/horizon/internal/db2/history/account_signers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/account_signers_batch_insert_builder.go
@@ -4,8 +4,8 @@ import (
 	"context"
 )
 
-func (i *accountSignersBatchInsertBuilder) Add(ctx context.Context, signer AccountSigner) error {
-	return i.builder.Row(ctx, map[string]interface{}{
+func (i *accountSignersBatchInsertBuilder) Add(signer AccountSigner) error {
+	return i.builder.Row(map[string]interface{}{
 		"account_id": signer.Account,
 		"signer":     signer.Signer,
 		"weight":     signer.Weight,
@@ -14,5 +14,5 @@ func (i *accountSignersBatchInsertBuilder) Add(ctx context.Context, signer Accou
 }
 
 func (i *accountSignersBatchInsertBuilder) Exec(ctx context.Context) error {
-	return i.builder.Exec(ctx)
+	return i.builder.Exec(ctx, i.session, i.table)
 }

--- a/services/horizon/internal/db2/history/mock_account_signers_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_account_signers_batch_insert_builder.go
@@ -9,8 +9,8 @@ type MockAccountSignersBatchInsertBuilder struct {
 	mock.Mock
 }
 
-func (m *MockAccountSignersBatchInsertBuilder) Add(ctx context.Context, signer AccountSigner) error {
-	a := m.Called(ctx, signer)
+func (m *MockAccountSignersBatchInsertBuilder) Add(signer AccountSigner) error {
+	a := m.Called(signer)
 	return a.Error(0)
 }
 

--- a/services/horizon/internal/db2/history/mock_q_signers.go
+++ b/services/horizon/internal/db2/history/mock_q_signers.go
@@ -32,8 +32,8 @@ func (m *MockQSigners) AccountsForSigner(ctx context.Context, signer string, pag
 	return a.Get(0).([]AccountSigner), a.Error(1)
 }
 
-func (m *MockQSigners) NewAccountSignersBatchInsertBuilder(maxBatchSize int) AccountSignersBatchInsertBuilder {
-	a := m.Called(maxBatchSize)
+func (m *MockQSigners) NewAccountSignersBatchInsertBuilder() AccountSignersBatchInsertBuilder {
+	a := m.Called()
 	return a.Get(0).(AccountSignersBatchInsertBuilder)
 }
 

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -22,7 +22,6 @@ import (
 
 func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 	ctx := context.Background()
-	maxBatchSize := 100000
 
 	mockSession := &db.MockSession{}
 
@@ -41,15 +40,15 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 
 	mockAccountSignersBatchInsertBuilder := &history.MockAccountSignersBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockAccountSignersBatchInsertBuilder)
-	mockAccountSignersBatchInsertBuilder.On("Add", ctx, history.AccountSigner{
+	mockAccountSignersBatchInsertBuilder.On("Add", history.AccountSigner{
 		Account: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
 		Signer:  "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
 		Weight:  1,
 		Sponsor: null.String{},
 	}).Return(nil).Once()
 	mockAccountSignersBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
-	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
-		Return(mockAccountSignersBatchInsertBuilder).Once()
+	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder").
+		Return(mockAccountSignersBatchInsertBuilder).Twice()
 
 	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
 	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
@@ -81,7 +80,6 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 
 func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 	ctx := context.Background()
-	maxBatchSize := 100000
 
 	config := Config{
 		NetworkPassphrase: network.PublicNetworkPassphrase,
@@ -120,14 +118,14 @@ func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 
 	mockAccountSignersBatchInsertBuilder := &history.MockAccountSignersBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockAccountSignersBatchInsertBuilder)
-	mockAccountSignersBatchInsertBuilder.On("Add", ctx, history.AccountSigner{
+	mockAccountSignersBatchInsertBuilder.On("Add", history.AccountSigner{
 		Account: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
 		Signer:  "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
 		Weight:  1,
 	}).Return(nil).Once()
 	mockAccountSignersBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
-	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
-		Return(mockAccountSignersBatchInsertBuilder).Once()
+	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder").
+		Return(mockAccountSignersBatchInsertBuilder).Twice()
 
 	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
 	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
@@ -158,7 +156,6 @@ func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 
 func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t *testing.T) {
 	ctx := context.Background()
-	maxBatchSize := 100000
 
 	config := Config{
 		NetworkPassphrase: network.PublicNetworkPassphrase,
@@ -174,7 +171,7 @@ func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t 
 
 	mockAccountSignersBatchInsertBuilder := &history.MockAccountSignersBatchInsertBuilder{}
 	defer mock.AssertExpectationsForObjects(t, mockAccountSignersBatchInsertBuilder)
-	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
+	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder").
 		Return(mockAccountSignersBatchInsertBuilder).Once()
 
 	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
@@ -211,13 +208,12 @@ func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t 
 
 func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 	ctx := context.Background()
-	maxBatchSize := 100000
 
 	q := &mockDBQ{}
 	defer mock.AssertExpectationsForObjects(t, q)
 
 	// Twice = checking ledgerSource and historyArchiveSource
-	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
+	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder").
 		Return(&history.MockAccountSignersBatchInsertBuilder{}).Twice()
 
 	mockClaimableBalanceBatchInsertBuilder := &history.MockClaimableBalanceBatchInsertBuilder{}
@@ -467,8 +463,8 @@ func TestProcessorRunnerRunAllProcessorsOnLedgerProtocolVersionNotSupported(t *t
 		Return(mockTransactionsBatchInsertBuilder).Twice()
 
 	mockAccountSignersBatchInsertBuilder := &history.MockAccountSignersBatchInsertBuilder{}
-	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
-		Return(mockAccountSignersBatchInsertBuilder).Once()
+	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder").
+		Return(mockAccountSignersBatchInsertBuilder).Twice()
 
 	mockOperationsBatchInsertBuilder := &history.MockOperationsBatchInsertBuilder{}
 	q.MockQOperations.On("NewOperationBatchInsertBuilder").
@@ -501,8 +497,9 @@ func mockBatchBuilders(q *mockDBQ, mockSession *db.MockSession, ctx context.Cont
 		Return(mockTransactionsBatchInsertBuilder)
 
 	mockAccountSignersBatchInsertBuilder := &history.MockAccountSignersBatchInsertBuilder{}
-	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
-		Return(mockAccountSignersBatchInsertBuilder).Once()
+	mockAccountSignersBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
+	q.MockQSigners.On("NewAccountSignersBatchInsertBuilder").
+		Return(mockAccountSignersBatchInsertBuilder).Twice()
 
 	mockOperationsBatchInsertBuilder := &history.MockOperationsBatchInsertBuilder{}
 	mockOperationsBatchInsertBuilder.On("Exec", ctx, mockSession).Return(nil).Once()

--- a/services/horizon/internal/ingest/processors/signer_processor_test.go
+++ b/services/horizon/internal/ingest/processors/signer_processor_test.go
@@ -4,13 +4,13 @@ package processors
 
 import (
 	"context"
-	"github.com/stellar/go/support/errors"
 	"testing"
 
 	"github.com/guregu/null"
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/suite"
 )

--- a/services/horizon/internal/ingest/processors/signer_processor_test.go
+++ b/services/horizon/internal/ingest/processors/signer_processor_test.go
@@ -33,8 +33,8 @@ func (s *AccountsSignerProcessorTestSuiteState) SetupTest() {
 	s.mockBatchInsertBuilder = &history.MockAccountSignersBatchInsertBuilder{}
 
 	s.mockQ.
-		On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
-		Return(s.mockBatchInsertBuilder).Once()
+		On("NewAccountSignersBatchInsertBuilder").
+		Return(s.mockBatchInsertBuilder).Twice()
 
 	s.processor = NewSignersProcessor(s.mockQ, false)
 }
@@ -53,7 +53,7 @@ func (s *AccountsSignerProcessorTestSuiteState) TestNoEntries() {
 
 func (s *AccountsSignerProcessorTestSuiteState) TestCreatesSigners() {
 	s.mockBatchInsertBuilder.
-		On("Add", s.ctx, history.AccountSigner{
+		On("Add", history.AccountSigner{
 			Account: "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 			Signer:  "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 			Weight:  int32(1),
@@ -75,7 +75,7 @@ func (s *AccountsSignerProcessorTestSuiteState) TestCreatesSigners() {
 	s.Assert().NoError(err)
 
 	s.mockBatchInsertBuilder.
-		On("Add", s.ctx, history.AccountSigner{
+		On("Add", history.AccountSigner{
 			Account: "GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX",
 			Signer:  "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 			Weight:  int32(10),
@@ -105,7 +105,7 @@ func (s *AccountsSignerProcessorTestSuiteState) TestCreatesSigners() {
 
 func (s *AccountsSignerProcessorTestSuiteState) TestCreatesSignerWithSponsor() {
 	s.mockBatchInsertBuilder.
-		On("Add", s.ctx, history.AccountSigner{
+		On("Add", history.AccountSigner{
 			Account: "GCCCU34WDY2RATQTOOQKY6SZWU6J5DONY42SWGW2CIXGW4LICAGNRZKX",
 			Signer:  "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
 			Weight:  int32(10),
@@ -156,17 +156,20 @@ func TestAccountsSignerProcessorTestSuiteLedger(t *testing.T) {
 
 type AccountsSignerProcessorTestSuiteLedger struct {
 	suite.Suite
-	ctx       context.Context
-	processor *SignersProcessor
-	mockQ     *history.MockQSigners
+	ctx                                  context.Context
+	processor                            *SignersProcessor
+	mockQ                                *history.MockQSigners
+	mockAccountSignersBatchInsertBuilder *history.MockAccountSignersBatchInsertBuilder
 }
 
 func (s *AccountsSignerProcessorTestSuiteLedger) SetupTest() {
 	s.ctx = context.Background()
 	s.mockQ = &history.MockQSigners{}
+	s.mockAccountSignersBatchInsertBuilder = &history.MockAccountSignersBatchInsertBuilder{}
 	s.mockQ.
-		On("NewAccountSignersBatchInsertBuilder", maxBatchSize).
-		Return(&history.MockAccountSignersBatchInsertBuilder{}).Once()
+		On("NewAccountSignersBatchInsertBuilder").
+		Return(s.mockAccountSignersBatchInsertBuilder).Twice()
+	s.mockAccountSignersBatchInsertBuilder.On("Exec", s.ctx).Return(nil)
 
 	s.processor = NewSignersProcessor(s.mockQ, true)
 }

--- a/services/horizon/internal/ingest/processors/signer_processor_test.go
+++ b/services/horizon/internal/ingest/processors/signer_processor_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/suite"
 )
@@ -35,12 +34,12 @@ func (s *AccountsSignerProcessorTestSuiteState) SetupTest() {
 	s.mockQ.
 		On("NewAccountSignersBatchInsertBuilder").
 		Return(s.mockBatchInsertBuilder).Twice()
+	s.mockBatchInsertBuilder.On("Exec", s.ctx).Return(nil)
 
 	s.processor = NewSignersProcessor(s.mockQ, false)
 }
 
 func (s *AccountsSignerProcessorTestSuiteState) TearDownTest() {
-	s.mockBatchInsertBuilder.On("Exec", s.ctx).Return(nil).Once()
 	s.Assert().NoError(s.processor.Commit(s.ctx))
 
 	s.mockQ.AssertExpectations(s.T())
@@ -184,16 +183,17 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNoTransactions() {
 }
 
 func (s *AccountsSignerProcessorTestSuiteLedger) TestNewAccount() {
-	s.mockQ.
+	s.mockAccountSignersBatchInsertBuilder.
 		On(
-			"CreateAccountSigner",
-			s.ctx,
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-			int32(1),
-			(*string)(nil),
+			"Add",
+			history.AccountSigner{
+				"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+				"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+				int32(1),
+				null.String{},
+			},
 		).
-		Return(int64(1), nil).Once()
+		Return(nil).Once()
 
 	err := s.processor.ProcessChange(s.ctx, ingest.Change{
 		Type: xdr.LedgerEntryTypeAccount,
@@ -250,27 +250,28 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestNewSigner() {
 		Return(int64(1), nil).Once()
 
 	// Create new and old signer
-	s.mockQ.
+	s.mockAccountSignersBatchInsertBuilder.
 		On(
-			"CreateAccountSigner",
-			s.ctx,
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-			"GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
-			int32(10),
-			(*string)(nil),
+			"Add",
+			history.AccountSigner{
+				"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+				"GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
+				int32(10),
+				null.String{},
+			},
 		).
-		Return(int64(1), nil).Once()
+		Return(nil).Once()
 
-	s.mockQ.
+	s.mockAccountSignersBatchInsertBuilder.
 		On(
-			"CreateAccountSigner",
-			s.ctx,
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-			"GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS",
-			int32(15),
-			(*string)(nil),
+			"Add",
+			history.AccountSigner{
+				"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+				"GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS",
+				int32(15),
+				null.StringFromPtr(nil)},
 		).
-		Return(int64(1), nil).Once()
+		Return(nil).Once()
 
 	err := s.processor.ProcessChange(s.ctx, ingest.Change{
 		Type: xdr.LedgerEntryTypeAccount,
@@ -332,16 +333,17 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestSignerRemoved() {
 		Return(int64(1), nil).Once()
 
 	// Create new signer
-	s.mockQ.
+	s.mockAccountSignersBatchInsertBuilder.
 		On(
-			"CreateAccountSigner",
-			s.ctx,
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-			"GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS",
-			int32(15),
-			(*string)(nil),
+			"Add",
+			history.AccountSigner{
+				"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+				"GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS",
+				int32(15),
+				null.String{},
+			},
 		).
-		Return(int64(1), nil).Once()
+		Return(nil).Once()
 
 	err := s.processor.ProcessChange(s.ctx, ingest.Change{
 		Type: xdr.LedgerEntryTypeAccount,
@@ -405,16 +407,17 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestSignerPreAuthTxRemovedTxFai
 		Return(int64(1), nil).Once()
 
 	// Create new signer
-	s.mockQ.
+	s.mockAccountSignersBatchInsertBuilder.
 		On(
-			"CreateAccountSigner",
-			s.ctx,
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-			"GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
-			int32(10),
-			(*string)(nil),
+			"Add",
+			history.AccountSigner{
+				"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+				"GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
+				int32(10),
+				null.String{},
+			},
 		).
-		Return(int64(1), nil).Once()
+		Return(nil).Once()
 
 	err := s.processor.ProcessChange(s.ctx, ingest.Change{
 		Type: xdr.LedgerEntryTypeAccount,
@@ -482,81 +485,6 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccount() {
 	s.Assert().NoError(s.processor.Commit(s.ctx))
 }
 
-func (s *AccountsSignerProcessorTestSuiteLedger) TestNewAccountNoRowsAffected() {
-	s.mockQ.
-		On(
-			"CreateAccountSigner",
-			s.ctx,
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-			int32(1),
-			(*string)(nil),
-		).
-		Return(int64(0), nil).Once()
-
-	err := s.processor.ProcessChange(s.ctx, ingest.Change{
-		Type: xdr.LedgerEntryTypeAccount,
-		Pre:  nil,
-		Post: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type: xdr.LedgerEntryTypeAccount,
-				Account: &xdr.AccountEntry{
-					AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-					Thresholds: [4]byte{1, 1, 1, 1},
-				},
-			},
-		},
-	})
-	s.Assert().NoError(err)
-
-	err = s.processor.Commit(s.ctx)
-	s.Assert().Error(err)
-	s.Assert().IsType(ingest.StateError{}, errors.Cause(err))
-	s.Assert().EqualError(
-		err,
-		"0 rows affected when inserting "+
-			"account=GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML "+
-			"signer=GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML to database",
-	)
-}
-
-func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccountNoRowsAffected() {
-	s.mockQ.
-		On(
-			"RemoveAccountSigner",
-			s.ctx,
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-		).
-		Return(int64(0), nil).Once()
-
-	err := s.processor.ProcessChange(s.ctx, ingest.Change{
-		Type: xdr.LedgerEntryTypeAccount,
-		Pre: &xdr.LedgerEntry{
-			Data: xdr.LedgerEntryData{
-				Type: xdr.LedgerEntryTypeAccount,
-				Account: &xdr.AccountEntry{
-					AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
-					Thresholds: [4]byte{1, 1, 1, 1},
-				},
-			},
-		},
-		Post: nil,
-	})
-	s.Assert().NoError(err)
-
-	err = s.processor.Commit(s.ctx)
-	s.Assert().Error(err)
-	s.Assert().IsType(ingest.StateError{}, errors.Cause(err))
-	s.Assert().EqualError(
-		err,
-		"Expected "+
-			"account=GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML "+
-			"signer=GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML in database but not found when removing "+
-			"(rows affected = 0)",
-	)
-}
-
 func (s *AccountsSignerProcessorTestSuiteLedger) TestProcessUpgradeChange() {
 	// Remove old signer
 	s.mockQ.
@@ -569,27 +497,28 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestProcessUpgradeChange() {
 		Return(int64(1), nil).Once()
 
 	// Create new and old (updated) signer
-	s.mockQ.
+	s.mockAccountSignersBatchInsertBuilder.
 		On(
-			"CreateAccountSigner",
-			s.ctx,
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-			"GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
-			int32(12),
-			(*string)(nil),
+			"Add",
+			history.AccountSigner{
+				"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+				"GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
+				int32(12),
+				null.String{},
+			},
 		).
-		Return(int64(1), nil).Once()
+		Return(nil).Once()
 
-	s.mockQ.
+	s.mockAccountSignersBatchInsertBuilder.
 		On(
-			"CreateAccountSigner",
-			s.ctx,
-			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
-			"GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS",
-			int32(15),
-			(*string)(nil),
-		).
-		Return(int64(1), nil).Once()
+			"Add",
+			history.AccountSigner{
+				"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+				"GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS",
+				int32(15),
+				null.String{},
+			},
+		).Return(nil).Once()
 
 	err := s.processor.ProcessChange(s.ctx, ingest.Change{
 		Type: xdr.LedgerEntryTypeAccount,

--- a/services/horizon/internal/ingest/processors/signer_processor_test.go
+++ b/services/horizon/internal/ingest/processors/signer_processor_test.go
@@ -4,6 +4,7 @@ package processors
 
 import (
 	"context"
+	"github.com/stellar/go/support/errors"
 	"testing"
 
 	"github.com/guregu/null"
@@ -483,6 +484,43 @@ func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccount() {
 	})
 	s.Assert().NoError(err)
 	s.Assert().NoError(s.processor.Commit(s.ctx))
+}
+
+func (s *AccountsSignerProcessorTestSuiteLedger) TestRemoveAccountNoRowsAffected() {
+	s.mockQ.
+		On(
+			"RemoveAccountSigner",
+			s.ctx,
+			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+			"GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML",
+		).
+		Return(int64(0), nil).Once()
+
+	err := s.processor.ProcessChange(s.ctx, ingest.Change{
+		Type: xdr.LedgerEntryTypeAccount,
+		Pre: &xdr.LedgerEntry{
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeAccount,
+				Account: &xdr.AccountEntry{
+					AccountId:  xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+					Thresholds: [4]byte{1, 1, 1, 1},
+				},
+			},
+		},
+		Post: nil,
+	})
+	s.Assert().NoError(err)
+
+	err = s.processor.Commit(s.ctx)
+	s.Assert().Error(err)
+	s.Assert().IsType(ingest.StateError{}, errors.Cause(err))
+	s.Assert().EqualError(
+		err,
+		"Expected "+
+			"account=GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML "+
+			"signer=GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML in database but not found when removing "+
+			"(rows affected = 0)",
+	)
 }
 
 func (s *AccountsSignerProcessorTestSuiteLedger) TestProcessUpgradeChange() {

--- a/services/horizon/internal/ingest/processors/signers_processor.go
+++ b/services/horizon/internal/ingest/processors/signers_processor.go
@@ -58,11 +58,11 @@ func (p *SignersProcessor) ProcessChange(ctx context.Context, change ingest.Chan
 
 	if change.Pre == nil && change.Post != nil {
 		postAccountEntry := change.Post.Data.MustAccount()
-		if err := p.addSigners(postAccountEntry); err != nil {
+		if err := p.addAccountSigners(postAccountEntry); err != nil {
 			return err
 		}
 	} else {
-		return errors.New("AssetStatsProSignersProcessor is in insert only mode")
+		return errors.New("SignersProcessor is in insert only mode")
 	}
 
 	return nil
@@ -81,15 +81,13 @@ func (p *SignersProcessor) Commit(ctx context.Context) error {
 			// The code below removes all Pre signers adds Post signers but
 			// can be improved by finding a diff (check performance first).
 			if change.Pre != nil {
-				preAccountEntry := change.Pre.Data.MustAccount()
-				if err := p.removeSigners(ctx, preAccountEntry); err != nil {
+				if err := p.removeAccountSigners(ctx, change.Pre.Data.MustAccount()); err != nil {
 					return err
 				}
 			}
 
 			if change.Post != nil {
-				postAccountEntry := change.Post.Data.MustAccount()
-				if err := p.addSigners(postAccountEntry); err != nil {
+				if err := p.addAccountSigners(change.Post.Data.MustAccount()); err != nil {
 					return err
 				}
 			}
@@ -104,9 +102,9 @@ func (p *SignersProcessor) Commit(ctx context.Context) error {
 	return nil
 }
 
-func (p *SignersProcessor) removeSigners(ctx context.Context, preAccountEntry xdr.AccountEntry) error {
-	for signer := range preAccountEntry.SignerSummary() {
-		rowsAffected, err := p.signersQ.RemoveAccountSigner(ctx, preAccountEntry.AccountId.Address(), signer)
+func (p *SignersProcessor) removeAccountSigners(ctx context.Context, accountEntry xdr.AccountEntry) error {
+	for signer := range accountEntry.SignerSummary() {
+		rowsAffected, err := p.signersQ.RemoveAccountSigner(ctx, accountEntry.AccountId.Address(), signer)
 		if err != nil {
 			return errors.Wrap(err, "Error removing a signer")
 		}
@@ -114,7 +112,7 @@ func (p *SignersProcessor) removeSigners(ctx context.Context, preAccountEntry xd
 		if rowsAffected != 1 {
 			return ingest.NewStateError(errors.Errorf(
 				"Expected account=%s signer=%s in database but not found when removing (rows affected = %d)",
-				preAccountEntry.AccountId.Address(),
+				accountEntry.AccountId.Address(),
 				signer,
 				rowsAffected,
 			))
@@ -123,7 +121,7 @@ func (p *SignersProcessor) removeSigners(ctx context.Context, preAccountEntry xd
 	return nil
 }
 
-func (p *SignersProcessor) addSigners(accountEntry xdr.AccountEntry) error {
+func (p *SignersProcessor) addAccountSigners(accountEntry xdr.AccountEntry) error {
 	sponsorsPerSigner := accountEntry.SponsorPerSigner()
 	for signer, weight := range accountEntry.SignerSummary() {
 		// Ignore master key
@@ -134,15 +132,13 @@ func (p *SignersProcessor) addSigners(accountEntry xdr.AccountEntry) error {
 			}
 		}
 
-		err := p.batchInsertBuilder.Add(history.AccountSigner{
+		if err := p.batchInsertBuilder.Add(history.AccountSigner{
 			Account: accountEntry.AccountId.Address(),
 			Signer:  signer,
 			Weight:  weight,
 			Sponsor: sponsor,
-		})
-		if err != nil {
-			return errors.Wrapf(err, "Error adding signer (%s) to AccountSignersBatchInsertBuilder",
-				signer)
+		}); err != nil {
+			return errors.Wrapf(err, "Error adding signer (%s) to AccountSignersBatchInsertBuilder", signer)
 		}
 	}
 	return nil

--- a/services/horizon/internal/ingest/processors/signers_processor.go
+++ b/services/horizon/internal/ingest/processors/signers_processor.go
@@ -56,29 +56,13 @@ func (p *SignersProcessor) ProcessChange(ctx context.Context, change ingest.Chan
 		return nil
 	}
 
-	if !(change.Pre == nil && change.Post != nil) {
-		return errors.New("AssetStatsProSignersProcessorcessor is in insert only mode")
-	}
-
-	accountEntry := change.Post.Data.MustAccount()
-	account := accountEntry.AccountId.Address()
-
-	sponsors := accountEntry.SponsorPerSigner()
-	for signer, weight := range accountEntry.SignerSummary() {
-		var sponsor null.String
-		if sponsorDesc, isSponsored := sponsors[signer]; isSponsored {
-			sponsor = null.StringFrom(sponsorDesc.Address())
+	if change.Pre == nil && change.Post != nil {
+		postAccountEntry := change.Post.Data.MustAccount()
+		if err := p.addSigners(postAccountEntry); err != nil {
+			return err
 		}
-
-		err := p.batchInsertBuilder.Add(history.AccountSigner{
-			Account: account,
-			Signer:  signer,
-			Weight:  weight,
-			Sponsor: sponsor,
-		})
-		if err != nil {
-			return errors.Wrap(err, "Error adding row to accountSignerBatch")
-		}
+	} else {
+		return errors.New("AssetStatsProSignersProcessor is in insert only mode")
 	}
 
 	return nil
@@ -87,64 +71,26 @@ func (p *SignersProcessor) ProcessChange(ctx context.Context, change ingest.Chan
 func (p *SignersProcessor) Commit(ctx context.Context) error {
 	defer p.reset()
 
-	if !p.useLedgerEntryCache {
-		err := p.batchInsertBuilder.Exec(ctx)
-		if err != nil {
-			return errors.Wrap(err, "error executing AccountSignersBatchInsertBuilder")
-		}
-		return nil
-	}
+	if p.useLedgerEntryCache {
+		changes := p.cache.GetChanges()
+		for _, change := range changes {
+			if !change.AccountSignersChanged() {
+				continue
+			}
 
-	changes := p.cache.GetChanges()
-	for _, change := range changes {
-		if !change.AccountSignersChanged() {
-			continue
-		}
-
-		// The code below removes all Pre signers adds Post signers but
-		// can be improved by finding a diff (check performance first).
-		if change.Pre != nil {
-			preAccountEntry := change.Pre.Data.MustAccount()
-			for signer := range preAccountEntry.SignerSummary() {
-				rowsAffected, err := p.signersQ.RemoveAccountSigner(ctx, preAccountEntry.AccountId.Address(), signer)
-				if err != nil {
-					return errors.Wrap(err, "Error removing a signer")
-				}
-
-				if rowsAffected != 1 {
-					return ingest.NewStateError(errors.Errorf(
-						"Expected account=%s signer=%s in database but not found when removing (rows affected = %d)",
-						preAccountEntry.AccountId.Address(),
-						signer,
-						rowsAffected,
-					))
+			// The code below removes all Pre signers adds Post signers but
+			// can be improved by finding a diff (check performance first).
+			if change.Pre != nil {
+				preAccountEntry := change.Pre.Data.MustAccount()
+				if err := p.removeSigners(ctx, preAccountEntry); err != nil {
+					return err
 				}
 			}
-		}
 
-		if change.Post != nil {
-			postAccountEntry := change.Post.Data.MustAccount()
-			sponsorsPerSigner := postAccountEntry.SponsorPerSigner()
-			for signer, weight := range postAccountEntry.SignerSummary() {
-
-				// Ignore master key
-				var sponsor *string
-				if signer != postAccountEntry.AccountId.Address() {
-					if s, ok := sponsorsPerSigner[signer]; ok {
-						a := s.Address()
-						sponsor = &a
-					}
-				}
-
-				err := p.batchInsertBuilder.Add(history.AccountSigner{
-					Account: postAccountEntry.AccountId.Address(),
-					Signer:  signer,
-					Weight:  weight,
-					Sponsor: null.StringFromPtr(sponsor),
-				})
-				if err != nil {
-					return errors.Wrapf(err, "Error adding signer (%s) to AccountSignersBatchInsertBuilder",
-						signer)
+			if change.Post != nil {
+				postAccountEntry := change.Post.Data.MustAccount()
+				if err := p.addSigners(postAccountEntry); err != nil {
+					return err
 				}
 			}
 		}
@@ -153,6 +99,51 @@ func (p *SignersProcessor) Commit(ctx context.Context) error {
 	err := p.batchInsertBuilder.Exec(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error executing AccountSignersBatchInsertBuilder")
+	}
+
+	return nil
+}
+
+func (p *SignersProcessor) removeSigners(ctx context.Context, preAccountEntry xdr.AccountEntry) error {
+	for signer := range preAccountEntry.SignerSummary() {
+		rowsAffected, err := p.signersQ.RemoveAccountSigner(ctx, preAccountEntry.AccountId.Address(), signer)
+		if err != nil {
+			return errors.Wrap(err, "Error removing a signer")
+		}
+
+		if rowsAffected != 1 {
+			return ingest.NewStateError(errors.Errorf(
+				"Expected account=%s signer=%s in database but not found when removing (rows affected = %d)",
+				preAccountEntry.AccountId.Address(),
+				signer,
+				rowsAffected,
+			))
+		}
+	}
+	return nil
+}
+
+func (p *SignersProcessor) addSigners(accountEntry xdr.AccountEntry) error {
+	sponsorsPerSigner := accountEntry.SponsorPerSigner()
+	for signer, weight := range accountEntry.SignerSummary() {
+		// Ignore master key
+		var sponsor null.String
+		if signer != accountEntry.AccountId.Address() {
+			if sponsorDesc, isSponsored := sponsorsPerSigner[signer]; isSponsored {
+				sponsor = null.StringFrom(sponsorDesc.Address())
+			}
+		}
+
+		err := p.batchInsertBuilder.Add(history.AccountSigner{
+			Account: accountEntry.AccountId.Address(),
+			Signer:  signer,
+			Weight:  weight,
+			Sponsor: sponsor,
+		})
+		if err != nil {
+			return errors.Wrapf(err, "Error adding signer (%s) to AccountSignersBatchInsertBuilder",
+				signer)
+		}
 	}
 	return nil
 }

--- a/services/horizon/internal/ingest/processors/signers_processor.go
+++ b/services/horizon/internal/ingest/processors/signers_processor.go
@@ -88,7 +88,11 @@ func (p *SignersProcessor) Commit(ctx context.Context) error {
 	defer p.reset()
 
 	if !p.useLedgerEntryCache {
-		return p.batchInsertBuilder.Exec(ctx)
+		err := p.batchInsertBuilder.Exec(ctx)
+		if err != nil {
+			return errors.Wrap(err, "error executing AccountSignersBatchInsertBuilder")
+		}
+		return nil
 	}
 
 	changes := p.cache.GetChanges()
@@ -132,23 +136,15 @@ func (p *SignersProcessor) Commit(ctx context.Context) error {
 					}
 				}
 
-				rowsAffected, err := p.signersQ.CreateAccountSigner(ctx,
-					postAccountEntry.AccountId.Address(),
-					signer,
-					weight,
-					sponsor,
-				)
+				err := p.batchInsertBuilder.Add(history.AccountSigner{
+					Account: postAccountEntry.AccountId.Address(),
+					Signer:  signer,
+					Weight:  weight,
+					Sponsor: null.StringFromPtr(sponsor),
+				})
 				if err != nil {
-					return errors.Wrapf(err, "Error inserting a signer (%s)", signer)
-				}
-
-				if rowsAffected != 1 {
-					return ingest.NewStateError(errors.Errorf(
-						"%d rows affected when inserting account=%s signer=%s to database",
-						rowsAffected,
-						postAccountEntry.AccountId.Address(),
-						signer,
-					))
+					return errors.Wrapf(err, "Error adding signer (%s) to AccountSignersBatchInsertBuilder",
+						signer)
 				}
 			}
 		}

--- a/services/horizon/internal/ingest/processors/signers_processor.go
+++ b/services/horizon/internal/ingest/processors/signers_processor.go
@@ -14,8 +14,8 @@ import (
 type SignersProcessor struct {
 	signersQ history.QSigners
 
-	cache *ingest.ChangeCompactor
-	batch history.AccountSignersBatchInsertBuilder
+	cache              *ingest.ChangeCompactor
+	batchInsertBuilder history.AccountSignersBatchInsertBuilder
 	// insertOnlyMode is a mode in which we don't use ledger cache and we just
 	// add signers to a batch, then we Exec all signers in one insert query.
 	// This is done to make history buckets processing faster (batch inserting).
@@ -31,7 +31,7 @@ func NewSignersProcessor(
 }
 
 func (p *SignersProcessor) reset() {
-	p.batch = p.signersQ.NewAccountSignersBatchInsertBuilder(maxBatchSize)
+	p.batchInsertBuilder = p.signersQ.NewAccountSignersBatchInsertBuilder()
 	p.cache = ingest.NewChangeCompactor()
 }
 
@@ -51,7 +51,6 @@ func (p *SignersProcessor) ProcessChange(ctx context.Context, change ingest.Chan
 			if err != nil {
 				return errors.Wrap(err, "error in Commit")
 			}
-			p.reset()
 		}
 
 		return nil
@@ -71,7 +70,7 @@ func (p *SignersProcessor) ProcessChange(ctx context.Context, change ingest.Chan
 			sponsor = null.StringFrom(sponsorDesc.Address())
 		}
 
-		err := p.batch.Add(ctx, history.AccountSigner{
+		err := p.batchInsertBuilder.Add(history.AccountSigner{
 			Account: account,
 			Signer:  signer,
 			Weight:  weight,
@@ -86,8 +85,10 @@ func (p *SignersProcessor) ProcessChange(ctx context.Context, change ingest.Chan
 }
 
 func (p *SignersProcessor) Commit(ctx context.Context) error {
+	defer p.reset()
+
 	if !p.useLedgerEntryCache {
-		return p.batch.Exec(ctx)
+		return p.batchInsertBuilder.Exec(ctx)
 	}
 
 	changes := p.cache.GetChanges()
@@ -153,5 +154,9 @@ func (p *SignersProcessor) Commit(ctx context.Context) error {
 		}
 	}
 
+	err := p.batchInsertBuilder.Exec(ctx)
+	if err != nil {
+		return errors.Wrap(err, "error executing AccountSignersBatchInsertBuilder")
+	}
 	return nil
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Optimize the `SignersProcessor` to use `FastBatchInsertBuilder` which uses `COPY` to bulk insert into the database table `account_signers`.

* Using the `FastBatchInsertBuilder` when inserting into the `account_signers` table during building state (i.e. `useLedgerEntryCache` is false).
* Introducing another optimization in the insertion process during live ingestion (i.e., `useLedgerEntryCache` is true) to also use bulk insert via `FastBatchInsertBuilder`.
* Refactor the code to reduce code duplication and improve overall readability.


### Why

see #5098

### Known limitations

Previously in SignersProcessor, during live ingestion, each row was inserted individually and a `ingest.StateError` was thrown in case of failure. With the bulk write, this individual check is no longer possible and so the system now throws an error for the entire batch if a failure occurs.
