### PR TITLE
services/horizon/internal/db2/history: Fix account transactions query

### DIFF
--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -883,6 +883,7 @@ type TransactionsQ struct {
 	parent        *Q
 	sql           sq.SelectBuilder
 	includeFailed bool
+	txIdCol       string
 }
 
 // TrustLine is row of data from the `trust_lines` table from horizon DB

--- a/services/horizon/internal/db2/history/transaction.go
+++ b/services/horizon/internal/db2/history/transaction.go
@@ -93,6 +93,7 @@ func (q *Q) Transactions() *TransactionsQ {
 		parent:        q,
 		sql:           selectTransactionHistory,
 		includeFailed: false,
+		txIdCol:       "ht.id",
 	}
 }
 
@@ -107,6 +108,7 @@ func (q *TransactionsQ) ForAccount(ctx context.Context, aid string) *Transaction
 	q.sql = q.sql.
 		Join("history_transaction_participants htp ON htp.history_transaction_id = ht.id").
 		Where("htp.history_account_id = ?", account.ID)
+	q.txIdCol = "htp.history_transaction_id"
 
 	return q
 }
@@ -123,6 +125,7 @@ func (q *TransactionsQ) ForClaimableBalance(ctx context.Context, cbID string) *T
 	q.sql = q.sql.
 		Join("history_transaction_claimable_balances htcb ON htcb.history_transaction_id = ht.id").
 		Where("htcb.history_claimable_balance_id = ?", hCB.InternalID)
+	q.txIdCol = "htcb.history_transaction_id"
 
 	return q
 }
@@ -139,6 +142,7 @@ func (q *TransactionsQ) ForLiquidityPool(ctx context.Context, poolID string) *Tr
 	q.sql = q.sql.
 		Join("history_transaction_liquidity_pools htlp ON htlp.history_transaction_id = ht.id").
 		Where("htlp.history_liquidity_pool_id = ?", hLP.InternalID)
+	q.txIdCol = "htlp.history_transaction_id"
 
 	return q
 }
@@ -175,7 +179,7 @@ func (q *TransactionsQ) Page(page db2.PageQuery) *TransactionsQ {
 		return q
 	}
 
-	q.sql, q.Err = page.ApplyTo(q.sql, "ht.id")
+	q.sql, q.Err = page.ApplyTo(q.sql, q.txIdCol)
 	return q
 }
 

--- a/services/horizon/internal/db2/history/transaction_test.go
+++ b/services/horizon/internal/db2/history/transaction_test.go
@@ -9,6 +9,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/guregu/null"
 
+	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/xdr"
 
 	"github.com/stellar/go/ingest"
