### PR TITLE
services/horizon/internal/ingest: Add missing tables to TruncateIngestStateTables()

### DIFF
--- a/services/horizon/internal/db2/history/ingestion.go
+++ b/services/horizon/internal/db2/history/ingestion.go
@@ -17,6 +17,8 @@ func (q *Q) TruncateIngestStateTables(ctx context.Context) error {
 		"claimable_balances",
 		"claimable_balance_claimants",
 		"exp_asset_stats",
+		"contract_asset_balances",
+		"contract_asset_stats",
 		"liquidity_pools",
 		"offers",
 		"trust_lines",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The `contract_asset_balances` and `contract_asset_stats` tables were missing from `TruncateIngestStateTables()` which means that those tables would not get cleared during state rebuilds. It is necessary for all tables which hold ledger entries to be truncated in `TruncateIngestStateTables()` otherwise state rebuilds may fail because Horizon can try to insert rows that already exist in the state tables which would result in a duplicate key errors from postgres.

### Known limitations

[N/A]
