### PR TITLE
/services/horizon/ingest: add SKIP_TXMETA

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -120,7 +120,7 @@ jobs:
           key: ${{ env.COMBINED_SOURCE_HASH }}
 
       - if: ${{ steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
-        run: go test -race -timeout 65m -v ./services/horizon/internal/integration/...
+        run: go test -race -timeout 45m -v ./services/horizon/internal/integration/...
 
       - name: Save Horizon binary and integration tests source hash to cache
         if: ${{ success() && steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -120,7 +120,7 @@ jobs:
           key: ${{ env.COMBINED_SOURCE_HASH }}
 
       - if: ${{ steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}
-        run: go test -race -timeout 45m -v ./services/horizon/internal/integration/...
+        run: go test -race -timeout 65m -v ./services/horizon/internal/integration/...
 
       - name: Save Horizon binary and integration tests source hash to cache
         if: ${{ success() && steps.horizon_binary_tests_hash.outputs.cache-hit != 'true' }}

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -36,6 +36,11 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 - We now include metrics for history archive requests ([5166](https://github.com/stellar/go/pull/5166))
 - Http history archive requests now include a unique user agent ([5166](https://github.com/stellar/go/pull/5166))
 - Added a deprecation warning for using command-line flags when running Horizon ([5051](https://github.com/stellar/go/pull/5051))
+- New optional config `DISABLE_SOROBAN_INGEST` ([5175](https://github.com/stellar/go/issues/5175)). Defaults to `FALSE`, when `TRUE` and a soroban transaction is ingested, the following will occur:
+  * no effects will be generated for contract invocations.
+  * history_transactions.tx_meta column will have serialized xdr that equates to an empty `xdr.TransactionMeta.V3`, `Operations`, `TxChangesAfter`, `TxChangesBefore` will empty arrays and `SorobanMeta` will be nil.
+  * API transaction model for `result_meta_xdr` will have same empty serialized xdr for `xdr.TransactionMeta.V3`, `Operations`, `TxChangesAfter`, `TxChangesBefore` will empty arrays and `SorobanMeta` will be nil.
+  * API `Operation` model for `InvokeHostFunctionOp` type, will have empty `asset_balance_changes`
 
 ### Breaking Changes
 - Deprecation of legacy, non-captive core ingestion([5158](https://github.com/stellar/go/pull/5158)): 

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this
 file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.28.3
+
+### Added
+- New optional config `SKIP_TXMETA` ([5189](https://github.com/stellar/go/issues/5189)). Defaults to `FALSE`, when `TRUE` the following will occur:
+  * history_transactions.tx_meta column will have serialized xdr that equates to empty for any protocol version, such as for `xdr.TransactionMeta.V3`, `Operations`, `TxChangesAfter`, `TxChangesBefore` will be empty arrays and `SorobanMeta` will be nil. 
+
+### Breaking Changes
+- Removed `DISABLE_SOROBAN_INGEST` configuration parameter, use the new `SKIP_TXMETA` parameter instead.
+
 ## 2.28.2
 
 ### Fixed

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -27,11 +27,6 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 - We now include metrics for history archive requests ([5166](https://github.com/stellar/go/pull/5166))
 - Http history archive requests now include a unique user agent ([5166](https://github.com/stellar/go/pull/5166))
 - Added a deprecation warning for using command-line flags when running Horizon ([5051](https://github.com/stellar/go/pull/5051))
-- New optional config `DISABLE_SOROBAN_INGEST` ([5175](https://github.com/stellar/go/issues/5175)). Defaults to `FALSE`, when `TRUE` and a soroban transaction is ingested, the following will occur:
-  * no effects will be generated for contract invocations.
-  * history_transactions.tx_meta column will have serialized xdr that equates to an empty `xdr.TransactionMeta.V3`, `Operations`, `TxChangesAfter`, `TxChangesBefore` will empty arrays and `SorobanMeta` will be nil.
-  * API transaction model for `result_meta_xdr` will have same empty serialized xdr for `xdr.TransactionMeta.V3`, `Operations`, `TxChangesAfter`, `TxChangesBefore` will empty arrays and `SorobanMeta` will be nil.
-  * API `Operation` model for `InvokeHostFunctionOp` type, will have empty `asset_balance_changes`
 
 ### Breaking Changes
 - Deprecation of legacy, non-captive core ingestion([5158](https://github.com/stellar/go/pull/5158)): 

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -420,7 +420,6 @@ func runDBReingestRange(ledgerRanges []history.LedgerRange, reingestForce bool, 
 		RoundingSlippageFilter:      config.RoundingSlippageFilter,
 		EnableIngestionFiltering:    config.EnableIngestionFiltering,
 		MaxLedgerPerFlush:           maxLedgersPerFlush,
-		SkipSorobanIngestion:        config.SkipSorobanIngestion,
 	}
 
 	if ingestConfig.HistorySession, err = db.Open("postgres", config.DatabaseURL); err != nil {

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -420,6 +420,7 @@ func runDBReingestRange(ledgerRanges []history.LedgerRange, reingestForce bool, 
 		RoundingSlippageFilter:      config.RoundingSlippageFilter,
 		EnableIngestionFiltering:    config.EnableIngestionFiltering,
 		MaxLedgerPerFlush:           maxLedgersPerFlush,
+		SkipTxmeta:                  config.SkipTxmeta,
 	}
 
 	if ingestConfig.HistorySession, err = db.Open("postgres", config.DatabaseURL); err != nil {

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -109,6 +109,4 @@ type Config struct {
 	Network string
 	// DisableTxSub disables transaction submission functionality for Horizon.
 	DisableTxSub bool
-	// SkipSorobanIngestion skips Soroban related ingestion processing.
-	SkipSorobanIngestion bool
 }

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -109,4 +109,6 @@ type Config struct {
 	Network string
 	// DisableTxSub disables transaction submission functionality for Horizon.
 	DisableTxSub bool
+	// SkipTxmeta, when enabled, will not store meta xdr in history transaction table
+	SkipTxmeta bool
 }

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -60,8 +60,6 @@ const (
 	EnableIngestionFilteringFlagName = "exp-enable-ingestion-filtering"
 	// DisableTxSubFlagName is the command line flag for disabling transaction submission feature of Horizon
 	DisableTxSubFlagName = "disable-tx-sub"
-	// SkipSorobanIngestionFlagName is the command line flag for disabling Soroban related ingestion processing
-	SkipSorobanIngestionFlagName = "disable-soroban-ingest"
 
 	// StellarPubnet is a constant representing the Stellar public network
 	StellarPubnet = "pubnet"
@@ -737,15 +735,6 @@ func Flags() (*Config, support.ConfigOptions) {
 				" It automatically configures network settings, including %s, %s, and %s.",
 				StellarPubnet, StellarTestnet, NetworkPassphraseFlagName,
 				HistoryArchiveURLsFlagName, CaptiveCoreConfigPathName),
-			UsedInCommands: IngestionCommands,
-		},
-		&support.ConfigOption{
-			Name:           SkipSorobanIngestionFlagName,
-			ConfigKey:      &config.SkipSorobanIngestion,
-			OptType:        types.Bool,
-			FlagDefault:    false,
-			Required:       false,
-			Usage:          "excludes Soroban data during ingestion processing",
 			UsedInCommands: IngestionCommands,
 		},
 	}

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -60,6 +60,8 @@ const (
 	EnableIngestionFilteringFlagName = "exp-enable-ingestion-filtering"
 	// DisableTxSubFlagName is the command line flag for disabling transaction submission feature of Horizon
 	DisableTxSubFlagName = "disable-tx-sub"
+	// SkipTxmeta is the command line flag for disabling persistence of tx meta in history transaction table
+	SkipTxmeta = "skip-txmeta"
 
 	// StellarPubnet is a constant representing the Stellar public network
 	StellarPubnet = "pubnet"
@@ -735,6 +737,15 @@ func Flags() (*Config, support.ConfigOptions) {
 				" It automatically configures network settings, including %s, %s, and %s.",
 				StellarPubnet, StellarTestnet, NetworkPassphraseFlagName,
 				HistoryArchiveURLsFlagName, CaptiveCoreConfigPathName),
+			UsedInCommands: IngestionCommands,
+		},
+		&support.ConfigOption{
+			Name:           SkipTxmeta,
+			ConfigKey:      &config.SkipTxmeta,
+			OptType:        types.Bool,
+			FlagDefault:    false,
+			Required:       false,
+			Usage:          "excludes tx meta from persistence on transaction history",
 			UsedInCommands: IngestionCommands,
 		},
 	}

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -108,8 +108,6 @@ type Config struct {
 
 	EnableIngestionFiltering bool
 	MaxLedgerPerFlush        uint32
-
-	SkipSorobanIngestion bool
 }
 
 const (

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -108,6 +108,7 @@ type Config struct {
 
 	EnableIngestionFiltering bool
 	MaxLedgerPerFlush        uint32
+	SkipTxmeta               bool
 }
 
 const (

--- a/services/horizon/internal/ingest/processor_runner.go
+++ b/services/horizon/internal/ingest/processor_runner.go
@@ -111,7 +111,6 @@ func buildChangeProcessor(
 	source ingestionSource,
 	ledgerSequence uint32,
 	networkPassphrase string,
-	skipSorobanIngestion bool,
 ) *groupChangeProcessors {
 	statsChangeProcessor := &statsChangeProcessor{
 		StatsChangeProcessor: changeStats,
@@ -145,13 +144,13 @@ func (s *ProcessorRunner) buildTransactionProcessor(ledgersProcessor *processors
 
 	processors := []horizonTransactionProcessor{
 		statsLedgerTransactionProcessor,
-		processors.NewEffectProcessor(accountLoader, s.historyQ.NewEffectBatchInsertBuilder(), s.config.NetworkPassphrase, s.config.SkipSorobanIngestion),
+		processors.NewEffectProcessor(accountLoader, s.historyQ.NewEffectBatchInsertBuilder(), s.config.NetworkPassphrase),
 		ledgersProcessor,
-		processors.NewOperationProcessor(s.historyQ.NewOperationBatchInsertBuilder(), s.config.NetworkPassphrase, s.config.SkipSorobanIngestion),
+		processors.NewOperationProcessor(s.historyQ.NewOperationBatchInsertBuilder(), s.config.NetworkPassphrase),
 		tradeProcessor,
 		processors.NewParticipantsProcessor(accountLoader,
 			s.historyQ.NewTransactionParticipantsBatchInsertBuilder(), s.historyQ.NewOperationParticipantBatchInsertBuilder()),
-		processors.NewTransactionProcessor(s.historyQ.NewTransactionBatchInsertBuilder(), s.config.SkipSorobanIngestion),
+		processors.NewTransactionProcessor(s.historyQ.NewTransactionBatchInsertBuilder()),
 		processors.NewClaimableBalancesTransactionProcessor(cbLoader,
 			s.historyQ.NewTransactionClaimableBalanceBatchInsertBuilder(), s.historyQ.NewOperationClaimableBalanceBatchInsertBuilder()),
 		processors.NewLiquidityPoolsTransactionProcessor(lpLoader,
@@ -173,10 +172,7 @@ func (s *ProcessorRunner) buildFilteredOutProcessor() *groupTransactionProcessor
 	// when in online mode, the submission result processor must always run (regardless of filtering)
 	var p []horizonTransactionProcessor
 	if s.config.EnableIngestionFiltering {
-		txSubProc := processors.NewTransactionFilteredTmpProcessor(
-			s.historyQ.NewTransactionFilteredTmpBatchInsertBuilder(),
-			s.config.SkipSorobanIngestion,
-		)
+		txSubProc := processors.NewTransactionFilteredTmpProcessor(s.historyQ.NewTransactionFilteredTmpBatchInsertBuilder())
 		p = append(p, txSubProc)
 	}
 
@@ -239,7 +235,6 @@ func (s *ProcessorRunner) RunHistoryArchiveIngestion(
 		historyArchiveSource,
 		checkpointLedger,
 		s.config.NetworkPassphrase,
-		s.config.SkipSorobanIngestion,
 	)
 
 	if checkpointLedger == 1 {
@@ -498,7 +493,6 @@ func (s *ProcessorRunner) RunAllProcessorsOnLedger(ledger xdr.LedgerCloseMeta) (
 		ledgerSource,
 		ledger.LedgerSequence(),
 		s.config.NetworkPassphrase,
-		s.config.SkipSorobanIngestion,
 	)
 	err = s.runChangeProcessorOnLedger(groupChangeProcessors, ledger)
 	if err != nil {

--- a/services/horizon/internal/ingest/processor_runner.go
+++ b/services/horizon/internal/ingest/processor_runner.go
@@ -150,7 +150,7 @@ func (s *ProcessorRunner) buildTransactionProcessor(ledgersProcessor *processors
 		tradeProcessor,
 		processors.NewParticipantsProcessor(accountLoader,
 			s.historyQ.NewTransactionParticipantsBatchInsertBuilder(), s.historyQ.NewOperationParticipantBatchInsertBuilder()),
-		processors.NewTransactionProcessor(s.historyQ.NewTransactionBatchInsertBuilder()),
+		processors.NewTransactionProcessor(s.historyQ.NewTransactionBatchInsertBuilder(), s.config.SkipTxmeta),
 		processors.NewClaimableBalancesTransactionProcessor(cbLoader,
 			s.historyQ.NewTransactionClaimableBalanceBatchInsertBuilder(), s.historyQ.NewOperationClaimableBalanceBatchInsertBuilder()),
 		processors.NewLiquidityPoolsTransactionProcessor(lpLoader,
@@ -172,7 +172,7 @@ func (s *ProcessorRunner) buildFilteredOutProcessor() *groupTransactionProcessor
 	// when in online mode, the submission result processor must always run (regardless of filtering)
 	var p []horizonTransactionProcessor
 	if s.config.EnableIngestionFiltering {
-		txSubProc := processors.NewTransactionFilteredTmpProcessor(s.historyQ.NewTransactionFilteredTmpBatchInsertBuilder())
+		txSubProc := processors.NewTransactionFilteredTmpProcessor(s.historyQ.NewTransactionFilteredTmpBatchInsertBuilder(), s.config.SkipTxmeta)
 		p = append(p, txSubProc)
 	}
 

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -180,7 +180,7 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 	}
 
 	stats := &ingest.StatsChangeProcessor{}
-	processor := buildChangeProcessor(runner.historyQ, stats, ledgerSource, 123, "", false)
+	processor := buildChangeProcessor(runner.historyQ, stats, ledgerSource, 123, "")
 	assert.IsType(t, &groupChangeProcessors{}, processor)
 
 	assert.IsType(t, &statsChangeProcessor{}, processor.processors[0])
@@ -201,7 +201,7 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 		filters:  &MockFilters{},
 	}
 
-	processor = buildChangeProcessor(runner.historyQ, stats, historyArchiveSource, 456, "", false)
+	processor = buildChangeProcessor(runner.historyQ, stats, historyArchiveSource, 456, "")
 	assert.IsType(t, &groupChangeProcessors{}, processor)
 
 	assert.IsType(t, &statsChangeProcessor{}, processor.processors[0])
@@ -271,7 +271,6 @@ func TestProcessorRunnerWithFilterEnabled(t *testing.T) {
 	config := Config{
 		NetworkPassphrase:        network.PublicNetworkPassphrase,
 		EnableIngestionFiltering: true,
-		SkipSorobanIngestion:     false,
 	}
 
 	q := &mockDBQ{}

--- a/services/horizon/internal/ingest/processors/claimable_balances_transaction_processor_test.go
+++ b/services/horizon/internal/ingest/processors/claimable_balances_transaction_processor_test.go
@@ -67,7 +67,7 @@ func (s *ClaimableBalancesTransactionProcessorTestSuiteLedger) TestEmptyClaimabl
 
 func (s *ClaimableBalancesTransactionProcessorTestSuiteLedger) testOperationInserts(balanceID xdr.ClaimableBalanceId, body xdr.OperationBody, change xdr.LedgerEntryChange) {
 	// Setup the transaction
-	txn := createTransaction(true, 1)
+	txn := createTransaction(true, 1, 2)
 	txn.Envelope.Operations()[0].Body = body
 	txn.UnsafeMeta.V = 2
 	txn.UnsafeMeta.V2.Operations = []xdr.OperationMeta{

--- a/services/horizon/internal/ingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/ingest/processors/effects_processor_test.go
@@ -143,7 +143,6 @@ func (s *EffectsProcessorTestSuiteLedger) SetupTest() {
 		s.accountLoader,
 		s.mockBatchInsertBuilder,
 		networkPassphrase,
-		false,
 	)
 
 	s.txs = []ingest.LedgerTransaction{

--- a/services/horizon/internal/ingest/processors/liquidity_pools_transaction_processor_test.go
+++ b/services/horizon/internal/ingest/processors/liquidity_pools_transaction_processor_test.go
@@ -68,7 +68,7 @@ func (s *LiquidityPoolsTransactionProcessorTestSuiteLedger) TestEmptyLiquidityPo
 
 func (s *LiquidityPoolsTransactionProcessorTestSuiteLedger) testOperationInserts(poolID xdr.PoolId, body xdr.OperationBody, change xdr.LedgerEntryChange) {
 	// Setup the transaction
-	txn := createTransaction(true, 1)
+	txn := createTransaction(true, 1, 2)
 	txn.Envelope.Operations()[0].Body = body
 	txn.UnsafeMeta.V = 2
 	txn.UnsafeMeta.V2.Operations = []xdr.OperationMeta{

--- a/services/horizon/internal/ingest/processors/operations_processor_test.go
+++ b/services/horizon/internal/ingest/processors/operations_processor_test.go
@@ -42,7 +42,6 @@ func (s *OperationsProcessorTestSuiteLedger) SetupTest() {
 	s.processor = NewOperationProcessor(
 		s.mockBatchInsertBuilder,
 		"test network",
-		false,
 	)
 }
 
@@ -375,65 +374,6 @@ func (s *OperationsProcessorTestSuiteLedger) TestOperationTypeInvokeHostFunction
 			}
 		}
 		s.Assert().Equal(found, 4, "should have one balance changed record for each of mint, burn, clawback, transfer")
-	})
-
-	s.T().Run("InvokeContractAssetBalancesElidedFromDetails", func(t *testing.T) {
-		randomIssuer := keypair.MustRandom()
-		randomAsset := xdr.MustNewCreditAsset("TESTING", randomIssuer.Address())
-		passphrase := "passphrase"
-		randomAccount := keypair.MustRandom().Address()
-		contractId := [32]byte{}
-		zeroContractStrKey, err := strkey.Encode(strkey.VersionByteContract, contractId[:])
-		s.Assert().NoError(err)
-
-		transferContractEvent := contractevents.GenerateEvent(contractevents.EventTypeTransfer, randomAccount, zeroContractStrKey, "", randomAsset, big.NewInt(10000000), passphrase)
-		burnContractEvent := contractevents.GenerateEvent(contractevents.EventTypeBurn, zeroContractStrKey, "", "", randomAsset, big.NewInt(10000000), passphrase)
-		mintContractEvent := contractevents.GenerateEvent(contractevents.EventTypeMint, "", zeroContractStrKey, randomAccount, randomAsset, big.NewInt(10000000), passphrase)
-		clawbackContractEvent := contractevents.GenerateEvent(contractevents.EventTypeClawback, zeroContractStrKey, "", randomAccount, randomAsset, big.NewInt(10000000), passphrase)
-
-		tx = ingest.LedgerTransaction{
-			UnsafeMeta: xdr.TransactionMeta{
-				V: 3,
-				V3: &xdr.TransactionMetaV3{
-					SorobanMeta: &xdr.SorobanTransactionMeta{
-						Events: []xdr.ContractEvent{
-							transferContractEvent,
-							burnContractEvent,
-							mintContractEvent,
-							clawbackContractEvent,
-						},
-					},
-				},
-			},
-		}
-		wrapper := transactionOperationWrapper{
-			skipSorobanDetails: true,
-			transaction:        tx,
-			operation: xdr.Operation{
-				SourceAccount: &source,
-				Body: xdr.OperationBody{
-					Type: xdr.OperationTypeInvokeHostFunction,
-					InvokeHostFunctionOp: &xdr.InvokeHostFunctionOp{
-						HostFunction: xdr.HostFunction{
-							Type: xdr.HostFunctionTypeHostFunctionTypeInvokeContract,
-							InvokeContract: &xdr.InvokeContractArgs{
-								ContractAddress: xdr.ScAddress{
-									Type:       xdr.ScAddressTypeScAddressTypeContract,
-									ContractId: &xdr.Hash{0x1, 0x2},
-								},
-								FunctionName: "foo",
-								Args:         xdr.ScVec{},
-							},
-						},
-					},
-				},
-			},
-			network: passphrase,
-		}
-
-		details, err := wrapper.Details()
-		s.Assert().NoError(err)
-		s.Assert().Len(details["asset_balance_changes"], 0, "for invokehostfn op, no asset balances should be in details when skip soroban is enabled")
 	})
 }
 

--- a/services/horizon/internal/ingest/processors/operations_processor_test.go
+++ b/services/horizon/internal/ingest/processors/operations_processor_test.go
@@ -407,7 +407,7 @@ func (s *OperationsProcessorTestSuiteLedger) TestAddOperationSucceeds() {
 			Ed25519: *unmuxed.Ed25519,
 		},
 	}
-	firstTx := createTransaction(true, 1)
+	firstTx := createTransaction(true, 1, 2)
 	firstTx.Index = 1
 	firstTx.Envelope.Operations()[0].Body = xdr.OperationBody{
 		Type: xdr.OperationTypePayment,
@@ -418,8 +418,8 @@ func (s *OperationsProcessorTestSuiteLedger) TestAddOperationSucceeds() {
 		},
 	}
 	firstTx.Envelope.V1.Tx.SourceAccount = muxed
-	secondTx := createTransaction(false, 3)
-	thirdTx := createTransaction(true, 4)
+	secondTx := createTransaction(false, 3, 2)
+	thirdTx := createTransaction(true, 4, 2)
 
 	txs := []ingest.LedgerTransaction{
 		firstTx,
@@ -451,7 +451,7 @@ func (s *OperationsProcessorTestSuiteLedger) TestAddOperationFails() {
 			},
 		},
 	}
-	tx := createTransaction(true, 1)
+	tx := createTransaction(true, 1, 2)
 
 	s.mockBatchInsertBuilder.
 		On(
@@ -482,7 +482,7 @@ func (s *OperationsProcessorTestSuiteLedger) TestExecFails() {
 			},
 		},
 	}
-	tx := createTransaction(true, 1)
+	tx := createTransaction(true, 1, 2)
 
 	s.mockBatchInsertBuilder.
 		On(

--- a/services/horizon/internal/ingest/processors/participants_processor_test.go
+++ b/services/horizon/internal/ingest/processors/participants_processor_test.go
@@ -62,13 +62,13 @@ func (s *ParticipantsProcessorTestSuiteLedger) SetupTest() {
 		"GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
 	}
 
-	s.firstTx = createTransaction(true, 1)
+	s.firstTx = createTransaction(true, 1, 2)
 	s.firstTx.Index = 1
 	aid := xdr.MustAddress(s.addresses[0])
 	s.firstTx.Envelope.V1.Tx.SourceAccount = aid.ToMuxedAccount()
 	s.firstTxID = toid.New(int32(sequence), 1, 0).ToInt64()
 
-	s.secondTx = createTransaction(true, 1)
+	s.secondTx = createTransaction(true, 1, 2)
 	s.secondTx.Index = 2
 	s.secondTx.Envelope.Operations()[0].Body = xdr.OperationBody{
 		Type: xdr.OperationTypeCreateAccount,
@@ -80,7 +80,7 @@ func (s *ParticipantsProcessorTestSuiteLedger) SetupTest() {
 	s.secondTx.Envelope.V1.Tx.SourceAccount = aid.ToMuxedAccount()
 	s.secondTxID = toid.New(int32(sequence), 2, 0).ToInt64()
 
-	s.thirdTx = createTransaction(true, 1)
+	s.thirdTx = createTransaction(true, 1, 2)
 	s.thirdTx.Index = 3
 	aid = xdr.MustAddress(s.addresses[0])
 	s.thirdTx.Envelope.V1.Tx.SourceAccount = aid.ToMuxedAccount()
@@ -150,7 +150,7 @@ func (s *ParticipantsProcessorTestSuiteLedger) TestEmptyParticipants() {
 }
 
 func (s *ParticipantsProcessorTestSuiteLedger) TestFeeBumptransaction() {
-	feeBumpTx := createTransaction(true, 0)
+	feeBumpTx := createTransaction(true, 0, 2)
 	feeBumpTx.Index = 1
 	aid := xdr.MustAddress(s.addresses[0])
 	feeBumpTx.Envelope.V1.Tx.SourceAccount = aid.ToMuxedAccount()

--- a/services/horizon/internal/ingest/processors/trades_processor_test.go
+++ b/services/horizon/internal/ingest/processors/trades_processor_test.go
@@ -229,7 +229,7 @@ func (s *TradeProcessorTestSuiteLedger) TearDownTest() {
 
 func (s *TradeProcessorTestSuiteLedger) TestIgnoreFailedTransactions() {
 	ctx := context.Background()
-	err := s.processor.ProcessTransaction(s.lcm, createTransaction(false, 1))
+	err := s.processor.ProcessTransaction(s.lcm, createTransaction(false, 1, 2))
 	s.Assert().NoError(err)
 
 	err = s.processor.Flush(ctx, s.mockSession)
@@ -806,7 +806,7 @@ func TestTradeProcessor_ProcessTransaction_MuxedAccount(t *testing.T) {
 			Ed25519: *unmuxed.Ed25519,
 		},
 	}
-	tx := createTransaction(true, 1)
+	tx := createTransaction(true, 1, 2)
 	tx.Index = 1
 	tx.Envelope.Operations()[0].Body = xdr.OperationBody{
 		Type: xdr.OperationTypePayment,

--- a/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
+++ b/services/horizon/internal/ingest/processors/transaction_operation_wrapper_test.go
@@ -798,7 +798,7 @@ func TestTransactionOperationDetails(t *testing.T) {
 		})
 	}
 
-	tx := createTransaction(true, 1)
+	tx := createTransaction(true, 1, 2)
 	tx.Index = 1
 
 	tx.Envelope.Operations()[0].Body = xdr.OperationBody{
@@ -1477,7 +1477,7 @@ var (
 
 func getSponsoredSandwichWrappers() []*transactionOperationWrapper {
 	const ledgerSeq = uint32(12345)
-	tx := createTransaction(true, 3)
+	tx := createTransaction(true, 3, 2)
 	tx.Index = 1
 	tx.UnsafeMeta = xdr.TransactionMeta{
 		V: 2,

--- a/services/horizon/internal/ingest/processors/transactions_processor.go
+++ b/services/horizon/internal/ingest/processors/transactions_processor.go
@@ -11,23 +11,52 @@ import (
 )
 
 type TransactionProcessor struct {
-	batch history.TransactionBatchInsertBuilder
+	batch      history.TransactionBatchInsertBuilder
+	skipTxmeta bool
 }
 
-func NewTransactionFilteredTmpProcessor(batch history.TransactionBatchInsertBuilder) *TransactionProcessor {
+func NewTransactionFilteredTmpProcessor(batch history.TransactionBatchInsertBuilder, skipTxmeta bool) *TransactionProcessor {
 	return &TransactionProcessor{
-		batch: batch,
+		batch:      batch,
+		skipTxmeta: skipTxmeta,
 	}
 }
 
-func NewTransactionProcessor(batch history.TransactionBatchInsertBuilder) *TransactionProcessor {
+func NewTransactionProcessor(batch history.TransactionBatchInsertBuilder, skipTxmeta bool) *TransactionProcessor {
 	return &TransactionProcessor{
-		batch: batch,
+		batch:      batch,
+		skipTxmeta: skipTxmeta,
 	}
 }
 
 func (p *TransactionProcessor) ProcessTransaction(lcm xdr.LedgerCloseMeta, transaction ingest.LedgerTransaction) error {
-	if err := p.batch.Add(transaction, lcm.LedgerSequence()); err != nil {
+	elidedTransaction := transaction
+
+	if p.skipTxmeta {
+		switch elidedTransaction.UnsafeMeta.V {
+		case 3:
+			elidedTransaction.UnsafeMeta.V3 = &xdr.TransactionMetaV3{
+				Ext:             xdr.ExtensionPoint{},
+				TxChangesBefore: xdr.LedgerEntryChanges{},
+				Operations:      []xdr.OperationMeta{},
+				TxChangesAfter:  xdr.LedgerEntryChanges{},
+				SorobanMeta:     nil,
+			}
+		case 2:
+			elidedTransaction.UnsafeMeta.V2 = &xdr.TransactionMetaV2{
+				TxChangesBefore: xdr.LedgerEntryChanges{},
+				Operations:      []xdr.OperationMeta{},
+				TxChangesAfter:  xdr.LedgerEntryChanges{},
+			}
+		case 1:
+			elidedTransaction.UnsafeMeta.V1 = &xdr.TransactionMetaV1{
+				TxChanges:  xdr.LedgerEntryChanges{},
+				Operations: []xdr.OperationMeta{},
+			}
+		}
+	}
+
+	if err := p.batch.Add(elidedTransaction, lcm.LedgerSequence()); err != nil {
 		return errors.Wrap(err, "Error batch inserting transaction rows")
 	}
 

--- a/services/horizon/internal/ingest/processors/transactions_processor.go
+++ b/services/horizon/internal/ingest/processors/transactions_processor.go
@@ -53,6 +53,8 @@ func (p *TransactionProcessor) ProcessTransaction(lcm xdr.LedgerCloseMeta, trans
 				TxChanges:  xdr.LedgerEntryChanges{},
 				Operations: []xdr.OperationMeta{},
 			}
+		default:
+			return errors.Errorf("SKIP_TXMETA is enabled, but received an un-supported tx-meta version %v, can't proceed with removal", elidedTransaction.UnsafeMeta.V)
 		}
 	}
 

--- a/services/horizon/internal/ingest/processors/transactions_processor_test.go
+++ b/services/horizon/internal/ingest/processors/transactions_processor_test.go
@@ -29,7 +29,7 @@ func TestTransactionsProcessorTestSuiteLedger(t *testing.T) {
 func (s *TransactionsProcessorTestSuiteLedger) SetupTest() {
 	s.ctx = context.Background()
 	s.mockBatchInsertBuilder = &history.MockTransactionsBatchInsertBuilder{}
-	s.processor = NewTransactionProcessor(s.mockBatchInsertBuilder, false)
+	s.processor = NewTransactionProcessor(s.mockBatchInsertBuilder)
 }
 
 func (s *TransactionsProcessorTestSuiteLedger) TearDownTest() {

--- a/services/horizon/internal/ingest/processors/transactions_processor_test.go
+++ b/services/horizon/internal/ingest/processors/transactions_processor_test.go
@@ -6,11 +6,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -29,14 +31,14 @@ func TestTransactionsProcessorTestSuiteLedger(t *testing.T) {
 func (s *TransactionsProcessorTestSuiteLedger) SetupTest() {
 	s.ctx = context.Background()
 	s.mockBatchInsertBuilder = &history.MockTransactionsBatchInsertBuilder{}
-	s.processor = NewTransactionProcessor(s.mockBatchInsertBuilder)
+	s.processor = NewTransactionProcessor(s.mockBatchInsertBuilder, false)
 }
 
 func (s *TransactionsProcessorTestSuiteLedger) TearDownTest() {
 	s.mockBatchInsertBuilder.AssertExpectations(s.T())
 }
 
-func (s *TransactionsProcessorTestSuiteLedger) TestAddTransactionsSucceeds() {
+func (s *TransactionsProcessorTestSuiteLedger) TestAddTransactionsWithMetaSucceeds() {
 	sequence := uint32(20)
 	lcm := xdr.LedgerCloseMeta{
 		V0: &xdr.LedgerCloseMetaV0{
@@ -47,13 +49,55 @@ func (s *TransactionsProcessorTestSuiteLedger) TestAddTransactionsSucceeds() {
 			},
 		},
 	}
-	firstTx := createTransaction(true, 1)
-	secondTx := createTransaction(false, 3)
-	thirdTx := createTransaction(true, 4)
+	creator := xdr.MustAddress("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	ledgerEntryChange := xdr.LedgerEntryChange{
+		Type: 3,
+		State: &xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 0x39,
+			Data: xdr.LedgerEntryData{
+				Type: 0,
+				Account: &xdr.AccountEntry{
+					AccountId:     creator,
+					Balance:       800152377009533292,
+					SeqNum:        25,
+					InflationDest: &creator,
+					Thresholds:    xdr.Thresholds{0x1, 0x0, 0x0, 0x0},
+				},
+			},
+		},
+	}
 
-	s.mockBatchInsertBuilder.On("Add", firstTx, sequence).Return(nil).Once()
-	s.mockBatchInsertBuilder.On("Add", secondTx, sequence).Return(nil).Once()
-	s.mockBatchInsertBuilder.On("Add", thirdTx, sequence+1).Return(nil).Once()
+	firstTx := createTransaction(true, 1, 1)
+	firstTx.UnsafeMeta.V1.TxChanges = xdr.LedgerEntryChanges{ledgerEntryChange}
+	secondTx := createTransaction(false, 3, 2)
+	secondTx.UnsafeMeta.V2.TxChangesBefore = xdr.LedgerEntryChanges{ledgerEntryChange}
+	secondTx.UnsafeMeta.V2.TxChangesAfter = xdr.LedgerEntryChanges{ledgerEntryChange}
+	thirdTx := createTransaction(true, 4, 3)
+	thirdTx.UnsafeMeta.V3.TxChangesBefore = xdr.LedgerEntryChanges{ledgerEntryChange}
+	thirdTx.UnsafeMeta.V3.TxChangesAfter = xdr.LedgerEntryChanges{ledgerEntryChange}
+	thirdTx.UnsafeMeta.V3.SorobanMeta = &xdr.SorobanTransactionMeta{}
+
+	s.mockBatchInsertBuilder.On("Add", firstTx, sequence).Run(func(args mock.Arguments) {
+		tx := args.Get(0).(ingest.LedgerTransaction)
+		s.Assert().Len(tx.UnsafeMeta.V1.TxChanges, 1)
+		s.Assert().Len(tx.UnsafeMeta.V1.Operations, 1)
+	}).Return(nil).Once()
+
+	s.mockBatchInsertBuilder.On("Add", secondTx, sequence).Run(func(args mock.Arguments) {
+		tx := args.Get(0).(ingest.LedgerTransaction)
+		s.Assert().Len(tx.UnsafeMeta.V2.TxChangesAfter, 1)
+		s.Assert().Len(tx.UnsafeMeta.V2.TxChangesBefore, 1)
+		s.Assert().Len(tx.UnsafeMeta.V2.Operations, 3)
+	}).Return(nil).Once()
+
+	s.mockBatchInsertBuilder.On("Add", thirdTx, sequence+1).Run(func(args mock.Arguments) {
+		tx := args.Get(0).(ingest.LedgerTransaction)
+		s.Assert().Len(tx.UnsafeMeta.V3.TxChangesAfter, 1)
+		s.Assert().Len(tx.UnsafeMeta.V3.TxChangesBefore, 1)
+		s.Assert().NotNil(tx.UnsafeMeta.V3.SorobanMeta)
+		s.Assert().Len(tx.UnsafeMeta.V3.Operations, 4)
+	}).Return(nil).Once()
+
 	s.mockBatchInsertBuilder.On("Exec", s.ctx, s.mockSession).Return(nil).Once()
 
 	s.Assert().NoError(s.processor.ProcessTransaction(lcm, firstTx))
@@ -62,6 +106,78 @@ func (s *TransactionsProcessorTestSuiteLedger) TestAddTransactionsSucceeds() {
 	s.Assert().NoError(s.processor.ProcessTransaction(lcm, thirdTx))
 
 	s.Assert().NoError(s.processor.Flush(s.ctx, s.mockSession))
+}
+
+func (s *TransactionsProcessorTestSuiteLedger) TestAddTransactionsWithSkippedMetaSucceeds() {
+	elidingTxProcessor := NewTransactionProcessor(s.mockBatchInsertBuilder, false)
+
+	sequence := uint32(20)
+	lcm := xdr.LedgerCloseMeta{
+		V0: &xdr.LedgerCloseMetaV0{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					LedgerSeq: xdr.Uint32(sequence),
+				},
+			},
+		},
+	}
+	creator := xdr.MustAddress("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	ledgerEntryChange := xdr.LedgerEntryChange{
+		Type: 3,
+		State: &xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 0x39,
+			Data: xdr.LedgerEntryData{
+				Type: 0,
+				Account: &xdr.AccountEntry{
+					AccountId:     creator,
+					Balance:       800152377009533292,
+					SeqNum:        25,
+					InflationDest: &creator,
+					Thresholds:    xdr.Thresholds{0x1, 0x0, 0x0, 0x0},
+				},
+			},
+		},
+	}
+
+	firstTx := createTransaction(true, 1, 1)
+	firstTx.UnsafeMeta.V1.TxChanges = xdr.LedgerEntryChanges{ledgerEntryChange}
+	secondTx := createTransaction(false, 3, 2)
+	secondTx.UnsafeMeta.V2.TxChangesBefore = xdr.LedgerEntryChanges{ledgerEntryChange}
+	secondTx.UnsafeMeta.V2.TxChangesAfter = xdr.LedgerEntryChanges{ledgerEntryChange}
+	thirdTx := createTransaction(true, 4, 3)
+	thirdTx.UnsafeMeta.V3.TxChangesBefore = xdr.LedgerEntryChanges{ledgerEntryChange}
+	thirdTx.UnsafeMeta.V3.TxChangesAfter = xdr.LedgerEntryChanges{ledgerEntryChange}
+	thirdTx.UnsafeMeta.V3.SorobanMeta = &xdr.SorobanTransactionMeta{}
+
+	s.mockBatchInsertBuilder.On("Add", firstTx, sequence).Run(func(args mock.Arguments) {
+		tx := args.Get(0).(ingest.LedgerTransaction)
+		s.Assert().Len(tx.UnsafeMeta.V1.TxChanges, 0)
+		s.Assert().Len(tx.UnsafeMeta.V1.Operations, 0)
+	}).Return(nil).Once()
+
+	s.mockBatchInsertBuilder.On("Add", secondTx, sequence).Run(func(args mock.Arguments) {
+		tx := args.Get(0).(ingest.LedgerTransaction)
+		s.Assert().Len(tx.UnsafeMeta.V2.TxChangesAfter, 0)
+		s.Assert().Len(tx.UnsafeMeta.V2.TxChangesBefore, 0)
+		s.Assert().Len(tx.UnsafeMeta.V2.Operations, 3)
+	}).Return(nil).Once()
+
+	s.mockBatchInsertBuilder.On("Add", thirdTx, sequence).Run(func(args mock.Arguments) {
+		tx := args.Get(0).(ingest.LedgerTransaction)
+		s.Assert().Len(tx.UnsafeMeta.V3.TxChangesAfter, 0)
+		s.Assert().Len(tx.UnsafeMeta.V3.TxChangesBefore, 0)
+		s.Assert().Nil(tx.UnsafeMeta.V3.SorobanMeta)
+		s.Assert().Len(tx.UnsafeMeta.V3.Operations, 4)
+	}).Return(nil).Once()
+
+	s.mockBatchInsertBuilder.On("Exec", s.ctx, s.mockSession).Return(nil).Once()
+
+	s.Assert().NoError(elidingTxProcessor.ProcessTransaction(lcm, firstTx))
+	s.Assert().NoError(elidingTxProcessor.ProcessTransaction(lcm, secondTx))
+	lcm.V0.LedgerHeader.Header.LedgerSeq++
+	s.Assert().NoError(elidingTxProcessor.ProcessTransaction(lcm, thirdTx))
+
+	s.Assert().NoError(elidingTxProcessor.Flush(s.ctx, s.mockSession))
 }
 
 func (s *TransactionsProcessorTestSuiteLedger) TestAddTransactionsFails() {
@@ -75,7 +191,7 @@ func (s *TransactionsProcessorTestSuiteLedger) TestAddTransactionsFails() {
 			},
 		},
 	}
-	firstTx := createTransaction(true, 1)
+	firstTx := createTransaction(true, 1, 2)
 	s.mockBatchInsertBuilder.On("Add", firstTx, sequence).
 		Return(errors.New("transient error")).Once()
 
@@ -95,7 +211,7 @@ func (s *TransactionsProcessorTestSuiteLedger) TestExecFails() {
 			},
 		},
 	}
-	firstTx := createTransaction(true, 1)
+	firstTx := createTransaction(true, 1, 2)
 
 	s.mockBatchInsertBuilder.On("Add", firstTx, sequence).Return(nil).Once()
 	s.mockBatchInsertBuilder.On("Exec", s.ctx, s.mockSession).Return(errors.New("transient error")).Once()

--- a/services/horizon/internal/ingest/verify_test.go
+++ b/services/horizon/internal/ingest/verify_test.go
@@ -292,7 +292,7 @@ func TestStateVerifierLockBusy(t *testing.T) {
 	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 
 	checkpointLedger := uint32(63)
-	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "", false)
+	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
 
 	gen := randxdr.NewGenerator()
 	var changes []xdr.LedgerEntryChange
@@ -350,7 +350,7 @@ func TestStateVerifier(t *testing.T) {
 
 	ledger := rand.Int31()
 	checkpointLedger := uint32(ledger - (ledger % 64) - 1)
-	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "", false)
+	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, ledgerSource, checkpointLedger, "")
 	mockChangeReader := &ingest.MockChangeReader{}
 
 	gen := randxdr.NewGenerator()

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -111,6 +111,7 @@ func initIngester(app *App) {
 		EnableExtendedLogLedgerStats:         app.config.IngestEnableExtendedLogLedgerStats,
 		RoundingSlippageFilter:               app.config.RoundingSlippageFilter,
 		EnableIngestionFiltering:             app.config.EnableIngestionFiltering,
+		SkipTxmeta:                           app.config.SkipTxmeta,
 	})
 
 	if err != nil {

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -111,7 +111,6 @@ func initIngester(app *App) {
 		EnableExtendedLogLedgerStats:         app.config.IngestEnableExtendedLogLedgerStats,
 		RoundingSlippageFilter:               app.config.RoundingSlippageFilter,
 		EnableIngestionFiltering:             app.config.EnableIngestionFiltering,
-		SkipSorobanIngestion:                 app.config.SkipSorobanIngestion,
 	})
 
 	if err != nil {

--- a/services/horizon/internal/integration/transaction_test.go
+++ b/services/horizon/internal/integration/transaction_test.go
@@ -1,0 +1,133 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/services/horizon/internal/test/integration"
+	"github.com/stellar/go/txnbuild"
+	"github.com/stellar/go/xdr"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestP19MetaTransaction(t *testing.T) {
+	itest := integration.NewTest(t, integration.Config{
+		ProtocolVersion:  19,
+		EnableSorobanRPC: false,
+	})
+
+	masterAccount, err := itest.Client().AccountDetail(horizonclient.AccountRequest{
+		AccountID: itest.Master().Address(),
+	})
+	require.NoError(t, err)
+
+	op := &txnbuild.Payment{
+		SourceAccount: itest.Master().Address(),
+		Destination:   itest.Master().Address(),
+		Asset:         txnbuild.NativeAsset{},
+		Amount:        "10",
+	}
+
+	clientTx := itest.MustSubmitOperations(&masterAccount, itest.Master(), op)
+
+	var txMetaResult xdr.TransactionMeta
+	err = xdr.SafeUnmarshalBase64(clientTx.ResultMetaXdr, &txMetaResult)
+	require.NoError(t, err)
+
+	assert.Greater(t, len(txMetaResult.MustV2().Operations), 0)
+	assert.Greater(t, len(txMetaResult.MustV2().TxChangesBefore), 0)
+	// TODO, generate TxChangesAfter also
+	//assert.Greater(t, len(txMetaResult.MustV2().TxChangesAfter), 0)
+}
+func TestP19MetaDisabledTransaction(t *testing.T) {
+	itest := integration.NewTest(t, integration.Config{
+		ProtocolVersion:    19,
+		HorizonEnvironment: map[string]string{"SKIP_TXMETA": "TRUE"},
+		EnableSorobanRPC:   false,
+	})
+
+	masterAccount, err := itest.Client().AccountDetail(horizonclient.AccountRequest{
+		AccountID: itest.Master().Address(),
+	})
+	require.NoError(t, err)
+
+	op := &txnbuild.Payment{
+		SourceAccount: itest.Master().Address(),
+		Destination:   itest.Master().Address(),
+		Asset:         txnbuild.NativeAsset{},
+		Amount:        "10",
+	}
+
+	clientTx := itest.MustSubmitOperations(&masterAccount, itest.Master(), op)
+
+	var txMetaResult xdr.TransactionMeta
+	err = xdr.SafeUnmarshalBase64(clientTx.ResultMetaXdr, &txMetaResult)
+	require.NoError(t, err)
+
+	assert.Equal(t, len(txMetaResult.MustV2().Operations), 0)
+	assert.Equal(t, len(txMetaResult.MustV2().TxChangesAfter), 0)
+	assert.Equal(t, len(txMetaResult.MustV2().TxChangesBefore), 0)
+}
+
+func TestP20MetaTransaction(t *testing.T) {
+	if integration.GetCoreMaxSupportedProtocol() < 20 {
+		t.Skip("This test run does not support less than Protocol 20")
+	}
+
+	itest := integration.NewTest(t, integration.Config{
+		ProtocolVersion:  20,
+		EnableSorobanRPC: true,
+	})
+
+	// establish which account will be contract owner, and load it's current seq
+	sourceAccount, err := itest.Client().AccountDetail(horizonclient.AccountRequest{
+		AccountID: itest.Master().Address(),
+	})
+	require.NoError(t, err)
+
+	installContractOp := assembleInstallContractCodeOp(t, itest.Master().Address(), add_u64_contract)
+	preFlightOp, minFee := itest.PreflightHostFunctions(&sourceAccount, *installContractOp)
+	clientTx := itest.MustSubmitOperationsWithFee(&sourceAccount, itest.Master(), minFee+txnbuild.MinBaseFee, &preFlightOp)
+
+	var txMetaResult xdr.TransactionMeta
+	err = xdr.SafeUnmarshalBase64(clientTx.ResultMetaXdr, &txMetaResult)
+	require.NoError(t, err)
+
+	assert.Greater(t, len(txMetaResult.MustV3().Operations), 0)
+	assert.NotNil(t, txMetaResult.MustV3().SorobanMeta)
+	assert.Greater(t, len(txMetaResult.MustV3().TxChangesAfter), 0)
+	assert.Greater(t, len(txMetaResult.MustV3().TxChangesBefore), 0)
+}
+
+func TestP20MetaDisabledTransaction(t *testing.T) {
+	if integration.GetCoreMaxSupportedProtocol() < 20 {
+		t.Skip("This test run does not support less than Protocol 20")
+	}
+
+	itest := integration.NewTest(t, integration.Config{
+		ProtocolVersion:    20,
+		HorizonEnvironment: map[string]string{"SKIP_TXMETA": "TRUE"},
+		EnableSorobanRPC:   true,
+	})
+
+	// establish which account will be contract owner, and load it's current seq
+	sourceAccount, err := itest.Client().AccountDetail(horizonclient.AccountRequest{
+		AccountID: itest.Master().Address(),
+	})
+	require.NoError(t, err)
+
+	installContractOp := assembleInstallContractCodeOp(t, itest.Master().Address(), add_u64_contract)
+	preFlightOp, minFee := itest.PreflightHostFunctions(&sourceAccount, *installContractOp)
+	clientTx := itest.MustSubmitOperationsWithFee(&sourceAccount, itest.Master(), minFee+txnbuild.MinBaseFee, &preFlightOp)
+
+	var txMetaResult xdr.TransactionMeta
+	err = xdr.SafeUnmarshalBase64(clientTx.ResultMetaXdr, &txMetaResult)
+	require.NoError(t, err)
+
+	assert.Equal(t, len(txMetaResult.MustV3().Operations), 0)
+	assert.Nil(t, txMetaResult.MustV3().SorobanMeta)
+	assert.Equal(t, len(txMetaResult.MustV3().TxChangesAfter), 0)
+	assert.Equal(t, len(txMetaResult.MustV3().TxChangesBefore), 0)
+}

--- a/services/horizon/internal/integration/transaction_test.go
+++ b/services/horizon/internal/integration/transaction_test.go
@@ -38,9 +38,10 @@ func TestP19MetaTransaction(t *testing.T) {
 
 	assert.Greater(t, len(txMetaResult.MustV2().Operations), 0)
 	assert.Greater(t, len(txMetaResult.MustV2().TxChangesBefore), 0)
-	// TODO, generate TxChangesAfter also
+	// TODO figure out how to generate TxChangesAfter also
 	//assert.Greater(t, len(txMetaResult.MustV2().TxChangesAfter), 0)
 }
+
 func TestP19MetaDisabledTransaction(t *testing.T) {
 	itest := integration.NewTest(t, integration.Config{
 		ProtocolVersion:    19,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Added new `SKIP_TXMETA`. Defaults to `FALSE`. When `TRUE` the transaction model for classic or soroban tx's won't have tx meta populated anymore, on database, history_transactions.tx_meta column will have serialized xdr that equates to empty for any protocol version, such as for protocol 20,`xdr.TransactionMeta.V3`, `Operations`, `TxChangesAfter`, `TxChangesBefore` will be empty arrays and `SorobanMeta` will be nil and API responses with transaction model will have same empty/nil.

Removed `DISABLE_SOROBAN_INGEST` configuration parameter and it's cohort by reverting https://github.com/stellar/go/pull/5176, it did similar tx-meta removal but was limited to just soroban specific,  `SKIP_TXMETA` parameter instead and removed parsing effects/ops aspects derived from tx-meta, which wasn't needed.

### Why

to prevent extended storage space needs on db.
Closes #5189 

### Known limitations


