### PR TITLE
services/regulated-assets-approval-server: bump the Go version in Dockerfile that it was missed in #5249

### DIFF
--- a/services/regulated-assets-approval-server/docker/Dockerfile
+++ b/services/regulated-assets-approval-server/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.1 as build
+FROM golang:1.22-bullseye as build
 
 ADD . /src/regulated-assets-approval-server
 WORKDIR /src/regulated-assets-approval-server


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Bump the Go version in Dockerfile that it was missed in #5249

### Why

The toolchain command in go.mod was requiring a Go version newer than the one in the Dockerfile, which was causing docker-build [to fail](https://stellarfoundation.slack.com/archives/C018BLTP2AU/p1714004215758189).

Toolchain command:
https://github.com/stellar/go/blob/ee9bbbf03be79bbac4000ea97b874ed010757b1b/go.mod#L3-L5

Container version incompatible with that toolchain version:
https://github.com/stellar/go/blob/ee9bbbf03be79bbac4000ea97b874ed010757b1b/services/regulated-assets-approval-server/docker/Dockerfile#L1