### PR TITLE
support/datastore: Fix putFile in gcs_datastore  to correctly upload to the bucket

### DIFF
--- a/support/datastore/gcs_datastore.go
+++ b/support/datastore/gcs_datastore.go
@@ -162,7 +162,7 @@ func (b GCSDataStore) putFile(ctx context.Context, filePath string, in io.Writer
 	w.SendCRC32C = true
 	// we must set CRC32C before invoking w.Write() for the first time
 	w.CRC32C = crc32.Checksum(buf.Bytes(), crc32.MakeTable(crc32.Castagnoli))
-	if _, err := in.WriteTo(w); err != nil {
+	if _, err := io.Copy(w, buf); err != nil {
 		return errors.Wrapf(err, "failed to put file: %s", filePath)
 	}
 	return w.Close()

--- a/support/datastore/gcs_datastore.go
+++ b/support/datastore/gcs_datastore.go
@@ -162,7 +162,7 @@ func (b GCSDataStore) putFile(ctx context.Context, filePath string, in io.Writer
 	w.SendCRC32C = true
 	// we must set CRC32C before invoking w.Write() for the first time
 	w.CRC32C = crc32.Checksum(buf.Bytes(), crc32.MakeTable(crc32.Castagnoli))
-	if _, err := in.WriteTo(buf); err != nil {
+	if _, err := in.WriteTo(w); err != nil {
 		return errors.Wrapf(err, "failed to put file: %s", filePath)
 	}
 	return w.Close()


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Fix issue in `putFile` of `gcs_datastore` to correctly write the object to the bucket.

### Why
Without this fix, empty files were uploaded to the datastore.

### Known limitations
N/A
