### PR TITLE
services/horizon/internal: Add flag to enable / disable reaping of lookup tables

### DIFF
--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -85,6 +85,8 @@ type Config struct {
 	// If ReapFrequency is set to 2 history is reaped after ingesting every two ledgers.
 	// etc...
 	ReapFrequency uint
+	// ReapLookupTables enables the reaping of history lookup tables
+	ReapLookupTables bool
 	// StaleThreshold represents the number of ledgers a history database may be
 	// out-of-date by before horizon begins to respond with an error to history
 	// requests.

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -687,6 +687,14 @@ func Flags() (*Config, support.ConfigOptions) {
 				return nil
 			},
 		},
+		{
+			Name:           "reap-lookup-tables",
+			ConfigKey:      &config.ReapLookupTables,
+			OptType:        types.Bool,
+			FlagDefault:    true,
+			Usage:          "enables the reaping of history lookup tables.",
+			UsedInCommands: IngestionCommands,
+		},
 		&support.ConfigOption{
 			Name:           "history-stale-threshold",
 			ConfigKey:      &config.StaleThreshold,

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -95,7 +95,7 @@ type Config struct {
 	HistoryArchiveCaching bool
 
 	DisableStateVerification     bool
-	EnableReapLookupTables       bool
+	ReapLookupTables             bool
 	EnableExtendedLogLedgerStats bool
 
 	MaxReingestRetries          int
@@ -757,7 +757,7 @@ func (s *system) maybeVerifyState(lastIngestedLedger uint32, expectedBucketListH
 }
 
 func (s *system) maybeReapLookupTables(lastIngestedLedger uint32) {
-	if !s.config.EnableReapLookupTables {
+	if !s.config.ReapLookupTables {
 		return
 	}
 

--- a/services/horizon/internal/ingest/resume_state_test.go
+++ b/services/horizon/internal/ingest/resume_state_test.go
@@ -402,9 +402,9 @@ func (s *ResumeTestTestSuite) TestReapingObjectsDisabled() {
 }
 
 func (s *ResumeTestTestSuite) TestErrorReapingObjectsIgnored() {
-	s.system.config.EnableReapLookupTables = true
+	s.system.config.ReapLookupTables = true
 	defer func() {
-		s.system.config.EnableReapLookupTables = false
+		s.system.config.ReapLookupTables = false
 	}()
 	s.historyQ.On("Begin", s.ctx).Return(nil).Once()
 	s.historyQ.On("GetLastLedgerIngest", s.ctx).Return(uint32(100), nil).Once()

--- a/services/horizon/internal/init.go
+++ b/services/horizon/internal/init.go
@@ -99,7 +99,7 @@ func initIngester(app *App) {
 		DisableStateVerification:             app.config.IngestDisableStateVerification,
 		StateVerificationCheckpointFrequency: uint32(app.config.IngestStateVerificationCheckpointFrequency),
 		StateVerificationTimeout:             app.config.IngestStateVerificationTimeout,
-		EnableReapLookupTables:               app.config.HistoryRetentionCount > 0,
+		ReapLookupTables:                     app.config.ReapLookupTables && app.config.HistoryRetentionCount > 0,
 		EnableExtendedLogLedgerStats:         app.config.IngestEnableExtendedLogLedgerStats,
 		RoundingSlippageFilter:               app.config.RoundingSlippageFilter,
 		SkipTxmeta:                           app.config.SkipTxmeta,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add flag to enable / disable reaping of lookup tables.

### Why

Reaping of lookup tables is an operation which blocks the ingestion thread and it can be a lengthy operation. We need to have a mechanism to disable reaping of lookup tables while still enabling reaping of history so we can prevent ingestion lag from occurring when reaping of lookup tables takes too long.

Note that it is safe to run horizon with reaping of history enabled and reaping of lookup tables disabled. The only negative consequence of such a configuration is that there may be rows in the lookup tables which are not referenced anymore (e.g. a history account id which is no longer used in any of the history tables). But, once reaping of lookup tables is re-enabled those rows should eventually be deleted.

### Known limitations

[N/A]
