### PR TITLE
services/horizon/internal/db2/history: Improve performance of effects query

### DIFF
--- a/services/horizon/internal/actions/effects.go
+++ b/services/horizon/internal/actions/effects.go
@@ -95,25 +95,20 @@ func (handler GetEffectsHandler) GetResourcePage(w HeaderWriter, r *http.Request
 }
 
 func loadEffectRecords(ctx context.Context, hq *history.Q, qp EffectsQuery, pq db2.PageQuery) ([]history.Effect, error) {
-	effects := hq.Effects()
-
 	switch {
 	case qp.AccountID != "":
-		effects.ForAccount(ctx, qp.AccountID)
+		return hq.EffectsForAccount(ctx, qp.AccountID, pq)
 	case qp.LiquidityPoolID != "":
-		effects.ForLiquidityPool(ctx, pq, qp.LiquidityPoolID)
+		return hq.EffectsForLiquidityPool(ctx, qp.LiquidityPoolID, pq)
 	case qp.OperationID > 0:
-		effects.ForOperation(int64(qp.OperationID))
+		return hq.EffectsForOperation(ctx, int64(qp.OperationID), pq)
 	case qp.LedgerID > 0:
-		effects.ForLedger(ctx, int32(qp.LedgerID))
+		return hq.EffectsForLedger(ctx, int32(qp.LedgerID), pq)
 	case qp.TxHash != "":
-		effects.ForTransaction(ctx, qp.TxHash)
+		return hq.EffectsForTransaction(ctx, qp.TxHash, pq)
+	default:
+		return hq.Effects(ctx, pq)
 	}
-
-	var result []history.Effect
-	err := effects.Page(pq).Select(ctx, &result)
-
-	return result, err
 }
 
 func loadEffectLedgers(ctx context.Context, hq *history.Q, effects []history.Effect) (map[int32]history.Ledger, error) {

--- a/services/horizon/internal/db2/history/effect_batch_insert_builder_test.go
+++ b/services/horizon/internal/db2/history/effect_batch_insert_builder_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/guregu/null"
 
+	"github.com/stellar/go/services/horizon/internal/db2"
 	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stellar/go/toid"
 )
