### PR TITLE
ingest/ledgerbackend - Pass user agent in ledger backend

### DIFF
--- a/historyarchive/archive_pool_test.go
+++ b/historyarchive/archive_pool_test.go
@@ -1,0 +1,39 @@
+// Copyright 2016 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+package historyarchive
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stellar/go/support/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfiguresHttpUserAgentForArchivePool(t *testing.T) {
+	var userAgent string
+	var archiveURLs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgent = r.Header["User-Agent"][0]
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	archiveURLs = append(archiveURLs, server.URL)
+
+	archiveOptions := ArchiveOptions{
+		ConnectOptions: storage.ConnectOptions{
+			UserAgent: "uatest",
+		},
+	}
+
+	archivePool, err := NewArchivePool(archiveURLs, archiveOptions)
+	assert.NoError(t, err)
+
+	ok, err := archivePool.BucketExists(EmptyXdrArrayHash())
+	assert.True(t, ok)
+	assert.NoError(t, err)
+	assert.Equal(t, userAgent, "uatest")
+}

--- a/ingest/ledgerbackend/captive_core_backend.go
+++ b/ingest/ledgerbackend/captive_core_backend.go
@@ -179,7 +179,8 @@ func NewCaptive(config CaptiveCoreConfig) (*CaptiveStellarCore, error) {
 			NetworkPassphrase:   config.NetworkPassphrase,
 			CheckpointFrequency: config.CheckpointFrequency,
 			ConnectOptions: storage.ConnectOptions{
-				Context: config.Context,
+				Context:   config.Context,
+				UserAgent: config.UserAgent,
 			},
 		},
 	)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

* Passing user agent in the captive core backend
* Add user agent configuration test for ArchivePool

### Why

Help in identifying history archive usage patterns

### Known limitations
