### PR TITLE
services/horizon/internal/db2/history: Use FastBatchInsertBuilder for asset stats

### DIFF
--- a/services/horizon/internal/db2/history/asset_stats.go
+++ b/services/horizon/internal/db2/history/asset_stats.go
@@ -49,17 +49,15 @@ func (q *Q) InsertAssetStats(ctx context.Context, assetStats []ExpAssetStat) err
 		return nil
 	}
 
-	builder := &db.BatchInsertBuilder{
-		Table: q.GetTable("exp_asset_stats"),
-	}
+	builder := &db.FastBatchInsertBuilder{}
 
 	for _, assetStat := range assetStats {
-		if err := builder.Row(ctx, assetStatToMap(assetStat)); err != nil {
+		if err := builder.Row(assetStatToMap(assetStat)); err != nil {
 			return errors.Wrap(err, "could not insert asset assetStat row")
 		}
 	}
 
-	if err := builder.Exec(ctx); err != nil {
+	if err := builder.Exec(ctx, q, "exp_asset_stats"); err != nil {
 		return errors.Wrap(err, "could not exec asset assetStats insert builder")
 	}
 
@@ -71,17 +69,15 @@ func (q *Q) InsertContractAssetStats(ctx context.Context, rows []ContractAssetSt
 	if len(rows) == 0 {
 		return nil
 	}
-	builder := &db.BatchInsertBuilder{
-		Table: q.GetTable("contract_asset_stats"),
-	}
+	builder := &db.FastBatchInsertBuilder{}
 
 	for _, row := range rows {
-		if err := builder.RowStruct(ctx, row); err != nil {
+		if err := builder.RowStruct(row); err != nil {
 			return errors.Wrap(err, "could not insert asset assetStat row")
 		}
 	}
 
-	if err := builder.Exec(ctx); err != nil {
+	if err := builder.Exec(ctx, q, "contract_asset_stats"); err != nil {
 		return errors.Wrap(err, "could not exec asset assetStats insert builder")
 	}
 
@@ -106,17 +102,15 @@ func (q *Q) InsertContractAssetBalances(ctx context.Context, rows []ContractAsse
 	if len(rows) == 0 {
 		return nil
 	}
-	builder := &db.BatchInsertBuilder{
-		Table: q.GetTable("contract_asset_balances"),
-	}
+	builder := &db.FastBatchInsertBuilder{}
 
 	for _, row := range rows {
-		if err := builder.RowStruct(ctx, row); err != nil {
+		if err := builder.RowStruct(row); err != nil {
 			return errors.Wrap(err, "could not insert asset assetStat row")
 		}
 	}
 
-	if err := builder.Exec(ctx); err != nil {
+	if err := builder.Exec(ctx, q, "contract_asset_balances"); err != nil {
 		return errors.Wrap(err, "could not exec asset assetStats insert builder")
 	}
 

--- a/services/horizon/internal/db2/history/asset_stats_test.go
+++ b/services/horizon/internal/db2/history/asset_stats_test.go
@@ -21,6 +21,8 @@ func TestAssetStatContracts(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
 
+	tt.Assert.NoError(q.Begin(context.Background()))
+
 	assetStats := []ExpAssetStat{
 		{
 			AssetType: xdr.AssetTypeAssetTypeNative,
@@ -86,6 +88,7 @@ func TestAssetStatContracts(t *testing.T) {
 		contractID[0]++
 	}
 	tt.Assert.NoError(q.InsertAssetStats(tt.Ctx, assetStats))
+	tt.Assert.NoError(q.Commit())
 
 	contractID[0] = 0
 	for i := 0; i < 2; i++ {
@@ -122,6 +125,8 @@ func TestAssetContractStats(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
+
+	tt.Assert.NoError(q.Begin(context.Background()))
 
 	c1 := ContractAssetStatRow{
 		ContractID: []byte{1},
@@ -183,6 +188,8 @@ func TestAssetContractStats(t *testing.T) {
 		tt.Assert.NoError(err)
 		tt.Assert.Equal(result, row)
 	}
+
+	tt.Assert.NoError(q.Rollback())
 }
 
 func TestInsertAssetStats(t *testing.T) {
@@ -190,6 +197,9 @@ func TestInsertAssetStats(t *testing.T) {
 	defer tt.Finish()
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &Q{tt.HorizonSession()}
+
+	tt.Assert.NoError(q.Begin(context.Background()))
+
 	tt.Assert.NoError(q.InsertAssetStats(tt.Ctx, []ExpAssetStat{}))
 
 	assetStats := []ExpAssetStat{
@@ -239,6 +249,8 @@ func TestInsertAssetStats(t *testing.T) {
 		tt.Assert.NoError(err)
 		tt.Assert.Equal(got, assetStat)
 	}
+
+	tt.Assert.NoError(q.Rollback())
 }
 
 func TestInsertAssetStat(t *testing.T) {
@@ -1011,6 +1023,8 @@ func TestInsertContractAssetBalances(t *testing.T) {
 
 	q := &Q{tt.HorizonSession()}
 
+	tt.Assert.NoError(q.Begin(context.Background()))
+
 	keyHash := [32]byte{}
 	contractID := [32]byte{1}
 	balance := ContractAssetBalance{
@@ -1038,6 +1052,8 @@ func TestInsertContractAssetBalances(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	assertContractAssetBalancesEqual(t, balances, []ContractAssetBalance{balance, otherBalance})
+
+	tt.Assert.NoError(q.Rollback())
 }
 
 func TestRemoveContractAssetBalances(t *testing.T) {
@@ -1046,6 +1062,7 @@ func TestRemoveContractAssetBalances(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 
 	q := &Q{tt.HorizonSession()}
+	tt.Assert.NoError(q.Begin(context.Background()))
 
 	keyHash := [32]byte{}
 	contractID := [32]byte{1}
@@ -1086,6 +1103,8 @@ func TestRemoveContractAssetBalances(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	assertContractAssetBalancesEqual(t, balances, []ContractAssetBalance{balance})
+
+	tt.Assert.NoError(q.Rollback())
 }
 
 func TestUpdateContractAssetBalanceAmounts(t *testing.T) {
@@ -1094,6 +1113,7 @@ func TestUpdateContractAssetBalanceAmounts(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 
 	q := &Q{tt.HorizonSession()}
+	tt.Assert.NoError(q.Begin(context.Background()))
 
 	keyHash := [32]byte{}
 	contractID := [32]byte{1}
@@ -1133,6 +1153,8 @@ func TestUpdateContractAssetBalanceAmounts(t *testing.T) {
 	balance.Amount = "2"
 	otherBalance.Amount = "1"
 	assertContractAssetBalancesEqual(t, balances, []ContractAssetBalance{balance, otherBalance})
+
+	tt.Assert.NoError(q.Rollback())
 }
 
 func TestUpdateContractAssetBalanceExpirations(t *testing.T) {
@@ -1141,6 +1163,7 @@ func TestUpdateContractAssetBalanceExpirations(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 
 	q := &Q{tt.HorizonSession()}
+	tt.Assert.NoError(q.Begin(context.Background()))
 
 	keyHash := [32]byte{}
 	contractID := [32]byte{1}
@@ -1195,4 +1218,6 @@ func TestUpdateContractAssetBalanceExpirations(t *testing.T) {
 	balances, err = q.GetContractAssetBalancesExpiringAt(context.Background(), 200)
 	tt.Assert.NoError(err)
 	assertContractAssetBalancesEqual(t, balances, []ContractAssetBalance{balance, otherBalance})
+
+	tt.Assert.NoError(q.Rollback())
 }

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -376,7 +376,11 @@ type ContractStat struct {
 }
 
 func (c ContractStat) Value() (driver.Value, error) {
-	return json.Marshal(c)
+	// Convert the byte array into a string as a workaround to bypass buggy encoding in the pq driver
+	// (More info about this bug here https://github.com/stellar/go/issues/5086#issuecomment-1773215436).
+	// By doing so, the data will be written as a string rather than hex encoded bytes.
+	val, err := json.Marshal(c)
+	return string(val), err
 }
 
 func (c *ContractStat) Scan(src interface{}) error {
@@ -445,7 +449,11 @@ type ExpAssetStatAccounts struct {
 }
 
 func (e ExpAssetStatAccounts) Value() (driver.Value, error) {
-	return json.Marshal(e)
+	// Convert the byte array into a string as a workaround to bypass buggy encoding in the pq driver
+	// (More info about this bug here https://github.com/stellar/go/issues/5086#issuecomment-1773215436).
+	// By doing so, the data will be written as a string rather than hex encoded bytes.
+	val, err := json.Marshal(e)
+	return string(val), err
 }
 
 func (e *ExpAssetStatAccounts) Scan(src interface{}) error {
@@ -525,7 +533,11 @@ func (e ExpAssetStatBalances) IsZero() bool {
 }
 
 func (e ExpAssetStatBalances) Value() (driver.Value, error) {
-	return json.Marshal(e)
+	// Convert the byte array into a string as a workaround to bypass buggy encoding in the pq driver
+	// (More info about this bug here https://github.com/stellar/go/issues/5086#issuecomment-1773215436).
+	// By doing so, the data will be written as a string rather than hex encoded bytes.
+	val, err := json.Marshal(e)
+	return string(val), err
 }
 
 func (e *ExpAssetStatBalances) Scan(src interface{}) error {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Use FastBatchInsertBuilder for asset stats to speed up db operations where we need to insert a lot of asset stat rows.