### PR TITLE
services/horizon: Use COPY for inserting into liquidity_pools table

### DIFF
--- a/services/horizon/internal/db2/history/liquidity_pool_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/liquidity_pool_batch_insert_builder.go
@@ -1,0 +1,36 @@
+package history
+
+import (
+	"context"
+
+	"github.com/stellar/go/support/db"
+)
+
+type LiquidityPoolBatchInsertBuilder interface {
+	Add(liquidityPool LiquidityPool) error
+	Exec(ctx context.Context) error
+}
+
+type liquidityPoolBatchInsertBuilder struct {
+	session db.SessionInterface
+	builder db.FastBatchInsertBuilder
+	table   string
+}
+
+func (q *Q) NewLiquidityPoolBatchInsertBuilder() LiquidityPoolBatchInsertBuilder {
+	return &liquidityPoolBatchInsertBuilder{
+		session: q,
+		builder: db.FastBatchInsertBuilder{},
+		table:   "liquidity_pools",
+	}
+}
+
+// Add adds a new liquidity pool to the batch
+func (i *liquidityPoolBatchInsertBuilder) Add(liquidityPool LiquidityPool) error {
+	return i.builder.RowStruct(liquidityPool)
+}
+
+// Exec writes the batch of liquidity pools to the database.
+func (i *liquidityPoolBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx, i.session, i.table)
+}

