### PR TITLE
Fix for transaction submission timeout

### DIFF
--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -235,5 +235,6 @@ func initSubmissionSystem(app *App) {
 		DB: func(ctx context.Context) txsub.HorizonDB {
 			return &history.Q{SessionInterface: app.HorizonSession()}
 		},
+		LedgerState: app.ledgerState,
 	}
 }

--- a/services/horizon/internal/ledger/main.go
+++ b/services/horizon/internal/ledger/main.go
@@ -1,3 +1,8 @@
+// Package ledger provides useful utilities concerning ledgers within stellar,
+// specifically as a central location to store a cached snapshot of the state of
+// both horizon's and stellar-core's views of the ledger.  This package is
+// intended to be at the lowest levels of horizon's dependency tree, please keep
+// it free of dependencies to other horizon packages.
 package ledger
 
 import (

--- a/services/horizon/internal/ledger/main.go
+++ b/services/horizon/internal/ledger/main.go
@@ -1,15 +1,9 @@
-// Package ledger provides useful utilities concerning ledgers within stellar,
-// specifically as a central location to store a cached snapshot of the state of
-// both horizon's and stellar-core's views of the ledger.  This package is
-// intended to be at the lowest levels of horizon's dependency tree, please keep
-// it free of dependencies to other horizon packages.
 package ledger
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
 	"sync"
 	"time"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Status represents a snapshot of both horizon's and stellar-core's view of the
@@ -31,7 +25,7 @@ type HorizonStatus struct {
 }
 
 // State is an in-memory data structure which holds a snapshot of both
-// horizon's and stellar-core's view of the the network
+// horizon's and stellar-core's view of the network
 type State struct {
 	sync.RWMutex
 	current Status
@@ -42,6 +36,14 @@ type State struct {
 		HistoryElderLedgerCounter         prometheus.CounterFunc
 		CoreLatestLedgerCounter           prometheus.CounterFunc
 	}
+}
+
+type StateInterface interface {
+	CurrentStatus() Status
+	SetStatus(next Status)
+	SetCoreStatus(next CoreStatus)
+	SetHorizonStatus(next HorizonStatus)
+	RegisterMetrics(registry *prometheus.Registry)
 }
 
 // CurrentStatus returns the cached snapshot of ledger state

--- a/services/horizon/internal/txsub/helpers_test.go
+++ b/services/horizon/internal/txsub/helpers_test.go
@@ -9,6 +9,8 @@ package txsub
 import (
 	"context"
 	"database/sql"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stretchr/testify/mock"
@@ -71,4 +73,34 @@ func (m *mockDBQ) PreFilteredTransactionByHash(ctx context.Context, dest interfa
 func (m *mockDBQ) TransactionByHash(ctx context.Context, dest interface{}, hash string) error {
 	args := m.Called(ctx, dest, hash)
 	return args.Error(0)
+}
+
+type MockLedgerState struct {
+	mock.Mock
+}
+
+// CurrentStatus mocks the CurrentStatus method.
+func (m *MockLedgerState) CurrentStatus() ledger.Status {
+	args := m.Called()
+	return args.Get(0).(ledger.Status)
+}
+
+// SetStatus mocks the SetStatus method.
+func (m *MockLedgerState) SetStatus(next ledger.Status) {
+	m.Called(next)
+}
+
+// SetCoreStatus mocks the SetCoreStatus method.
+func (m *MockLedgerState) SetCoreStatus(next ledger.CoreStatus) {
+	m.Called(next)
+}
+
+// SetHorizonStatus mocks the SetHorizonStatus method.
+func (m *MockLedgerState) SetHorizonStatus(next ledger.HorizonStatus) {
+	m.Called(next)
+}
+
+// RegisterMetrics mocks the RegisterMetrics method.
+func (m *MockLedgerState) RegisterMetrics(registry *prometheus.Registry) {
+	m.Called(registry)
 }

--- a/services/horizon/internal/txsub/system.go
+++ b/services/horizon/internal/txsub/system.go
@@ -41,7 +41,7 @@ type System struct {
 	Submitter         Submitter
 	SubmissionTimeout time.Duration
 	Log               *log.Entry
-	LedgerState       *ledger.State
+	LedgerState       ledger.StateInterface
 
 	Metrics struct {
 		// SubmissionDuration exposes timing metrics about the rate and latency of
@@ -144,14 +144,6 @@ func (sys *System) Submit(
 			return
 		}
 
-		// Check if Horizon and Core have synced up: If yes, then no need to wait for account sequence
-		// and send txBAD_SEQ right away.
-		currentStatus := sys.LedgerState.CurrentStatus()
-		if currentStatus.CoreLatest == currentStatus.HistoryLatest {
-			sys.finish(ctx, hash, resultCh, Result{Err: sr.Err})
-			return
-		}
-
 		// Even if a transaction is successfully submitted to core, Horizon ingestion might
 		// be lagging behind leading to txBAD_SEQ. This function will block a txsub request
 		// until the request times out or account sequence is bumped to txn sequence.
@@ -200,7 +192,7 @@ func (sys *System) waitUntilAccountSequence(ctx context.Context, db HorizonDB, s
 					WithField("sourceAddress", sourceAddress).
 					Warn("missing sequence number for account")
 			}
-			if num >= seq {
+			if num >= seq || sys.isSyncedUp() {
 				return nil
 			}
 		}
@@ -212,6 +204,13 @@ func (sys *System) waitUntilAccountSequence(ctx context.Context, db HorizonDB, s
 			timer.Reset(sys.accountSeqPollInterval)
 		}
 	}
+}
+
+// isSyncedUp Check if Horizon and Core have synced up: If yes, then no need to wait for account sequence
+// and send txBAD_SEQ right away.
+func (sys *System) isSyncedUp() bool {
+	currentStatus := sys.LedgerState.CurrentStatus()
+	return int(currentStatus.CoreLatest) == int(currentStatus.HistoryLatest)
 }
 
 func (sys *System) deriveTxSubError(ctx context.Context) error {

--- a/services/horizon/internal/txsub/system.go
+++ b/services/horizon/internal/txsub/system.go
@@ -210,7 +210,7 @@ func (sys *System) waitUntilAccountSequence(ctx context.Context, db HorizonDB, s
 // and send txBAD_SEQ right away.
 func (sys *System) isSyncedUp() bool {
 	currentStatus := sys.LedgerState.CurrentStatus()
-	return int(currentStatus.CoreLatest) == int(currentStatus.HistoryLatest)
+	return int(currentStatus.CoreLatest) <= int(currentStatus.HistoryLatest)
 }
 
 func (sys *System) deriveTxSubError(ctx context.Context) error {

--- a/services/horizon/internal/txsub/system.go
+++ b/services/horizon/internal/txsub/system.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"sync"
 	"time"
 
@@ -40,6 +41,7 @@ type System struct {
 	Submitter         Submitter
 	SubmissionTimeout time.Duration
 	Log               *log.Entry
+	LedgerState       *ledger.State
 
 	Metrics struct {
 		// SubmissionDuration exposes timing metrics about the rate and latency of
@@ -138,6 +140,14 @@ func (sys *System) Submit(
 			return
 		}
 		if !isBad {
+			sys.finish(ctx, hash, resultCh, Result{Err: sr.Err})
+			return
+		}
+
+		// Check if Horizon and Core have synced up: If yes, then no need to wait for account sequence
+		// and send txBAD_SEQ right away.
+		currentStatus := sys.LedgerState.CurrentStatus()
+		if currentStatus.CoreLatest == currentStatus.HistoryLatest {
 			sys.finish(ctx, hash, resultCh, Result{Err: sr.Err})
 			return
 		}

--- a/services/horizon/internal/txsub/system_test.go
+++ b/services/horizon/internal/txsub/system_test.go
@@ -353,7 +353,7 @@ func (suite *SystemTestSuite) TestSubmit_BadSeqNotFoundWhenInSync() {
 	suite.db.On("GetSequenceNumbers", suite.ctx, []string{suite.unmuxedSource.Address()}).
 		Return(map[string]uint64{suite.unmuxedSource.Address(): 0}, nil).
 		Twice()
-	
+
 	mockLedgerState := &MockLedgerState{}
 	mockLedgerState.On("CurrentStatus").Return(ledger.Status{
 		CoreStatus: ledger.CoreStatus{

--- a/services/horizon/internal/txsub/system_test.go
+++ b/services/horizon/internal/txsub/system_test.go
@@ -342,7 +342,7 @@ func (suite *SystemTestSuite) TestSubmit_BadSeqNotFound() {
 }
 
 // If error is bad_seq and horizon and core are in sync, then return error
-func (suite *SystemTestSuite) TestSubmit_BadSeqNotFoundWhenInSync() {
+func (suite *SystemTestSuite) TestSubmit_BadSeqErrorWhenInSync() {
 	suite.submitter.R = suite.badSeq
 	suite.db.On("PreFilteredTransactionByHash", suite.ctx, mock.Anything, suite.successTx.Transaction.TransactionHash).
 		Return(sql.ErrNoRows).Twice()
@@ -385,6 +385,7 @@ func (suite *SystemTestSuite) TestSubmit_BadSeqNotFoundWhenInSync() {
 	)
 
 	assert.NotNil(suite.T(), r.Err)
+	assert.Equal(suite.T(), r.Err.Error(), "tx failed: AAAAAAAAAAD////7AAAAAA==") // decodes to txBadSeq
 	assert.True(suite.T(), suite.submitter.WasSubmittedTo)
 }
 

--- a/services/horizon/internal/txsub/system_test.go
+++ b/services/horizon/internal/txsub/system_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"testing"
 	"time"
 
@@ -155,6 +156,17 @@ func (suite *SystemTestSuite) TestTimeoutDuringSequenceLoop() {
 	suite.db.On("GetSequenceNumbers", suite.ctx, []string{suite.unmuxedSource.Address()}).
 		Return(map[string]uint64{suite.unmuxedSource.Address(): 0}, nil)
 
+	mockLedgerState := &MockLedgerState{}
+	mockLedgerState.On("CurrentStatus").Return(ledger.Status{
+		CoreStatus: ledger.CoreStatus{
+			CoreLatest: 3,
+		},
+		HorizonStatus: ledger.HorizonStatus{
+			HistoryLatest: 1,
+		},
+	}).Twice()
+	suite.system.LedgerState = mockLedgerState
+
 	r := <-suite.system.Submit(
 		suite.ctx,
 		suite.successTx.Transaction.TxEnvelope,
@@ -186,6 +198,17 @@ func (suite *SystemTestSuite) TestClientDisconnectedDuringSequenceLoop() {
 		Once()
 	suite.db.On("GetSequenceNumbers", suite.ctx, []string{suite.unmuxedSource.Address()}).
 		Return(map[string]uint64{suite.unmuxedSource.Address(): 0}, nil)
+
+	mockLedgerState := &MockLedgerState{}
+	mockLedgerState.On("CurrentStatus").Return(ledger.Status{
+		CoreStatus: ledger.CoreStatus{
+			CoreLatest: 3,
+		},
+		HorizonStatus: ledger.HorizonStatus{
+			HistoryLatest: 1,
+		},
+	}).Once()
+	suite.system.LedgerState = mockLedgerState
 
 	r := <-suite.system.Submit(
 		suite.ctx,
@@ -253,6 +276,17 @@ func (suite *SystemTestSuite) TestSubmit_BadSeq() {
 		}).
 		Return(nil).Once()
 
+	mockLedgerState := &MockLedgerState{}
+	mockLedgerState.On("CurrentStatus").Return(ledger.Status{
+		CoreStatus: ledger.CoreStatus{
+			CoreLatest: 3,
+		},
+		HorizonStatus: ledger.HorizonStatus{
+			HistoryLatest: 1,
+		},
+	}).Twice()
+	suite.system.LedgerState = mockLedgerState
+
 	r := <-suite.system.Submit(
 		suite.ctx,
 		suite.successTx.Transaction.TxEnvelope,
@@ -280,6 +314,64 @@ func (suite *SystemTestSuite) TestSubmit_BadSeqNotFound() {
 	suite.db.On("GetSequenceNumbers", suite.ctx, []string{suite.unmuxedSource.Address()}).
 		Return(map[string]uint64{suite.unmuxedSource.Address(): 1}, nil).
 		Once()
+
+	mockLedgerState := &MockLedgerState{}
+	mockLedgerState.On("CurrentStatus").Return(ledger.Status{
+		CoreStatus: ledger.CoreStatus{
+			CoreLatest: 3,
+		},
+		HorizonStatus: ledger.HorizonStatus{
+			HistoryLatest: 1,
+		},
+	}).Times(3)
+	suite.system.LedgerState = mockLedgerState
+
+	// set poll interval to 1ms so we don't need to wait 3 seconds for the test to complete
+	suite.system.Init()
+	suite.system.accountSeqPollInterval = time.Millisecond
+
+	r := <-suite.system.Submit(
+		suite.ctx,
+		suite.successTx.Transaction.TxEnvelope,
+		suite.successXDR,
+		suite.successTx.Transaction.TransactionHash,
+	)
+
+	assert.NotNil(suite.T(), r.Err)
+	assert.True(suite.T(), suite.submitter.WasSubmittedTo)
+}
+
+// If error is bad_seq and horizon and core are in sync, then return error
+func (suite *SystemTestSuite) TestSubmit_BadSeqNotFoundWhenInSync() {
+	suite.submitter.R = suite.badSeq
+	suite.db.On("PreFilteredTransactionByHash", suite.ctx, mock.Anything, suite.successTx.Transaction.TransactionHash).
+		Return(sql.ErrNoRows).Twice()
+	suite.db.On("NoRows", sql.ErrNoRows).Return(true).Twice()
+	suite.db.On("TransactionByHash", suite.ctx, mock.Anything, suite.successTx.Transaction.TransactionHash).
+		Return(sql.ErrNoRows).Twice()
+	suite.db.On("NoRows", sql.ErrNoRows).Return(true).Twice()
+	suite.db.On("GetSequenceNumbers", suite.ctx, []string{suite.unmuxedSource.Address()}).
+		Return(map[string]uint64{suite.unmuxedSource.Address(): 0}, nil).
+		Twice()
+	
+	mockLedgerState := &MockLedgerState{}
+	mockLedgerState.On("CurrentStatus").Return(ledger.Status{
+		CoreStatus: ledger.CoreStatus{
+			CoreLatest: 3,
+		},
+		HorizonStatus: ledger.HorizonStatus{
+			HistoryLatest: 1,
+		},
+	}).Once()
+	mockLedgerState.On("CurrentStatus").Return(ledger.Status{
+		CoreStatus: ledger.CoreStatus{
+			CoreLatest: 1,
+		},
+		HorizonStatus: ledger.HorizonStatus{
+			HistoryLatest: 1,
+		},
+	}).Once()
+	suite.system.LedgerState = mockLedgerState
 
 	// set poll interval to 1ms so we don't need to wait 3 seconds for the test to complete
 	suite.system.Init()


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Adds a check in the transaction submission workflow, where it returns the bad sequence error immediately if Horizon and Core sync up with each other.

### Why

During a particular edge-case, if core reports bad-seq error, and Horizon and Core are synced up with each other, the txsub endpoint will still timeout instead of returning the error immediately.

closes #5192 

This is a bug due to how Horizon will keep waiting for the account sequence to catch up to the submitted tx seq.

### Known limitations

NA
