### PR TITLE
Create CI workflow for ledger exporter release

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -149,30 +149,3 @@ jobs:
         name: Push to DockerHub
         run: docker push stellar/horizon-verify-range:latest
 
-  ledger-exporter:
-    name: Test and push the Ledger Exporter images
-    runs-on: ubuntu-latest
-    env:
-      STELLAR_CORE_VERSION: 21.0.0-1872.c6f474133.focal
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          # For pull requests, build and test the PR head not a merge of the PR with the destination.
-          ref:  ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: Build Ledger Exporter docker
-        run: make -C exp/services/ledgerexporter docker-build
-
-      - name: Run Ledger Exporter test
-        run: make -C exp/services/ledgerexporter docker-test
-
-      # Push images
-      - if: github.ref == 'refs/heads/master'
-        name: Login to DockerHub
-        uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - if: github.ref == 'refs/heads/master'
-        name: Push to DockerHub
-        run: make -C exp/services/ledgerexporter docker-push

--- a/.github/workflows/ledgerexporter-release.yml
+++ b/.github/workflows/ledgerexporter-release.yml
@@ -1,0 +1,36 @@
+name: Ledger Exporter release
+
+on:
+  push:
+    tags: ['ledgerexporter-v*']
+
+jobs:
+
+  publish-docker:
+    name: Test and push the Ledger Exporter images
+    runs-on: ubuntu-latest
+    env:
+      STELLAR_CORE_VERSION: 21.0.0-1872.c6f474133.focal
+      VERSION: ${GITHUB_REF_NAME#ledgerexporter-v}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # For pull requests, build and test the PR head not a merge of the PR with the destination.
+          ref:  ${{ github.event.pull_request.head.sha || github.ref }}
+      - name: Build Ledger Exporter docker
+        run: make -C exp/services/ledgerexporter docker-build
+
+      - name: Run Ledger Exporter test
+        run: make -C exp/services/ledgerexporter docker-test
+
+      # Push images
+      - if: github.ref == 'refs/heads/master'
+        name: Login to DockerHub
+        uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - if: github.ref == 'refs/heads/master'
+        name: Push to DockerHub
+        run: make -C exp/services/ledgerexporter docker-push

--- a/.github/workflows/ledgerexporter-release.yml
+++ b/.github/workflows/ledgerexporter-release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           # For pull requests, build and test the PR head not a merge of the PR with the destination.
-          ref:  ${{ github.event.pull_request.head.sha || github.ref }}
+          ref: github.sha
       - name: Build Ledger Exporter docker
         run: make -C exp/services/ledgerexporter docker-build
 
@@ -24,13 +24,11 @@ jobs:
         run: make -C exp/services/ledgerexporter docker-test
 
       # Push images
-      - if: github.ref == 'refs/heads/master'
-        name: Login to DockerHub
+      - name: Login to DockerHub
         uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - if: github.ref == 'refs/heads/master'
-        name: Push to DockerHub
+      - name: Push to DockerHub
         run: make -C exp/services/ledgerexporter docker-push

--- a/.github/workflows/ledgerexporter-release.yml
+++ b/.github/workflows/ledgerexporter-release.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # For pull requests, build and test the PR head not a merge of the PR with the destination.
           ref: github.sha
       - name: Build Ledger Exporter docker
         run: make -C exp/services/ledgerexporter docker-build

--- a/.github/workflows/ledgerexporter-release.yml
+++ b/.github/workflows/ledgerexporter-release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Test and push the Ledger Exporter images
     runs-on: ubuntu-latest
     env:
-      STELLAR_CORE_VERSION: 21.0.0-1872.c6f474133.focal
+      STELLAR_CORE_VERSION: 21.1.0-1921.b3aeb14cc.focal
       VERSION: ${GITHUB_REF_NAME#ledgerexporter-v}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ledgerexporter.yml
+++ b/.github/workflows/ledgerexporter.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build and test Ledger Exporter image
     runs-on: ubuntu-latest
     env:
-      STELLAR_CORE_VERSION: 21.0.0-1872.c6f474133.focal
+      STELLAR_CORE_VERSION: 21.1.0-1921.b3aeb14cc.focal
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ledgerexporter.yml
+++ b/.github/workflows/ledgerexporter.yml
@@ -1,0 +1,24 @@
+name: LedgerExporter
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  ledger-exporter:
+    name: Build and test Ledger Exporter image
+    runs-on: ubuntu-latest
+    env:
+      STELLAR_CORE_VERSION: 21.0.0-1872.c6f474133.focal
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # For pull requests, build and test the PR head not a merge of the PR with the destination.
+          ref:  ${{ github.event.pull_request.head.sha || github.ref }}
+      - name: Build Ledger Exporter docker
+        run: make -C exp/services/ledgerexporter docker-build
+
+      - name: Run Ledger Exporter test
+        run: make -C exp/services/ledgerexporter docker-test
+

--- a/exp/services/ledgerexporter/Makefile
+++ b/exp/services/ledgerexporter/Makefile
@@ -2,7 +2,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 BUILD_DATE := $(shell date -u +%FT%TZ)
-VERSION ?= 1.0.0-$(shell git rev-parse --short HEAD)
+VERSION ?= $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE := stellar/ledger-exporter
 
 docker-build:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Two new git CI workflows for the ledger exporter:

1. PR Workflow: Runs whenever a pull request is merged to the master branch and does the following:
- Builds the ledger exporter docker image.
- Tests the image using a fake-gcs-storage emulator.

2. Release Workflow: Runs whenever a release tag is created for the ledger exporter and does the following:
- Extracts the version number from the branch name (e.g., "ledgerexporter-v1.2").
- Builds a docker image tagged with stellar/ledger-exporter:<version_number> (e.g., "stellar/ledger-exporter:1.2").
- Pushes the built image to the Stellar docker repo.

### Why

Fixes [HUBBLE-492
](https://stellarorg.atlassian.net/browse/HUBBLE-492)

### Known limitations

N/A