### PR TITLE
exp/services/ledgerexporter: Implement Docker based deployment

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -161,8 +161,11 @@ jobs:
         with:
           # For pull requests, build and test the PR head not a merge of the PR with the destination.
           ref:  ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: Build and test Ledger Exporter images
+      - name: Build Ledger Exporter docker
         run: make -C exp/services/ledgerexporter docker-build
+
+      - name: Run Ledger Exporter test
+        run: make -C exp/services/ledgerexporter docker-test
 
       # Push images
       - if: github.ref == 'refs/heads/master'

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -177,4 +177,6 @@ jobs:
 
       - if: github.ref == 'refs/heads/master'
         name: Push to DockerHub
-        run: make -C exp/services/ledgerexporter docker-push
+        run: |
+          make -C exp/services/ledgerexporter docker-push
+          VERSION=latest make -C exp/services/ledgerexporter docker-push

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -156,47 +156,22 @@ jobs:
   ledger-exporter:
     name: Test and push the Ledger Exporter images
     runs-on: ubuntu-latest
-    if: false # Disable the job
     steps:
       - uses: actions/checkout@v3
         with:
           # For pull requests, build and test the PR head not a merge of the PR with the destination.
           ref:  ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Build and test Ledger Exporter images
-        # Any range should do for basic testing, this range was chosen pretty early in history so that it only takes a few mins to run
-        run: |
-          chmod 755 ./exp/lighthorizon/build/build.sh
-          mkdir $PWD/ledgerexport
-          # mkdir $PWD/index
-
-          ./exp/lighthorizon/build/build.sh ledgerexporter stellar latest false
-          docker run -e ARCHIVE_TARGET=file:///ledgerexport\
-                     -e START=5\
-                     -e END=150\
-                     -e NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"\
-                     -e CAPTIVE_CORE_CONFIG="/captive-core-pubnet.cfg"\
-                     -e HISTORY_ARCHIVE_URLS="https://history.stellar.org/prd/core-live/core_live_001"\
-                     -v $PWD/ledgerexport:/ledgerexport\
-                     stellar/lighthorizon-ledgerexporter
-
-          # # run map job
-          # docker run -e NETWORK_PASSPHRASE='pubnet' -e JOB_INDEX_ENV=AWS_BATCH_JOB_ARRAY_INDEX -e AWS_BATCH_JOB_ARRAY_INDEX=0 -e BATCH_SIZE=64 -e FIRST_CHECKPOINT=64 \
-          #            -e WORKER_COUNT=1 -e RUN_MODE=map -v $PWD/ledgerexport:/ledgermeta -e TXMETA_SOURCE=file:///ledgermeta -v $PWD/index:/index -e INDEX_TARGET=file:///index stellar/lighthorizon-index-batch
-
-          # # run reduce job
-          # docker run -e NETWORK_PASSPHRASE='pubnet' -e JOB_INDEX_ENV=AWS_BATCH_JOB_ARRAY_INDEX -e AWS_BATCH_JOB_ARRAY_INDEX=0 -e MAP_JOB_COUNT=1 -e REDUCE_JOB_COUNT=1 \
-          #            -e WORKER_COUNT=1 -e RUN_MODE=reduce -v $PWD/index:/index -e INDEX_SOURCE_ROOT=file:///index -e INDEX_TARGET=file:///index stellar/lighthorizon-index-batch
+        run: make -C exp/services/ledgerexporter docker-build
 
       # Push images
-      - if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/lighthorizon'
+      - if: github.ref == 'refs/heads/master'
         name: Login to DockerHub
         uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/lighthorizon'
+      - if: github.ref == 'refs/heads/master'
         name: Push to DockerHub
-        run: |
-          chmod 755 ./exp/lighthorizon/build/build.sh
-          ./exp/lighthorizon/build/build.sh ledgerexporter stellar latest true
+        run: make -C exp/services/ledgerexporter docker-push

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -177,6 +177,4 @@ jobs:
 
       - if: github.ref == 'refs/heads/master'
         name: Push to DockerHub
-        run: |
-          make -C exp/services/ledgerexporter docker-push
-          VERSION=latest make -C exp/services/ledgerexporter docker-push
+        run: make -C exp/services/ledgerexporter docker-push

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ friendbot:
 horizon:
 	$(MAKE) -C services/horizon/ binary-build
 
+ledger-exporter:
+	$(MAKE) -C exp/services/ledgerexporter/ docker-build
+
 webauth:
 	$(MAKE) -C exp/services/webauth/ docker-build
 

