### PR TITLE
ledgerexporter: Add lexicographical ordering token to filenames

### DIFF
--- a/exp/services/ledgerexporter/internal/exportmanager_test.go
+++ b/exp/services/ledgerexporter/internal/exportmanager_test.go
@@ -2,7 +2,6 @@ package ledgerexporter
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -138,35 +137,6 @@ func (s *ExportManagerSuite) TestRunWithCanceledContext() {
 	require.EqualError(s.T(), err, "context canceled")
 }
 
-func (s *ExportManagerSuite) TestGetObjectKeyFromSequenceNumber() {
-	testCases := []struct {
-		filesPerPartition uint32
-		ledgerSeq         uint32
-		ledgersPerFile    uint32
-		fileSuffix        string
-		expectedKey       string
-	}{
-		{0, 5, 1, ".xdr.gz", "5.xdr.gz"},
-		{0, 5, 10, ".xdr.gz", "0-9.xdr.gz"},
-		{2, 10, 100, ".xdr.gz", "0-199/0-99.xdr.gz"},
-		{2, 150, 50, ".xdr.gz", "100-199/150-199.xdr.gz"},
-		{2, 300, 200, ".xdr.gz", "0-399/200-399.xdr.gz"},
-		{2, 1, 1, ".xdr.gz", "0-1/1.xdr.gz"},
-		{4, 10, 100, ".xdr.gz", "0-399/0-99.xdr.gz"},
-		{4, 250, 50, ".xdr.gz", "200-399/250-299.xdr.gz"},
-		{1, 300, 200, ".xdr.gz", "200-399.xdr.gz"},
-		{1, 1, 1, ".xdr.gz", "1.xdr.gz"},
-	}
-
-	for _, tc := range testCases {
-		s.T().Run(fmt.Sprintf("LedgerSeq-%d-LedgersPerFile-%d", tc.ledgerSeq, tc.ledgersPerFile), func(t *testing.T) {
-			config := datastore.LedgerBatchConfig{FilesPerPartition: tc.filesPerPartition, LedgersPerFile: tc.ledgersPerFile, FileSuffix: tc.fileSuffix}
-			key := config.GetObjectKeyFromSequenceNumber(tc.ledgerSeq)
-			require.Equal(t, tc.expectedKey, key)
-		})
-	}
-}
-
 func (s *ExportManagerSuite) TestAddLedgerCloseMeta() {
 	config := datastore.LedgerBatchConfig{LedgersPerFile: 1, FilesPerPartition: 10, FileSuffix: ".xdr.gz"}
 	registry := prometheus.NewRegistry()
@@ -174,7 +144,7 @@ func (s *ExportManagerSuite) TestAddLedgerCloseMeta() {
 	exporter, err := NewExportManager(config, &s.mockBackend, queue, registry)
 	require.NoError(s.T(), err)
 
-	expectedkeys := set.NewSet[string](10)
+	expectedKeys := set.NewSet[string](10)
 	actualKeys := set.NewSet[string](10)
 
 	wg := sync.WaitGroup{}
@@ -197,12 +167,12 @@ func (s *ExportManagerSuite) TestAddLedgerCloseMeta() {
 		require.NoError(s.T(), exporter.AddLedgerCloseMeta(context.Background(), datastore.CreateLedgerCloseMeta(i)))
 
 		key := config.GetObjectKeyFromSequenceNumber(i)
-		expectedkeys.Add(key)
+		expectedKeys.Add(key)
 	}
 
 	queue.Close()
 	wg.Wait()
-	require.Equal(s.T(), expectedkeys, actualKeys)
+	require.Equal(s.T(), expectedKeys, actualKeys)
 }
 
 func (s *ExportManagerSuite) TestAddLedgerCloseMetaContextCancel() {

--- a/support/datastore/ledgerbatch_config.go
+++ b/support/datastore/ledgerbatch_config.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"fmt"
+	"math"
 )
 
 type LedgerBatchConfig struct {
@@ -29,12 +30,13 @@ func (ec LedgerBatchConfig) GetObjectKeyFromSequenceNumber(ledgerSeq uint32) str
 		partitionSize := ec.LedgersPerFile * ec.FilesPerPartition
 		partitionStart := (ledgerSeq / partitionSize) * partitionSize
 		partitionEnd := partitionStart + partitionSize - 1
-		objectKey = fmt.Sprintf("%d-%d/", partitionStart, partitionEnd)
+
+		objectKey = fmt.Sprintf("%08X--%d-%d/", math.MaxUint32-partitionStart, partitionStart, partitionEnd)
 	}
 
 	fileStart := ec.GetSequenceNumberStartBoundary(ledgerSeq)
 	fileEnd := ec.GetSequenceNumberEndBoundary(ledgerSeq)
-	objectKey += fmt.Sprintf("%d", fileStart)
+	objectKey += fmt.Sprintf("%08X--%d", math.MaxUint32-fileStart, fileStart)
 
 	// Multiple ledgers per file
 	if fileStart != fileEnd {

--- a/support/datastore/ledgerbatch_config_test.go
+++ b/support/datastore/ledgerbatch_config_test.go
@@ -15,16 +15,16 @@ func TestGetObjectKeyFromSequenceNumber(t *testing.T) {
 		fileSuffix        string
 		expectedKey       string
 	}{
-		{0, 5, 1, ".xdr.gz", "5.xdr.gz"},
-		{0, 5, 10, ".xdr.gz", "0-9.xdr.gz"},
-		{2, 10, 100, ".xdr.gz", "0-199/0-99.xdr.gz"},
-		{2, 150, 50, ".xdr.gz", "100-199/150-199.xdr.gz"},
-		{2, 300, 200, ".xdr.gz", "0-399/200-399.xdr.gz"},
-		{2, 1, 1, ".xdr.gz", "0-1/1.xdr.gz"},
-		{4, 10, 100, ".xdr.gz", "0-399/0-99.xdr.gz"},
-		{4, 250, 50, ".xdr.gz", "200-399/250-299.xdr.gz"},
-		{1, 300, 200, ".xdr.gz", "200-399.xdr.gz"},
-		{1, 1, 1, ".xdr.gz", "1.xdr.gz"},
+		{0, 5, 1, ".xdr.gz", "FFFFFFFA--5.xdr.gz"},
+		{0, 5, 10, ".xdr.gz", "FFFFFFFF--0-9.xdr.gz"},
+		{2, 10, 100, ".xdr.gz", "FFFFFFFF--0-199/FFFFFFFF--0-99.xdr.gz"},
+		{2, 150, 50, ".xdr.gz", "FFFFFF9B--100-199/FFFFFF69--150-199.xdr.gz"},
+		{2, 300, 200, ".xdr.gz", "FFFFFFFF--0-399/FFFFFF37--200-399.xdr.gz"},
+		{2, 1, 1, ".xdr.gz", "FFFFFFFF--0-1/FFFFFFFE--1.xdr.gz"},
+		{4, 10, 100, ".xdr.gz", "FFFFFFFF--0-399/FFFFFFFF--0-99.xdr.gz"},
+		{4, 250, 50, ".xdr.gz", "FFFFFF37--200-399/FFFFFF05--250-299.xdr.gz"},
+		{1, 300, 200, ".xdr.gz", "FFFFFF37--200-399.xdr.gz"},
+		{1, 1, 1, ".xdr.gz", "FFFFFFFE--1.xdr.gz"},
 	}
 
 	for _, tc := range testCases {

--- a/support/datastore/resumablemanager_test.go
+++ b/support/datastore/resumablemanager_test.go
@@ -208,58 +208,58 @@ func TestResumability(t *testing.T) {
 	mockDataStore := &MockDataStore{}
 
 	//"End ledger same as start, data store has it"
-	mockDataStore.On("Exists", ctx, "0-9.xdr.gz").Return(true, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFFFF--0-9.xdr.gz").Return(true, nil).Once()
 
 	//"End ledger same as start, data store does not have it"
-	mockDataStore.On("Exists", ctx, "10-19.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFFF5--10-19.xdr.gz").Return(false, nil).Once()
 
 	//"binary search encounters an error during datastore retrieval",
-	mockDataStore.On("Exists", ctx, "20-29.xdr.gz").Return(false, errors.New("datastore error happened")).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFFEB--20-29.xdr.gz").Return(false, errors.New("datastore error happened")).Once()
 
 	//"Data store is beyond boundary aligned start ledger"
-	mockDataStore.On("Exists", ctx, "30-39.xdr.gz").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "40-49.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFFE1--30-39.xdr.gz").Return(true, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFFD7--40-49.xdr.gz").Return(false, nil).Once()
 
 	//"Data store is beyond non boundary aligned start ledger"
-	mockDataStore.On("Exists", ctx, "70-79.xdr.gz").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "80-89.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFFB9--70-79.xdr.gz").Return(true, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFFAF--80-89.xdr.gz").Return(false, nil).Once()
 
 	//"Data store is beyond start and end ledger"
-	mockDataStore.On("Exists", ctx, "260-269.xdr.gz").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "270-279.xdr.gz").Return(true, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFEFB--260-269.xdr.gz").Return(true, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFEF1--270-279.xdr.gz").Return(true, nil).Once()
 
 	//"Data store is not beyond start ledger"
-	mockDataStore.On("Exists", ctx, "110-119.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "100-109.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "90-99.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFF91--110-119.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFF9B--100-109.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFFA5--90-99.xdr.gz").Return(false, nil).Once()
 
 	//"No end ledger provided, data store not beyond start" uses latest from network="test2"
-	mockDataStore.On("Exists", ctx, "1630-1639.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "1390-1399.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "1260-1269.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "1200-1209.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "1160-1169.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "1170-1179.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "1150-1159.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "1140-1149.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF9A1--1630-1639.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFA91--1390-1399.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFB13--1260-1269.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFB4F--1200-1209.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFB77--1160-1169.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFB6D--1170-1179.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFB81--1150-1159.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFB8B--1140-1149.xdr.gz").Return(false, nil).Once()
 
 	//"No end ledger provided, data store is beyond start" uses latest from network="test3"
-	mockDataStore.On("Exists", ctx, "2630-2639.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "2390-2399.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "2260-2269.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "2250-2259.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "2240-2249.xdr.gz").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "2230-2239.xdr.gz").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "2200-2209.xdr.gz").Return(true, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF5B9--2630-2639.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF6A9--2390-2399.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF72B--2260-2269.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF735--2250-2259.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF73F--2240-2249.xdr.gz").Return(true, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF749--2230-2239.xdr.gz").Return(true, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF767--2200-2209.xdr.gz").Return(true, nil).Once()
 
 	//"No end ledger provided, data store is beyond start and archive network latest, and partially into checkpoint frequency padding" uses latest from network="test4"
-	mockDataStore.On("Exists", ctx, "3630-3639.xdr.gz").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "3880-3889.xdr.gz").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "4000-4009.xdr.gz").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "4060-4069.xdr.gz").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "4090-4099.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "4080-4089.xdr.gz").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "4070-4079.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF1D1--3630-3639.xdr.gz").Return(true, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF0D7--3880-3889.xdr.gz").Return(true, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF05F--4000-4009.xdr.gz").Return(true, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF023--4060-4069.xdr.gz").Return(true, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF005--4090-4099.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF00F--4080-4089.xdr.gz").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFF019--4070-4079.xdr.gz").Return(false, nil).Once()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

For [HUBBLE-395](https://stellarorg.atlassian.net/browse/HUBBLE-395)
Add a lexicographical ordering token as a prefix to the partition and file names so that the first file within a cloud storage bucket (e.g. GCS) is the largest ledger sequence number.

Example: `/bucket/FFFF05FE-64001-128000/FFFF05FE-64001-64064.xdr.gz`

### Why

The current ordering of partitions and files are integers but the sorting in GCS is alphanumeric making some files appear out of order within GCS.

### Known limitations

This does add more text to the filenames which make it slightly less human readable.
