### PR TITLE
services/horizon: Avoid combining SQL clauses when filtering is disabled

### DIFF
--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -237,6 +237,6 @@ func initSubmissionSystem(app *App) {
 			return &history.Q{SessionInterface: app.HorizonSession()}
 		},
 		LedgerState:       app.ledgerState,
-		FilteredIngestion: app.config.EnableIngestionFiltering,
+		FilteringDisabled: !app.config.EnableIngestionFiltering,
 	}
 }

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -236,6 +236,7 @@ func initSubmissionSystem(app *App) {
 		DB: func(ctx context.Context) txsub.HorizonDB {
 			return &history.Q{SessionInterface: app.HorizonSession()}
 		},
-		LedgerState: app.ledgerState,
+		LedgerState:       app.ledgerState,
+		FilteredIngestion: app.config.EnableIngestionFiltering,
 	}
 }

--- a/services/horizon/internal/txsub/helpers_test.go
+++ b/services/horizon/internal/txsub/helpers_test.go
@@ -9,6 +9,7 @@ package txsub
 import (
 	"context"
 	"database/sql"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stellar/go/services/horizon/internal/ledger"
 
@@ -57,8 +58,11 @@ func (m *mockDBQ) GetSequenceNumbers(ctx context.Context, addresses []string) (m
 	return args.Get(0).(map[string]uint64), args.Error(1)
 }
 
-func (m *mockDBQ) AllTransactionsByHashesSinceLedger(ctx context.Context, hashes []string, sinceLedgerSeq uint32) ([]history.Transaction, error) {
-	args := m.Called(ctx, hashes, sinceLedgerSeq)
+func (m *mockDBQ) AllTransactionsByHashesSinceLedger(
+	ctx context.Context,
+	hashes []string, sinceLedgerSeq uint32, includeFiltered bool,
+) ([]history.Transaction, error) {
+	args := m.Called(ctx, hashes, sinceLedgerSeq, includeFiltered)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/services/horizon/internal/txsub/results_test.go
+++ b/services/horizon/internal/txsub/results_test.go
@@ -27,7 +27,7 @@ func TestGetIngestedTxHashes(t *testing.T) {
 	defer tt.Finish()
 	q := &history.Q{SessionInterface: tt.HorizonSession()}
 	hashes := []string{"2374e99349b9ef7dba9a5db3339b78fda8f34777b1af33ba468ad5c0df946d4d"}
-	txs, err := q.AllTransactionsByHashesSinceLedger(tt.Ctx, hashes, 0)
+	txs, err := q.AllTransactionsByHashesSinceLedger(tt.Ctx, hashes, 0, true)
 	tt.Assert.NoError(err)
 	tt.Assert.Equal(hashes[0], txs[0].TransactionHash)
 }

--- a/services/horizon/internal/txsub/system.go
+++ b/services/horizon/internal/txsub/system.go
@@ -45,7 +45,7 @@ type System struct {
 	SubmissionTimeout time.Duration
 	Log               *log.Entry
 	LedgerState       ledger.StateInterface
-	FilteredIngestion bool
+	FilteringDisabled bool
 
 	Metrics struct {
 		// SubmissionDuration exposes timing metrics about the rate and latency of
@@ -316,8 +316,10 @@ func (sys *System) Tick(ctx context.Context) {
 			sinceLedgerSeq = 0
 		}
 
-		txs, err := db.AllTransactionsByHashesSinceLedger(ctx, pending,
-			uint32(sinceLedgerSeq), sys.FilteredIngestion)
+		txs, err := db.AllTransactionsByHashesSinceLedger(ctx,
+			pending,
+			uint32(sinceLedgerSeq),
+			!sys.FilteringDisabled)
 		if err != nil && !db.NoRows(err) {
 			logger.WithError(err).Error("error getting transactions by hashes")
 			return

--- a/services/horizon/internal/txsub/system_test.go
+++ b/services/horizon/internal/txsub/system_test.go
@@ -6,9 +6,10 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"github.com/stellar/go/services/horizon/internal/ledger"
 	"testing"
 	"time"
+
+	"github.com/stellar/go/services/horizon/internal/ledger"
 
 	"github.com/guregu/null"
 	"github.com/prometheus/client_golang/prometheus"
@@ -432,8 +433,12 @@ func (suite *SystemTestSuite) TestTick_FinishesTransactions() {
 		ReadOnly:  true,
 	}).Return(nil).Once()
 	suite.db.On("Rollback").Return(nil).Once()
-	suite.db.On("AllTransactionsByHashesSinceLedger", suite.ctx, []string{suite.successTx.Transaction.TransactionHash}, uint32(940)).
-		Return(nil, sql.ErrNoRows).Once()
+	suite.db.On("AllTransactionsByHashesSinceLedger",
+		suite.ctx,
+		[]string{suite.successTx.Transaction.TransactionHash},
+		uint32(940),
+		true,
+	).Return(nil, sql.ErrNoRows).Once()
 	suite.db.On("NoRows", sql.ErrNoRows).Return(true).Once()
 
 	suite.system.Tick(suite.ctx)
@@ -446,8 +451,12 @@ func (suite *SystemTestSuite) TestTick_FinishesTransactions() {
 		ReadOnly:  true,
 	}).Return(nil).Once()
 	suite.db.On("Rollback").Return(nil).Once()
-	suite.db.On("AllTransactionsByHashesSinceLedger", suite.ctx, []string{suite.successTx.Transaction.TransactionHash}, uint32(940)).
-		Return([]history.Transaction{suite.successTx.Transaction}, nil).Once()
+	suite.db.On("AllTransactionsByHashesSinceLedger",
+		suite.ctx,
+		[]string{suite.successTx.Transaction.TransactionHash},
+		uint32(940),
+		true,
+	).Return([]history.Transaction{suite.successTx.Transaction}, nil).Once()
 
 	suite.system.Tick(suite.ctx)
 
@@ -490,8 +499,12 @@ func (suite *SystemTestSuite) TestTickFinishFeeBumpTransaction() {
 		ReadOnly:  true,
 	}).Return(nil).Once()
 	suite.db.On("Rollback").Return(nil).Once()
-	suite.db.On("AllTransactionsByHashesSinceLedger", suite.ctx, []string{innerHash}, uint32(940)).
-		Return([]history.Transaction{feeBumpTx.Transaction}, nil).Once()
+	suite.db.On("AllTransactionsByHashesSinceLedger",
+		suite.ctx,
+		[]string{innerHash},
+		uint32(940),
+		true,
+	).Return([]history.Transaction{feeBumpTx.Transaction}, nil).Once()
 
 	suite.system.Tick(suite.ctx)
 
@@ -514,8 +527,12 @@ func (suite *SystemTestSuite) TestTick_RemovesStaleSubmissions() {
 		ReadOnly:  true,
 	}).Return(nil).Once()
 	suite.db.On("Rollback").Return(nil).Once()
-	suite.db.On("AllTransactionsByHashesSinceLedger", suite.ctx, []string{suite.successTx.Transaction.TransactionHash}, uint32(940)).
-		Return(nil, sql.ErrNoRows).Once()
+	suite.db.On("AllTransactionsByHashesSinceLedger",
+		suite.ctx,
+		[]string{suite.successTx.Transaction.TransactionHash},
+		uint32(940),
+		true,
+	).Return(nil, sql.ErrNoRows).Once()
 	suite.db.On("NoRows", sql.ErrNoRows).Return(true).Once()
 
 	suite.system.Tick(suite.ctx)


### PR DESCRIPTION
### What
Stop adding the `UNION ALL` clause alongside a filter for transaction hashes in the `history_transactions_filtered_tmp` table when ingestion filtering is disabled.

Previously, the final SQL statement would look something like this:

```sql
ListOfPendingTxs = [ ... ]

SELECT `...[fields from ht and hl]...`
    FROM
        history_transactions ht LEFT JOIN history_ledgers hl 
        ON ht.ledger_sequence = hl.sequence 
    WHERE 
        (ht.ledger_sequence >= $1 AND 
        (ht.transaction_hash IN ListOfPendingTxs) OR 
        (ht.inner_transaction_hash ListOfPendingTxs))
UNION ALL 
SELECT `...[fields from ht and hl]...`
    FROM
        history_transactions_filtered_tmp ht LEFT JOIN history_ledgers hl 
        ON ht.ledger_sequence = hl.sequence 
    WHERE 
        (ht.ledger_sequence >= $1 AND 
        (ht.transaction_hash IN ListOfPendingTxs) OR 
        (ht.inner_transaction_hash ListOfPendingTxs))
```

whereas now it will only include the portion prior to the `UNION ALL` clause.

### Why
There's no reason to have the additional clause when the `history_transactions_filtered_tmp` table is guaranteed to be empty if the `EXP_ENABLE_INGESTION_FILTERING` flag is set to `false`.

### Known limitations
n/a