### PR TITLE
ingest/ledgerbackend: Remove captive core info request error logs

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -218,7 +218,6 @@ func (c *CaptiveStellarCore) coreSyncedMetric() float64 {
 
 	info, err := c.stellarCoreClient.Info(c.config.Context)
 	if err != nil {
-		c.config.Log.WithError(err).Warn("Cannot connect to Captive Stellar-Core HTTP server")
 		return -1
 	}
 
@@ -236,7 +235,6 @@ func (c *CaptiveStellarCore) coreVersionMetric() float64 {
 
 	info, err := c.stellarCoreClient.Info(c.config.Context)
 	if err != nil {
-		c.config.Log.WithError(err).Warn("Cannot connect to Captive Stellar-Core HTTP server")
 		return -1
 	}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Captive core configures two prometheus metrics which periodically probe the info http endpoint on captive core. If the info request fails, we currently log the error. 

### Why

This commit removes the logs because we are already probing the info http endpoint and logging errors in https://github.com/stellar/go/blame/master/services/horizon/internal/app.go#L401C15-L401C36 . Therefore the logs here are redundant. Also, in https://github.com/stellar/go/pull/4894 and https://github.com/stellar/go/pull/5108 we added logic to suppress error logs during the build state, and if we keep this logging code we will have to reimplement this logic again.

### Known limitations

[N/A]