@@ -920,4 +921,121 @@ func TestHistoryTransactionSchemasMatch(t *testing.T) {
 	tt.Assert.NoError(err)
 
 	tt.Assert.ElementsMatch(txColumns, txTmpFilteredTmpColumns)
+}
+
+func TestTransactionQueryBuilder(t *testing.T) {
+	tt := test.Start(t)
+	defer tt.Finish()
+	test.ResetHorizonDB(t, tt.HorizonDB)
+	q := &Q{tt.HorizonSession()}
+
+	tt.Assert.NoError(q.Begin(tt.Ctx))
+
+	address := "GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON"
+	accountLoader := NewAccountLoader()
+	accountLoader.GetFuture(address)
+
+	cbID := "00000000178826fbfe339e1f5c53417c6fedfe2c05e8bec14303143ec46b38981b09c3f9"
+	cbLoader := NewClaimableBalanceLoader()
+	cbLoader.GetFuture(cbID)
+
+	lpID := "0000a8198b5e25994c1ca5b0556faeb27325ac746296944144e0a7406d501e8a"
+	lpLoader := NewLiquidityPoolLoader()
+	lpLoader.GetFuture(lpID)
+
+	tt.Assert.NoError(accountLoader.Exec(tt.Ctx, q))
+	tt.Assert.NoError(cbLoader.Exec(tt.Ctx, q))
+	tt.Assert.NoError(lpLoader.Exec(tt.Ctx, q))
+
+	tt.Assert.NoError(q.Commit())
+
+	txQ := q.Transactions().ForAccount(tt.Ctx, address).Page(db2.PageQuery{Cursor: "8589938689", Order: "asc", Limit: 10})
+	tt.Assert.NoError(txQ.Err)
+	got, _, err := txQ.sql.ToSql()
+	tt.Assert.NoError(err)
+	// Transactions for account queries will use
+	// history_transaction_participants.history_transaction_id in their predicates.
+	want := "SELECT " +
+		"ht.id, ht.transaction_hash, ht.ledger_sequence, ht.application_order, " +
+		"ht.account, ht.account_muxed, ht.account_sequence, ht.max_fee, " +
+		"COALESCE(ht.fee_charged, ht.max_fee) as fee_charged, ht.operation_count, " +
+		"ht.tx_envelope, ht.tx_result, ht.tx_meta, ht.tx_fee_meta, ht.created_at, " +
+		"ht.updated_at, COALESCE(ht.successful, true) as successful, ht.signatures, " +
+		"ht.memo_type, ht.memo, ht.time_bounds, ht.ledger_bounds, ht.min_account_sequence, " +
+		"ht.min_account_sequence_age, ht.min_account_sequence_ledger_gap, ht.extra_signers, " +
+		"hl.closed_at AS ledger_close_time, ht.inner_transaction_hash, ht.fee_account, " +
+		"ht.fee_account_muxed, ht.new_max_fee, ht.inner_signatures " +
+		"FROM history_transactions ht " +
+		"LEFT JOIN history_ledgers hl ON ht.ledger_sequence = hl.sequence " +
+		"JOIN history_transaction_participants htp ON htp.history_transaction_id = ht.id " +
+		"WHERE htp.history_account_id = ? AND htp.history_transaction_id > ? " +
+		"ORDER BY htp.history_transaction_id asc LIMIT 10"
+	tt.Assert.EqualValues(want, got)
+
+	txQ = q.Transactions().ForClaimableBalance(tt.Ctx, cbID).Page(db2.PageQuery{Cursor: "8589938689", Order: "asc", Limit: 10})
+	tt.Assert.NoError(txQ.Err)
+	got, _, err = txQ.sql.ToSql()
+	tt.Assert.NoError(err)
+	// Transactions for claimable balance queries will use
+	// history_transaction_claimable_balances.history_transaction_id in their predicates.
+	want = "SELECT " +
+		"ht.id, ht.transaction_hash, ht.ledger_sequence, ht.application_order, " +
+		"ht.account, ht.account_muxed, ht.account_sequence, ht.max_fee, " +
+		"COALESCE(ht.fee_charged, ht.max_fee) as fee_charged, ht.operation_count, " +
+		"ht.tx_envelope, ht.tx_result, ht.tx_meta, ht.tx_fee_meta, ht.created_at, " +
+		"ht.updated_at, COALESCE(ht.successful, true) as successful, ht.signatures, " +
+		"ht.memo_type, ht.memo, ht.time_bounds, ht.ledger_bounds, ht.min_account_sequence, " +
+		"ht.min_account_sequence_age, ht.min_account_sequence_ledger_gap, ht.extra_signers, " +
+		"hl.closed_at AS ledger_close_time, ht.inner_transaction_hash, ht.fee_account, " +
+		"ht.fee_account_muxed, ht.new_max_fee, ht.inner_signatures " +
+		"FROM history_transactions ht " +
+		"LEFT JOIN history_ledgers hl ON ht.ledger_sequence = hl.sequence " +
+		"JOIN history_transaction_claimable_balances htcb ON htcb.history_transaction_id = ht.id " +
+		"WHERE htcb.history_claimable_balance_id = ? AND htcb.history_transaction_id > ? " +
+		"ORDER BY htcb.history_transaction_id asc LIMIT 10"
+	tt.Assert.EqualValues(want, got)
+
+	txQ = q.Transactions().ForLiquidityPool(tt.Ctx, lpID).Page(db2.PageQuery{Cursor: "8589938689", Order: "asc", Limit: 10})
+	tt.Assert.NoError(txQ.Err)
+	got, _, err = txQ.sql.ToSql()
+	tt.Assert.NoError(err)
+	// Transactions for liquidity pool queries will use
+	// history_transaction_liquidity_pools.history_transaction_id in their predicates.
+	want = "SELECT " +
+		"ht.id, ht.transaction_hash, ht.ledger_sequence, ht.application_order, " +
+		"ht.account, ht.account_muxed, ht.account_sequence, ht.max_fee, " +
+		"COALESCE(ht.fee_charged, ht.max_fee) as fee_charged, ht.operation_count, " +
+		"ht.tx_envelope, ht.tx_result, ht.tx_meta, ht.tx_fee_meta, ht.created_at, " +
+		"ht.updated_at, COALESCE(ht.successful, true) as successful, ht.signatures, " +
+		"ht.memo_type, ht.memo, ht.time_bounds, ht.ledger_bounds, ht.min_account_sequence, " +
+		"ht.min_account_sequence_age, ht.min_account_sequence_ledger_gap, ht.extra_signers, " +
+		"hl.closed_at AS ledger_close_time, ht.inner_transaction_hash, ht.fee_account, " +
+		"ht.fee_account_muxed, ht.new_max_fee, ht.inner_signatures " +
+		"FROM history_transactions ht " +
+		"LEFT JOIN history_ledgers hl ON ht.ledger_sequence = hl.sequence " +
+		"JOIN history_transaction_liquidity_pools htlp ON htlp.history_transaction_id = ht.id " +
+		"WHERE htlp.history_liquidity_pool_id = ? AND htlp.history_transaction_id > ? " +
+		"ORDER BY htlp.history_transaction_id asc LIMIT 10"
+	tt.Assert.EqualValues(want, got)
+
+	txQ = q.Transactions().Page(db2.PageQuery{Cursor: "8589938689", Order: "asc", Limit: 10})
+	tt.Assert.NoError(txQ.Err)
+	got, _, err = txQ.sql.ToSql()
+	tt.Assert.NoError(err)
+	// Other Transaction queries will use history_transactions.id in their predicates.
+	want = "SELECT " +
+		"ht.id, ht.transaction_hash, ht.ledger_sequence, ht.application_order, " +
+		"ht.account, ht.account_muxed, ht.account_sequence, ht.max_fee, " +
+		"COALESCE(ht.fee_charged, ht.max_fee) as fee_charged, ht.operation_count, " +
+		"ht.tx_envelope, ht.tx_result, ht.tx_meta, ht.tx_fee_meta, ht.created_at, " +
+		"ht.updated_at, COALESCE(ht.successful, true) as successful, ht.signatures, " +
+		"ht.memo_type, ht.memo, ht.time_bounds, ht.ledger_bounds, ht.min_account_sequence, " +
+		"ht.min_account_sequence_age, ht.min_account_sequence_ledger_gap, ht.extra_signers, " +
+		"hl.closed_at AS ledger_close_time, ht.inner_transaction_hash, ht.fee_account, " +
+		"ht.fee_account_muxed, ht.new_max_fee, ht.inner_signatures " +
+		"FROM history_transactions ht " +
+		"LEFT JOIN history_ledgers hl ON ht.ledger_sequence = hl.sequence " +
+		"WHERE ht.id > ? " +
+		"ORDER BY ht.id asc LIMIT 10"
+	tt.Assert.EqualValues(want, got)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The transactions for account query is one the most common queries which appears in the slow query logs and in the Top SQL dashboard in the RDS performance insights page. 

```sql
SELECT
    
ht.id, ht.transaction_hash, ht.ledger_sequence, ht.application_order, ht.account, ht.account_muxed, ht.account_sequence, ht.max_fee, COALESCE(ht.fee_charged, ht.max_fee) as fee_charged, ht.operation_count, ht.tx_envelope, ht.tx_result, ht.tx_meta, ht.tx_fee_meta, ht.created_at, ht.updated_at, COALESCE(ht.successful, true) as successful, ht.signatures, ht.memo_type, ht.memo, ht.time_bounds, ht.ledger_bounds, ht.min_account_sequence, ht.min_account_sequence_age, ht.min_account_sequence_ledger_gap, ht.extra_signers, hl.closed_at AS ledger_close_time, ht.inner_transaction_hash, ht.fee_account, ht.fee_account_muxed, ht.new_max_fee, ht.inner_signatures

FROM history_transactions ht
LEFT JOIN history_ledgers hl ON ht.ledger_sequence = hl.sequence
JOIN history_transaction_participants htp ON htp.history_transaction_id = ht.id
WHERE htp.history_account_id = $1 AND ht.id > $2 AND (ht.successful = true OR ht.successful IS NULL)
ORDER BY ht.id asc LIMIT 10
```

The output from explain analyze is:

```
                                                                                         QUERY PLAN                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=32.89..233583.48 rows=8 width=2297) (actual time=21213.562..21588.159 rows=5 loops=1)
   ->  Nested Loop Left Join  (cost=32.89..233583.48 rows=8 width=2297) (actual time=21213.561..21588.155 rows=5 loops=1)
         ->  Merge Join  (cost=32.33..233563.11 rows=8 width=2289) (actual time=21213.531..21588.064 rows=5 loops=1)
               Merge Cond: (ht.id = htp.history_transaction_id)
               ->  Index Scan using hs_transaction_by_id on history_transactions ht  (cost=0.58..71163.40 rows=168386 width=2289) (actual time=0.025..1746.134 rows=305174 loops=1)
                     Index Cond: (id > '217362973387501568'::bigint)
                     Filter: (successful OR (successful IS NULL))
                     Rows Removed by Filter: 1248208
               ->  Index Only Scan using hist_tx_p_id on history_transaction_participants htp  (cost=0.71..165349.94 rows=305950 width=8) (actual time=1.417..19806.698 rows=33250 loops=1)
                     Index Cond: (history_account_id = '4231259336'::bigint)
                     Heap Fetches: 33271
         ->  Index Scan using index_history_ledgers_on_sequence on history_ledgers hl  (cost=0.56..2.55 rows=1 width=12) (actual time=0.011..0.011 rows=1 loops=5)
               Index Cond: (sequence = ht.ledger_sequence)
 Planning Time: 92.901 ms
 Execution Time: 21588.304 ms
(15 rows)
```

The problem is the combination of:
- filtering transactions by account
- filtering transactions with id > cursor

It has to use two separate indexes for this query:
`hs_transaction_by_id` to filter transactions with id > cursor:
`"hs_transaction_by_id" UNIQUE, btree (id)`

`hist_tx_p_id to filter transactions` by account:
    `"hist_tx_p_id" UNIQUE, btree (history_account_id, history_transaction_id)`

But if you look closely at `hist_tx_p_id`  you will see that index already includes the transaction id.

The problem is in the where clause:

```sql
WHERE htp.history_account_id = $1 AND ht.id > $2 AND (ht.successful = true OR ht.successful IS NULL)
```

If it is rewritten to:
```sql
WHERE htp.history_account_id = $1 AND htp.history_transaction_id > $2 AND (ht.successful = true OR ht.successful IS NULL)
```

that will make the query use just one index to handle both the account and transaction id filter


With the new where clause the query is extremely fast!

```sql
EXPLAIN ANALYZE
SELECT
    ht.id, ht.transaction_hash, ht.ledger_sequence, ht.application_order, ht.account, ht.account_muxed, ht.account_sequence, ht.max_fee, COALESCE(ht.fee_charged, ht.max_fee) as fee_charged, ht.operation_count, ht.tx_envelope, ht.tx_result, ht.tx_meta, ht.tx_fee_meta, ht.created_at, ht.updated_at, COALESCE(ht.successful, true) as successful, ht.signatures, ht.memo_type, ht.memo, ht.time_bounds, ht.ledger_bounds, ht.min_account_sequence, ht.min_account_sequence_age, ht.min_account_sequence_ledger_gap, ht.extra_signers, hl.closed_at AS ledger_close_time, ht.inner_transaction_hash, ht.fee_account, ht.fee_account_muxed, ht.new_max_fee, ht.inner_signatures
FROM history_transactions ht
LEFT JOIN history_ledgers hl ON ht.ledger_sequence = hl.sequence
JOIN history_transaction_participants htp ON htp.history_transaction_id = ht.id
WHERE htp.history_account_id = 4231259336 AND htp.history_transaction_id > 217362973387501568 AND (ht.successful = true OR ht.successful IS NULL)
ORDER BY ht.id asc LIMIT 10;
                                                                                 QUERY PLAN                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1.86..81.94 rows=10 width=2297) (actual time=0.078..0.184 rows=5 loops=1)
   ->  Nested Loop Left Join  (cost=1.86..121.99 rows=15 width=2297) (actual time=0.078..0.182 rows=5 loops=1)
         ->  Nested Loop  (cost=1.29..83.90 rows=15 width=2289) (actual time=0.064..0.142 rows=5 loops=1)
               ->  Index Only Scan using hist_tx_p_id on history_transaction_participants htp  (cost=0.71..16.30 rows=26 width=8) (actual time=0.045..0.087 rows=5 loops=1)
                     Index Cond: ((history_account_id = '4231259336'::bigint) AND (history_transaction_id > '217362973387501568'::bigint))
                     Heap Fetches: 5
               ->  Index Scan using hs_transaction_by_id on history_transactions ht  (cost=0.58..2.60 rows=1 width=2289) (actual time=0.010..0.010 rows=1 loops=5)
                     Index Cond: (id = htp.history_transaction_id)
                     Filter: (successful OR (successful IS NULL))
         ->  Index Scan using index_history_ledgers_on_sequence on history_ledgers hl  (cost=0.56..2.54 rows=1 width=12) (actual time=0.007..0.007 rows=1 loops=5)
               Index Cond: (sequence = ht.ledger_sequence)
 Planning Time: 1.832 ms
 Execution Time: 0.247 ms
(13 rows)

```




After deploying this change to staging and we can [observe](https://grafana.stellar-ops.com/explore?left=%7B%22datasource%22:%22Prometheus%22,%22queries%22:%5B%7B%22expr%22:%22%20rate%20(pg_stat_user_indexes_idx_scan%7Bdatname%3D%5C%22horizon%5C%22,indexrelname%3D~%5C%22(hist_tx_p_id%7Chs_transaction_by_id)%5C%22,%20relname%3D~%5C%22(account_filter_rules%7Caccounts%7Caccounts_data%7Caccounts_signers%7Casset_filter_rules%7Cclaimable_balance_claimants%7Cclaimable_balances%7Ccontract_asset_balances%7Ccontract_asset_stats%7Cexp_asset_stats%7Cgorp_migrations%7Chistory_accounts%7Chistory_assets%7Chistory_claimable_balances%7Chistory_effects%7Chistory_ledgers%7Chistory_liquidity_pools%7Chistory_operation_claimable_balances%7Chistory_operation_liquidity_pools%7Chistory_operation_participants%7Chistory_operations%7Chistory_trades%7Chistory_trades_60000%7Chistory_transaction_claimable_balances%7Chistory_transaction_liquidity_pools%7Chistory_transaction_participants%7Chistory_transactions%7Chistory_transactions_filtered_tmp%7Ckey_value_store%7Cliquidity_pools%7Coffers%7Ctrust_lines)%5C%22,server%3D~%5C%22stellar002-stg-horizon-pubnet-ro-01.c8bv0mxh0nqd.us-east-1.rds.amazonaws.com:5432%5C%22%7D%5B$__rate_interval%5D)%20%3E%200%22,%22hide%22:false,%22interval%22:%22%22,%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22000000001%22%7D%7D%5D,%22range%22:%7B%22from%22:%221709544600000%22,%22to%22:%221709548859000%22%7D%7D&orgId=1) a dramatic reduction in scans to the `hs_transaction_by_id` and `hist_tx_p_id` indexes:



<img width="1674" alt="Screenshot 2024-03-04 at 10 45 23 AM" src="https://github.com/stellar/go/assets/1445829/54168854-0a29-4769-8a7f-128079463eda">

We can also see a similar decline in database load on the AWS RDS performance insights dashboard when we specifically filter for the account transactions query:

<img width="1574" alt="Screenshot 2024-03-04 at 11 01 08 AM" src="https://github.com/stellar/go/assets/1445829/03ca025d-7ec2-4d45-916e-197b6e775dc7">


### Known limitations

[N/A]