--- a/exp/services/ledgerexporter/Makefile
+++ b/exp/services/ledgerexporter/Makefile
@@ -3,22 +3,16 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 BUILD_DATE := $(shell date -u +%FT%TZ)
 VERSION ?= $(shell git rev-parse --short HEAD)
-TAG ?= stellar/ledger-exporter:$(VERSION)
+DOCKER_IMAGE := stellar/ledger-exporter
 
 docker-build:
-ifndef STELLAR_CORE_VERSION
 	cd ../../../ && \
 	$(SUDO) docker build --platform linux/amd64 --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
 	--build-arg VERSION=$(VERSION) \
+$(if $(STELLAR_CORE_VERSION), --build-arg STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION)) \
 	-f exp/services/ledgerexporter/docker/Dockerfile \
-	-t $(TAG) .
-else
-	cd ../../../ && \
-	$(SUDO) docker build --platform linux/amd64 --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
-	--build-arg VERSION=$(VERSION) --build-arg STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION) \
-	-f exp/services/ledgerexporter/docker/Dockerfile \
-	-t $(TAG) .
-endif
+	-t $(DOCKER_IMAGE):$(VERSION) \
+	-t $(DOCKER_IMAGE):latest .
 
 docker-test:
 	# Create temp storage dir
@@ -38,7 +32,7 @@ docker-test:
 		 -e START=1000 \
 		 -e END=2000 \
 		 -e STORAGE_EMULATOR_HOST=http://fake-gcs-server:4443 \
-		 $(TAG)
+		 $(DOCKER_IMAGE):$(VERSION)
 
 	# Cleanup
 	$(SUDO) docker stop fake-gcs-server
@@ -47,4 +41,5 @@ docker-test:
 	$(SUDO) docker network rm test-network
 
 docker-push:
-	$(SUDO) docker push $(TAG)
+	$(SUDO) docker push $(DOCKER_IMAGE):$(VERSION)
+	$(SUDO) docker push $(DOCKER_IMAGE):latest

--- a/exp/services/ledgerexporter/Makefile
+++ b/exp/services/ledgerexporter/Makefile
@@ -1,0 +1,25 @@
+SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
+
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+BUILD_DATE := $(shell date -u +%FT%TZ)
+VERSION ?= latest
+TAG ?= stellar/ledger-exporter:$(VERSION)
+
+docker-build:
+ifndef STELLAR_CORE_VERSION
+	cd ../../../ && \
+	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	--build-arg VERSION=$(VERSION) \
+	-f exp/services/ledgerexporter/docker/Dockerfile \
+	-t $(TAG) .
+else
+	cd ../../../ && \
+	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	--build-arg VERSION=$(VERSION) --build-arg STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION) \
+	-f exp/services/ledgerexporter/docker/Dockerfile \
+	-t $(TAG) .
+endif
+
+docker-push:
+	cd ../../../ && \
+	$(SUDO) docker push $(TAG)

--- a/exp/services/ledgerexporter/Makefile
+++ b/exp/services/ledgerexporter/Makefile
@@ -20,6 +20,32 @@ else
 	-t $(TAG) .
 endif
 
+docker-test:
+	# Create temp storage dir
+	$(SUDO) mkdir -p ${PWD}/storage/exporter-test
+
+	# Create test network for docker
+	$(SUDO) docker network create test-network
+
+	# Run the fake GCS server
+	$(SUDO) docker run -d --name fake-gcs-server -p 4443:4443 \
+		 -v ${PWD}/storage:/data --network test-network fsouza/fake-gcs-server -scheme http
+
+	# Run the ledger-exporter
+	$(SUDO) docker run --platform linux/amd64 -t --network test-network\
+		 -e NETWORK=pubnet \
+		 -e ARCHIVE_TARGET=gcs://exporter-test \
+		 -e START=1000 \
+		 -e END=2000 \
+		 -e STORAGE_EMULATOR_HOST=http://fake-gcs-server:4443 \
+		 stellar/ledger-exporter
+
+	# Cleanup
+	$(SUDO) docker stop fake-gcs-server
+	$(SUDO) docker rm fake-gcs-server
+	$(SUDO) rm -rf ${PWD}/storage
+	$(SUDO) docker network rm test-network
+
 docker-push:
 	cd ../../../ && \
 	$(SUDO) docker push $(TAG)

--- a/exp/services/ledgerexporter/Makefile
+++ b/exp/services/ledgerexporter/Makefile
@@ -2,19 +2,19 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 BUILD_DATE := $(shell date -u +%FT%TZ)
-VERSION ?= latest
+VERSION ?= $(shell git rev-parse --short HEAD)
 TAG ?= stellar/ledger-exporter:$(VERSION)
 
 docker-build:
 ifndef STELLAR_CORE_VERSION
 	cd ../../../ && \
