### PR TITLE
Bump core to the stable v21 build.

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -32,11 +32,11 @@ jobs:
     env:
       HORIZON_INTEGRATION_TESTS_ENABLED: true
       HORIZON_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL: ${{ matrix.protocol-version }}
-      PROTOCOL_21_CORE_DEBIAN_PKG_VERSION: 21.0.0-1812.rc1.a10329cca.focal
-      PROTOCOL_21_CORE_DOCKER_IMG: stellar/unsafe-stellar-core:21.0.0-1812.rc1.a10329cca.focal
+      PROTOCOL_21_CORE_DEBIAN_PKG_VERSION: 21.0.0-1872.c6f474133.focal
+      PROTOCOL_21_CORE_DOCKER_IMG: stellar/stellar-core:21
       PROTOCOL_21_SOROBAN_RPC_DOCKER_IMG: stellar/soroban-rpc:21.0.0-rc2-73
-      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 21.0.0-1812.rc1.a10329cca.focal
-      PROTOCOL_20_CORE_DOCKER_IMG: stellar/unsafe-stellar-core:21.0.0-1812.rc1.a10329cca.focal
+      PROTOCOL_20_CORE_DEBIAN_PKG_VERSION: 21.0.0-1872.c6f474133.focal
+      PROTOCOL_20_CORE_DOCKER_IMG: stellar/stellar-core:21
       PROTOCOL_20_SOROBAN_RPC_DOCKER_IMG: stellar/soroban-rpc:21.0.0-rc2-73
       PGHOST: localhost
       PGPORT: 5432
@@ -125,7 +125,7 @@ jobs:
     name: Test (and push) verify-range image
     runs-on: ubuntu-22.04
     env:
-      STELLAR_CORE_VERSION: 19.14.0-1500.5664eff4e.focal
+      STELLAR_CORE_VERSION: 21.0.0-1872.c6f474133.focal
       CAPTIVE_CORE_STORAGE_PATH: /tmp
     steps:
       - uses: actions/checkout@v3
@@ -155,7 +155,7 @@ jobs:
     name: Test and push the Ledger Exporter images
     runs-on: ubuntu-latest
     env:
-      STELLAR_CORE_VERSION: 21.0.0-1812.rc1.a10329cca.focal
+      STELLAR_CORE_VERSION: 21.0.0-1872.c6f474133.focal
     steps:
       - uses: actions/checkout@v3
         with:

--- a/exp/tools/dump-ledger-state/Dockerfile
+++ b/exp/tools/dump-ledger-state/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ENV STELLAR_CORE_VERSION=19.14.0-1500.5664eff4e.focal
+ENV STELLAR_CORE_VERSION=21.0.0-1872.c6f474133.focal
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl wget gnupg apt-utils

--- a/exp/tools/dump-ledger-state/stellar-core-testnet.cfg
+++ b/exp/tools/dump-ledger-state/stellar-core-testnet.cfg
@@ -8,6 +8,8 @@ UNSAFE_QUORUM=true
 FAILURE_SAFETY=1
 CATCHUP_RECENT=8640
 
+DEPRECATED_SQL_LEDGER_STATE=false
+
 [HISTORY.cache]
 get="cp /opt/stellar/history-cache/{0} {1}"
 

--- a/exp/tools/dump-ledger-state/stellar-core.cfg
+++ b/exp/tools/dump-ledger-state/stellar-core.cfg
@@ -6,6 +6,8 @@ DATABASE="postgresql://dbname=core host=localhost user=circleci"
 NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 CATCHUP_RECENT=1
 
+DEPRECATED_SQL_LEDGER_STATE=false
+
 [HISTORY.cache]
 get="cp /opt/stellar/history-cache/{0} {1}"
 


### PR DESCRIPTION
I've also updated some v19 images which I suspect weren't being used (or at least the tests were set up with protocol 19).