### PR TITLE
services/horizon: Use COPY for inserting into accounts table

### DIFF
--- a/services/horizon/internal/db2/history/accounts_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/accounts_batch_insert_builder.go
@@ -1,0 +1,39 @@
+package history
+
+import (
+	"context"
+
+	"github.com/stellar/go/support/db"
+)
+
+// AccountsBatchInsertBuilder is used to insert accounts into the accounts table
+type AccountsBatchInsertBuilder interface {
+	Add(account AccountEntry) error
+	Exec(ctx context.Context) error
+}
+
+// AccountsBatchInsertBuilder is a simple wrapper around db.FastBatchInsertBuilder
+type accountsBatchInsertBuilder struct {
+	session db.SessionInterface
+	builder db.FastBatchInsertBuilder
+	table   string
+}
+
+// NewAccountsBatchInsertBuilder constructs a new AccountsBatchInsertBuilder instance
+func (q *Q) NewAccountsBatchInsertBuilder() AccountsBatchInsertBuilder {
+	return &accountsBatchInsertBuilder{
+		session: q,
+		builder: db.FastBatchInsertBuilder{},
+		table:   "accounts",
+	}
+}
+
+// Add adds a new account to the batch
+func (i *accountsBatchInsertBuilder) Add(account AccountEntry) error {
+	return i.builder.RowStruct(account)
+}
+
+// Exec writes the batch of accounts to the database.
+func (i *accountsBatchInsertBuilder) Exec(ctx context.Context) error {
+	return i.builder.Exec(ctx, i.session, i.table)
+}

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -312,6 +312,7 @@ type QAccounts interface {
 	GetAccountsByIDs(ctx context.Context, ids []string) ([]AccountEntry, error)
 	UpsertAccounts(ctx context.Context, accounts []AccountEntry) error
 	RemoveAccounts(ctx context.Context, accountIDs []string) (int64, error)
+	NewAccountsBatchInsertBuilder() AccountsBatchInsertBuilder
 }
 
 // AccountSigner is a row of data from the `accounts_signers` table

--- a/services/horizon/internal/db2/history/mock_accounts_batch_insert_builder.go
+++ b/services/horizon/internal/db2/history/mock_accounts_batch_insert_builder.go
@@ -1,0 +1,21 @@
+package history
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockAccountsBatchInsertBuilder struct {
+	mock.Mock
+}
+
+func (m *MockAccountsBatchInsertBuilder) Add(account AccountEntry) error {
+	a := m.Called(account)
+	return a.Error(0)
+}
+
+func (m *MockAccountsBatchInsertBuilder) Exec(ctx context.Context) error {
+	a := m.Called(ctx)
+	return a.Error(0)
+}

--- a/services/horizon/internal/db2/history/mock_q_accounts.go
+++ b/services/horizon/internal/db2/history/mock_q_accounts.go
@@ -25,3 +25,8 @@ func (m *MockQAccounts) RemoveAccounts(ctx context.Context, accountIDs []string)
 	a := m.Called(ctx, accountIDs)
 	return a.Get(0).(int64), a.Error(1)
 }
+
+func (m *MockQAccounts) NewAccountsBatchInsertBuilder() AccountsBatchInsertBuilder {
+	a := m.Called()
+	return a.Get(0).(AccountsBatchInsertBuilder)
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Optimize the `AccountsProcessor` to use `FastBatchInsertBuilder` which uses COPY to bulk insert into the database table `accounts`. Database update and removal operations remain unchanged.

### Why
#5098 

### Known limitations
N/A