### PR TITLE
services/horizon: Use COPY for inserting into trust_lines table

### DIFF
--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -846,6 +846,7 @@ type QTrustLines interface {
 	GetTrustLinesByKeys(ctx context.Context, ledgerKeys []string) ([]TrustLine, error)
 	UpsertTrustLines(ctx context.Context, trustlines []TrustLine) error
 	RemoveTrustLines(ctx context.Context, ledgerKeys []string) (int64, error)
+	NewTrustLinesBatchInsertBuilder() TrustLinesBatchInsertBuilder
 }
 
 func (q *Q) NewAccountSignersBatchInsertBuilder() AccountSignersBatchInsertBuilder {

--- a/services/horizon/internal/db2/history/mock_q_trust_lines.go
+++ b/services/horizon/internal/db2/history/mock_q_trust_lines.go
@@ -25,3 +25,8 @@ func (m *MockQTrustLines) RemoveTrustLines(ctx context.Context, ledgerKeys []str
 	a := m.Called(ctx, ledgerKeys)
 	return a.Get(0).(int64), a.Error(1)
 }
+
+func (m *MockQTrustLines) NewTrustLinesBatchInsertBuilder() TrustLinesBatchInsertBuilder {
+	a := m.Called()
+	return a.Get(0).(TrustLinesBatchInsertBuilder)
+}

--- a/services/horizon/internal/db2/history/mock_trust_lines_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_trust_lines_batch_insert_builder.go
@@ -1,0 +1,21 @@
+package history
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockTrustLinesBatchInsertBuilder struct {
+	mock.Mock
+}
+
+func (m *MockTrustLinesBatchInsertBuilder) Add(line TrustLine) error {
+	a := m.Called(line)
+	return a.Error(0)
+}
+
+func (m *MockTrustLinesBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
+	return a.Error(0)
+}

--- a/services/horizon/internal/db2/history/trust_lines_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/trust_lines_batch_insert_builder.go
@@ -1,0 +1,39 @@
+package history
+
+import (
+	"context"
+
+	"github.com/stellar/go/support/db"
+)
+
+// TrustLinesBatchInsertBuilder is used to insert trustlines into the trust_lines table
+type TrustLinesBatchInsertBuilder interface {
+	Add(line TrustLine) error
+	Exec(ctx context.Context) error
+}
+
+// trustLinesBatchInsertBuilder is a simple wrapper around db.FastBatchInsertBuilder
+type trustLinesBatchInsertBuilder struct {
+	session db.SessionInterface
+	builder db.FastBatchInsertBuilder
+	table   string
+}
+
+// NewTrustLinesBatchInsertBuilder constructs a new TrustLinesBatchInsertBuilder instance
+func (q *Q) NewTrustLinesBatchInsertBuilder() TrustLinesBatchInsertBuilder {
+	return &trustLinesBatchInsertBuilder{
+		session: q,
+		builder: db.FastBatchInsertBuilder{},
+		table:   "trust_lines",
+	}
+}
+
+// Add adds a new trustline to the batch
+func (i *trustLinesBatchInsertBuilder) Add(line TrustLine) error {
+	return i.builder.RowStruct(line)
+}
+
+// Exec writes the batch of trust lines to the database.
+func (i *trustLinesBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx, i.session, i.table)
+}

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -523,10 +523,18 @@ func mockChangeProcessorBatchBuilders(q *mockDBQ, ctx context.Context, mockExec 
 	q.MockQOffers.On("NewOffersBatchInsertBuilder").
 		Return(mockOfferBatchInsertBuilder).Twice()
 
+	mockTrustLinesBatchInsertBuilder := &history.MockTrustLinesBatchInsertBuilder{}
+	if mockExec {
+		mockTrustLinesBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
+	}
+	q.MockQTrustLines.On("NewTrustLinesBatchInsertBuilder").
+		Return(mockTrustLinesBatchInsertBuilder)
+
 	return []interface{}{mockAccountSignersBatchInsertBuilder,
 		mockClaimableBalanceBatchInsertBuilder,
 		mockClaimableBalanceClaimantBatchInsertBuilder,
 		mockLiquidityPoolBatchInsertBuilder,
 		mockOfferBatchInsertBuilder,
+		mockTrustLinesBatchInsertBuilder,
 	}
 }

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -48,7 +48,6 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 		Weight:  1,
 		Sponsor: null.String{},
 	}).Return(nil).Once()
-	mockAccountSignersBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 
 	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -48,6 +48,7 @@ func TestProcessorRunnerRunHistoryArchiveIngestionGenesis(t *testing.T) {
 		Weight:  1,
 		Sponsor: null.String{},
 	}).Return(nil).Once()
+	mockAccountSignersBatchInsertBuilder.On("Exec", ctx).Return(nil).Once()
 
 	q.MockQAssetStats.On("InsertAssetStats", ctx, []history.ExpAssetStat{}, 100000).
 		Return(nil)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Optimize the `TrustLinesProcessor` to use `FastBatchInsertBuilder` which uses COPY to bulk insert into the database table `trust_lines`. Database update and removal operations remain unchanged.


### Why

#5098 

### Known limitations
N/A