@@ -42,8 +43,12 @@ func TestAddEffect(t *testing.T) {
 	tt.Assert.NoError(builder.Exec(tt.Ctx, q))
 	tt.Assert.NoError(q.Commit())
 
-	effects := []Effect{}
-	tt.Assert.NoError(q.Effects().Select(tt.Ctx, &effects))
+	effects, err := q.Effects(tt.Ctx, db2.PageQuery{
+		Cursor: "0-0",
+		Order:  "asc",
+		Limit:  200,
+	})
+	tt.Require.NoError(err)
 	tt.Assert.Len(effects, 1)
 
 	effect := effects[0]

--- a/services/horizon/internal/db2/history/effect_test.go
+++ b/services/horizon/internal/db2/history/effect_test.go
@@ -57,11 +57,11 @@ func TestEffectsForLiquidityPool(t *testing.T) {
 	tt.Assert.NoError(q.Commit())
 
 	var result []Effect
-	err = q.Effects().ForLiquidityPool(tt.Ctx, db2.PageQuery{
+	result, err = q.EffectsForLiquidityPool(tt.Ctx, liquidityPoolID, db2.PageQuery{
 		Cursor: "0-0",
 		Order:  "asc",
 		Limit:  10,
-	}, liquidityPoolID).Select(tt.Ctx, &result)
+	})
 	tt.Assert.NoError(err)
 
 	tt.Assert.Len(result, 1)
@@ -156,8 +156,12 @@ func TestEffectsForTrustlinesSponsorshipEmptyAssetType(t *testing.T) {
 	tt.Require.NoError(builder.Exec(tt.Ctx, q))
 	tt.Assert.NoError(q.Commit())
 
-	var results []Effect
-	tt.Require.NoError(q.Effects().Select(tt.Ctx, &results))
+	results, err := q.Effects(tt.Ctx, db2.PageQuery{
+		Cursor: "0-0",
+		Order:  "asc",
+		Limit:  200,
+	})
+	tt.Require.NoError(err)
 	tt.Require.Len(results, len(tests))
 
 	for i, test := range tests {

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -632,14 +632,6 @@ type SequenceBumped struct {
 	NewSeq int64 `json:"new_seq"`
 }
 
-// EffectsQ is a helper struct to aid in configuring queries that loads
-// slices of Ledger structs.
-type EffectsQ struct {
-	Err    error
-	parent *Q
-	sql    sq.SelectBuilder
-}
-
 // EffectType is the numeric type for an effect, used as the `type` field in the
 // `history_effects` table.
 type EffectType int

--- a/services/horizon/internal/db2/history/transaction_test.go
+++ b/services/horizon/internal/db2/history/transaction_test.go
@@ -891,12 +891,20 @@ func TestFetchFeeBumpTransaction(t *testing.T) {
 		tt.Assert.Equal(byOuterhash, byInnerHash)
 	}
 
-	var outerEffects, innerEffects []Effect
-	err = q.Effects().ForTransaction(tt.Ctx, fixture.OuterHash).Select(tt.Ctx, &outerEffects)
+	var innerEffects []Effect
+	outerEffects, err := q.EffectsForTransaction(tt.Ctx, fixture.OuterHash, db2.PageQuery{
+		Cursor: "0-0",
+		Order:  "asc",
+		Limit:  200,
+	})
 	tt.Assert.NoError(err)
 	tt.Assert.Len(outerEffects, 1)
 
-	err = q.Effects().ForTransaction(tt.Ctx, fixture.InnerHash).Select(tt.Ctx, &innerEffects)
+	innerEffects, err = q.EffectsForTransaction(tt.Ctx, fixture.InnerHash, db2.PageQuery{
+		Cursor: "0-0",
+		Order:  "asc",
+		Limit:  200,
+	})
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(outerEffects, innerEffects)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The effects query below is one of the top 5 queries in the RDS performance insights dashboard:

```sql
SELECT heff.*, hacc.address FROM history_effects heff LEFT JOIN history_accounts hacc ON hacc.id = heff.history_account_id WHERE (
					 heff.history_operation_id >= $1
				AND (
					 heff.history_operation_id > $1OR
					(heff.history_operation_id = $1AND heff.order > $2)
				)) ORDER BY heff.history_operation_id asc, heff.order asc LIMIT ?
```

The output from explain analyze is:

```
                                                                                 QUERY PLAN                                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1001.17..371030.36 rows=200 width=473) (actual time=5.777..7.560 rows=200 loops=1)
   ->  Gather Merge  (cost=1001.17..1640230.48 rows=886 width=473) (actual time=5.776..7.543 rows=200 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Nested Loop Left Join  (cost=1.15..1639128.19 rows=369 width=473) (actual time=0.025..0.491 rows=181 loops=3)
               ->  Parallel Index Scan using hist_e_by_order on history_effects heff  (cost=0.71..1638226.97 rows=369 width=416) (actual time=0.012..0.059 rows=181 loops=3)
                     Index Cond: (history_operation_id >= '217570991537152001'::bigint)
                     Filter: ((history_operation_id > '217570991537152001'::bigint) OR ((history_operation_id = '217570991537152001'::bigint) AND ("order" > 12)))
                     Rows Removed by Filter: 4
               ->  Index Scan using index_history_accounts_on_id on history_accounts hacc  (cost=0.43..2.44 rows=1 width=65) (actual time=0.002..0.002 rows=1 loops=542)
                     Index Cond: (id = heff.history_account_id)
 Planning Time: 25.022 ms
 Execution Time: 35.089 ms
(13 rows)
```

The where clause can be simplified from:

```sql
WHERE (
					 heff.history_operation_id >= 217570991537152001
				AND (
					 heff.history_operation_id > 217570991537152001 OR
					(heff.history_operation_id = 217570991537152001AND heff.order > 12)
				)) 
```

to:

```sql
WHERE (heff.history_operation_id, heff.order) > (217570991537152001, 12)
```

Doing that removes the need for parallel workers and results in a faster execution time:

```
                                                                            QUERY PLAN                                                                             
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1.15..580.59 rows=200 width=473) (actual time=0.049..1.195 rows=200 loops=1)
   ->  Nested Loop Left Join  (cost=1.15..11046392.26 rows=3812781 width=473) (actual time=0.048..1.177 rows=200 loops=1)
         ->  Index Scan using hist_e_by_order on history_effects heff  (cost=0.71..1822418.86 rows=3812781 width=416) (actual time=0.032..0.103 rows=200 loops=1)
               Index Cond: (ROW(history_operation_id, "order") > ROW('217570991537152001'::bigint, 12))
         ->  Index Scan using index_history_accounts_on_id on history_accounts hacc  (cost=0.43..2.42 rows=1 width=65) (actual time=0.005..0.005 rows=1 loops=200)
               Index Cond: (id = heff.history_account_id)
 Planning Time: 19.978 ms
 Execution Time: 1.242 ms
(8 rows)
```

After deploying this change to staging, I saw that this effects query no longer appeared on the RDS performance insights dashboard.

I also noticed a decline in the number of scans on the `index_history_accounts_on_id` index after deploying this change to staging:

<img width="830" alt="Screenshot 2024-03-06 at 1 15 08 PM" src="https://github.com/stellar/go/assets/1445829/425aa722-5dd5-41dc-993f-71e5d9d12fa1">

Also, since this change was deployed to staging, we have not received any 503s on the `/effects` endpoint:

<img width="832" alt="Screenshot 2024-03-06 at 1 19 12 PM" src="https://github.com/stellar/go/assets/1445829/086c4272-a355-48ac-8ddb-719d915c04e3">

 
### Known limitations

[N/A]
