### PR TITLE
ingest/ledgerbacked/toml: Add support for ENABLE_DIAGNOSTICS_FOR_TX_SUBMISSION in captive core

### DIFF
--- a/ingest/ledgerbackend/toml.go
+++ b/ingest/ledgerbackend/toml.go
@@ -94,6 +94,7 @@ type captiveCoreTomlValues struct {
 	EnableSorobanDiagnosticEvents         *bool                `toml:"ENABLE_SOROBAN_DIAGNOSTIC_EVENTS,omitempty"`
 	TestingMinimumPersistentEntryLifetime *uint                `toml:"TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME,omitempty"`
 	TestingSorobanHighLimitOverride       *bool                `toml:"TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE,omitempty"`
+	EnableDiagnosticsForTxSubmission      *bool                `toml:"ENABLE_DIAGNOSTICS_FOR_TX_SUBMISSION,omitempty"`
 }
 
 // QuorumSetIsConfigured returns true if there is a quorum set defined in the configuration.


### PR DESCRIPTION
This is a followup of https://github.com/stellar/stellar-core/pull/4104 and https://github.com/stellar/go/pull/5148