--- a/services/horizon/internal/db2/history/liquidity_pools.go
+++ b/services/horizon/internal/db2/history/liquidity_pools.go
@@ -37,7 +37,8 @@ type LiquidityPool struct {
 type LiquidityPoolAssetReserves []LiquidityPoolAssetReserve
 
 func (c LiquidityPoolAssetReserves) Value() (driver.Value, error) {
-	return json.Marshal(c)
+	val, err := json.Marshal(c)
+	return string(val), err
 }
 
 func (c *LiquidityPoolAssetReserves) Scan(value interface{}) error {
@@ -91,6 +92,7 @@ type QLiquidityPools interface {
 	FindLiquidityPoolByID(ctx context.Context, liquidityPoolID string) (LiquidityPool, error)
 	GetUpdatedLiquidityPools(ctx context.Context, newerThanSequence uint32) ([]LiquidityPool, error)
 	CompactLiquidityPools(ctx context.Context, cutOffSequence uint32) (int64, error)
+	NewLiquidityPoolBatchInsertBuilder() LiquidityPoolBatchInsertBuilder
 }
 
 // UpsertLiquidityPools upserts a batch of liquidity pools  in the liquidity_pools table.

--- a/services/horizon/internal/db2/history/liquidity_pools.go
+++ b/services/horizon/internal/db2/history/liquidity_pools.go
@@ -37,6 +37,8 @@ type LiquidityPool struct {
 type LiquidityPoolAssetReserves []LiquidityPoolAssetReserve
 
 func (c LiquidityPoolAssetReserves) Value() (driver.Value, error) {
+	// Convert the byte array into a string as a workaround to bypass buggy encoding in the pq driver
+	// (More info about this bug here https://github.com/stellar/go/issues/5086#issuecomment-1773215436).
 	val, err := json.Marshal(c)
 	return string(val), err
 }

--- a/services/horizon/internal/db2/history/mock_liquidity_pool_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_liquidity_pool_batch_insert_builder.go
@@ -1,0 +1,21 @@
+package history
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockLiquidityPoolBatchInsertBuilder struct {
+	mock.Mock
+}
+
+func (m *MockLiquidityPoolBatchInsertBuilder) Add(liquidityPool LiquidityPool) error {
+	a := m.Called(liquidityPool)
+	return a.Error(0)
+}
+
+func (m *MockLiquidityPoolBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
+	return a.Error(0)
+}

--- a/services/horizon/internal/db2/history/mock_q_liquidity_pools.go
+++ b/services/horizon/internal/db2/history/mock_q_liquidity_pools.go
@@ -45,3 +45,8 @@ func (m *MockQLiquidityPools) CompactLiquidityPools(ctx context.Context, cutOffS
 	a := m.Called(ctx, cutOffSequence)
 	return a.Get(0).(int64), a.Error(1)
 }
+
+func (m *MockQLiquidityPools) NewLiquidityPoolBatchInsertBuilder() LiquidityPoolBatchInsertBuilder {
+	a := m.Called()
+	return a.Get(0).(LiquidityPoolBatchInsertBuilder)
+}

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -61,6 +61,12 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 	mockClaimantsBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	mockClaimableBalanceBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 
+	mockLiquidityPoolBatchInsertBuilder := &history.MockLiquidityPoolBatchInsertBuilder{}
+	q.MockQLiquidityPools.On("NewLiquidityPoolBatchInsertBuilder").
+		Return(mockLiquidityPoolBatchInsertBuilder).Twice()
+
+	mockLiquidityPoolBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
+
 	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
 
@@ -138,6 +144,12 @@ func TestProcessorRunnerRunHistoryArchiveIngestionHistoryArchive(t *testing.T) {
 	mockClaimantsBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	mockClaimableBalanceBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 
+	mockLiquidityPoolBatchInsertBuilder := &history.MockLiquidityPoolBatchInsertBuilder{}
+	q.MockQLiquidityPools.On("NewLiquidityPoolBatchInsertBuilder").
+		Return(mockLiquidityPoolBatchInsertBuilder).Twice()
+
+	mockLiquidityPoolBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
+
 	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
 
@@ -185,6 +197,12 @@ func TestProcessorRunnerRunHistoryArchiveIngestionProtocolVersionNotSupported(t 
 	mockClaimantsBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	mockClaimableBalanceBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 
+	mockLiquidityPoolBatchInsertBuilder := &history.MockLiquidityPoolBatchInsertBuilder{}
+	q.MockQLiquidityPools.On("NewLiquidityPoolBatchInsertBuilder").
+		Return(mockLiquidityPoolBatchInsertBuilder).Twice()
+
+	mockLiquidityPoolBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
+
 	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)
 
@@ -223,6 +241,12 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 	mockClaimantsBatchInsertBuilder := &history.MockClaimableBalanceClaimantBatchInsertBuilder{}
 	q.MockQClaimableBalances.On("NewClaimableBalanceClaimantBatchInsertBuilder").
 		Return(mockClaimantsBatchInsertBuilder).Twice()
+
+	mockLiquidityPoolBatchInsertBuilder := &history.MockLiquidityPoolBatchInsertBuilder{}
+	q.MockQLiquidityPools.On("NewLiquidityPoolBatchInsertBuilder").
+		Return(mockLiquidityPoolBatchInsertBuilder).Twice()
+
+	mockLiquidityPoolBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 
 	runner := ProcessorRunner{
 		ctx:      ctx,
@@ -359,6 +383,12 @@ func TestProcessorRunnerWithFilterEnabled(t *testing.T) {
 
 	mockClaimantsBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 	mockClaimableBalanceBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
+
+	mockLiquidityPoolBatchInsertBuilder := &history.MockLiquidityPoolBatchInsertBuilder{}
+	q.MockQLiquidityPools.On("NewLiquidityPoolBatchInsertBuilder").
+		Return(mockLiquidityPoolBatchInsertBuilder).Twice()
+
+	mockLiquidityPoolBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 
 	q.On("DeleteTransactionsFilteredTmpOlderThan", ctx, mock.AnythingOfType("uint64")).
 		Return(int64(0), nil)
@@ -550,6 +580,12 @@ func mockBatchBuilders(q *mockDBQ, mockSession *db.MockSession, ctx context.Cont
 	q.MockQClaimableBalances.On("NewClaimableBalanceBatchInsertBuilder").
 		Return(mockClaimableBalanceBatchInsertBuilder)
 	mockClaimableBalanceBatchInsertBuilder.On("Exec", ctx).Return(nil)
+
+	mockLiquidityPoolBatchInsertBuilder := &history.MockLiquidityPoolBatchInsertBuilder{}
+	q.MockQLiquidityPools.On("NewLiquidityPoolBatchInsertBuilder").
+		Return(mockLiquidityPoolBatchInsertBuilder).Twice()
+
+	mockLiquidityPoolBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 
 	q.On("NewTradeBatchInsertBuilder").Return(&history.MockTradeBatchInsertBuilder{})
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Optimize the `LiquidityPoolsChangeProcessor` to use `FastBatchInsertBuilder` which uses COPY to bulk insert into the database table `liquidity_pools`. Database update and removal operations remain unchanged.


### Why
#5098 

### Known limitations
N/A
