### PR TITLE
services/horizon: Bump the history archive cache size to increase hit rates

### DIFF
--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -230,7 +230,7 @@ func NewSystem(config Config) (System, error) {
 			CacheConfig: historyarchive.CacheOptions{
 				Cache:    true,
 				Path:     path.Join(config.CaptiveCoreStoragePath, "bucket-cache"),
-				MaxFiles: 50,
+				MaxFiles: 150,
 			},
 		},
 	)


### PR DESCRIPTION
### What
Triple the amount of files that are allowed to be cached.

### Why
We are experimenting with the optimal count in order to balance the size of the on-disk cache with the hit rate in avoiding repeated queries to the history archives.

### Known limitations
n/a