-	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	$(SUDO) docker build --platform linux/amd64 --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
 	--build-arg VERSION=$(VERSION) \
 	-f exp/services/ledgerexporter/docker/Dockerfile \
 	-t $(TAG) .
 else
 	cd ../../../ && \
-	$(SUDO) docker build --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	$(SUDO) docker build --platform linux/amd64 --pull --label org.opencontainers.image.created="$(BUILD_DATE)" \
 	--build-arg VERSION=$(VERSION) --build-arg STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION) \
 	-f exp/services/ledgerexporter/docker/Dockerfile \
 	-t $(TAG) .
@@ -38,7 +38,7 @@ docker-test:
 		 -e START=1000 \
 		 -e END=2000 \
 		 -e STORAGE_EMULATOR_HOST=http://fake-gcs-server:4443 \
-		 stellar/ledger-exporter
+		 $(TAG)
 
 	# Cleanup
 	$(SUDO) docker stop fake-gcs-server
@@ -47,5 +47,4 @@ docker-test:
 	$(SUDO) docker network rm test-network
 
 docker-push:
-	cd ../../../ && \
 	$(SUDO) docker push $(TAG)

--- a/exp/services/ledgerexporter/Makefile
+++ b/exp/services/ledgerexporter/Makefile
@@ -34,7 +34,6 @@ docker-test:
 		 -e STORAGE_EMULATOR_HOST=http://fake-gcs-server:4443 \
 		 $(DOCKER_IMAGE):$(VERSION)
 
-	# Cleanup
 	$(SUDO) docker stop fake-gcs-server
 	$(SUDO) docker rm fake-gcs-server
 	$(SUDO) rm -rf ${PWD}/storage

--- a/exp/services/ledgerexporter/docker/Dockerfile
+++ b/exp/services/ledgerexporter/docker/Dockerfile
@@ -25,11 +25,11 @@ RUN echo "deb https://apt.stellar.org focal unstable" >/etc/apt/sources.list.d/S
 RUN apt-get update && apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
 RUN apt-get clean
 
-COPY --from=builder /go/src/github.com/stellar/go/exp/services/ledgerexporter/docker/start /
+COPY exp/services/ledgerexporter/docker/start /
 
 RUN ["chmod", "+x", "/start"]
 
-COPY --from=builder /go/bin/ledgerexporter /
+COPY --from=builder /go/bin/ledgerexporter /usr/bin/ledgerexporter
 
 ENTRYPOINT ["/start"]
 

--- a/exp/services/ledgerexporter/docker/Dockerfile
+++ b/exp/services/ledgerexporter/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM golang:1.22-bullseye AS builder
+
+WORKDIR /go/src/github.com/stellar/go
+
+COPY go.mod ./
+COPY go.sum ./
+
+RUN go mod download
+
+COPY . ./
+
+RUN go install github.com/stellar/go/exp/services/ledgerexporter
+
+FROM ubuntu:22.04
+ARG STELLAR_CORE_VERSION
+ENV STELLAR_CORE_VERSION=${STELLAR_CORE_VERSION:-*}
+ENV STELLAR_CORE_BINARY_PATH /usr/bin/stellar-core
+
+ENV DEBIAN_FRONTEND=noninteractive
+# ca-certificates are required to make tls connections
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl wget gnupg apt-utils
+RUN wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key add -
+RUN echo "deb https://apt.stellar.org focal stable" >/etc/apt/sources.list.d/SDF.list
+RUN echo "deb https://apt.stellar.org focal unstable" >/etc/apt/sources.list.d/SDF-unstable.list
+RUN apt-get update && apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
+RUN apt-get clean
+
+COPY --from=builder /go/src/github.com/stellar/go/exp/services/ledgerexporter/docker/start /
+
+RUN ["chmod", "+x", "/start"]
+
+COPY --from=builder /go/bin/ledgerexporter /
+
+ENTRYPOINT ["/start"]
+
+

--- a/exp/services/ledgerexporter/docker/start
+++ b/exp/services/ledgerexporter/docker/start
@@ -28,11 +28,11 @@ EOF
 # Check if START or END variables are set
 if [[ -n "$START" || -n "$END" ]]; then
     echo "START: $START END: $END"
-    ./ledgerexporter --config-file config.toml --start $START --end $END
+    /usr/bin/ledgerexporter --config-file config.toml --start $START --end $END
 # Check if FROM_LAST variable is set
 elif [[ -n "$FROM_LAST" ]]; then
     echo "FROM_LAST: $FROM_LAST"
