### PR TITLE
support/db: Delay canceling queries from client side when there's a statement / transaction timeout configured in postgres

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -494,7 +494,7 @@ func (a *App) init() error {
 	a.UpdateStellarCoreInfo(a.ctx)
 
 	// horizon-db and core-db
-	dbServerSideTimeout := mustInitHorizonDB(a)
+	mustInitHorizonDB(a)
 
 	if a.config.Ingest {
 		// ingester
@@ -532,7 +532,7 @@ func (a *App) init() error {
 		SSEUpdateFrequency:       a.config.SSEUpdateFrequency,
 		StaleThreshold:           a.config.StaleThreshold,
 		ConnectionTimeout:        a.config.ConnectionTimeout,
-		DBServerSideTimeout:      dbServerSideTimeout,
+		CancelDBQueryTimeout:     a.config.CancelDBQueryTimeout,
 		MaxHTTPRequestSize:       a.config.MaxHTTPRequestSize,
 		NetworkPassphrase:        a.config.NetworkPassphrase,
 		MaxPathLength:            a.config.MaxPathLength,

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -494,7 +494,7 @@ func (a *App) init() error {
 	a.UpdateStellarCoreInfo(a.ctx)
 
 	// horizon-db and core-db
-	mustInitHorizonDB(a)
+	dbServerSideTimeout := mustInitHorizonDB(a)
 
 	if a.config.Ingest {
 		// ingester
@@ -532,6 +532,7 @@ func (a *App) init() error {
 		SSEUpdateFrequency:       a.config.SSEUpdateFrequency,
 		StaleThreshold:           a.config.StaleThreshold,
 		ConnectionTimeout:        a.config.ConnectionTimeout,
+		DBServerSideTimeout:      dbServerSideTimeout,
 		MaxHTTPRequestSize:       a.config.MaxHTTPRequestSize,
 		NetworkPassphrase:        a.config.NetworkPassphrase,
 		MaxPathLength:            a.config.MaxPathLength,

--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -532,7 +532,7 @@ func (a *App) init() error {
 		SSEUpdateFrequency:       a.config.SSEUpdateFrequency,
 		StaleThreshold:           a.config.StaleThreshold,
 		ConnectionTimeout:        a.config.ConnectionTimeout,
-		CancelDBQueryTimeout:     a.config.CancelDBQueryTimeout,
+		ClientQueryTimeout:       a.config.ClientQueryTimeout,
 		MaxHTTPRequestSize:       a.config.MaxHTTPRequestSize,
 		NetworkPassphrase:        a.config.NetworkPassphrase,
 		MaxPathLength:            a.config.MaxPathLength,

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -36,8 +36,9 @@ type Config struct {
 	HorizonDBMaxOpenConnections int
 	HorizonDBMaxIdleConnections int
 
-	SSEUpdateFrequency time.Duration
-	ConnectionTimeout  time.Duration
+	SSEUpdateFrequency   time.Duration
+	ConnectionTimeout    time.Duration
+	CancelDBQueryTimeout time.Duration
 	// MaxHTTPRequestSize is the maximum allowed request payload size
 	MaxHTTPRequestSize uint
 	RateQuota          *throttled.RateQuota

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -36,9 +36,9 @@ type Config struct {
 	HorizonDBMaxOpenConnections int
 	HorizonDBMaxIdleConnections int
 
-	SSEUpdateFrequency   time.Duration
-	ConnectionTimeout    time.Duration
-	CancelDBQueryTimeout time.Duration
+	SSEUpdateFrequency time.Duration
+	ConnectionTimeout  time.Duration
+	ClientQueryTimeout time.Duration
 	// MaxHTTPRequestSize is the maximum allowed request payload size
 	MaxHTTPRequestSize uint
 	RateQuota          *throttled.RateQuota

--- a/services/horizon/internal/db2/history/liquidity_pools.go
+++ b/services/horizon/internal/db2/history/liquidity_pools.go
@@ -9,8 +9,9 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/guregu/null"
-	"github.com/jmoiron/sqlx"
+
 	"github.com/stellar/go/services/horizon/internal/db2"
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -188,7 +189,7 @@ func (q *Q) GetLiquidityPools(ctx context.Context, query LiquidityPoolsQuery) ([
 }
 
 func (q *Q) StreamAllLiquidityPools(ctx context.Context, callback func(LiquidityPool) error) error {
-	var rows *sqlx.Rows
+	var rows *db.Rows
 	var err error
 
 	if rows, err = q.Query(ctx, selectLiquidityPools.Where("deleted = ?", false)); err != nil {

--- a/services/horizon/internal/db2/history/liquidity_pools_test.go
+++ b/services/horizon/internal/db2/history/liquidity_pools_test.go
@@ -112,6 +112,7 @@ func TestStreamAllLiquidity(t *testing.T) {
 		pools = append(pools, pool)
 		return nil
 	})
+	tt.Assert.NoError(err)
 	sort.Slice(pools, func(i, j int) bool {
 		return pools[i].PoolID < pools[j].PoolID
 	})

--- a/services/horizon/internal/db2/history/offers.go
+++ b/services/horizon/internal/db2/history/offers.go
@@ -5,8 +5,8 @@ import (
 	"database/sql"
 
 	sq "github.com/Masterminds/squirrel"
-	"github.com/jmoiron/sqlx"
 
+	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
 )
 
@@ -108,7 +108,7 @@ func (q *Q) StreamAllOffers(ctx context.Context, callback func(Offer) error) err
 }
 
 func (q *Q) streamAllOffersBatch(ctx context.Context, lastId int64, limit uint64, callback func(Offer) error) (int64, error) {
-	var rows *sqlx.Rows
+	var rows *db.Rows
 	var err error
 
 	rows, err = q.Query(ctx, selectOffers.

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -453,7 +453,7 @@ func Flags() (*Config, support.ConfigOptions) {
 				if duration < 0 {
 					return fmt.Errorf("%s cannot be negative", co.Name)
 				}
-				*(co.ConfigKey.(*time.Duration)) = time.Duration(viper.GetInt(co.Name)) * time.Second
+				*(co.ConfigKey.(*time.Duration)) = time.Duration(duration) * time.Second
 				return nil
 			},
 			Usage: "defines the timeout for when horizon will cancel all postgres queries connected to an HTTP request. The timeout is measured in seconds since the start of the HTTP request. Note, this timeout does not apply to POST /transactions. " +

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -69,6 +70,7 @@ const (
 	StellarTestnet = "testnet"
 
 	defaultMaxHTTPRequestSize = uint(200 * 1024)
+	clientQueryTimeoutNotSet  = -1
 )
 
 var (
@@ -438,15 +440,27 @@ func Flags() (*Config, support.ConfigOptions) {
 			UsedInCommands: ApiServerCommands,
 		},
 		&support.ConfigOption{
-			Name:           "cancel-db-query-timeout",
-			ConfigKey:      &config.CancelDBQueryTimeout,
-			OptType:        types.Int,
-			FlagDefault:    0,
-			CustomSetValue: support.SetDuration,
+			Name:        "client-query-timeout",
+			ConfigKey:   &config.ClientQueryTimeout,
+			OptType:     types.Int,
+			FlagDefault: clientQueryTimeoutNotSet,
+			CustomSetValue: func(co *support.ConfigOption) error {
+				if !support.IsExplicitlySet(co) {
+					*(co.ConfigKey.(*time.Duration)) = time.Duration(co.FlagDefault.(int))
+					return nil
+				}
+				duration := viper.GetInt(co.Name)
+				if duration < 0 {
+					return fmt.Errorf("%s cannot be negative", co.Name)
+				}
+				*(co.ConfigKey.(*time.Duration)) = time.Duration(viper.GetInt(co.Name)) * time.Second
+				return nil
+			},
 			Usage: "defines the timeout for when horizon will cancel all postgres queries connected to an HTTP request. The timeout is measured in seconds since the start of the HTTP request. Note, this timeout does not apply to POST /transactions. " +
-				"The difference between cancel-db-query-timeout and connection-timeout is that connection-timeout applies a postgres statement timeout whereas cancel-db-query-timeout will send an additional request to postgres to cancel the ongoing query. " +
-				"Generally, cancel-db-query-timeout should be configured to be higher than connection-timeout to allow the postgres statement timeout to kill long running queries without having to send the additional cancel request to postgres. " +
-				"By default, cancel-db-query-timeout will be set to twice the connection-timeout.",
+				"The difference between client-query-timeout and connection-timeout is that connection-timeout applies a postgres statement timeout whereas client-query-timeout will send an additional request to postgres to cancel the ongoing query. " +
+				"Generally, client-query-timeout should be configured to be higher than connection-timeout to allow the postgres statement timeout to kill long running queries without having to send the additional cancel request to postgres. " +
+				"By default, client-query-timeout will be set to twice the connection-timeout. Setting client-query-timeout to 0 will disable the timeout which means that Horizon will never kill long running queries using the cancel request, however, " +
+				"long running queries can still be killed through the postgres statement timeout which is configured via the connection-timeout flag.",
 			UsedInCommands: ApiServerCommands,
 		},
 		&support.ConfigOption{
@@ -995,9 +1009,9 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 			" If Horizon is behind both, use --behind-cloudflare only")
 	}
 
-	if config.CancelDBQueryTimeout == 0 {
+	if config.ClientQueryTimeout == clientQueryTimeoutNotSet {
 		// the default value for cancel-db-query-timeout is twice the connection-timeout
-		config.CancelDBQueryTimeout = config.ConnectionTimeout * 2
+		config.ClientQueryTimeout = config.ConnectionTimeout * 2
 	}
 
 	return nil

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -435,6 +436,17 @@ func Flags() (*Config, support.ConfigOptions) {
 			FlagDefault:    55,
 			CustomSetValue: support.SetDuration,
 			Usage:          "defines the timeout of connection after which 504 response will be sent or stream will be closed, if Horizon is behind a load balancer with idle connection timeout, this should be set to a few seconds less that idle timeout, does not apply to POST /transactions",
+			UsedInCommands: ApiServerCommands,
+		},
+		&support.ConfigOption{
+			Name:           "cancel-db-query-timeout",
+			ConfigKey:      &config.CancelDBQueryTimeout,
+			OptType:        types.Int,
+			CustomSetValue: support.SetDuration,
+			Usage: "defines the timeout for when horizon will cancel all postgres queries connected to an HTTP request. The timeout is measured in seconds since the start of the HTTP request. Note, this timeout does not apply to POST /transactions. " +
+				"The difference between cancel-db-query-timeout and connection-timeout is that connection-timeout applies a postgres statement timeout whereas cancel-db-query-timeout will send an additional request to postgres to cancel the ongoing query. " +
+				"Generally, cancel-db-query-timeout should be configured to be higher than connection-timeout to allow the postgres statement timeout to kill long running queries without having to send the additional cancel request to postgres. " +
+				"By default, cancel-db-query-timeout will be set to 2 seconds more than connection-timeout.",
 			UsedInCommands: ApiServerCommands,
 		},
 		&support.ConfigOption{
@@ -981,6 +993,11 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 	if config.BehindCloudflare && config.BehindAWSLoadBalancer {
 		return fmt.Errorf("invalid config: Only one option of --behind-cloudflare and --behind-aws-load-balancer is allowed." +
 			" If Horizon is behind both, use --behind-cloudflare only")
+	}
+
+	if config.CancelDBQueryTimeout == 0 {
+		// the default value for cancel-db-query-timeout is 2 seconds more than connection-timeout
+		config.CancelDBQueryTimeout = config.ConnectionTimeout + time.Second*2
 	}
 
 	return nil

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -442,6 +442,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			Name:           "cancel-db-query-timeout",
 			ConfigKey:      &config.CancelDBQueryTimeout,
 			OptType:        types.Int,
+			FlagDefault:    0,
 			CustomSetValue: support.SetDuration,
 			Usage: "defines the timeout for when horizon will cancel all postgres queries connected to an HTTP request. The timeout is measured in seconds since the start of the HTTP request. Note, this timeout does not apply to POST /transactions. " +
 				"The difference between cancel-db-query-timeout and connection-timeout is that connection-timeout applies a postgres statement timeout whereas cancel-db-query-timeout will send an additional request to postgres to cancel the ongoing query. " +

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -447,7 +446,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			Usage: "defines the timeout for when horizon will cancel all postgres queries connected to an HTTP request. The timeout is measured in seconds since the start of the HTTP request. Note, this timeout does not apply to POST /transactions. " +
 				"The difference between cancel-db-query-timeout and connection-timeout is that connection-timeout applies a postgres statement timeout whereas cancel-db-query-timeout will send an additional request to postgres to cancel the ongoing query. " +
 				"Generally, cancel-db-query-timeout should be configured to be higher than connection-timeout to allow the postgres statement timeout to kill long running queries without having to send the additional cancel request to postgres. " +
-				"By default, cancel-db-query-timeout will be set to 2 seconds more than connection-timeout.",
+				"By default, cancel-db-query-timeout will be set to twice the connection-timeout.",
 			UsedInCommands: ApiServerCommands,
 		},
 		&support.ConfigOption{
@@ -997,8 +996,8 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 	}
 
 	if config.CancelDBQueryTimeout == 0 {
-		// the default value for cancel-db-query-timeout is 2 seconds more than connection-timeout
-		config.CancelDBQueryTimeout = config.ConnectionTimeout + time.Second*2
+		// the default value for cancel-db-query-timeout is twice the connection-timeout
+		config.CancelDBQueryTimeout = config.ConnectionTimeout * 2
 	}
 
 	return nil

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -197,7 +197,7 @@ func recoverMiddleware(h http.Handler) http.Handler {
 // NewHistoryMiddleware adds session to the request context and ensures Horizon
 // is not in a stale state, which is when the difference between latest core
 // ledger and latest history ledger is higher than the given threshold
-func NewHistoryMiddleware(ledgerState *ledger.State, staleThreshold int32, session db.SessionInterface) func(http.Handler) http.Handler {
+func NewHistoryMiddleware(ledgerState *ledger.State, staleThreshold int32, session db.SessionInterface, contextDBTimeout time.Duration) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -205,6 +205,7 @@ func NewHistoryMiddleware(ledgerState *ledger.State, staleThreshold int32, sessi
 			if routePattern := supportHttp.GetChiRoutePattern(r); routePattern != "" {
 				ctx = context.WithValue(ctx, &db.RouteContextKey, routePattern)
 			}
+			ctx = setContextDBTimeout(contextDBTimeout, ctx)
 			if staleThreshold > 0 {
 				ls := ledgerState.CurrentStatus()
 				isStale := (ls.CoreLatest - ls.HistoryLatest) > int32(staleThreshold)
@@ -238,6 +239,7 @@ func NewHistoryMiddleware(ledgerState *ledger.State, staleThreshold int32, sessi
 // returning invalid data to the user)
 type StateMiddleware struct {
 	HorizonSession      db.SessionInterface
+	ContextDBTimeout    time.Duration
 	NoStateVerification bool
 }
 
@@ -276,6 +278,7 @@ func (m *StateMiddleware) WrapFunc(h http.HandlerFunc) http.HandlerFunc {
 		if routePattern := supportHttp.GetChiRoutePattern(r); routePattern != "" {
 			ctx = context.WithValue(ctx, &db.RouteContextKey, routePattern)
 		}
+		ctx = setContextDBTimeout(m.ContextDBTimeout, ctx)
 		session := m.HorizonSession.Clone()
 		q := &history.Q{session}
 		sseRequest := render.Negotiate(r) == render.MimeEventStream
@@ -342,6 +345,13 @@ func (m *StateMiddleware) WrapFunc(h http.HandlerFunc) http.HandlerFunc {
 			context.WithValue(ctx, &horizonContext.SessionContextKey, session),
 		))
 	}
+}
+
+func setContextDBTimeout(timeout time.Duration, ctx context.Context) context.Context {
+	if timeout > 0 {
+		ctx = context.WithValue(ctx, &db.DeadlineCtxKey, time.Now().Add(timeout))
+	}
+	return ctx
 }
 
 // WrapFunc executes the middleware on a given HTTP handler function

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -238,9 +238,9 @@ func NewHistoryMiddleware(ledgerState *ledger.State, staleThreshold int32, sessi
 // has been verified and is correct (Otherwise returns `500 Internal Server Error` to prevent
 // returning invalid data to the user)
 type StateMiddleware struct {
-	HorizonSession       db.SessionInterface
-	CancelDBQueryTimeout time.Duration
-	NoStateVerification  bool
+	HorizonSession      db.SessionInterface
+	ClientQueryTimeout  time.Duration
+	NoStateVerification bool
 }
 
 func ingestionStatus(ctx context.Context, q *history.Q) (uint32, bool, error) {
@@ -278,7 +278,7 @@ func (m *StateMiddleware) WrapFunc(h http.HandlerFunc) http.HandlerFunc {
 		if routePattern := supportHttp.GetChiRoutePattern(r); routePattern != "" {
 			ctx = context.WithValue(ctx, &db.RouteContextKey, routePattern)
 		}
-		ctx = setContextDBTimeout(m.CancelDBQueryTimeout, ctx)
+		ctx = setContextDBTimeout(m.ClientQueryTimeout, ctx)
 		session := m.HorizonSession.Clone()
 		q := &history.Q{session}
 		sseRequest := render.Negotiate(r) == render.MimeEventStream
@@ -348,10 +348,11 @@ func (m *StateMiddleware) WrapFunc(h http.HandlerFunc) http.HandlerFunc {
 }
 
 func setContextDBTimeout(timeout time.Duration, ctx context.Context) context.Context {
+	var deadline time.Time
 	if timeout > 0 {
-		ctx = context.WithValue(ctx, &db.DeadlineCtxKey, time.Now().Add(timeout))
+		deadline = time.Now().Add(timeout)
 	}
-	return ctx
+	return context.WithValue(ctx, &db.DeadlineCtxKey, deadline)
 }
 
 // WrapFunc executes the middleware on a given HTTP handler function

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -238,9 +238,9 @@ func NewHistoryMiddleware(ledgerState *ledger.State, staleThreshold int32, sessi
 // has been verified and is correct (Otherwise returns `500 Internal Server Error` to prevent
 // returning invalid data to the user)
 type StateMiddleware struct {
-	HorizonSession      db.SessionInterface
-	ContextDBTimeout    time.Duration
-	NoStateVerification bool
+	HorizonSession       db.SessionInterface
+	CancelDBQueryTimeout time.Duration
+	NoStateVerification  bool
 }
 
 func ingestionStatus(ctx context.Context, q *history.Q) (uint32, bool, error) {
@@ -278,7 +278,7 @@ func (m *StateMiddleware) WrapFunc(h http.HandlerFunc) http.HandlerFunc {
 		if routePattern := supportHttp.GetChiRoutePattern(r); routePattern != "" {
 			ctx = context.WithValue(ctx, &db.RouteContextKey, routePattern)
 		}
-		ctx = setContextDBTimeout(m.ContextDBTimeout, ctx)
+		ctx = setContextDBTimeout(m.CancelDBQueryTimeout, ctx)
 		session := m.HorizonSession.Clone()
 		q := &history.Q{session}
 		sseRequest := render.Negotiate(r) == render.MimeEventStream

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -38,6 +38,7 @@ type RouterConfig struct {
 	SSEUpdateFrequency       time.Duration
 	StaleThreshold           uint
 	ConnectionTimeout        time.Duration
+	DBServerSideTimeout      bool
 	MaxHTTPRequestSize       uint
 	NetworkPassphrase        string
 	MaxPathLength            uint
@@ -138,8 +139,13 @@ func (r *Router) addMiddleware(config *RouterConfig,
 }
 
 func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRateLimiter, ledgerState *ledger.State) {
+	var contextDBTimeout time.Duration
+	if config.DBServerSideTimeout {
+		contextDBTimeout = config.ConnectionTimeout * 15
+	}
 	stateMiddleware := StateMiddleware{
-		HorizonSession: config.DBSession,
+		HorizonSession:   config.DBSession,
+		ContextDBTimeout: contextDBTimeout,
 	}
 
 	r.Method(http.MethodGet, "/health", config.HealthCheck)
@@ -157,7 +163,7 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 		LedgerSourceFactory: historyLedgerSourceFactory{ledgerState: ledgerState, updateFrequency: config.SSEUpdateFrequency},
 	}
 
-	historyMiddleware := NewHistoryMiddleware(ledgerState, int32(config.StaleThreshold), config.DBSession)
+	historyMiddleware := NewHistoryMiddleware(ledgerState, int32(config.StaleThreshold), config.DBSession, contextDBTimeout)
 	// State endpoints behind stateMiddleware
 	r.Group(func(r chi.Router) {
 		r.Route("/accounts", func(r chi.Router) {

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -38,7 +38,7 @@ type RouterConfig struct {
 	SSEUpdateFrequency       time.Duration
 	StaleThreshold           uint
 	ConnectionTimeout        time.Duration
-	DBServerSideTimeout      bool
+	CancelDBQueryTimeout     time.Duration
 	MaxHTTPRequestSize       uint
 	NetworkPassphrase        string
 	MaxPathLength            uint
@@ -139,13 +139,9 @@ func (r *Router) addMiddleware(config *RouterConfig,
 }
 
 func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRateLimiter, ledgerState *ledger.State) {
-	var contextDBTimeout time.Duration
-	if config.DBServerSideTimeout {
-		contextDBTimeout = config.ConnectionTimeout * 15
-	}
 	stateMiddleware := StateMiddleware{
-		HorizonSession:   config.DBSession,
-		ContextDBTimeout: contextDBTimeout,
+		HorizonSession:       config.DBSession,
+		CancelDBQueryTimeout: config.CancelDBQueryTimeout,
 	}
 
 	r.Method(http.MethodGet, "/health", config.HealthCheck)
@@ -163,7 +159,7 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 		LedgerSourceFactory: historyLedgerSourceFactory{ledgerState: ledgerState, updateFrequency: config.SSEUpdateFrequency},
 	}
 
-	historyMiddleware := NewHistoryMiddleware(ledgerState, int32(config.StaleThreshold), config.DBSession, contextDBTimeout)
+	historyMiddleware := NewHistoryMiddleware(ledgerState, int32(config.StaleThreshold), config.DBSession, config.CancelDBQueryTimeout)
 	// State endpoints behind stateMiddleware
 	r.Group(func(r chi.Router) {
 		r.Route("/accounts", func(r chi.Router) {

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -38,7 +38,7 @@ type RouterConfig struct {
 	SSEUpdateFrequency       time.Duration
 	StaleThreshold           uint
 	ConnectionTimeout        time.Duration
-	CancelDBQueryTimeout     time.Duration
+	ClientQueryTimeout       time.Duration
 	MaxHTTPRequestSize       uint
 	NetworkPassphrase        string
 	MaxPathLength            uint
@@ -140,8 +140,8 @@ func (r *Router) addMiddleware(config *RouterConfig,
 
 func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRateLimiter, ledgerState *ledger.State) {
 	stateMiddleware := StateMiddleware{
-		HorizonSession:       config.DBSession,
-		CancelDBQueryTimeout: config.CancelDBQueryTimeout,
+		HorizonSession:     config.DBSession,
+		ClientQueryTimeout: config.ClientQueryTimeout,
 	}
 
 	r.Method(http.MethodGet, "/health", config.HealthCheck)
@@ -159,7 +159,7 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 		LedgerSourceFactory: historyLedgerSourceFactory{ledgerState: ledgerState, updateFrequency: config.SSEUpdateFrequency},
 	}
 
-	historyMiddleware := NewHistoryMiddleware(ledgerState, int32(config.StaleThreshold), config.DBSession, config.CancelDBQueryTimeout)
+	historyMiddleware := NewHistoryMiddleware(ledgerState, int32(config.StaleThreshold), config.DBSession, config.ClientQueryTimeout)
 	// State endpoints behind stateMiddleware
 	r.Group(func(r chi.Router) {
 		r.Route("/accounts", func(r chi.Router) {

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -30,8 +30,9 @@ func mustNewDBSession(subservice db.Subservice, databaseURL string, maxIdle, max
 	return db.RegisterMetrics(session, "horizon", subservice, registry)
 }
 
-func mustInitHorizonDB(app *App) {
+func mustInitHorizonDB(app *App) bool {
 	log.Infof("Initializing database...")
+	var dbServerSideTimeout bool
 
 	maxIdle := app.config.HorizonDBMaxIdleConnections
 	maxOpen := app.config.HorizonDBMaxOpenConnections
@@ -55,6 +56,7 @@ func mustInitHorizonDB(app *App) {
 				db.StatementTimeout(app.config.ConnectionTimeout),
 				db.IdleTransactionTimeout(app.config.ConnectionTimeout),
 			)
+			dbServerSideTimeout = true
 		}
 		app.historyQ = &history.Q{mustNewDBSession(
 			db.HistorySubservice,
@@ -70,6 +72,7 @@ func mustInitHorizonDB(app *App) {
 			db.StatementTimeout(app.config.ConnectionTimeout),
 			db.IdleTransactionTimeout(app.config.ConnectionTimeout),
 		}
+		dbServerSideTimeout = true
 		app.historyQ = &history.Q{mustNewDBSession(
 			db.HistorySubservice,
 			app.config.RoDatabaseURL,
@@ -87,6 +90,8 @@ func mustInitHorizonDB(app *App) {
 			app.prometheusRegistry,
 		)}
 	}
+
+	return dbServerSideTimeout
 }
 
 func initIngester(app *App) {

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -30,9 +30,8 @@ func mustNewDBSession(subservice db.Subservice, databaseURL string, maxIdle, max
 	return db.RegisterMetrics(session, "horizon", subservice, registry)
 }
 
-func mustInitHorizonDB(app *App) bool {
+func mustInitHorizonDB(app *App) {
 	log.Infof("Initializing database...")
-	var dbServerSideTimeout bool
 
 	maxIdle := app.config.HorizonDBMaxIdleConnections
 	maxOpen := app.config.HorizonDBMaxOpenConnections
@@ -46,40 +45,29 @@ func mustInitHorizonDB(app *App) bool {
 			log.Fatalf("max open connections to horizon db must be greater than %d", ingest.MaxDBConnections)
 		}
 	}
+	serverSidePGTimeoutConfigs := []db.ClientConfig{
+		db.StatementTimeout(app.config.ConnectionTimeout),
+		db.IdleTransactionTimeout(app.config.ConnectionTimeout),
+	}
 
 	if app.config.RoDatabaseURL == "" {
-		var clientConfigs []db.ClientConfig
-		if !app.config.Ingest {
-			// if we are not ingesting then we don't expect to have long db queries / transactions
-			clientConfigs = append(
-				clientConfigs,
-				db.StatementTimeout(app.config.ConnectionTimeout),
-				db.IdleTransactionTimeout(app.config.ConnectionTimeout),
-			)
-			dbServerSideTimeout = true
-		}
 		app.historyQ = &history.Q{mustNewDBSession(
 			db.HistorySubservice,
 			app.config.DatabaseURL,
 			maxIdle,
 			maxOpen,
 			app.prometheusRegistry,
-			clientConfigs...,
+			serverSidePGTimeoutConfigs...,
 		)}
 	} else {
 		// If RO set, use it for all DB queries
-		roClientConfigs := []db.ClientConfig{
-			db.StatementTimeout(app.config.ConnectionTimeout),
-			db.IdleTransactionTimeout(app.config.ConnectionTimeout),
-		}
-		dbServerSideTimeout = true
 		app.historyQ = &history.Q{mustNewDBSession(
 			db.HistorySubservice,
 			app.config.RoDatabaseURL,
 			maxIdle,
 			maxOpen,
 			app.prometheusRegistry,
-			roClientConfigs...,
+			serverSidePGTimeoutConfigs...,
 		)}
 
 		app.primaryHistoryQ = &history.Q{mustNewDBSession(
@@ -88,10 +76,9 @@ func mustInitHorizonDB(app *App) bool {
 			maxIdle,
 			maxOpen,
 			app.prometheusRegistry,
+			serverSidePGTimeoutConfigs...,
 		)}
 	}
-
-	return dbServerSideTimeout
 }
 
 func initIngester(app *App) {

--- a/services/horizon/internal/middleware_test.go
+++ b/services/horizon/internal/middleware_test.go
@@ -402,7 +402,7 @@ func TestCheckHistoryStaleMiddleware(t *testing.T) {
 			}
 			ledgerState := &ledger.State{}
 			ledgerState.SetStatus(state)
-			historyMiddleware := httpx.NewHistoryMiddleware(ledgerState, testCase.staleThreshold, tt.HorizonSession())
+			historyMiddleware := httpx.NewHistoryMiddleware(ledgerState, testCase.staleThreshold, tt.HorizonSession(), 0)
 			handler := chi.NewRouter()
 			handler.With(historyMiddleware).MethodFunc("GET", "/", endpoint)
 			w := httptest.NewRecorder()

--- a/staticcheck.sh
+++ b/staticcheck.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 set -e
 
-version='2023.1.1'
+version='2023.1.7'
 
 staticcheck='go run honnef.co/go/tools/cmd/staticcheck@'"$version"
 

--- a/support/config/config_option.go
+++ b/support/config/config_option.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/strutils"
 )
@@ -248,13 +249,12 @@ func parseEnvVars(entries []string) map[string]bool {
 	return set
 }
 
-var envVars = parseEnvVars(os.Environ())
-
 // IsExplicitlySet returns true if and only if the given config option was set explicitly either
 // via a command line argument or via an environment variable
 func IsExplicitlySet(co *ConfigOption) bool {
 	// co.flag.Changed is only set to true when the configuration is set via command line parameter.
 	// In the case where a variable is configured via environment variable we need to check envVars.
+	envVars := parseEnvVars(os.Environ())
 	return co.flag.Changed || envVars[co.EnvVar]
 }
 

--- a/support/config/config_option_test.go
+++ b/support/config/config_option_test.go
@@ -88,13 +88,8 @@ func TestConfigOption_optionalFlags_env_set_empty(t *testing.T) {
 	}
 	configOpts.Init(cmd)
 
-	prev := envVars
-	envVars = map[string]bool{
-		"STRING": true,
-	}
-	defer func() {
-		envVars = prev
-	}()
+	defer os.Setenv("STRING", os.Getenv("STRING"))
+	os.Setenv("STRING", "")
 
 	cmd.Execute()
 	assert.Equal(t, "", *optString)
@@ -118,14 +113,14 @@ func TestConfigOption_optionalFlags_env_set(t *testing.T) {
 	}
 	configOpts.Init(cmd)
 
-	prev := envVars
-	envVars = map[string]bool{
-		"STRING": true,
-		"UINT":   true,
-	}
-	defer func() {
-		envVars = prev
-	}()
+	//prev := envVars
+	//envVars = map[string]bool{
+	//	"STRING": true,
+	//	"UINT":   true,
+	//}
+	//defer func() {
+	//	envVars = prev
+	//}()
 
 	defer os.Setenv("STRING", os.Getenv("STRING"))
 	defer os.Setenv("UINT", os.Getenv("UINT"))

--- a/support/config/config_option_test.go
+++ b/support/config/config_option_test.go
@@ -113,15 +113,6 @@ func TestConfigOption_optionalFlags_env_set(t *testing.T) {
 	}
 	configOpts.Init(cmd)
 
-	//prev := envVars
-	//envVars = map[string]bool{
-	//	"STRING": true,
-	//	"UINT":   true,
-	//}
-	//defer func() {
-	//	envVars = prev
-	//}()
-
 	defer os.Setenv("STRING", os.Getenv("STRING"))
 	defer os.Setenv("UINT", os.Getenv("UINT"))
 	os.Setenv("STRING", "str")

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -142,8 +142,8 @@ type SessionInterface interface {
 	GetRaw(ctx context.Context, dest interface{}, query string, args ...interface{}) error
 	Select(ctx context.Context, dest interface{}, query squirrel.Sqlizer) error
 	SelectRaw(ctx context.Context, dest interface{}, query string, args ...interface{}) error
-	Query(ctx context.Context, query squirrel.Sqlizer) (*sqlx.Rows, error)
-	QueryRaw(ctx context.Context, query string, args ...interface{}) (*sqlx.Rows, error)
+	Query(ctx context.Context, query squirrel.Sqlizer) (*Rows, error)
+	QueryRaw(ctx context.Context, query string, args ...interface{}) (*Rows, error)
 	GetTable(name string) *Table
 	Exec(ctx context.Context, query squirrel.Sqlizer) (sql.Result, error)
 	ExecRaw(ctx context.Context, query string, args ...interface{}) (sql.Result, error)

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Masterminds/squirrel"
 	"github.com/jmoiron/sqlx"
+
 	"github.com/stellar/go/support/errors"
 
 	// Enable postgres
@@ -119,6 +120,7 @@ type Session struct {
 	DB *sqlx.DB
 
 	tx            *sqlx.Tx
+	txCancel      context.CancelFunc
 	txOptions     *sql.TxOptions
 	errorHandlers []ErrorHandlerFunc
 }

--- a/support/db/mock_session.go
+++ b/support/db/mock_session.go
@@ -72,14 +72,14 @@ func (m *MockSession) GetRaw(ctx context.Context, dest interface{}, query string
 	return argss.Error(0)
 }
 
-func (m *MockSession) Query(ctx context.Context, query squirrel.Sqlizer) (*sqlx.Rows, error) {
+func (m *MockSession) Query(ctx context.Context, query squirrel.Sqlizer) (*Rows, error) {
 	args := m.Called(ctx, query)
-	return args.Get(0).(*sqlx.Rows), args.Error(1)
+	return args.Get(0).(*Rows), args.Error(1)
 }
 
-func (m *MockSession) QueryRaw(ctx context.Context, query string, args ...interface{}) (*sqlx.Rows, error) {
+func (m *MockSession) QueryRaw(ctx context.Context, query string, args ...interface{}) (*Rows, error) {
 	argss := m.Called(ctx, query, args)
-	return argss.Get(0).(*sqlx.Rows), argss.Error(1)
+	return argss.Get(0).(*Rows), argss.Error(1)
 }
 
 func (m *MockSession) Select(ctx context.Context, dest interface{}, query squirrel.Sqlizer) error {

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -26,11 +26,15 @@ func noop() {}
 // If the override exists, we return a new context with the desired deadline. Otherwise, we return the
 // original context.
 // Note that the override will not be applied if requestCtx has already been terminated.
-// The timeout can be disabled by setting the DeadlineCtxKey value to 0.
+// The timeout can be disabled by setting the DeadlineCtxKey value to a zero time.Time value,
+// in that case the query will never be canceled.
 func (s *Session) context(requestCtx context.Context) (context.Context, context.CancelFunc, error) {
 	var ctx context.Context
 	var cancel context.CancelFunc
 
+	// if there is no DeadlineCtxKey value in the context we default to using the request context.
+	// this case is expected during ingestion where we don't want any queries to be canceled unless
+	// horizon is shutting down.
 	deadline, ok := requestCtx.Value(&DeadlineCtxKey).(time.Time)
 	if !ok {
 		return requestCtx, noop, nil

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -20,24 +20,30 @@ import (
 
 var DeadlineCtxKey = CtxKey("deadline")
 
-func noop() {}
-
 // context() checks if there is a override on the context timeout which is configured using DeadlineCtxKey.
 // If the override exists, we return a new context with the desired deadline. Otherwise, we return the
 // original context.
 // Note that the override will not be applied if requestCtx has already been terminated.
 func (s *Session) context(requestCtx context.Context) (context.Context, context.CancelFunc, error) {
+	var ctx context.Context
+	var cancel context.CancelFunc
+
 	deadline, ok := requestCtx.Value(&DeadlineCtxKey).(time.Time)
 	if !ok {
-		return requestCtx, noop, nil
+		ctx, cancel = context.WithCancel(requestCtx)
+		return ctx, cancel, nil
 	}
 
 	// if requestCtx is already terminated don't proceed with the db statement
 	if requestCtx.Err() != nil {
-		return requestCtx, noop, requestCtx.Err()
+		return requestCtx, nil, requestCtx.Err()
 	}
 
-	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	if deadline.IsZero() {
+		ctx, cancel = context.WithCancel(context.Background())
+	} else {
+		ctx, cancel = context.WithDeadline(context.Background(), deadline)
+	}
 	return ctx, cancel, nil
 }
 
@@ -48,7 +54,6 @@ func (s *Session) Begin(ctx context.Context) error {
 	}
 	ctx, cancel, err := s.context(ctx)
 	if err != nil {
-		cancel()
 		return err
 	}
 
@@ -77,7 +82,6 @@ func (s *Session) BeginTx(ctx context.Context, opts *sql.TxOptions) error {
 	}
 	ctx, cancel, err := s.context(ctx)
 	if err != nil {
-		cancel()
 		return err
 	}
 
@@ -178,10 +182,10 @@ func (s *Session) Get(ctx context.Context, dest interface{}, query sq.Sqlizer) e
 // `dest`, if any.
 func (s *Session) GetRaw(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
 	ctx, cancel, err := s.context(ctx)
-	defer cancel()
 	if err != nil {
 		return err
 	}
+	defer cancel()
 
 	query, err = s.ReplacePlaceholders(query)
 	if err != nil {
@@ -253,10 +257,10 @@ func (s *Session) ExecAll(ctx context.Context, script string) error {
 // ExecRaw runs `query` with `args`
 func (s *Session) ExecRaw(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
 	ctx, cancel, err := s.context(ctx)
-	defer cancel()
 	if err != nil {
 		return nil, err
 	}
+	defer cancel()
 
 	query, err = s.ReplacePlaceholders(query)
 	if err != nil {
@@ -359,10 +363,10 @@ func (s *Session) Query(ctx context.Context, query sq.Sqlizer) (*sqlx.Rows, erro
 // QueryRaw runs `query` with `args`
 func (s *Session) QueryRaw(ctx context.Context, query string, args ...interface{}) (*sqlx.Rows, error) {
 	ctx, cancel, err := s.context(ctx)
-	defer cancel()
 	if err != nil {
 		return nil, err
 	}
+	defer cancel()
 
 	query, err = s.ReplacePlaceholders(query)
 	if err != nil {
@@ -444,10 +448,10 @@ func (s *Session) SelectRaw(
 	args ...interface{},
 ) error {
 	ctx, cancel, err := s.context(ctx)
-	defer cancel()
 	if err != nil {
 		return err
 	}
+	defer cancel()
 
 	s.clearSliceIfPossible(dest)
 	query, err = s.ReplacePlaceholders(query)

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -261,10 +261,10 @@ func (s *Session) ExecRaw(ctx context.Context, query string, args ...interface{}
 	if err != nil {
 		return nil, err
 	}
-	defer cancel()
 
 	query, err = s.ReplacePlaceholders(query)
 	if err != nil {
+		cancel()
 		return nil, errors.Wrap(err, "replace placeholders failed")
 	}
 
@@ -275,6 +275,7 @@ func (s *Session) ExecRaw(ctx context.Context, query string, args ...interface{}
 	if err == nil {
 		return result, nil
 	}
+	defer cancel()
 
 	if knownErr := s.handleError(err, ctx); knownErr != nil {
 		return nil, knownErr
@@ -367,10 +368,10 @@ func (s *Session) QueryRaw(ctx context.Context, query string, args ...interface{
 	if err != nil {
 		return nil, err
 	}
-	defer cancel()
 
 	query, err = s.ReplacePlaceholders(query)
 	if err != nil {
+		cancel()
 		return nil, errors.Wrap(err, "replace placeholders failed")
 	}
 
@@ -381,6 +382,7 @@ func (s *Session) QueryRaw(ctx context.Context, query string, args ...interface{
 	if err == nil {
 		return result, nil
 	}
+	defer cancel()
 
 	if knownErr := s.handleError(err, ctx); knownErr != nil {
 		return nil, knownErr

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -20,6 +20,8 @@ import (
 
 var DeadlineCtxKey = CtxKey("deadline")
 
+func noop() {}
+
 // context() checks if there is a override on the context timeout which is configured using DeadlineCtxKey.
 // If the override exists, we return a new context with the desired deadline. Otherwise, we return the
 // original context.
@@ -31,8 +33,7 @@ func (s *Session) context(requestCtx context.Context) (context.Context, context.
 
 	deadline, ok := requestCtx.Value(&DeadlineCtxKey).(time.Time)
 	if !ok {
-		ctx, cancel = context.WithCancel(requestCtx)
-		return ctx, cancel, nil
+		return requestCtx, noop, nil
 	}
 
 	// if requestCtx is already terminated don't proceed with the db statement
@@ -41,7 +42,7 @@ func (s *Session) context(requestCtx context.Context) (context.Context, context.
 	}
 
 	if deadline.IsZero() {
-		ctx, cancel = context.WithCancel(context.Background())
+		ctx, cancel = context.Background(), noop
 	} else {
 		ctx, cancel = context.WithDeadline(context.Background(), deadline)
 	}
@@ -261,10 +262,10 @@ func (s *Session) ExecRaw(ctx context.Context, query string, args ...interface{}
 	if err != nil {
 		return nil, err
 	}
+	defer cancel()
 
 	query, err = s.ReplacePlaceholders(query)
 	if err != nil {
-		cancel()
 		return nil, errors.Wrap(err, "replace placeholders failed")
 	}
 
@@ -275,7 +276,6 @@ func (s *Session) ExecRaw(ctx context.Context, query string, args ...interface{}
 	if err == nil {
 		return result, nil
 	}
-	defer cancel()
 
 	if knownErr := s.handleError(err, ctx); knownErr != nil {
 		return nil, knownErr
@@ -354,7 +354,7 @@ func (s *Session) handleError(dbErr error, ctx context.Context) error {
 }
 
 // Query runs `query`, returns a *sqlx.Rows instance
-func (s *Session) Query(ctx context.Context, query sq.Sqlizer) (*sqlx.Rows, error) {
+func (s *Session) Query(ctx context.Context, query sq.Sqlizer) (*Rows, error) {
 	sql, args, err := s.build(query)
 	if err != nil {
 		return nil, err
@@ -362,8 +362,18 @@ func (s *Session) Query(ctx context.Context, query sq.Sqlizer) (*sqlx.Rows, erro
 	return s.QueryRaw(ctx, sql, args...)
 }
 
+type Rows struct {
+	sqlx.Rows
+	cancel context.CancelFunc
+}
+
+func (r *Rows) Close() error {
+	defer r.cancel()
+	return r.Rows.Close()
+}
+
 // QueryRaw runs `query` with `args`
-func (s *Session) QueryRaw(ctx context.Context, query string, args ...interface{}) (*sqlx.Rows, error) {
+func (s *Session) QueryRaw(ctx context.Context, query string, args ...interface{}) (*Rows, error) {
 	ctx, cancel, err := s.context(ctx)
 	if err != nil {
 		return nil, err
@@ -380,7 +390,10 @@ func (s *Session) QueryRaw(ctx context.Context, query string, args ...interface{
 	s.log(ctx, "query", start, query, args)
 
 	if err == nil {
-		return result, nil
+		return &Rows{
+			Rows:   *result,
+			cancel: cancel,
+		}, nil
 	}
 	defer cancel()
 

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -12,28 +12,65 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
+
 	"github.com/stellar/go/support/db/sqlutils"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
 )
+
+var DeadlineCtxKey = CtxKey("deadline")
+
+func noop() {}
+
+// context() checks if there is a override on the context timeout which is configured using DeadlineCtxKey.
+// If the override exists, we return a new context with the desired deadline. Otherwise, we return the
+// original context.
+// Note that the override will not be applied if requestCtx has already been terminated.
+func (s *Session) context(requestCtx context.Context) (context.Context, context.CancelFunc, error) {
+	deadline, ok := requestCtx.Value(&DeadlineCtxKey).(time.Time)
+	if !ok {
+		return requestCtx, noop, nil
+	}
+
+	// if requestCtx is already terminated don't proceed with the db statement
+	switch {
+	case requestCtx.Err() == context.Canceled:
+		return requestCtx, noop, ErrCancelled
+	case requestCtx.Err() == context.DeadlineExceeded:
+		return requestCtx, noop, ErrTimeout
+	case requestCtx.Err() != nil:
+		return requestCtx, noop, requestCtx.Err()
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	return ctx, cancel, nil
+}
 
 // Begin binds this session to a new transaction.
 func (s *Session) Begin(ctx context.Context) error {
 	if s.tx != nil {
 		return errors.New("already in transaction")
 	}
+	ctx, cancel, err := s.context(ctx)
+	if err != nil {
+		cancel()
+		return err
+	}
 
 	tx, err := s.DB.BeginTxx(ctx, nil)
 	if err != nil {
 		if knownErr := s.handleError(err, ctx); knownErr != nil {
+			cancel()
 			return knownErr
 		}
 
+		cancel()
 		return errors.Wrap(err, "beginx failed")
 	}
 	log.Debug("sql: begin")
 	s.tx = tx
 	s.txOptions = nil
+	s.txCancel = cancel
 	return nil
 }
 
@@ -43,19 +80,27 @@ func (s *Session) BeginTx(ctx context.Context, opts *sql.TxOptions) error {
 	if s.tx != nil {
 		return errors.New("already in transaction")
 	}
+	ctx, cancel, err := s.context(ctx)
+	if err != nil {
+		cancel()
+		return err
+	}
 
 	tx, err := s.DB.BeginTxx(ctx, opts)
 	if err != nil {
 		if knownErr := s.handleError(err, ctx); knownErr != nil {
+			cancel()
 			return knownErr
 		}
 
+		cancel()
 		return errors.Wrap(err, "beginTx failed")
 	}
 	log.Debug("sql: begin")
 
 	s.tx = tx
 	s.txOptions = opts
+	s.txCancel = cancel
 	return nil
 }
 
@@ -93,6 +138,8 @@ func (s *Session) Commit() error {
 	log.Debug("sql: commit")
 	s.tx = nil
 	s.txOptions = nil
+	s.txCancel()
+	s.txCancel = nil
 
 	if knownErr := s.handleError(err, context.Background()); knownErr != nil {
 		return knownErr
@@ -135,7 +182,13 @@ func (s *Session) Get(ctx context.Context, dest interface{}, query sq.Sqlizer) e
 // GetRaw runs `query` with `args`, setting the first result found on
 // `dest`, if any.
 func (s *Session) GetRaw(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
-	query, err := s.ReplacePlaceholders(query)
+	ctx, cancel, err := s.context(ctx)
+	defer cancel()
+	if err != nil {
+		return err
+	}
+
+	query, err = s.ReplacePlaceholders(query)
 	if err != nil {
 		return errors.Wrap(err, "replace placeholders failed")
 	}
@@ -204,7 +257,13 @@ func (s *Session) ExecAll(ctx context.Context, script string) error {
 
 // ExecRaw runs `query` with `args`
 func (s *Session) ExecRaw(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
-	query, err := s.ReplacePlaceholders(query)
+	ctx, cancel, err := s.context(ctx)
+	defer cancel()
+	if err != nil {
+		return nil, err
+	}
+
+	query, err = s.ReplacePlaceholders(query)
 	if err != nil {
 		return nil, errors.Wrap(err, "replace placeholders failed")
 	}
@@ -304,7 +363,13 @@ func (s *Session) Query(ctx context.Context, query sq.Sqlizer) (*sqlx.Rows, erro
 
 // QueryRaw runs `query` with `args`
 func (s *Session) QueryRaw(ctx context.Context, query string, args ...interface{}) (*sqlx.Rows, error) {
-	query, err := s.ReplacePlaceholders(query)
+	ctx, cancel, err := s.context(ctx)
+	defer cancel()
+	if err != nil {
+		return nil, err
+	}
+
+	query, err = s.ReplacePlaceholders(query)
 	if err != nil {
 		return nil, errors.Wrap(err, "replace placeholders failed")
 	}
@@ -350,6 +415,8 @@ func (s *Session) Rollback() error {
 	log.Debug("sql: rollback")
 	s.tx = nil
 	s.txOptions = nil
+	s.txCancel()
+	s.txCancel = nil
 
 	if knownErr := s.handleError(err, context.Background()); knownErr != nil {
 		return knownErr
@@ -381,8 +448,14 @@ func (s *Session) SelectRaw(
 	query string,
 	args ...interface{},
 ) error {
+	ctx, cancel, err := s.context(ctx)
+	defer cancel()
+	if err != nil {
+		return err
+	}
+
 	s.clearSliceIfPossible(dest)
-	query, err := s.ReplacePlaceholders(query)
+	query, err = s.ReplacePlaceholders(query)
 	if err != nil {
 		return errors.Wrap(err, "replace placeholders failed")
 	}

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -24,6 +24,7 @@ var DeadlineCtxKey = CtxKey("deadline")
 // If the override exists, we return a new context with the desired deadline. Otherwise, we return the
 // original context.
 // Note that the override will not be applied if requestCtx has already been terminated.
+// The timeout can be disabled by setting the DeadlineCtxKey value to 0.
 func (s *Session) context(requestCtx context.Context) (context.Context, context.CancelFunc, error) {
 	var ctx context.Context
 	var cancel context.CancelFunc

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -33,12 +33,7 @@ func (s *Session) context(requestCtx context.Context) (context.Context, context.
 	}
 
 	// if requestCtx is already terminated don't proceed with the db statement
-	switch {
-	case requestCtx.Err() == context.Canceled:
-		return requestCtx, noop, ErrCancelled
-	case requestCtx.Err() == context.DeadlineExceeded:
-		return requestCtx, noop, ErrTimeout
-	case requestCtx.Err() != nil:
+	if requestCtx.Err() != nil {
 		return requestCtx, noop, requestCtx.Err()
 	}
 

--- a/support/db/session_test.go
+++ b/support/db/session_test.go
@@ -169,7 +169,7 @@ func TestDeadlineOverride(t *testing.T) {
 
 	cancel()
 	_, _, err = sess.context(requestCtx)
-	assert.EqualError(t, err, "canceling statement due to user request")
+	assert.EqualError(t, err, "context canceled")
 }
 
 func TestSession(t *testing.T) {

--- a/support/db/session_test.go
+++ b/support/db/session_test.go
@@ -168,8 +168,15 @@ func TestDeadlineOverride(t *testing.T) {
 	assert.Equal(t, deadline, d)
 
 	cancel()
+	assert.NoError(t, resultCtx.Err())
 	_, _, err = sess.context(requestCtx)
 	assert.EqualError(t, err, "context canceled")
+
+	var emptyTime time.Time
+	resultCtx, _, err = sess.context(context.WithValue(context.Background(), &DeadlineCtxKey, emptyTime))
+	assert.NoError(t, err)
+	_, ok = resultCtx.Deadline()
+	assert.False(t, ok)
 }
 
 func TestSession(t *testing.T) {

--- a/support/db/session_test.go
+++ b/support/db/session_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
-	//"github.com/lib/pq"
 	"github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stellar/go/support/db/dbtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go/support/db/dbtest"
 )
 
 func TestContextTimeoutDuringSql(t *testing.T) {
@@ -138,6 +138,38 @@ func TestStatementTimeout(t *testing.T) {
 	err = sess.GetRaw(context.Background(), &count, "SELECT pg_sleep(2) FROM people")
 	assert.ErrorIs(err, ErrStatementTimeout)
 	assertDbErrorMetrics(reg, "n/a", "57014", "statement_timeout", assert)
+}
+
+func TestDeadlineOverride(t *testing.T) {
+	db := dbtest.Postgres(t).Load(testSchema)
+	defer db.Close()
+
+	sess := &Session{DB: db.Open()}
+	defer sess.DB.Close()
+
+	resultCtx, _, err := sess.context(context.Background())
+	assert.NoError(t, err)
+	_, ok := resultCtx.Deadline()
+	assert.False(t, ok)
+
+	deadline := time.Now().Add(time.Hour)
+	requestCtx := context.WithValue(context.Background(), &DeadlineCtxKey, deadline)
+	resultCtx, _, err = sess.context(requestCtx)
+	assert.NoError(t, err)
+	d, ok := resultCtx.Deadline()
+	assert.True(t, ok)
+	assert.Equal(t, deadline, d)
+
+	requestCtx, cancel := context.WithDeadline(requestCtx, time.Now().Add(time.Minute*30))
+	resultCtx, _, err = sess.context(requestCtx)
+	assert.NoError(t, err)
+	d, ok = resultCtx.Deadline()
+	assert.True(t, ok)
+	assert.Equal(t, deadline, d)
+
+	cancel()
+	_, _, err = sess.context(requestCtx)
+	assert.EqualError(t, err, "canceling statement due to user request")
 }
 
 func TestSession(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add a `--cancel-db-query-timeout` flag which configures a timeout on all db queries invoked by a horizon HTTP request. This timeout is a postgres client side timeout which means that it is triggered by horizon establishing a new connection to postgres in order to cancel the ongoing query.

### Why

Previously, we configured both postgres client side timeouts and server side timeouts (in the form of the [statement_timeout](https://www.postgresql.org/docs/current/runtime-config-client.html) postgres setting). However, the client side timeout is redundant when the postgres server will enforce its own statement timeout. In fact, the client side timeout can result in additional load which will exacerbate situations when the postgres DB cannot keep up with the ongoing query traffic.

In our horizon deployments, we plan to configure the client side db timeout to be longer than the server side db timeout. We expect the server side timeout to terminate a majority of the long running queries and the client side timeout will be a fallback in the unexpected scenario where the db query has surpassed the server side timeout.
 
### Known limitations

[N/A]
