### PR TITLE
clients/horizonclient: allow sending user-defined headers on requests

### DIFF
--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -258,6 +258,10 @@ func (c *Client) setClientAppHeaders(req *http.Request) {
 	req.Header.Set("X-Client-Version", c.Version())
 	req.Header.Set("X-App-Name", c.AppName)
 	req.Header.Set("X-App-Version", c.AppVersion)
+
+	for key, value := range c.Headers {
+		req.Header.Set(key, value)
+	}
 }
 
 // setDefaultClient sets the default HTTP client when none is provided.

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -254,14 +254,14 @@ func (c *Client) stream(
 }
 
 func (c *Client) setClientAppHeaders(req *http.Request) {
+	for key, value := range c.Headers {
+		req.Header.Set(key, value)
+	}
+
 	req.Header.Set("X-Client-Name", "go-stellar-sdk")
 	req.Header.Set("X-Client-Version", c.Version())
 	req.Header.Set("X-App-Name", c.AppName)
 	req.Header.Set("X-App-Version", c.AppVersion)
-
-	for key, value := range c.Headers {
-		req.Header.Set(key, value)
-	}
 }
 
 // setDefaultClient sets the default HTTP client when none is provided.

--- a/clients/horizonclient/client_test.go
+++ b/clients/horizonclient/client_test.go
@@ -13,7 +13,7 @@ func setupClient() *Client {
 	}
 }
 
-func TestSetClientAppHeaders(t *testing.T) {
+func TestSetClientAppHeaders_DefaultLogic(t *testing.T) {
 	client := setupClient()
 
 	request := LedgerRequest{
@@ -34,7 +34,7 @@ func TestSetClientAppHeaders(t *testing.T) {
 	assert.Equal(t, "4.5.7", req.Header.Get("X-App-Version"))
 }
 
-func TestSetClientAppHeaders_customHeaders(t *testing.T) {
+func TestSetClientAppHeaders_CustomHeadersLogic(t *testing.T) {
 	client := setupClient()
 
 	client.Headers = make(map[string]string)

--- a/clients/horizonclient/client_test.go
+++ b/clients/horizonclient/client_test.go
@@ -1,0 +1,60 @@
+package horizonclient
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func setupClient() *Client {
+	return &Client{
+		HorizonURL: "https://localhost/",
+		AppName:    "client_test",
+		AppVersion: "4.5.7",
+	}
+}
+
+func TestSetClientAppHeaders(t *testing.T) {
+	client := setupClient()
+
+	request := LedgerRequest{
+		Order: OrderAsc,
+		Limit: 5,
+	}
+
+	req, err := request.HTTPRequest(client.HorizonURL)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(req.Header))
+
+	client.setClientAppHeaders(req)
+	assert.Equal(t, 4, len(req.Header))
+
+	assert.Equal(t, "go-stellar-sdk", req.Header.Get("X-Client-Name"))
+	assert.Equal(t, version, req.Header.Get("X-Client-Version"))
+	assert.Equal(t, "client_test", req.Header.Get("X-App-Name"))
+	assert.Equal(t, "4.5.7", req.Header.Get("X-App-Version"))
+}
+
+func TestSetClientAppHeaders_customHeaders(t *testing.T) {
+	client := setupClient()
+
+	client.Headers = make(map[string]string)
+	client.Headers["X-Api-Key"] = "abcde"
+
+	request := LedgerRequest{
+		Order: OrderAsc,
+		Limit: 5,
+	}
+
+	req, err := request.HTTPRequest(client.HorizonURL)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(req.Header))
+
+	client.setClientAppHeaders(req)
+	assert.Equal(t, 5, len(req.Header))
+
+	assert.Equal(t, "go-stellar-sdk", req.Header.Get("X-Client-Name"))
+	assert.Equal(t, version, req.Header.Get("X-Client-Version"))
+	assert.Equal(t, "client_test", req.Header.Get("X-App-Name"))
+	assert.Equal(t, "4.5.7", req.Header.Get("X-App-Version"))
+	assert.Equal(t, "abcde", req.Header.Get("X-Api-Key"))
+}

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -145,6 +145,9 @@ type Client struct {
 	AppVersion     string
 	horizonTimeout time.Duration
 
+	// Headers allows specifying additional HTTP headers for requests made by the client.
+	Headers map[string]string
+
 	// clock is a Clock returning the current time.
 	clock *clock.Clock
 }


### PR DESCRIPTION
### What

Add Headers field to the Client struct in order to allow passing custom HTTP headers with requests made by the SDK.

### Why

This change enables users of SDK to include custom headers, such as authorization headers, when making HTTP requests to Stellar API. Previously, there was no built-in mechanism to add custom headers, which limited the flexibility of the SDK in certain scenarios. By introducing the Headers field, users can now easily include any additional headers required for their specific use cases.

### Known limitations

N/A
