### PR TITLE
support/datastore: Add CRC32C validation when exporting and consuming tx meta files

### DIFF
--- a/support/datastore/gcs_datastore.go
+++ b/support/datastore/gcs_datastore.go
@@ -1,8 +1,10 @@
 package datastore
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"net/http"
 	"os"
@@ -64,7 +66,13 @@ func NewGCSDataStore(ctx context.Context, params map[string]string, network stri
 // GetFile retrieves a file from the GCS bucket.
 func (b GCSDataStore) GetFile(ctx context.Context, filePath string) (io.ReadCloser, error) {
 	filePath = path.Join(b.prefix, filePath)
-	r, err := b.bucket.Object(filePath).NewReader(ctx)
+	// setting ReadCompressed(true) will avoid transcoding of compressed files
+	// by including an "Accept-Encoding: gzip" header to the request:
+	// https://github.com/googleapis/google-cloud-go/blob/main/storage/http_client.go#L1307-L1309
+	// https://cloud.google.com/storage/docs/transcoding#decompressive_transcoding
+	// This will ensure that the reader performs CRC validation when finishing the download:
+	// https://pkg.go.dev/cloud.google.com/go/storage#Reader
+	r, err := b.bucket.Object(filePath).ReadCompressed(true).NewReader(ctx)
 	if err != nil {
 		if err == storage.ErrObjectNotExist {
 			return nil, os.ErrNotExist
@@ -147,7 +155,13 @@ func (b GCSDataStore) putFile(ctx context.Context, filePath string, in io.Writer
 		o = o.If(*conditions)
 	}
 	w := o.NewWriter(ctx)
-	if _, err := in.WriteTo(w); err != nil {
+	buf := &bytes.Buffer{}
+	if _, err := in.WriteTo(buf); err != nil {
+		return errors.Wrapf(err, "failed to write file: %s", filePath)
+	}
+	w.SendCRC32C = true
+	w.CRC32C = crc32.Checksum(buf.Bytes(), crc32.MakeTable(crc32.Castagnoli))
+	if _, err := in.WriteTo(buf); err != nil {
 		return errors.Wrapf(err, "failed to put file: %s", filePath)
 	}
 	return w.Close()


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add CRC32C validation validation when uploading and downloading tx meta files.

<del>https://stellarorg.atlassian.net/browse/HUBBLE-271</del>
https://stellarorg.atlassian.net/browse/HUBBLE-278

### Why

From https://cloud.google.com/storage/docs/hashes-etags

> There are a variety of ways that data can be corrupted while uploading to or downloading from the Cloud:
 > - Memory errors on client or server computers, or routers along the path
 > - Software bugs (e.g., in a library that customers use)
> - Changes to the source file when an upload occurs over an extended period of time

> Cloud Storage supports two types of hashes you can use to check the integrity of your data: CRC32C and MD5. CRC32C is the [recommended validation method](https://cloud.google.com/storage/docs/hashes-etags#validation) for performing integrity checks.

### Known limitations

Unfortunately, the CRC32 hash must be computed at the beginning of the HTTP request which means we must write out the payload to a temporary buffer instead of computing the hash on the fly.
