### PR TITLE
historyarchive: Improve existence checks and performance

### DIFF
--- a/ingest/verify/main.go
+++ b/ingest/verify/main.go
@@ -66,7 +66,7 @@ func (v *StateVerifier) GetLedgerEntries(count int) ([]xdr.LedgerEntry, error) {
 	}
 
 	entries := make([]xdr.LedgerEntry, 0, count)
-	v.currentEntries = make(map[string]xdr.LedgerEntry)
+	v.currentEntries = make(map[string]xdr.LedgerEntry, count)
 
 	for count > 0 {
 		entryChange, err := v.stateReader.Read()

--- a/services/horizon/internal/ingest/verify.go
+++ b/services/horizon/internal/ingest/verify.go
@@ -157,8 +157,8 @@ func (s *system) verifyState(verifyAgainstLatestCheckpoint bool) error {
 				}
 			}
 		}
-		log.WithField("duration", duration).Info("State verification finished")
 
+		localLog.WithField("duration", duration).Info("State verification finished")
 	}()
 
 	localLog.Info("Creating state reader...")


### PR DESCRIPTION
### What
This optimizes existence checks in the case of concurrent history archive sessions sharing a cache.

It also makes a slight performance improvement to state verification memory allocation and improves logging in the state verifier.

### Why
This will reduce churn on `Exists()` requests to the archives.

### Known limitations
n/a