### PR TITLE
Fix ingestion logging duration time

### DIFF
--- a/services/horizon/internal/ingest/fsm_reingest_history_range_state.go
+++ b/services/horizon/internal/ingest/fsm_reingest_history_range_state.go
@@ -124,13 +124,14 @@ func (h reingestHistoryRangeState) run(s *system) (transition, error) {
 		h.fromLedger = 2
 	}
 
-	startTime := time.Now()
+	var startTime time.Time
 
 	if h.force {
 		if t, err := h.prepareRange(s); err != nil {
 			return t, err
 		}
 
+		startTime = time.Now()
 		if err := s.historyQ.Begin(s.ctx); err != nil {
 			return stop(), errors.Wrap(err, "Error starting a transaction")
 		}
@@ -167,6 +168,7 @@ func (h reingestHistoryRangeState) run(s *system) (transition, error) {
 			return t, err
 		}
 
+		startTime = time.Now()
 		if err := s.historyQ.Begin(s.ctx); err != nil {
 			return stop(), errors.Wrap(err, "Error starting a transaction")
 		}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

removed inclusion of range prep time in the duration logged by `Reingestion done` , it was inadvertently moved as part of ingestion performance overhaul.

### Why

keeps the meaning of `Reingestion done` consistent to prior versions of horizon which don't include range prep time.

closes #5156 

### Known limitations


