### PR TITLE
services/horizon/internal: fix flag usage for max-concurrent-requests

### DIFF
--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -478,7 +478,7 @@ func Flags() (*Config, support.ConfigOptions) {
 			OptType:     types.Uint,
 			FlagDefault: defaultMaxConcurrentRequests,
 			Usage: "sets the limit on the maximum number of concurrent http requests, default is 1000, to disable the limit set to 0. " +
-				"If Horizon receives a request which would exceed the limit of concurrent http requests, Horizon will respond with a 429 status code.",
+				"If Horizon receives a request which would exceed the limit of concurrent http requests, Horizon will respond with a 503 status code.",
 			UsedInCommands: ApiServerCommands,
 		},
 		&support.ConfigOption{


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

We are using go-chi version 4.1 in horizon:

https://github.com/stellar/go/blob/release-horizon-v2.29.0/go.mod#L22

And, in that version, the request throttler middleware uses a response code of 503 when the number of in flight requests exceeds the limit:

https://github.com/go-chi/chi/blob/v4.1.3/middleware/throttle.go#L106

### Known limitations

[N/A]
