### PR TITLE
services/horizon/internal/db2/history: Improve asset loader query

### DIFF
--- a/services/horizon/internal/db2/history/asset_loader.go
+++ b/services/horizon/internal/db2/history/asset_loader.go
@@ -7,8 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	sq "github.com/Masterminds/squirrel"
-
 	"github.com/stellar/go/support/collections/set"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/errors"
@@ -106,13 +104,17 @@ func (a *AssetLoader) lookupKeys(ctx context.Context, q *Q, keys []AssetKey) err
 	for i := 0; i < len(keys); i += loaderLookupBatchSize {
 		end := ordered.Min(len(keys), i+loaderLookupBatchSize)
 		subset := keys[i:end]
-		keyStrings := make([]string, 0, len(subset))
+		args := make([]interface{}, 0, 3*len(subset))
+		placeHolders := make([]string, 0, len(subset))
 		for _, key := range subset {
-			keyStrings = append(keyStrings, key.Type+"/"+key.Code+"/"+key.Issuer)
+			args = append(args, key.Code, key.Type, key.Issuer)
+			placeHolders = append(placeHolders, "(?, ?, ?)")
 		}
-		err := q.Select(ctx, &rows, sq.Select("*").From("history_assets").Where(sq.Eq{
-			"concat(asset_type, '/', asset_code, '/', asset_issuer)": keyStrings,
-		}))
+		rawSQL := fmt.Sprintf(
+			"SELECT * FROM  history_assets WHERE (asset_code, asset_type, asset_issuer) in (%s)",
+			strings.Join(placeHolders, ", "),
+		)
+		err := q.SelectRaw(ctx, &rows, rawSQL, args...)
 		if err != nil {
 			return errors.Wrap(err, "could not select assets")
 		}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

We spend up to 250ms querying rows from the `history_assets` table during ingestion despite the fact we look up only ~10 rows on average during every ingestion round. The reason for that is because the query we're doing uses a table scan:

```sql
horizon=> explain analyze select * from history_assets where concat(asset_type, '/', asset_code, '/', asset_issuer) in ('native//', 'credit_alphanum4/ETH/GBSTRH4QOTWNSVA6E4HFERETX4ZLSR3CIUBLK7AXYII277PFJC4BBYOG');
                                                                                  QUERY PLAN                                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Seq Scan on history_assets  (cost=0.00..4137.10 rows=1269 width=85) (actual time=0.010..48.273 rows=2 loops=1)
   Filter: (concat(asset_type, '/', asset_code, '/', asset_issuer) = ANY ('{native//,credit_alphanum4/ETH/GBSTRH4QOTWNSVA6E4HFERETX4ZLSR3CIUBLK7AXYII277PFJC4BBYOG}'::text[]))
   Rows Removed by Filter: 125288
 Planning Time: 0.042 ms
 Execution Time: 48.289 ms
(5 rows)
```

There is already an index on the (asset_code, asset_type, asset_issuer) combination:

```sql
horizon=> \d+ history_assets;
                                                          Table "public.history_assets"
    Column    |         Type          | Collation | Nullable |                  Default                   | Storage  | Stats target | Description 
--------------+-----------------------+-----------+----------+--------------------------------------------+----------+--------------+-------------
 id           | integer               |           | not null | nextval('history_assets_id_seq'::regclass) | plain    |              | 
 asset_type   | character varying(64) |           | not null |                                            | extended |              | 
 asset_code   | character varying(12) |           | not null |                                            | extended |              | 
 asset_issuer | character varying(56) |           | not null |                                            | extended |              | 
Indexes:
    "history_assets_pkey" PRIMARY KEY, btree (id)
    "history_assets_asset_code_asset_type_asset_issuer_key" UNIQUE CONSTRAINT, btree (asset_code, asset_type, asset_issuer)
Access method: heap
```

So if we rewrite the query to make use of that index we can make it faster:

```sql
horizon=> explain analyze select * from history_assets where (asset_code, asset_type, asset_issuer) in ( ('', 'native', ''), ('ETH', 'credit_alphanum4', 'GBSTRH4QOTWNSVA6E4HFERETX4ZLSR3CIUBLK7AXYII277PFJC4BBYOG'));

                                                                                                                                                          QUERY PLAN                                                                                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Bitmap Heap Scan on history_assets  (cost=2.86..3.89 rows=1 width=85) (actual time=0.029..0.030 rows=2 loops=1)
   Recheck Cond: ((((asset_code)::text = ''::text) AND ((asset_type)::text = 'native'::text) AND ((asset_issuer)::text = ''::text)) OR (((asset_code)::text = 'ETH'::text) AND ((asset_type)::text = 'credit_alphanum4'::text) AND ((asset_issuer)::text = 'GBSTRH4QOTWNSVA6E4HFERETX4ZLSR3CIUBLK7AXYII277PFJC4BBYOG'::text)))
   Heap Blocks: exact=1
   ->  BitmapOr  (cost=2.86..2.86 rows=1 width=0) (actual time=0.027..0.027 rows=0 loops=1)
         ->  Bitmap Index Scan on history_assets_asset_code_asset_type_asset_issuer_key  (cost=0.00..1.43 rows=1 width=0) (actual time=0.019..0.019 rows=1 loops=1)
               Index Cond: (((asset_code)::text = ''::text) AND ((asset_type)::text = 'native'::text) AND ((asset_issuer)::text = ''::text))
         ->  Bitmap Index Scan on history_assets_asset_code_asset_type_asset_issuer_key  (cost=0.00..1.43 rows=1 width=0) (actual time=0.008..0.008 rows=1 loops=1)
               Index Cond: (((asset_code)::text = 'ETH'::text) AND ((asset_type)::text = 'credit_alphanum4'::text) AND ((asset_issuer)::text = 'GBSTRH4QOTWNSVA6E4HFERETX4ZLSR3CIUBLK7AXYII277PFJC4BBYOG'::text))
 Planning Time: 0.223 ms
 Execution Time: 0.046 ms
(10 rows)
```

After deploying this to staging, I observed the duration of asset loader queries drop down to less than 10 ms:

<img width="1662" alt="Screenshot 2024-03-07 at 4 03 23 PM" src="https://github.com/stellar/go/assets/1445829/ed539902-89b1-499a-9ee8-e53e341db622">

This change also eliminated the `history_assets` table scans that were occurring during ingestion: 

<img width="835" alt="Screenshot 2024-03-07 at 4 03 03 PM" src="https://github.com/stellar/go/assets/1445829/fcf86b21-1e4b-4c5b-bf7b-b551fafc6b0e">

### Known limitations

[N/A]
