### PR TITLE
services/horizon/internal/httpx: Add prometheus metrics for requests in flight and requests received

### DIFF
--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -80,13 +80,14 @@ func loggerMiddleware(serverMetrics *ServerMetrics) func(next http.Handler) http
 			streaming := strings.Contains(acceptHeader, render.MimeEventStream)
 			route := supportHttp.GetChiRoutePattern(r)
 
-			inFlightLabels := prometheus.Labels{
+			requestLabels := prometheus.Labels{
 				"route":     route,
 				"streaming": strconv.FormatBool(streaming),
 				"method":    r.Method,
 			}
-			serverMetrics.RequestsInFlightGauge.With(inFlightLabels).Inc()
-			defer serverMetrics.RequestsInFlightGauge.With(inFlightLabels).Dec()
+			serverMetrics.RequestsInFlightGauge.With(requestLabels).Inc()
+			defer serverMetrics.RequestsInFlightGauge.With(requestLabels).Dec()
+			serverMetrics.RequestsReceivedCounter.With(requestLabels).Inc()
 
 			then := time.Now()
 			next.ServeHTTP(mw, r.WithContext(ctx))

--- a/services/horizon/internal/httpx/middleware.go
+++ b/services/horizon/internal/httpx/middleware.go
@@ -78,11 +78,20 @@ func loggerMiddleware(serverMetrics *ServerMetrics) func(next http.Handler) http
 			// is reset before sending the first event no Content-Type header is sent in a response.
 			acceptHeader := r.Header.Get("Accept")
 			streaming := strings.Contains(acceptHeader, render.MimeEventStream)
+			route := supportHttp.GetChiRoutePattern(r)
+
+			inFlightLabels := prometheus.Labels{
+				"route":     route,
+				"streaming": strconv.FormatBool(streaming),
+				"method":    r.Method,
+			}
+			serverMetrics.RequestsInFlightGauge.With(inFlightLabels).Inc()
+			defer serverMetrics.RequestsInFlightGauge.With(inFlightLabels).Dec()
 
 			then := time.Now()
 			next.ServeHTTP(mw, r.WithContext(ctx))
 			duration := time.Since(then)
-			logEndOfRequest(ctx, r, serverMetrics.RequestDurationSummary, duration, mw, streaming)
+			logEndOfRequest(ctx, r, route, serverMetrics.RequestDurationSummary, duration, mw, streaming)
 		})
 	}
 }
@@ -129,8 +138,7 @@ func getClientData(r *http.Request, headerName string) string {
 	return value
 }
 
-func logEndOfRequest(ctx context.Context, r *http.Request, requestDurationSummary *prometheus.SummaryVec, duration time.Duration, mw middleware.WrapResponseWriter, streaming bool) {
-	route := supportHttp.GetChiRoutePattern(r)
+func logEndOfRequest(ctx context.Context, r *http.Request, route string, requestDurationSummary *prometheus.SummaryVec, duration time.Duration, mw middleware.WrapResponseWriter, streaming bool) {
 
 	referer := r.Referer()
 	if referer == "" {

--- a/services/horizon/internal/httpx/server.go
+++ b/services/horizon/internal/httpx/server.go
@@ -24,6 +24,7 @@ type ServerMetrics struct {
 	RequestDurationSummary  *prometheus.SummaryVec
 	ReplicaLagErrorsCounter prometheus.Counter
 	RequestsInFlightGauge   *prometheus.GaugeVec
+	RequestsReceivedCounter *prometheus.CounterVec
 }
 
 type TLSConfig struct {
@@ -79,6 +80,12 @@ func NewServer(serverConfig ServerConfig, routerConfig RouterConfig, ledgerState
 			},
 			[]string{"route", "streaming", "method"},
 		),
+		RequestsReceivedCounter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "horizon", Subsystem: "http", Name: "requests_received",
+			},
+			[]string{"route", "streaming", "method"},
+		),
 		ReplicaLagErrorsCounter: prometheus.NewCounter(
 			prometheus.CounterOpts{
 				Namespace: "horizon", Subsystem: "http", Name: "replica_lag_errors_count",
@@ -118,6 +125,7 @@ func (s *Server) RegisterMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(s.Metrics.RequestDurationSummary)
 	registry.MustRegister(s.Metrics.ReplicaLagErrorsCounter)
 	registry.MustRegister(s.Metrics.RequestsInFlightGauge)
+	registry.MustRegister(s.Metrics.RequestsReceivedCounter)
 }
 
 func (s *Server) Serve() error {

--- a/services/horizon/internal/httpx/server.go
+++ b/services/horizon/internal/httpx/server.go
@@ -23,6 +23,7 @@ import (
 type ServerMetrics struct {
 	RequestDurationSummary  *prometheus.SummaryVec
 	ReplicaLagErrorsCounter prometheus.Counter
+	RequestsInFlightGauge   *prometheus.GaugeVec
 }
 
 type TLSConfig struct {
@@ -71,6 +72,13 @@ func NewServer(serverConfig ServerConfig, routerConfig RouterConfig, ledgerState
 			},
 			[]string{"status", "route", "streaming", "method"},
 		),
+		RequestsInFlightGauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "horizon", Subsystem: "http", Name: "requests_in_flight",
+				Help: "HTTP requests in flight",
+			},
+			[]string{"route", "streaming", "method"},
+		),
 		ReplicaLagErrorsCounter: prometheus.NewCounter(
 			prometheus.CounterOpts{
 				Namespace: "horizon", Subsystem: "http", Name: "replica_lag_errors_count",
@@ -109,6 +117,7 @@ func NewServer(serverConfig ServerConfig, routerConfig RouterConfig, ledgerState
 func (s *Server) RegisterMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(s.Metrics.RequestDurationSummary)
 	registry.MustRegister(s.Metrics.ReplicaLagErrorsCounter)
+	registry.MustRegister(s.Metrics.RequestsInFlightGauge)
 }
 
 func (s *Server) Serve() error {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add prometheus metrics for requests in flight and requests received.


### Why

We already have metrics for requests served but we don't have any metrics for requests received or requests in flight. Having these metrics will allow us to detect cases where there are a large amount of requests building up in horizon. This would also be helpful in debugging cases where there is a spike in TCP connections.

### Known limitations

[N/A]
