### PR TITLE
services/horizon: Fix docker compose Files for Horizon "testnet" and Integration Tests

### DIFF
--- a/services/horizon/docker/docker-compose.integration-tests.yml
+++ b/services/horizon/docker/docker-compose.integration-tests.yml
@@ -14,7 +14,8 @@ services:
     # Note: Please keep the image pinned to an immutable tag matching the Captive Core version.
     #       This avoid implicit updates which break compatibility between
     #       the Core container and captive core.
-    image: ${CORE_IMAGE:-chowbao/stellar-core:19.11.1-1357.e38ee728d.focal-sorobanP10}
+    image: ${CORE_IMAGE:-stellar/stellar-core:19.13.1-1481.3acf6dd26.focal}
+
     depends_on:
       - core-postgres
     restart: on-failure

--- a/services/horizon/docker/docker-compose.yml
+++ b/services/horizon/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   horizon-postgres:
     platform: linux/amd64
-    image: postgres:postgres:12-bullseye
+    image: postgres:12-bullseye
     restart: on-failure
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Updated docker-compose.yml and docker-compose.integration.yml

### Why
The `docker-compose.yml` file is used by the start.sh script to start Horizon in `testnet`.
The core image in docker-compose.integration.yml is updated to match the one used by gh  for  successfully running integration tests locally.

### Known limitations
N/A