### PR TITLE
support/datastore: Make resumability robust to unexpected overlaps in adjacent ranges

### DIFF
--- a/support/datastore/resumablemanager_test.go
+++ b/support/datastore/resumablemanager_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/stellar/go/historyarchive"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go/historyarchive"
 )
 
 func TestResumability(t *testing.T) {
@@ -58,6 +59,42 @@ func TestResumability(t *testing.T) {
 			ledgerBatchConfig: LedgerBatchConfig{
 				FilesPerPartition: uint32(1),
 				LedgersPerFile:    uint32(10),
+			},
+			networkName: "test",
+		},
+		{
+			name:         "start and end ledger are in same file, data store does not have it",
+			startLedger:  64,
+			endLedger:    68,
+			absentLedger: 64,
+			findStartOk:  true,
+			ledgerBatchConfig: LedgerBatchConfig{
+				FilesPerPartition: uint32(100),
+				LedgersPerFile:    uint32(64),
+			},
+			networkName: "test",
+		},
+		{
+			name:         "start and end ledger are in same file, data store has it",
+			startLedger:  128,
+			endLedger:    130,
+			absentLedger: 0,
+			findStartOk:  false,
+			ledgerBatchConfig: LedgerBatchConfig{
+				FilesPerPartition: uint32(100),
+				LedgersPerFile:    uint32(64),
+			},
+			networkName: "test",
+		},
+		{
+			name:         "ledger range overlaps with an range which is already exported",
+			startLedger:  2,
+			endLedger:    127,
+			absentLedger: 2,
+			findStartOk:  true,
+			ledgerBatchConfig: LedgerBatchConfig{
+				FilesPerPartition: uint32(1000),
+				LedgersPerFile:    uint32(64),
 			},
 			networkName: "test",
 		},
@@ -198,24 +235,36 @@ func TestResumability(t *testing.T) {
 	mockDataStore.On("Exists", ctx, "FFFFFFFF--0-9.xdr.zstd").Return(true, nil).Once()
 
 	//"End ledger same as start, data store does not have it"
-	mockDataStore.On("Exists", ctx, "FFFFFFF5--10-19.xdr.zstd").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFFF5--10-19.xdr.zstd").Return(false, nil).Twice()
+
+	// start and end ledger are in same file, data store does not have it
+	mockDataStore.On("Exists", ctx, "FFFFFFFF--0-6399/FFFFFFBF--64-127.xdr.zstd").Return(false, nil).Twice()
+
+	// start and end ledger are in same file, data store has it
+	mockDataStore.On("Exists", ctx, "FFFFFFFF--0-6399/FFFFFF7F--128-191.xdr.zstd").Return(true, nil).Once()
+
+	// ledger range overlaps with an range which is already exported
+	mockDataStore.On("Exists", ctx, "FFFFFFFF--0-63999/FFFFFFBF--64-127.xdr.zstd").Return(true, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFFFF--0-63999/FFFFFFFF--0-63.xdr.zstd").Return(false, nil).Once()
 
 	//"binary search encounters an error during datastore retrieval",
 	mockDataStore.On("Exists", ctx, "FFFFFFEB--20-29.xdr.zstd").Return(false, errors.New("datastore error happened")).Once()
 
 	//"Data store is beyond boundary aligned start ledger"
+	mockDataStore.On("Exists", ctx, "FFFFFFCD--50-59.xdr.zstd").Return(false, nil).Once()
 	mockDataStore.On("Exists", ctx, "FFFFFFE1--30-39.xdr.zstd").Return(true, nil).Once()
 	mockDataStore.On("Exists", ctx, "FFFFFFD7--40-49.xdr.zstd").Return(false, nil).Once()
 
 	//"Data store is beyond non boundary aligned start ledger"
 	mockDataStore.On("Exists", ctx, "FFFFFFB9--70-79.xdr.zstd").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFFAF--80-89.xdr.zstd").Return(false, nil).Once()
+	mockDataStore.On("Exists", ctx, "FFFFFFAF--80-89.xdr.zstd").Return(false, nil).Twice()
 
 	//"Data store is beyond start and end ledger"
 	mockDataStore.On("Exists", ctx, "FFFFFEFB--260-269.xdr.zstd").Return(true, nil).Once()
 	mockDataStore.On("Exists", ctx, "FFFFFEF1--270-279.xdr.zstd").Return(true, nil).Once()
 
 	//"Data store is not beyond start ledger"
+	mockDataStore.On("Exists", ctx, "FFFFFF87--120-129.xdr.zstd").Return(false, nil).Once()
 	mockDataStore.On("Exists", ctx, "FFFFFF91--110-119.xdr.zstd").Return(false, nil).Once()
 	mockDataStore.On("Exists", ctx, "FFFFFF9B--100-109.xdr.zstd").Return(false, nil).Once()
 	mockDataStore.On("Exists", ctx, "FFFFFFA5--90-99.xdr.zstd").Return(false, nil).Once()

--- a/support/datastore/resumablemanager_test.go
+++ b/support/datastore/resumablemanager_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestResumability(t *testing.T) {
-
+	ctx := context.Background()
 	tests := []struct {
 		name              string
 		startLedger       uint32
@@ -23,6 +23,7 @@ func TestResumability(t *testing.T) {
 		latestLedger      uint32
 		errorSnippet      string
 		archiveError      error
+		registerMockCalls func(*MockDataStore)
 	}{
 		{
 			name:         "archive error when resolving network latest",
@@ -34,9 +35,10 @@ func TestResumability(t *testing.T) {
 				FilesPerPartition: uint32(1),
 				LedgersPerFile:    uint32(10),
 			},
-			networkName:  "test",
-			errorSnippet: "archive error",
-			archiveError: errors.New("archive error"),
+			networkName:       "test",
+			errorSnippet:      "archive error",
+			archiveError:      errors.New("archive error"),
+			registerMockCalls: func(store *MockDataStore) {},
 		},
 		{
 			name:         "End ledger same as start, data store has it",
@@ -49,6 +51,9 @@ func TestResumability(t *testing.T) {
 				LedgersPerFile:    uint32(10),
 			},
 			networkName: "test",
+			registerMockCalls: func(mockDataStore *MockDataStore) {
+				mockDataStore.On("Exists", ctx, "FFFFFFFF--0-9.xdr.zstd").Return(true, nil).Once()
+			},
 		},
 		{
 			name:         "End ledger same as start, data store does not have it",
@@ -61,6 +66,9 @@ func TestResumability(t *testing.T) {
 				LedgersPerFile:    uint32(10),
 			},
 			networkName: "test",
+			registerMockCalls: func(mockDataStore *MockDataStore) {
+				mockDataStore.On("Exists", ctx, "FFFFFFF5--10-19.xdr.zstd").Return(false, nil).Twice()
+			},
 		},
 		{
 			name:         "start and end ledger are in same file, data store does not have it",
@@ -73,6 +81,9 @@ func TestResumability(t *testing.T) {
 				LedgersPerFile:    uint32(64),
 			},
 			networkName: "test",
+			registerMockCalls: func(mockDataStore *MockDataStore) {
+				mockDataStore.On("Exists", ctx, "FFFFFFFF--0-6399/FFFFFFBF--64-127.xdr.zstd").Return(false, nil).Twice()
+			},
 		},
 		{
 			name:         "start and end ledger are in same file, data store has it",
@@ -85,18 +96,25 @@ func TestResumability(t *testing.T) {
 				LedgersPerFile:    uint32(64),
 			},
 			networkName: "test",
+			registerMockCalls: func(mockDataStore *MockDataStore) {
+				mockDataStore.On("Exists", ctx, "FFFFFFFF--0-6399/FFFFFF7F--128-191.xdr.zstd").Return(true, nil).Once()
+			},
 		},
 		{
-			name:         "ledger range overlaps with an range which is already exported",
+			name:         "ledger range overlaps with a range which is already exported",
 			startLedger:  2,
 			endLedger:    127,
 			absentLedger: 2,
 			findStartOk:  true,
 			ledgerBatchConfig: LedgerBatchConfig{
-				FilesPerPartition: uint32(1000),
+				FilesPerPartition: uint32(100),
 				LedgersPerFile:    uint32(64),
 			},
 			networkName: "test",
+			registerMockCalls: func(mockDataStore *MockDataStore) {
+				mockDataStore.On("Exists", ctx, "FFFFFFFF--0-6399/FFFFFFBF--64-127.xdr.zstd").Return(true, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFFFF--0-6399/FFFFFFFF--0-63.xdr.zstd").Return(false, nil).Once()
+			},
 		},
 		{
 			name:         "binary search encounters an error during datastore retrieval",
@@ -110,6 +128,9 @@ func TestResumability(t *testing.T) {
 			},
 			networkName:  "test",
 			errorSnippet: "datastore error happened",
+			registerMockCalls: func(mockDataStore *MockDataStore) {
+				mockDataStore.On("Exists", ctx, "FFFFFFEB--20-29.xdr.zstd").Return(false, errors.New("datastore error happened")).Once()
+			},
 		},
 		{
 			name:         "Data store is beyond boundary aligned start ledger",
@@ -122,6 +143,11 @@ func TestResumability(t *testing.T) {
 				LedgersPerFile:    uint32(10),
 			},
 			networkName: "test",
+			registerMockCalls: func(mockDataStore *MockDataStore) {
+				mockDataStore.On("Exists", ctx, "FFFFFFCD--50-59.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFFE1--30-39.xdr.zstd").Return(true, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFFD7--40-49.xdr.zstd").Return(false, nil).Once()
+			},
 		},
 		{
 			name:         "Data store is beyond non boundary aligned start ledger",
@@ -134,6 +160,10 @@ func TestResumability(t *testing.T) {
 				LedgersPerFile:    uint32(10),
 			},
 			networkName: "test",
+			registerMockCalls: func(mockDataStore *MockDataStore) {
+				mockDataStore.On("Exists", ctx, "FFFFFFB9--70-79.xdr.zstd").Return(true, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFFAF--80-89.xdr.zstd").Return(false, nil).Twice()
+			},
 		},
 		{
 			name:         "Data store is beyond start and end ledger",
@@ -146,6 +176,10 @@ func TestResumability(t *testing.T) {
 				LedgersPerFile:    uint32(10),
 			},
 			networkName: "test",
+			registerMockCalls: func(mockDataStore *MockDataStore) {
+				mockDataStore.On("Exists", ctx, "FFFFFEFB--260-269.xdr.zstd").Return(true, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFEF1--270-279.xdr.zstd").Return(true, nil).Once()
+			},
 		},
 		{
 			name:         "Data store is not beyond start ledger",
@@ -158,6 +192,12 @@ func TestResumability(t *testing.T) {
 				LedgersPerFile:    uint32(10),
 			},
 			networkName: "test",
+			registerMockCalls: func(mockDataStore *MockDataStore) {
+				mockDataStore.On("Exists", ctx, "FFFFFF87--120-129.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFF91--110-119.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFF9B--100-109.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFFA5--90-99.xdr.zstd").Return(false, nil).Once()
+			},
 		},
 		{
 			name:         "No start ledger provided",
@@ -169,8 +209,9 @@ func TestResumability(t *testing.T) {
 				FilesPerPartition: uint32(1),
 				LedgersPerFile:    uint32(10),
 			},
-			networkName:  "test",
-			errorSnippet: "Invalid start value",
+			networkName:       "test",
+			errorSnippet:      "Invalid start value",
+			registerMockCalls: func(store *MockDataStore) {},
 		},
 		{
 			name:         "No end ledger provided, data store not beyond start",
@@ -184,6 +225,16 @@ func TestResumability(t *testing.T) {
 			},
 			networkName:  "test2",
 			latestLedger: uint32(2000),
+			registerMockCalls: func(mockDataStore *MockDataStore) {
+				mockDataStore.On("Exists", ctx, "FFFFF9A1--1630-1639.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFA91--1390-1399.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFB13--1260-1269.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFB4F--1200-1209.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFB77--1160-1169.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFB6D--1170-1179.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFB81--1150-1159.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFFB8B--1140-1149.xdr.zstd").Return(false, nil).Once()
+			},
 		},
 		{
 			name:         "No end ledger provided, data store is beyond start",
@@ -197,6 +248,15 @@ func TestResumability(t *testing.T) {
 			},
 			networkName:  "test3",
 			latestLedger: uint32(3000),
+			registerMockCalls: func(mockDataStore *MockDataStore) {
+				mockDataStore.On("Exists", ctx, "FFFFF5B9--2630-2639.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFF6A9--2390-2399.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFF72B--2260-2269.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFF735--2250-2259.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFF73F--2240-2249.xdr.zstd").Return(true, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFF749--2230-2239.xdr.zstd").Return(true, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFF767--2200-2209.xdr.zstd").Return(true, nil).Once()
+			},
 		},
 		{
 			name:         "No end ledger provided, data store is beyond start and archive network latest, and partially into checkpoint frequency padding",
@@ -210,6 +270,15 @@ func TestResumability(t *testing.T) {
 			},
 			networkName:  "test4",
 			latestLedger: uint32(4000),
+			registerMockCalls: func(mockDataStore *MockDataStore) {
+				mockDataStore.On("Exists", ctx, "FFFFF1D1--3630-3639.xdr.zstd").Return(true, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFF0D7--3880-3889.xdr.zstd").Return(true, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFF05F--4000-4009.xdr.zstd").Return(true, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFF023--4060-4069.xdr.zstd").Return(true, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFF005--4090-4099.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFF00F--4080-4089.xdr.zstd").Return(false, nil).Once()
+				mockDataStore.On("Exists", ctx, "FFFFF019--4070-4079.xdr.zstd").Return(false, nil).Once()
+			},
 		},
 		{
 			name:         "No end ledger provided, start is beyond archive network latest and checkpoint frequency padding",
@@ -221,86 +290,19 @@ func TestResumability(t *testing.T) {
 				FilesPerPartition: uint32(1),
 				LedgersPerFile:    uint32(10),
 			},
-			networkName:  "test5",
-			latestLedger: uint32(5000),
-			errorSnippet: "Invalid start value of 5129, it is greater than network's latest ledger of 5128",
+			networkName:       "test5",
+			latestLedger:      uint32(5000),
+			errorSnippet:      "Invalid start value of 5129, it is greater than network's latest ledger of 5128",
+			registerMockCalls: func(store *MockDataStore) {},
 		},
 	}
-
-	ctx := context.Background()
-
-	mockDataStore := &MockDataStore{}
-
-	//"End ledger same as start, data store has it"
-	mockDataStore.On("Exists", ctx, "FFFFFFFF--0-9.xdr.zstd").Return(true, nil).Once()
-
-	//"End ledger same as start, data store does not have it"
-	mockDataStore.On("Exists", ctx, "FFFFFFF5--10-19.xdr.zstd").Return(false, nil).Twice()
-
-	// start and end ledger are in same file, data store does not have it
-	mockDataStore.On("Exists", ctx, "FFFFFFFF--0-6399/FFFFFFBF--64-127.xdr.zstd").Return(false, nil).Twice()
-
-	// start and end ledger are in same file, data store has it
-	mockDataStore.On("Exists", ctx, "FFFFFFFF--0-6399/FFFFFF7F--128-191.xdr.zstd").Return(true, nil).Once()
-
-	// ledger range overlaps with an range which is already exported
-	mockDataStore.On("Exists", ctx, "FFFFFFFF--0-63999/FFFFFFBF--64-127.xdr.zstd").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFFFF--0-63999/FFFFFFFF--0-63.xdr.zstd").Return(false, nil).Once()
-
-	//"binary search encounters an error during datastore retrieval",
-	mockDataStore.On("Exists", ctx, "FFFFFFEB--20-29.xdr.zstd").Return(false, errors.New("datastore error happened")).Once()
-
-	//"Data store is beyond boundary aligned start ledger"
-	mockDataStore.On("Exists", ctx, "FFFFFFCD--50-59.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFFE1--30-39.xdr.zstd").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFFD7--40-49.xdr.zstd").Return(false, nil).Once()
-
-	//"Data store is beyond non boundary aligned start ledger"
-	mockDataStore.On("Exists", ctx, "FFFFFFB9--70-79.xdr.zstd").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFFAF--80-89.xdr.zstd").Return(false, nil).Twice()
-
-	//"Data store is beyond start and end ledger"
-	mockDataStore.On("Exists", ctx, "FFFFFEFB--260-269.xdr.zstd").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFEF1--270-279.xdr.zstd").Return(true, nil).Once()
-
-	//"Data store is not beyond start ledger"
-	mockDataStore.On("Exists", ctx, "FFFFFF87--120-129.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFF91--110-119.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFF9B--100-109.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFFA5--90-99.xdr.zstd").Return(false, nil).Once()
-
-	//"No end ledger provided, data store not beyond start" uses latest from network="test2"
-	mockDataStore.On("Exists", ctx, "FFFFF9A1--1630-1639.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFA91--1390-1399.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFB13--1260-1269.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFB4F--1200-1209.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFB77--1160-1169.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFB6D--1170-1179.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFB81--1150-1159.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFFB8B--1140-1149.xdr.zstd").Return(false, nil).Once()
-
-	//"No end ledger provided, data store is beyond start" uses latest from network="test3"
-	mockDataStore.On("Exists", ctx, "FFFFF5B9--2630-2639.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFF6A9--2390-2399.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFF72B--2260-2269.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFF735--2250-2259.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFF73F--2240-2249.xdr.zstd").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFF749--2230-2239.xdr.zstd").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFF767--2200-2209.xdr.zstd").Return(true, nil).Once()
-
-	//"No end ledger provided, data store is beyond start and archive network latest, and partially into checkpoint frequency padding" uses latest from network="test4"
-	mockDataStore.On("Exists", ctx, "FFFFF1D1--3630-3639.xdr.zstd").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFF0D7--3880-3889.xdr.zstd").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFF05F--4000-4009.xdr.zstd").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFF023--4060-4069.xdr.zstd").Return(true, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFF005--4090-4099.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFF00F--4080-4089.xdr.zstd").Return(false, nil).Once()
-	mockDataStore.On("Exists", ctx, "FFFFF019--4070-4079.xdr.zstd").Return(false, nil).Once()
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockArchive := &historyarchive.MockArchive{}
 			mockArchive.On("GetRootHAS").Return(historyarchive.HistoryArchiveState{CurrentLedger: tt.latestLedger}, tt.archiveError).Once()
+
+			mockDataStore := &MockDataStore{}
+			tt.registerMockCalls(mockDataStore)
 
 			resumableManager := NewResumableManager(mockDataStore, tt.networkName, tt.ledgerBatchConfig, mockArchive)
 			absentLedger, ok, err := resumableManager.FindStart(ctx, tt.startLedger, tt.endLedger)
@@ -315,8 +317,8 @@ func TestResumability(t *testing.T) {
 				// archives are only expected to be called when end = 0
 				mockArchive.AssertExpectations(t)
 			}
+			mockDataStore.AssertExpectations(t)
 		})
 	}
 
-	mockDataStore.AssertExpectations(t)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Adjacent ranges may end up overlapping due to the clamping behavior in [`adjustLedgerRange()`](https://github.com/stellar/go/blob/fff01229a5af77dee170a37bf0c71b2ce8bb8474/exp/services/ledgerexporter/internal/config.go#L173-L192)

For example, assuming 64 ledgers per file, [2, 100] and [101, 150] get adjusted to [2, 127] and [64, 191]

If we export [64, 191] and then try to resume on [2, 127], the binary search logic will determine that [2, 127] is fully exported because:

1. the midpoint [2, 127] is 64
2. ledger 64 is present on the data store given that we already exported [64, 191]

This behavior will therefore return an incorrect result if ledgers [2, 63] are missing from the data store.

We can fix this issue by querying the end ledger and, if it is present, only do the binary search on all the preceding files. So, in the example above, when exporting [2, 127], we will:

1. check if ledger 127 is present on the data store
2. since the ledger is present we will only do the binary search on the range of [2, 63] instead of [2, 127]
3. If the ledger file corresponding to [2, 63] is missing, resumability will correctly determine we must start from ledger 2


Note that if there is an overlap in adjacent ranges caused by [`adjustLedgerRange()`](https://github.com/stellar/go/blob/fff01229a5af77dee170a37bf0c71b2ce8bb8474/exp/services/ledgerexporter/internal/config.go#L173-L192), the size of the overlap will never be larger than the number of files per partition and that is why it is sufficient to only check if the end ledger is present.

### Known limitations

[N/A]