-    ./ledgerexporter --config-file config.toml --from-last  $FROM_LAST
+    /usr/bin/ledgerexporter --config-file config.toml --from-last  $FROM_LAST
 else
     echo "Error: No ledger range provided."
     exit 1

--- a/exp/services/ledgerexporter/docker/start
+++ b/exp/services/ledgerexporter/docker/start
@@ -1,0 +1,44 @@
+#! /usr/bin/env bash
+set -e
+
+# Validation
+if [ -z "$ARCHIVE_TARGET" ]; then
+  echo "error: undefined ARCHIVE_TARGET env variable"
+  exit 1
+fi
+
+if [ -z "$NETWORK" ]; then
+  echo "error: undefined NETWORK env variable"
+  exit 1
+fi
+
+if [[ -n "$FROM_LAST" && (-n "$START" || -n "$END") ]]; then
+    echo "Error: Cannot provide both FROM_LAST and START/END options simultaneously."
+    exit 1
+fi
+
+ledgers_per_file="${LEDGERS_PER_FILE:-1}"
+files_per_partition="${FILES_PER_PARTITION:-64000}"
+
+# Generate TOML configuration
+cat <<EOF > config.toml
+network = "${NETWORK}"
+destination_url = "${ARCHIVE_TARGET}"
+
+[exporter_config]
+  ledgers_per_file = $ledgers_per_file
+  files_per_partition = $files_per_partition
+EOF
+
+# Check if START or END variables are set
+if [[ -n "$START" || -n "$END" ]]; then
+    echo "START: $START END: $END"
+    ./ledgerexporter --config-file config.toml --start $START --end $END
+# Check if FROM_LAST variable is set
+elif [[ -n "$FROM_LAST" ]]; then
+    echo "FROM_LAST: $FROM_LAST"
+    ./ledgerexporter --config-file config.toml --from-last  $FROM_LAST
+else
+    echo "Error: No ledger range provided."
+    exit 1
+fi

--- a/exp/services/ledgerexporter/docker/start
+++ b/exp/services/ledgerexporter/docker/start
@@ -12,11 +12,6 @@ if [ -z "$NETWORK" ]; then
   exit 1
 fi
 
-if [[ -n "$FROM_LAST" && (-n "$START" || -n "$END") ]]; then
-    echo "Error: Cannot provide both FROM_LAST and START/END options simultaneously."
-    exit 1
-fi
-
 ledgers_per_file="${LEDGERS_PER_FILE:-1}"
 files_per_partition="${FILES_PER_PARTITION:-64000}"
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

- Created a Dockerfile to build the Ledger Exporter image. 
    - Currently, there is no versioning scheme for the Ledge Exporter, so the Docker image is created with the `latest` tag. 
    - Command line parameters such as `start`, `end`, and `from_last` are passed as env variables when running the container. For configuring the Captive Core, the Ledger Exporter only accepts the `NETWORK` configuration parameter which can be set to 'testnet' or 'pubnet'. The destination URL is provided as `ARCHIVE_TARGET` env variable and it is currently limited to GCS only. These config params are also passed as env variables in Docker.
  For example:
```sh     
docker run --platform linux/amd64 -t -v "$HOME/.config/gcloud/application_default_credentials.json":/gcp/creds.json:ro -e GOOGLE_APPLICATION_CREDENTIALS=/gcp/creds.json -e NETWORK=testnet -e ARCHIVE_TARGET=gcs://exporter-test -e START=100  -e END=200 stellar/ledger-exporter:latest
```

Since there is no CLI support for config params in the Ledger Exporter, a startup script creates a configuration file based on the provided parameters. 
There are two additional optional configuration params, 'ledgers_per_file' and 'files_per_partition', which default to 1 and 64000. These can be overridden by passing the corresponding env variables when running the docker container.


- Created a Makefile with the following commands:
    1. `docker-build`: Builds a Docker image from the Dockerfile.
    2. `docker-test`: Tests the Ledger Exporter Docker image for a specific range of ledgers using the GCP emulator for storage. It spins up two containers: one for the GCP emulator and the other for the Ledger Exporter.
    3. `docker-push`: Pushes the Docker image to the Stellar Docker registry.

- The above commands are integrated into the `horizon.yml` GitHub workflow. 
    - The first two are executed on pull requests and `docker-push` is executed on merging into the master.


### Why

https://stellarorg.atlassian.net/browse/HUBBLE-270

### Known limitations
No deb package, only Docker.
Doesn't have versioning. Each push to the master will update the Docker image.
