### PR TITLE
exp/services/ledgerexporter/internal: Call PrepareRange() in exporter manager goroutine

### DIFF
--- a/exp/services/ledgerexporter/internal/app.go
+++ b/exp/services/ledgerexporter/internal/app.go
@@ -112,7 +112,7 @@ func (a *App) init(ctx context.Context) error {
 
 	logger.Infof("Final computed ledger range for backend retrieval and export, start=%d, end=%d", a.config.StartLedger, a.config.EndLedger)
 
-	if a.ledgerBackend, err = newLedgerBackend(ctx, a.config, registry); err != nil {
+	if a.ledgerBackend, err = newLedgerBackend(a.config, registry); err != nil {
 		return err
 	}
 
@@ -247,7 +247,7 @@ func (a *App) Run() {
 
 // newLedgerBackend Creates and initializes captive core ledger backend
 // Currently, only supports captive-core as ledger backend
-func newLedgerBackend(ctx context.Context, config *Config, prometheusRegistry *prometheus.Registry) (ledgerbackend.LedgerBackend, error) {
+func newLedgerBackend(config *Config, prometheusRegistry *prometheus.Registry) (ledgerbackend.LedgerBackend, error) {
 	captiveConfig, err := config.GenerateCaptiveCoreConfig()
 	if err != nil {
 		return nil, err
@@ -261,15 +261,5 @@ func newLedgerBackend(ctx context.Context, config *Config, prometheusRegistry *p
 	}
 	backend = ledgerbackend.WithMetrics(backend, prometheusRegistry, "ledger_exporter")
 
-	var ledgerRange ledgerbackend.Range
-	if config.EndLedger == 0 {
-		ledgerRange = ledgerbackend.UnboundedRange(config.StartLedger)
-	} else {
-		ledgerRange = ledgerbackend.BoundedRange(config.StartLedger, config.EndLedger)
-	}
-
-	if err = backend.PrepareRange(ctx, ledgerRange); err != nil {
-		return nil, errors.Wrap(err, "Could not prepare captive core ledger backend")
-	}
 	return backend, nil
 }

--- a/exp/services/ledgerexporter/internal/exportmanager.go
+++ b/exp/services/ledgerexporter/internal/exportmanager.go
@@ -89,21 +89,25 @@ func (e *ExportManager) Run(ctx context.Context, startLedger, endLedger uint32) 
 		"end_ledger":   strconv.FormatUint(uint64(endLedger), 10),
 	}
 
+	var ledgerRange ledgerbackend.Range
+	if endLedger < 1 {
+		ledgerRange = ledgerbackend.UnboundedRange(startLedger)
+	} else {
+		ledgerRange = ledgerbackend.BoundedRange(startLedger, endLedger)
+	}
+	if err := e.ledgerBackend.PrepareRange(ctx, ledgerRange); err != nil {
+		return errors.Wrap(err, "Could not prepare captive core ledger backend")
+	}
+
 	for nextLedger := startLedger; endLedger < 1 || nextLedger <= endLedger; nextLedger++ {
-		select {
-		case <-ctx.Done():
-			logger.Info("Stopping ExportManager due to context cancellation")
-			return ctx.Err()
-		default:
-			ledgerCloseMeta, err := e.ledgerBackend.GetLedger(ctx, nextLedger)
-			if err != nil {
-				return errors.Wrapf(err, "failed to retrieve ledger %d from the ledger backend", nextLedger)
-			}
-			e.latestLedgerMetric.With(labels).Set(float64(nextLedger))
-			err = e.AddLedgerCloseMeta(ctx, ledgerCloseMeta)
-			if err != nil {
-				return errors.Wrapf(err, "failed to add ledgerCloseMeta for ledger %d", nextLedger)
-			}
+		ledgerCloseMeta, err := e.ledgerBackend.GetLedger(ctx, nextLedger)
+		if err != nil {
+			return errors.Wrapf(err, "failed to retrieve ledger %d from the ledger backend", nextLedger)
+		}
+		e.latestLedgerMetric.With(labels).Set(float64(nextLedger))
+		err = e.AddLedgerCloseMeta(ctx, ledgerCloseMeta)
+		if err != nil {
+			return errors.Wrapf(err, "failed to add ledgerCloseMeta for ledger %d", nextLedger)
 		}
 	}
 	logger.Infof("ExportManager successfully exported ledgers from %d to %d", startLedger, endLedger)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Call PrepareRange() in exporter manager goroutine instead of during app initialization.

### Why

PrepareRange() can block up to 15 minutes because it will wait until the first ledger has been emitted over the captive core pipe. So if we call it during the app initialization we will have no metrics during this period because we first initialize the ledger backend before initializing the metrics server.

### Known limitations

[N/A]
