### PR TITLE
services/horizon/internal/ingest/processors: Dedupe participants deterministically

### DIFF
--- a/services/horizon/internal/ingest/processors/liquidity_pools_transaction_processor.go
+++ b/services/horizon/internal/ingest/processors/liquidity_pools_transaction_processor.go
@@ -2,10 +2,10 @@ package processors
 
 import (
 	"context"
+	"sort"
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
-	"github.com/stellar/go/support/collections/set"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/toid"
@@ -73,16 +73,18 @@ func liquidityPoolsForTransaction(transaction ingest.LedgerTransaction) ([]strin
 }
 
 func dedupeStrings(in []string) []string {
-	set := set.Set[string]{}
-	for _, id := range in {
-		set.Add(id)
+	sort.Strings(in)
+	insert := 1
+	for cur := 1; cur < len(in); cur++ {
+		if in[cur] == in[cur-1] {
+			continue
+		}
+		if insert != cur {
+			in[insert] = in[cur]
+		}
+		insert++
 	}
-
-	out := make([]string, 0, len(in))
-	for id := range set {
-		out = append(out, id)
-	}
-	return out
+	return in[:insert]
 }
 
 func liquidityPoolsForChanges(

--- a/services/horizon/internal/ingest/processors/liquidity_pools_transaction_processor.go
+++ b/services/horizon/internal/ingest/processors/liquidity_pools_transaction_processor.go
@@ -73,6 +73,9 @@ func liquidityPoolsForTransaction(transaction ingest.LedgerTransaction) ([]strin
 }
 
 func dedupeStrings(in []string) []string {
+	if len(in) <= 1 {
+		return in
+	}
 	sort.Strings(in)
 	insert := 1
 	for cur := 1; cur < len(in); cur++ {

--- a/services/horizon/internal/ingest/processors/operations_processor.go
+++ b/services/horizon/internal/ingest/processors/operations_processor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/guregu/null"
 
@@ -1034,16 +1035,22 @@ func (operation *transactionOperationWrapper) Participants() ([]xdr.AccountId, e
 }
 
 // dedupeParticipants remove any duplicate ids from `in`
-func dedupeParticipants(in []xdr.AccountId) (out []xdr.AccountId) {
-	set := map[string]xdr.AccountId{}
-	for _, id := range in {
-		set[id.Address()] = id
+func dedupeParticipants(in []xdr.AccountId) []xdr.AccountId {
+	sort.Slice(in, func(i, j int) bool {
+		return in[i].Address() < in[j].Address()
+	})
+	insert := 1
+	for cur := 1; cur < len(in); cur++ {
+		if in[cur].Equals(in[cur-1]) {
+			continue
+		}
+		if insert != cur {
+			in[insert] = in[cur]
+		}
+		insert++
 	}
+	return in[:insert]
 
-	for _, id := range set {
-		out = append(out, id)
-	}
-	return
 }
 
 // OperationsParticipants returns a map with all participants per operation

--- a/services/horizon/internal/ingest/processors/operations_processor.go
+++ b/services/horizon/internal/ingest/processors/operations_processor.go
@@ -1036,6 +1036,9 @@ func (operation *transactionOperationWrapper) Participants() ([]xdr.AccountId, e
 
 // dedupeParticipants remove any duplicate ids from `in`
 func dedupeParticipants(in []xdr.AccountId) []xdr.AccountId {
+	if len(in) <= 1 {
+		return in
+	}
 	sort.Slice(in, func(i, j int) bool {
 		return in[i].Address() < in[j].Address()
 	})


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

There are a few places in horizon's ingestion code where we extract unique elements (for example, account participants for an operation) using a map data structure. The problem with that approach is that traversing elements in a map in Go produces a random ordering. We want to make horizon's ingestion workflow completely deterministic so this commit uses sorting to extract unique elements instead.

### Why

Having a deterministic ingestion workflow makes it easier to test the correctness of ingestion.

### Known limitations

N / A