### PR TITLE
services/horizon/ingest: added more description to the history archive metrics labels

### DIFF
--- a/historyarchive/archive.go
+++ b/historyarchive/archive.go
@@ -119,7 +119,8 @@ func (arch *Archive) GetCheckpointManager() CheckpointManager {
 func (a *Archive) GetPathHAS(path string) (HistoryArchiveState, error) {
 	var has HistoryArchiveState
 	rdr, err := a.backend.GetFile(path)
-	a.stats.incrementDownloads()
+	// this is a query on the HA server state, not a data/bucket file download
+	a.stats.incrementRequests()
 	if err != nil {
 		return has, err
 	}

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -409,7 +409,13 @@ func (s *system) initMetrics() {
 	s.metrics.HistoryArchiveStatsCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "horizon", Subsystem: "ingest", Name: "history_archive_stats_total",
-			Help: "counters of different history archive stats",
+			Help: "counters of different history archive requests.\n" +
+				"'source' label will provide name/address of the physical history archive server from the pool for which a request may be sent\n" +
+				"'type' label will further categorize the potential request into specific requests such as\n" +
+				"'file_downloads' - the count of files downloaded from an archive server\n" +
+				"'file_uploads' - the count of files uploaded to an archive server\n" +
+				"'requests' - the count of non-download, http query requests sent to an archive server\n" +
+				"'cache_hits' - the count of requests for an archive file that were found on local cache instead, no download request sent to archive server",
 		},
 		[]string{"source", "type"},
 	)

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -409,13 +409,13 @@ func (s *system) initMetrics() {
 	s.metrics.HistoryArchiveStatsCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "horizon", Subsystem: "ingest", Name: "history_archive_stats_total",
-			Help: "counters of different history archive requests.\n" +
-				"'source' label will provide name/address of the physical history archive server from the pool for which a request may be sent\n" +
-				"'type' label will further categorize the potential request into specific requests such as\n" +
-				"'file_downloads' - the count of files downloaded from an archive server\n" +
-				"'file_uploads' - the count of files uploaded to an archive server\n" +
-				"'requests' - the count of non-download, http query requests sent to an archive server\n" +
-				"'cache_hits' - the count of requests for an archive file that were found on local cache instead, no download request sent to archive server",
+			Help: "Counters of different history archive requests.  " +
+				"'source' label will provide name/address of the physical history archive server from the pool for which a request may be sent.  " +
+				"'type' label will further categorize the potential request into specific requests, " +
+				"'file_downloads' - the count of files downloaded from an archive server, " +
+				"'file_uploads' - the count of files uploaded to an archive server, " +
+				"'requests' - the count of non-download, http query requests sent to an archive server, " +
+				"'cache_hits' - the count of requests for an archive file that were found on local cache instead, no download request sent to archive server.",
 		},
 		[]string{"source", "type"},
 	)

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -414,7 +414,7 @@ func (s *system) initMetrics() {
 				"'type' label will further categorize the potential request into specific requests, " +
 				"'file_downloads' - the count of files downloaded from an archive server, " +
 				"'file_uploads' - the count of files uploaded to an archive server, " +
-				"'requests' - the count of non-download, http query requests sent to an archive server, " +
+				"'requests' - the count of all http query requests sent to an archive server, " +
 				"'cache_hits' - the count of requests for an archive file that were found on local cache instead, no download request sent to archive server.",
 		},
 		[]string{"source", "type"},

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -414,7 +414,7 @@ func (s *system) initMetrics() {
 				"'type' label will further categorize the potential request into specific requests, " +
 				"'file_downloads' - the count of files downloaded from an archive server, " +
 				"'file_uploads' - the count of files uploaded to an archive server, " +
-				"'requests' - the count of all http query requests sent to an archive server, " +
+				"'requests' - the count of all http requests(includes both queries and file downloads) sent to an archive server, " +
 				"'cache_hits' - the count of requests for an archive file that were found on local cache instead, no download request sent to archive server.",
 		},
 		[]string{"source", "type"},


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

added more content to the history archive request metrics

### Why

there are sub-labels for the history archive metrics key, and the additional docs help describe what each label is counting.

### Known limitations

