### PR TITLE
do not append UNSTABLE to tag for horizon docker builds

### DIFF
--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -4,9 +4,6 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 BUILD_DATE := $(shell date -u +%FT%TZ)
 
 TAG ?= stellar/stellar-horizon:$(VERSION)
-ifeq ($(ALLOW_CORE_UNSTABLE),yes)
-	TAG := $(TAG)-UNSTABLE
-endif
 
 docker-build:
 ifndef VERSION


### PR DESCRIPTION
### What
do not append UNSTABLE to tag for horizon docker builds even if unstable core is used

### Why
they've decided they want to be able to bundle unstable captivecore with production horizon, so no point in appending UNSTABLE to the tag

### Testing
https://buildmeister-v3.stellar-ops.com/job/Platform/job/stellar-horizon-docker-builder/149/

### Issue addressed by this PR
https://github.com/stellar/ops/issues/2812

