### PR TITLE
services/horizon: Fix claimable balance query

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -35,7 +35,7 @@ jobs:
       HORIZON_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL: ${{ matrix.protocol-version }}
       PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 20.1.0-1656.114b833e7.focal
       PROTOCOL_20_CORE_DOCKER_IMG: stellar/unsafe-stellar-core:20.1.0-1656.114b833e7.focal
-      PROTOCOL_20_SOROBAN_RPC_DOCKER_IMG: stellar/soroban-rpc:20.2.0
+      PROTOCOL_20_SOROBAN_RPC_DOCKER_IMG: stellar/soroban-rpc:20.2.0@sha256:2b1237a6ca43ea5768031d9ab442e4895d0ce5437b38cbfee4c8ab9237f231ae 
       PROTOCOL_19_CORE_DEBIAN_PKG_VERSION: 19.14.0-1500.5664eff4e.focal
       PROTOCOL_19_CORE_DOCKER_IMG: stellar/stellar-core:19.14.0-1500.5664eff4e.focal
       PGHOST: localhost

--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -67,17 +67,17 @@ func applyClaimableBalancesQueriesCursor(sql sq.SelectBuilder, lCursor int64, rC
 	case db2.OrderAscending:
 		if hasPagedLimit {
 			sql = sql.
-				Where(sq.Expr("(last_modified_ledger, id) > (?, ?)", lCursor, rCursor))
+				Where(sq.Expr("(cb.last_modified_ledger, cb.id) > (?, ?)", lCursor, rCursor))
 
 		}
-		sql = sql.OrderBy("last_modified_ledger asc, id asc")
+		sql = sql.OrderBy("cb.last_modified_ledger asc, cb.id asc")
 	case db2.OrderDescending:
 		if hasPagedLimit {
 			sql = sql.
-				Where(sq.Expr("(last_modified_ledger, id) < (?, ?)", lCursor, rCursor))
+				Where(sq.Expr("(cb.last_modified_ledger, cb.id) < (?, ?)", lCursor, rCursor))
 		}
 
-		sql = sql.OrderBy("last_modified_ledger desc, id desc")
+		sql = sql.OrderBy("cb.last_modified_ledger desc, cb.id desc")
 	default:
 		return sql, errors.Errorf("invalid order: %s", order)
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Explicitly qualify columns with table name/alias in claimable balance db query.

Query before the fix:
SELECT cb.id, cb.claimants, cb.asset, cb.amount, cb.sponsor, cb.last_modified_ledger, cb.flags FROM claimable_balances cb JOIN claimable_balance_claimants ON claimable_balance_claimants.id = cb.id WHERE `(last_modified_ledger, id) > ($1, $2)` AND claimable_balance_claimants.destination = $3 AND cb.asset = $4 ORDER BY last_modified_ledger ASC, id ASC LIMIT 200

With the fix:
SELECT cb.id, cb.claimants, cb.asset, cb.amount, cb.sponsor, cb.last_modified_ledger, cb.flags FROM claimable_balances cb JOIN claimable_balance_claimants ON claimable_balance_claimants.id = cb.id WHERE `(cb.last_modified_ledger, cb.id) > ($1, $2)` AND claimable_balance_claimants.destination = $3 AND cb.asset = $4 ORDER BY last_modified_ledger ASC, id ASC LIMIT 200

### Why

Resolves Issue #5199 

Issue #4907 introduced a join between claimable_balances and claimable_balance_claimants tables which resulted in unqualified columns in claimable balance query with cursor cursor causing database error `column reference 'last_modified_ledger' is ambiguous`.









### Known limitations
