### PR TITLE
services/horizon/internal/db2/history: Fix claimable_balance_claimants subquery in GetClaimableBalances()

### DIFF
--- a/services/horizon/internal/db2/history/claimable_balances.go
+++ b/services/horizon/internal/db2/history/claimable_balances.go
@@ -10,6 +10,7 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/guregu/null"
+
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
@@ -57,7 +58,7 @@ func (cbq ClaimableBalancesQuery) Cursor() (int64, string, error) {
 // ApplyCursor applies cursor to the given sql. For performance reason the limit
 // is not applied here. This allows us to hint the planner later to use the right
 // indexes.
-func applyClaimableBalancesQueriesCursor(sql sq.SelectBuilder, lCursor int64, rCursor string, order string) (sq.SelectBuilder, error) {
+func applyClaimableBalancesQueriesCursor(sql sq.SelectBuilder, tableName string, lCursor int64, rCursor string, order string) (sq.SelectBuilder, error) {
 	hasPagedLimit := false
 	if lCursor > 0 && rCursor != "" {
 		hasPagedLimit = true
@@ -67,17 +68,26 @@ func applyClaimableBalancesQueriesCursor(sql sq.SelectBuilder, lCursor int64, rC
 	case db2.OrderAscending:
 		if hasPagedLimit {
 			sql = sql.
-				Where(sq.Expr("(cb.last_modified_ledger, cb.id) > (?, ?)", lCursor, rCursor))
-
+				Where(
+					sq.Expr(
+						fmt.Sprintf("(%s.last_modified_ledger, %s.id) > (?, ?)", tableName, tableName),
+						lCursor, rCursor,
+					),
+				)
 		}
-		sql = sql.OrderBy("cb.last_modified_ledger asc, cb.id asc")
+		sql = sql.OrderBy(fmt.Sprintf("%s.last_modified_ledger asc, %s.id asc", tableName, tableName))
 	case db2.OrderDescending:
 		if hasPagedLimit {
 			sql = sql.
-				Where(sq.Expr("(cb.last_modified_ledger, cb.id) < (?, ?)", lCursor, rCursor))
+				Where(
+					sq.Expr(
+						fmt.Sprintf("(%s.last_modified_ledger, %s.id) < (?, ?)", tableName, tableName),
+						lCursor,
+						rCursor,
+					),
+				)
 		}
-
-		sql = sql.OrderBy("cb.last_modified_ledger desc, cb.id desc")
+		sql = sql.OrderBy(fmt.Sprintf("%s.last_modified_ledger desc, %s.id desc", tableName, tableName))
 	default:
 		return sql, errors.Errorf("invalid order: %s", order)
 	}
@@ -216,7 +226,7 @@ func (q *Q) GetClaimableBalances(ctx context.Context, query ClaimableBalancesQue
 		return nil, errors.Wrap(err, "error getting cursor")
 	}
 
-	sql, err := applyClaimableBalancesQueriesCursor(selectClaimableBalances, l, r, query.PageQuery.Order)
+	sql, err := applyClaimableBalancesQueriesCursor(selectClaimableBalances, "cb", l, r, query.PageQuery.Order)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not apply query to page")
 	}
@@ -242,10 +252,10 @@ func (q *Q) GetClaimableBalances(ctx context.Context, query ClaimableBalancesQue
 		// does not perform efficiently. Instead, use a subquery (with LIMIT) to retrieve claimable balances based on
 		// the claimant's address.
 
-		var selectClaimableBalanceClaimants = sq.Select("id").From("claimable_balance_claimants").
-			Where("destination = ?", query.Claimant.Address()).Limit(query.PageQuery.Limit)
+		var selectClaimableBalanceClaimants = sq.Select("claimable_balance_claimants.id").From("claimable_balance_claimants").
+			Where("claimable_balance_claimants.destination = ?", query.Claimant.Address()).Limit(query.PageQuery.Limit)
 
-		subSql, err := applyClaimableBalancesQueriesCursor(selectClaimableBalanceClaimants, l, r, query.PageQuery.Order)
+		subSql, err := applyClaimableBalancesQueriesCursor(selectClaimableBalanceClaimants, "claimable_balance_claimants", l, r, query.PageQuery.Order)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not apply subquery to page")
 		}

--- a/services/horizon/internal/db2/history/claimable_balances_test.go
+++ b/services/horizon/internal/db2/history/claimable_balances_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/guregu/null"
+
 	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/xdr"
@@ -203,7 +204,7 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 	tt.Assert.Equal(dest2, cbs[0].Claimants[1].Destination)
 
 	// this validates the cb query with claimant and cb.id/ledger cursor parameters
-	query.PageQuery = db2.MustPageQuery(fmt.Sprintf("%v-%s", 150, cbs[0].BalanceID), false, "", 10)
+	query.PageQuery = db2.MustPageQuery(fmt.Sprintf("%v-%s", 150, cbs[0].BalanceID), false, "asc", 10)
 	query.Claimant = xdr.MustAddressPtr(dest1)
 	cbs, err = q.GetClaimableBalances(tt.Ctx, query)
 	tt.Assert.NoError(err)
@@ -212,7 +213,7 @@ func TestFindClaimableBalancesByDestination(t *testing.T) {
 
 	// this validates the cb query with no claimant parameter,
 	// should still produce working sql, as it triggers different LIMIT position in sql.
-	query.PageQuery = db2.MustPageQuery("", false, "", 1)
+	query.PageQuery = db2.MustPageQuery("", false, "desc", 1)
 	query.Claimant = nil
 	cbs, err = q.GetClaimableBalances(tt.Ctx, query)
 	tt.Assert.NoError(err)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The request to `/claimable_balances?claimant=GDFZV7N7WXJCHL27IX4CI6TQY7ZDHLXMLVX5XHOV6CPCQVUCGDKKFPGQ` times out on staging (running horizon 2.28.2) but not on production (running horizon 2.28.0). The degradation in this endpoint is caused by bug introduced in https://github.com/stellar/go/pull/5200

The query corresponding to `/claimable_balances?claimant=GDFZV7N7WXJCHL27IX4CI6TQY7ZDHLXMLVX5XHOV6CPCQVUCGDKKFPGQ` in horizon 2.28.2 is:

```
SELECT
        cb.id, cb.claimants, cb.asset, cb.amount, cb.sponsor, cb.last_modified_ledger, cb.flags
FROM claimable_balances cb
WHERE cb.id IN (
        SELECT id FROM claimable_balance_claimants WHERE destination = 'GDFZV7N7WXJCHL27IX4CI6TQY7ZDHLXMLVX5XHOV6CPCQVUCGDKKFPGQ'
        ORDER BY cb.last_modified_ledger asc, cb.id asc
        LIMIT 10
)
ORDER BY cb.last_modified_ledger asc, cb.id asc LIMIT 10
```

The problem is in the subquery which selects from `claimable_balance_claimants`:

```
SELECT id FROM claimable_balance_claimants WHERE destination = 'GDFZV7N7WXJCHL27IX4CI6TQY7ZDHLXMLVX5XHOV6CPCQVUCGDKKFPGQ'
        ORDER BY cb.last_modified_ledger asc, cb.id asc
        LIMIT 10
```

Notice that the order by clause refers to the `claimable_balances` table. It should actually be referring to the `claimable_balance_claimants` table.

In this commit, the query is fixed to:

 ```
SELECT
        cb.id, cb.claimants, cb.asset, cb.amount, cb.sponsor, cb.last_modified_ledger, cb.flags
FROM claimable_balances cb
WHERE cb.id IN (
        SELECT claimable_balance_claimants.id FROM claimable_balance_claimants WHERE claimable_balance_claimants.destination = 'GDFZV7N7WXJCHL27IX4CI6TQY7ZDHLXMLVX5XHOV6CPCQVUCGDKKFPGQ'
        ORDER BY claimable_balance_claimants.last_modified_ledger asc, claimable_balance_claimants.id asc
        LIMIT 10
)
ORDER BY cb.last_modified_ledger asc, cb.id asc LIMIT 10
```

Now the subquery explicitly refers to claimable_balance_claimants instead of the claimable_balances table.

### Known limitations

[N/A]
