### PR TITLE
Refactor GetDiagnosticEvents so that it can be used directly from TransactionMeta

### DIFF
--- a/ingest/ledger_transaction.go
+++ b/ingest/ledger_transaction.go
@@ -1,8 +1,6 @@
 package ingest
 
 import (
-	"fmt"
-
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -155,40 +153,5 @@ func operationChanges(ops []xdr.OperationMeta, index uint32) []Change {
 
 // GetDiagnosticEvents returns all contract events emitted by a given operation.
 func (t *LedgerTransaction) GetDiagnosticEvents() ([]xdr.DiagnosticEvent, error) {
-	switch t.UnsafeMeta.V {
-	case 1:
-		return nil, nil
-	case 2:
-		return nil, nil
-	case 3:
-		var diagnosticEvents []xdr.DiagnosticEvent
-		var contractEvents []xdr.ContractEvent
-		if sorobanMeta := t.UnsafeMeta.MustV3().SorobanMeta; sorobanMeta != nil {
-			diagnosticEvents = sorobanMeta.DiagnosticEvents
-			if len(diagnosticEvents) > 0 {
-				// all contract events and diag events for a single operation(by it's index in the tx) were available
-				// in tx meta's DiagnosticEvents, no need to look anywhere else for events
-				return diagnosticEvents, nil
-			}
-
-			contractEvents = sorobanMeta.Events
-			if len(contractEvents) == 0 {
-				// no events were present in this tx meta
-				return nil, nil
-			}
-		}
-
-		// tx meta only provided contract events, no diagnostic events, we convert the contract
-		// event to a diagnostic event, to fit the response interface.
-		convertedDiagnosticEvents := make([]xdr.DiagnosticEvent, len(contractEvents))
-		for i, event := range contractEvents {
-			convertedDiagnosticEvents[i] = xdr.DiagnosticEvent{
-				InSuccessfulContractCall: true,
-				Event:                    event,
-			}
-		}
-		return convertedDiagnosticEvents, nil
-	default:
-		return nil, fmt.Errorf("unsupported TransactionMeta version: %v", t.UnsafeMeta.V)
-	}
+	return t.UnsafeMeta.GetDiagnosticEvents()
 }

--- a/xdr/transaction_meta.go
+++ b/xdr/transaction_meta.go
@@ -1,5 +1,9 @@
 package xdr
 
+import (
+	"fmt"
+)
+
 // Operations is a helper on TransactionMeta that returns operations
 // meta from `TransactionMeta.Operations` or `TransactionMeta.V1.Operations`.
 func (transactionMeta *TransactionMeta) OperationsMeta() []OperationMeta {
@@ -14,5 +18,45 @@ func (transactionMeta *TransactionMeta) OperationsMeta() []OperationMeta {
 		return transactionMeta.MustV3().Operations
 	default:
 		panic("Unsupported TransactionMeta version")
+	}
+}
+
+// GetDiagnosticEvents returns all contract events emitted by a given operation.
+func (t *TransactionMeta) GetDiagnosticEvents() ([]DiagnosticEvent, error) {
+	switch t.V {
+	case 1:
+		return nil, nil
+	case 2:
+		return nil, nil
+	case 3:
+		var diagnosticEvents []DiagnosticEvent
+		var contractEvents []ContractEvent
+		if sorobanMeta := t.MustV3().SorobanMeta; sorobanMeta != nil {
+			diagnosticEvents = sorobanMeta.DiagnosticEvents
+			if len(diagnosticEvents) > 0 {
+				// all contract events and diag events for a single operation(by it's index in the tx) were available
+				// in tx meta's DiagnosticEvents, no need to look anywhere else for events
+				return diagnosticEvents, nil
+			}
+
+			contractEvents = sorobanMeta.Events
+			if len(contractEvents) == 0 {
+				// no events were present in this tx meta
+				return nil, nil
+			}
+		}
+
+		// tx meta only provided contract events, no diagnostic events, we convert the contract
+		// event to a diagnostic event, to fit the response interface.
+		convertedDiagnosticEvents := make([]DiagnosticEvent, len(contractEvents))
+		for i, event := range contractEvents {
+			convertedDiagnosticEvents[i] = DiagnosticEvent{
+				InSuccessfulContractCall: true,
+				Event:                    event,
+			}
+		}
+		return convertedDiagnosticEvents, nil
+	default:
+		return nil, fmt.Errorf("unsupported TransactionMeta version: %v", t.V)
 	}
 }

--- a/xdr/transaction_meta.go
+++ b/xdr/transaction_meta.go
@@ -34,7 +34,7 @@ func (t *TransactionMeta) GetDiagnosticEvents() ([]DiagnosticEvent, error) {
 		if sorobanMeta := t.MustV3().SorobanMeta; sorobanMeta != nil {
 			diagnosticEvents = sorobanMeta.DiagnosticEvents
 			if len(diagnosticEvents) > 0 {
-				// all contract events and diag events for a single operation(by it's index in the tx) were available
+				// all contract events and diag events for a single operation(by its index in the tx) were available
 				// in tx meta's DiagnosticEvents, no need to look anywhere else for events
 				return diagnosticEvents, nil
 			}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Moving core logic of GetDiagnosticEvents from LedgerTransaction to TransactionMeta

### Why

In order to use GetDiagnosticEvents directly from TransactionMeta in soroban-rpc. This is mainly required for this feature --> https://github.com/stellar/soroban-rpc/issues/16

### Known limitations

N/A
