### PR TITLE
services/horizon/internal: Add limit on number of horizon requests in flight

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -533,6 +533,7 @@ func (a *App) init() error {
 		StaleThreshold:           a.config.StaleThreshold,
 		ConnectionTimeout:        a.config.ConnectionTimeout,
 		ClientQueryTimeout:       a.config.ClientQueryTimeout,
+		MaxConcurrentRequests:    a.config.MaxConcurrentRequests,
 		MaxHTTPRequestSize:       a.config.MaxHTTPRequestSize,
 		NetworkPassphrase:        a.config.NetworkPassphrase,
 		MaxPathLength:            a.config.MaxPathLength,

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -40,11 +40,12 @@ type Config struct {
 	ConnectionTimeout  time.Duration
 	ClientQueryTimeout time.Duration
 	// MaxHTTPRequestSize is the maximum allowed request payload size
-	MaxHTTPRequestSize uint
-	RateQuota          *throttled.RateQuota
-	FriendbotURL       *url.URL
-	LogLevel           logrus.Level
-	LogFile            string
+	MaxHTTPRequestSize    uint
+	RateQuota             *throttled.RateQuota
+	MaxConcurrentRequests uint
+	FriendbotURL          *url.URL
+	LogLevel              logrus.Level
+	LogFile               string
 
 	// MaxPathLength is the maximum length of the path returned by `/paths` endpoint.
 	MaxPathLength uint

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -69,8 +69,9 @@ const (
 	// StellarTestnet is a constant representing the Stellar test network
 	StellarTestnet = "testnet"
 
-	defaultMaxHTTPRequestSize = uint(200 * 1024)
-	clientQueryTimeoutNotSet  = -1
+	defaultMaxConcurrentRequests = 1000
+	defaultMaxHTTPRequestSize    = uint(200 * 1024)
+	clientQueryTimeoutNotSet     = -1
 )
 
 var (
@@ -469,6 +470,15 @@ func Flags() (*Config, support.ConfigOptions) {
 			OptType:        types.Uint,
 			FlagDefault:    defaultMaxHTTPRequestSize,
 			Usage:          "sets the limit on the maximum allowed http request payload size, default is 200kb, to disable the limit check, set to 0, only do so if you acknowledge the implications of accepting unbounded http request payload sizes.",
+			UsedInCommands: ApiServerCommands,
+		},
+		&support.ConfigOption{
+			Name:        "max-concurrent-requests",
+			ConfigKey:   &config.MaxConcurrentRequests,
+			OptType:     types.Uint,
+			FlagDefault: defaultMaxConcurrentRequests,
+			Usage: "sets the limit on the maximum number of concurrent http requests, default is 1000, to disable the limit set to 0. " +
+				"If Horizon receives a request which would exceed the limit of concurrent http requests, Horizon will respond with a 429 status code.",
 			UsedInCommands: ApiServerCommands,
 		},
 		&support.ConfigOption{

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -69,7 +69,7 @@ const (
 	// StellarTestnet is a constant representing the Stellar test network
 	StellarTestnet = "testnet"
 
-	defaultMaxConcurrentRequests = 1000
+	defaultMaxConcurrentRequests = uint(1000)
 	defaultMaxHTTPRequestSize    = uint(200 * 1024)
 	clientQueryTimeoutNotSet     = -1
 )


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add limit on number of horizon requests in flight.

### Why

We observed a case where a staging horizon node received too many requests which caused it to OOM. See https://stellarfoundation.slack.com/archives/C02B04RMK/p1710326856362359?thread_ts=1710235095.516249&cid=C02B04RMK for more details. 

### Known limitations

[N/A]
