### PR TITLE
xdr: Add wrapper to fetch a ledger's close time

### DIFF
--- a/xdr/ledger_close_meta.go
+++ b/xdr/ledger_close_meta.go
@@ -19,6 +19,10 @@ func (l LedgerCloseMeta) LedgerSequence() uint32 {
 	return uint32(l.LedgerHeaderHistoryEntry().Header.LedgerSeq)
 }
 
+func (l LedgerCloseMeta) LedgerCloseTime() int64 {
+	return int64(l.LedgerHeaderHistoryEntry().Header.ScpValue.CloseTime)
+}
+
 func (l LedgerCloseMeta) LedgerHash() Hash {
 	return l.LedgerHeaderHistoryEntry().Hash
 }


### PR DESCRIPTION
### What
This introduces a method `xdr.LedgerCloseMeta.LedgerCloseTime()` which extracts the close time from the structure.

### Why
It's annoying and error-prone to dig into the raw structure.

### Known limitations
n/a

There are no tests but you can see that this is exactly how it's done, e.g. 

https://github.com/stellar/soroban-rpc/blob/638c62d8f58707ec5e079f68b4e6dbf96b94401b/cmd/soroban-rpc/internal/transactions/transactions.go#L119

