### PR TITLE
Update URLs to Developer Documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ change is, and why it is being made, with enough context for anyone to understan
 
 <details>
   <summary>PR Checklist</summary>
-  
+
 ### PR Structure
 
 * [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
@@ -17,7 +17,7 @@ change is, and why it is being made, with enough context for anyone to understan
 ### Thoroughness
 
 * [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
-* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
+* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/docs/data/horizon), `.md`
   files, etc... affected by this change). Take a look in the `docs` folder for a given service,
   like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
 

--- a/address/main.go
+++ b/address/main.go
@@ -1,5 +1,5 @@
 // Package address provides utility functions for working with stellar
-// addresses. See https://developers.stellar.org/docs/glossary/federation/
+// addresses. See https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/federation
 // html#stellar-addresses for more on addresses.
 package address
 

--- a/clients/horizonclient/README.md
+++ b/clients/horizonclient/README.md
@@ -1,7 +1,7 @@
 # horizonclient
 
 
-`horizonclient` is a [Stellar Go SDK](https://developers.stellar.org/api/) package that provides client access to a horizon server. It supports all endpoints exposed by the [horizon API](https://developers.stellar.org/api/introduction/).
+`horizonclient` is a [Stellar Go SDK](https://developers.stellar.org/docs/data/horizon) package that provides client access to a horizon server. It supports all endpoints exposed by the [horizon API](https://developers.stellar.org/docs/data/horizon/api-reference).
 
 This project is maintained by the Stellar Development Foundation.
 

--- a/clients/horizonclient/client.go
+++ b/clients/horizonclient/client.go
@@ -296,14 +296,14 @@ func (c *Client) HorizonTimeout() time.Duration {
 
 // Accounts returns accounts who have a given signer or
 // have a trustline to an asset.
-// See https://developers.stellar.org/api/resources/accounts/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/accounts
 func (c *Client) Accounts(request AccountsRequest) (accounts hProtocol.AccountsPage, err error) {
 	err = c.sendRequest(request, &accounts)
 	return
 }
 
 // AccountDetail returns information for a single account.
-// See https://developers.stellar.org/api/resources/accounts/single/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/retrieve-an-account
 func (c *Client) AccountDetail(request AccountRequest) (account hProtocol.Account, err error) {
 	if request.AccountID == "" {
 		err = errors.New("no account ID provided")
@@ -318,7 +318,7 @@ func (c *Client) AccountDetail(request AccountRequest) (account hProtocol.Accoun
 }
 
 // AccountData returns a single data associated with a given account
-// See https://developers.stellar.org/api/resources/accounts/data/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/get-data-by-account-id
 func (c *Client) AccountData(request AccountRequest) (accountData hProtocol.AccountData, err error) {
 	if request.AccountID == "" || request.DataKey == "" {
 		err = errors.New("too few parameters")
@@ -332,7 +332,7 @@ func (c *Client) AccountData(request AccountRequest) (accountData hProtocol.Acco
 	return
 }
 
-// Effects returns effects (https://developers.stellar.org/api/resources/effects/)
+// Effects returns effects (https://developers.stellar.org/docs/data/horizon/api-reference/resources/effects)
 // It can be used to return effects for an account, a ledger, an operation, a transaction and all effects on the network.
 func (c *Client) Effects(request EffectRequest) (effects effects.EffectsPage, err error) {
 	err = c.sendRequest(request, &effects)
@@ -340,21 +340,21 @@ func (c *Client) Effects(request EffectRequest) (effects effects.EffectsPage, er
 }
 
 // Assets returns asset information.
-// See https://developers.stellar.org/api/resources/assets/list/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/list-all-assets
 func (c *Client) Assets(request AssetRequest) (assets hProtocol.AssetsPage, err error) {
 	err = c.sendRequest(request, &assets)
 	return
 }
 
 // Ledgers returns information about all ledgers.
-// See https://developers.stellar.org/api/resources/ledgers/list/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/list-all-ledgers
 func (c *Client) Ledgers(request LedgerRequest) (ledgers hProtocol.LedgersPage, err error) {
 	err = c.sendRequest(request, &ledgers)
 	return
 }
 
 // LedgerDetail returns information about a particular ledger for a given sequence number
-// See https://developers.stellar.org/api/resources/ledgers/single/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/retrieve-a-ledger
 func (c *Client) LedgerDetail(sequence uint32) (ledger hProtocol.Ledger, err error) {
 	if sequence == 0 {
 		err = errors.New("invalid sequence number provided")
@@ -370,7 +370,7 @@ func (c *Client) LedgerDetail(sequence uint32) (ledger hProtocol.Ledger, err err
 }
 
 // FeeStats returns information about fees in the last 5 ledgers.
-// See https://developers.stellar.org/api/aggregations/fee-stats/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/aggregations/fee-stats
 func (c *Client) FeeStats() (feestats hProtocol.FeeStats, err error) {
 	request := feeStatsRequest{endpoint: "fee_stats"}
 	err = c.sendRequest(request, &feestats)
@@ -378,14 +378,14 @@ func (c *Client) FeeStats() (feestats hProtocol.FeeStats, err error) {
 }
 
 // Offers returns information about offers made on the SDEX.
-// See https://developers.stellar.org/api/resources/offers/list/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/get-all-offers
 func (c *Client) Offers(request OfferRequest) (offers hProtocol.OffersPage, err error) {
 	err = c.sendRequest(request, &offers)
 	return
 }
 
 // OfferDetails returns information for a single offer.
-// See https://developers.stellar.org/api/resources/offers/single/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/get-offer-by-offer-id
 func (c *Client) OfferDetails(offerID string) (offer hProtocol.Offer, err error) {
 	if len(offerID) == 0 {
 		err = errors.New("no offer ID provided")
@@ -401,7 +401,7 @@ func (c *Client) OfferDetails(offerID string) (offer hProtocol.Offer, err error)
 	return
 }
 
-// Operations returns stellar operations (https://developers.stellar.org/api/resources/operations/list/)
+// Operations returns stellar operations (https://developers.stellar.org/docs/data/horizon/api-reference/resources/list-all-operations)
 // It can be used to return operations for an account, a ledger, a transaction and all operations on the network.
 func (c *Client) Operations(request OperationRequest) (ops operations.OperationsPage, err error) {
 	err = c.sendRequest(request.SetOperationsEndpoint(), &ops)
@@ -409,7 +409,7 @@ func (c *Client) Operations(request OperationRequest) (ops operations.Operations
 }
 
 // OperationDetail returns a single stellar operation for a given operation id
-// See https://developers.stellar.org/api/resources/operations/single/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/retrieve-an-operation
 func (c *Client) OperationDetail(id string) (ops operations.Operation, err error) {
 	if id == "" {
 		return ops, errors.New("invalid operation id provided")
@@ -479,7 +479,7 @@ func (c *Client) validateTx(transaction *txnbuild.Transaction, opts SubmitTxOpts
 }
 
 // SubmitTransactionXDR submits a transaction represented as a base64 XDR string to the network. err can be either error object or horizon.Error object.
-// See https://developers.stellar.org/api/resources/transactions/post/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/submit-a-transaction
 func (c *Client) SubmitTransactionXDR(transactionXdr string) (tx hProtocol.Transaction,
 	err error) {
 	request := submitRequest{endpoint: "transactions", transactionXdr: transactionXdr}
@@ -495,7 +495,7 @@ func (c *Client) SubmitTransactionXDR(transactionXdr string) (tx hProtocol.Trans
 //
 // If you want to skip this check, use SubmitTransactionWithOptions.
 //
-// See https://developers.stellar.org/api/resources/transactions/post/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/submit-a-transaction
 func (c *Client) SubmitFeeBumpTransaction(transaction *txnbuild.FeeBumpTransaction) (tx hProtocol.Transaction, err error) {
 	return c.SubmitFeeBumpTransactionWithOptions(transaction, SubmitTxOpts{})
 }
@@ -503,7 +503,7 @@ func (c *Client) SubmitFeeBumpTransaction(transaction *txnbuild.FeeBumpTransacti
 // SubmitFeeBumpTransactionWithOptions submits a fee bump transaction to the network, allowing
 // you to pass SubmitTxOpts. err can be either an error object or a horizon.Error object.
 //
-// See https://developers.stellar.org/api/resources/transactions/post/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/submit-a-transaction
 func (c *Client) SubmitFeeBumpTransactionWithOptions(transaction *txnbuild.FeeBumpTransaction, opts SubmitTxOpts) (tx hProtocol.Transaction, err error) {
 	// only check if memo is required if skip is false and the inner transaction
 	// doesn't have a memo.
@@ -523,7 +523,7 @@ func (c *Client) SubmitFeeBumpTransactionWithOptions(transaction *txnbuild.FeeBu
 //
 // If you want to skip this check, use SubmitTransactionWithOptions.
 //
-// See https://developers.stellar.org/api/resources/transactions/post/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/submit-a-transaction
 func (c *Client) SubmitTransaction(transaction *txnbuild.Transaction) (tx hProtocol.Transaction, err error) {
 	return c.SubmitTransactionWithOptions(transaction, SubmitTxOpts{})
 }
@@ -531,7 +531,7 @@ func (c *Client) SubmitTransaction(transaction *txnbuild.Transaction) (tx hProto
 // SubmitTransactionWithOptions submits a transaction to the network, allowing
 // you to pass SubmitTxOpts. err can be either an error object or a horizon.Error object.
 //
-// See https://developers.stellar.org/api/resources/transactions/post/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/submit-a-transaction
 func (c *Client) SubmitTransactionWithOptions(transaction *txnbuild.Transaction, opts SubmitTxOpts) (tx hProtocol.Transaction, err error) {
 	// only check if memo is required if skip is false and the transaction
 	// doesn't have a memo.
@@ -599,7 +599,7 @@ func (c *Client) AsyncSubmitTransactionWithOptions(transaction *txnbuild.Transac
 	return c.AsyncSubmitTransactionXDR(txeBase64)
 }
 
-// Transactions returns stellar transactions (https://developers.stellar.org/api/resources/transactions/list/)
+// Transactions returns stellar transactions (https://developers.stellar.org/docs/data/horizon/api-reference/resources/list-all-transactions)
 // It can be used to return transactions for an account, a ledger,and all transactions on the network.
 func (c *Client) Transactions(request TransactionRequest) (txs hProtocol.TransactionsPage, err error) {
 	err = c.sendRequest(request, &txs)
@@ -607,7 +607,7 @@ func (c *Client) Transactions(request TransactionRequest) (txs hProtocol.Transac
 }
 
 // TransactionDetail returns information about a particular transaction for a given transaction hash
-// See https://developers.stellar.org/api/resources/transactions/single/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/resources/retrieve-a-transaction
 func (c *Client) TransactionDetail(txHash string) (tx hProtocol.Transaction, err error) {
 	if txHash == "" {
 		return tx, errors.New("no transaction hash provided")
@@ -618,26 +618,26 @@ func (c *Client) TransactionDetail(txHash string) (tx hProtocol.Transaction, err
 	return
 }
 
-// OrderBook returns the orderbook for an asset pair (https://developers.stellar.org/api/aggregations/order-books/single/)
+// OrderBook returns the orderbook for an asset pair (https://developers.stellar.org/docs/data/horizon/api-reference/aggregations/order-books/single)
 func (c *Client) OrderBook(request OrderBookRequest) (obs hProtocol.OrderBookSummary, err error) {
 	err = c.sendRequest(request, &obs)
 	return
 }
 
-// Paths returns the available paths to make a strict receive path payment. See https://developers.stellar.org/api/aggregations/paths/strict-receive/
+// Paths returns the available paths to make a strict receive path payment. See https://developers.stellar.org/docs/data/horizon/api-reference/aggregations/paths/strict-receive
 // This function is an alias for `client.StrictReceivePaths` and will be deprecated, use `client.StrictReceivePaths` instead.
 func (c *Client) Paths(request PathsRequest) (paths hProtocol.PathsPage, err error) {
 	paths, err = c.StrictReceivePaths(request)
 	return
 }
 
-// StrictReceivePaths returns the available paths to make a strict receive path payment. See https://developers.stellar.org/api/aggregations/paths/strict-receive/
+// StrictReceivePaths returns the available paths to make a strict receive path payment. See https://developers.stellar.org/docs/data/horizon/api-reference/aggregations/paths/strict-receive
 func (c *Client) StrictReceivePaths(request PathsRequest) (paths hProtocol.PathsPage, err error) {
 	err = c.sendRequest(request, &paths)
 	return
 }
 
-// StrictSendPaths returns the available paths to make a strict send path payment. See https://developers.stellar.org/api/aggregations/paths/strict-send/
+// StrictSendPaths returns the available paths to make a strict send path payment. See https://developers.stellar.org/docs/data/horizon/api-reference/aggregations/paths/strict-send
 func (c *Client) StrictSendPaths(request StrictSendPathsRequest) (paths hProtocol.PathsPage, err error) {
 	err = c.sendRequest(request, &paths)
 	return
@@ -650,7 +650,7 @@ func (c *Client) Payments(request OperationRequest) (ops operations.OperationsPa
 	return
 }
 
-// Trades returns stellar trades (https://developers.stellar.org/api/resources/trades/list/)
+// Trades returns stellar trades (https://developers.stellar.org/docs/data/horizon/api-reference/resources/get-all-trades)
 // It can be used to return trades for an account, an offer and all trades on the network.
 func (c *Client) Trades(request TradeRequest) (tds hProtocol.TradesPage, err error) {
 	err = c.sendRequest(request, &tds)
@@ -658,7 +658,7 @@ func (c *Client) Trades(request TradeRequest) (tds hProtocol.TradesPage, err err
 }
 
 // Fund creates a new account funded from friendbot. It only works on test networks. See
-// https://developers.stellar.org/docs/tutorials/create-account/ for more information.
+// https://developers.stellar.org/docs/build/guides/basics/create-account for more information.
 func (c *Client) Fund(addr string) (tx hProtocol.Transaction, err error) {
 	friendbotURL := fmt.Sprintf("%sfriendbot?addr=%s", c.fixHorizonURL(), addr)
 	err = c.sendGetRequest(friendbotURL, &tx)
@@ -676,7 +676,7 @@ func (c *Client) StreamTrades(ctx context.Context, request TradeRequest, handler
 	return
 }
 
-// TradeAggregations returns stellar trade aggregations (https://developers.stellar.org/api/aggregations/trade-aggregations/list/)
+// TradeAggregations returns stellar trade aggregations (https://developers.stellar.org/docs/data/horizon/api-reference/aggregations/trade-aggregations/list)
 func (c *Client) TradeAggregations(request TradeAggregationRequest) (tds hProtocol.TradeAggregationsPage, err error) {
 	err = c.sendRequest(request, &tds)
 	return

--- a/clients/horizonclient/main.go
+++ b/clients/horizonclient/main.go
@@ -391,7 +391,7 @@ type OrderBookRequest struct {
 // PathsRequest struct contains data for getting available strict receive path payments from a horizon server.
 // All the Destination related parameters are required and you need to include either
 // SourceAccount or SourceAssets.
-// See https://developers.stellar.org/api/aggregations/paths/strict-receive/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/aggregations/paths/strict-receive
 type PathsRequest struct {
 	DestinationAccount     string
 	DestinationAssetType   AssetType
@@ -405,7 +405,7 @@ type PathsRequest struct {
 // StrictSendPathsRequest struct contains data for getting available strict send path payments from a horizon server.
 // All the Source related parameters are required and you need to include either
 // DestinationAccount or DestinationAssets.
-// See https://developers.stellar.org/api/aggregations/paths/strict-send/
+// See https://developers.stellar.org/docs/data/horizon/api-reference/aggregations/paths/strict-send
 type StrictSendPathsRequest struct {
 	DestinationAccount string
 	DestinationAssets  string

--- a/clients/horizonclient/main_test.go
+++ b/clients/horizonclient/main_test.go
@@ -2241,7 +2241,7 @@ var multipleOpsResponse = `{
         "selling_asset_code": "XRP",
         "selling_asset_issuer": "GBVOL67TMUQBGL4TZYNMY3ZQ5WGQYFPFD5VJRWXR72VA33VFNL225PL5",
         "offer_id": "73938565"
-      },  
+      },
       {
         "_links": {
           "self": {
@@ -2271,7 +2271,7 @@ var multipleOpsResponse = `{
         "starting_balance": "2.0000000",
         "funder": "GD7C4MQJDM3AHXKO2Z2OF7BK3FYL6QMNBGVEO4H2DHM65B7JMHD2IU2E",
         "account": "GD6LCN37TNJZW3JF2R7N5EYGQGVWRPMSGQHR6RZD4X4NATEQLP7RFAMA"
-      }          
+      }
     ]
   }
 }`
@@ -2361,7 +2361,7 @@ var transactionFailure = `{
   "type": "https://stellar.org/horizon-errors/transaction_failed",
   "title": "Transaction Failed",
   "status": 400,
-  "detail": "The transaction failed when submitted to the stellar network. The extras.result_codes field on this response contains further details.  Descriptions of each code can be found at: https://developers.stellar.org/docs/start/list-of-operations/",
+  "detail": "The transaction failed when submitted to the stellar network. The extras.result_codes field on this response contains further details.  Descriptions of each code can be found at: https://developers.stellar.org/docs/data/horizon/api-reference/aggregations/order-books/single",
   "instance": "horizon-testnet-001.prd.stellar001.internal.stellar-ops.com/4elYz2fHhC-528285",
   "extras": {
     "envelope_xdr": "AAAAAKpmDL6Z4hvZmkTBkYpHftan4ogzTaO4XTB7joLgQnYYAAAAZAAAAAAABeoyAAAAAAAAAAEAAAAAAAAAAQAAAAAAAAABAAAAAD3sEVVGZGi/NoC3ta/8f/YZKMzyi9ZJpOi0H47x7IqYAAAAAAAAAAAF9eEAAAAAAAAAAAA=",

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -7,7 +7,7 @@ The Go SDK is a set of packages for interacting with most aspects of the Stellar
 ## Horizon SDK
 
 The Horizon SDK is composed of two complementary libraries: `txnbuild` + `horizonclient`.
-The `txnbuild` ([source](https://github.com/stellar/go/tree/master/txnbuild), [docs](https://godoc.org/github.com/stellar/go/txnbuild)) package enables the construction, signing and encoding of Stellar [transactions](https://developers.stellar.org/docs/glossary/transactions/) and [operations](https://developers.stellar.org/docs/start/list-of-operations/) in Go. The `horizonclient` ([source](https://github.com/stellar/go/tree/master/clients/horizonclient), [docs](https://godoc.org/github.com/stellar/go/clients/horizonclient)) package provides a web client for interfacing with [Horizon](https://developers.stellar.org/docs/start/introduction/) server REST endpoints to retrieve ledger information, and to submit transactions built with `txnbuild`.
+The `txnbuild` ([source](https://github.com/stellar/go/tree/master/txnbuild), [docs](https://godoc.org/github.com/stellar/go/txnbuild)) package enables the construction, signing and encoding of Stellar [transactions](https://developers.stellar.org/docs/learn/glossary#transaction) and [operations](https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations) in Go. The `horizonclient` ([source](https://github.com/stellar/go/tree/master/clients/horizonclient), [docs](https://godoc.org/github.com/stellar/go/clients/horizonclient)) package provides a web client for interfacing with [Horizon](https://developers.stellar.org/docs/data/horizon) server REST endpoints to retrieve ledger information, and to submit transactions built with `txnbuild`.
 
 ## List of major SDK packages
 

--- a/exp/services/ledgerexporter/DEVELOPER_GUIDE.md
+++ b/exp/services/ledgerexporter/DEVELOPER_GUIDE.md
@@ -24,16 +24,16 @@ To achieve its goals, the ledger exporter uses the following architecture, which
 ## Data Format
 - Ledger exporter uses a compact and efficient data format called [XDR](https://developers.stellar.org/docs/learn/encyclopedia/data-format/xdr) (External Data Representation), which is a compact binary format. A Stellar Captive Core instance emits data in this format and the data structure is referred to as `LedgerCloseMeta`. The exporter bundles multiple `LedgerCloseMeta`'s into a single object using a custom XDR structure called `LedgerCloseMetaBatch` which is defined in [Stellar-exporter.x](https://github.com/stellar/go/blob/master/xdr/Stellar-exporter.x).
 
-- The metadata for the same batch is also stored alongside each exported object. Supported metadata is defined in [metadata.go](https://github.com/stellar/go/blob/master/support/datastore/metadata.go). 
+- The metadata for the same batch is also stored alongside each exported object. Supported metadata is defined in [metadata.go](https://github.com/stellar/go/blob/master/support/datastore/metadata.go).
 
 - Objects are compressed before uploading using the [zstd](http://facebook.github.io/zstd/) (zstandard) compression algorithm to optimize network usage and storage needs.
 
 ## Data Storage
-- An example implementation of `DataStore` for GCS, Google Cloud Storage. This plugin is located in the [support](https://github.com/stellar/go/tree/master/support/datastore) package. 
+- An example implementation of `DataStore` for GCS, Google Cloud Storage. This plugin is located in the [support](https://github.com/stellar/go/tree/master/support/datastore) package.
 - The ledger exporter currently implements the interface only for Google Cloud Storage (GCS). The [GCS plugin](https://github.com/stellar/go/blob/master/support/datastore/gcs_datastore.go) uses GCS-specific behaviors like conditional puts, automatic retry, metadata, and CRC checksum.
 
 ## Build, Run and Test using Docker
-The Dockerfile contains all the necessary dependencies (e.g., Stellar-core) required to run the ledger exporter. 
+The Dockerfile contains all the necessary dependencies (e.g., Stellar-core) required to run the ledger exporter.
 
 - Build: To build the Docker container, use the provided [Makefile](./Makefile). Simply run make `make docker-build` to build a new container after making any changes.
 
@@ -45,7 +45,7 @@ The Dockerfile contains all the necessary dependencies (e.g., Stellar-core) requ
 Support for different data storage types are encapsulated as 'plugins', which are implementation of `DataStore` interface in a go package. To add a data storage plugin based on a new storage type (e.g. AWS S3), follow these steps:
 
 - A data storage plugin must implement the [DataStore](https://github.com/stellar/go/blob/master/support/datastore/datastore.go) interface.
-- Add support for new datastore-specific features. Implement any datastore-specific custom logic. Different datastores have different ways of handling 
+- Add support for new datastore-specific features. Implement any datastore-specific custom logic. Different datastores have different ways of handling
   - race conditions
   - automatic retries
   - metadata storage, etc.

--- a/protocols/horizon/README.md
+++ b/protocols/horizon/README.md
@@ -17,7 +17,7 @@ For each new version we will only track changes from the previous version.
 
 #### Changes
 
-* In ["Transaction"](https://developers.stellar.org/api/horizon/resources/transactions/object),
+* In ["Transaction"](https://developers.stellar.org/docs/data/horizon/api-reference/resources/transactions/object),
 `result_meta_xdr` field is [now nullable](https://github.com/stellar/go/pull/5228), and will be `null` when Horizon has `SKIP_TXMETA=true` set, otherwise if Horizon is configured with `SKIP_TXMETA=false` which is default, then `result_meta_xdr` will be the same value of base64 encoded xdr.
 * Operations responses may include a `transaction` field which represents the transaction that created the operation.
 
@@ -32,14 +32,14 @@ For each new version we will only track changes from the previous version.
 
 * Assets stats are disabled by default. This can be changed using an environment variable (`ENABLE_ASSET_STATS=true`) or
 CLI parameter (`--enable-asset-stats=true`). Please note that it has a negative impact on a DB and ingestion time.
-* In ["Offers for Account"](https://developers.stellar.org/api/resources/accounts/offers/),
+* In ["Offers for Account"](https://developers.stellar.org/docs/data/horizon/api-reference/resources/get-offers-by-account-id),
 `last_modified_time` field  endpoint can be `null` when ledger data is not available (has not been ingested yet).
-* ["Trades for Offer"](https://developers.stellar.org/api/resources/offers/trades/) endpoint
+* ["Trades for Offer"](https://developers.stellar.org/docs/data/horizon/api-reference/resources/get-trades-by-offer-id) endpoint
 will query for trades that match the given offer on either side of trades, rather than just the "sell" offer.
-Offer IDs are now [synthetic](https://developers.stellar.org/api/resources/trades/).
+Offer IDs are now [synthetic](https://developers.stellar.org/docs/data/horizon/api-reference/resources/trades).
 * New `/operation_fee_stats` endpoint includes fee stats for the last 5 ledgers.
-* ["Trades"](https://developers.stellar.org/api/resources/trades/list/) endpoint can now be streamed.
-* In ["Trade Aggregations"](https://developers.stellar.org/api/aggregations/trade-aggregations/list/) endpoint,
+* ["Trades"](https://developers.stellar.org/docs/data/horizon/api-reference/resources/get-all-trades) endpoint can now be streamed.
+* In ["Trade Aggregations"](https://developers.stellar.org/docs/data/horizon/api-reference/aggregations/trade-aggregations/list) endpoint,
 `offset` parameter has been added.
 * Account flags now display `auth_immutable` value.
 * Rate limiting in streams has been changed to be more fair. Now 1 *credit* has to be *paid* every time there's a new ledger

--- a/services/federation/README.md
+++ b/services/federation/README.md
@@ -1,7 +1,7 @@
 # federation server
 
 
-Go implementation of [Federation](https://developers.stellar.org/docs/glossary/federation/) protocol server. This federation server is designed to be dropped in to your existing infrastructure. It can be configured to pull the data it needs out of your existing DB.
+Go implementation of [Federation](https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/federation) protocol server. This federation server is designed to be dropped in to your existing infrastructure. It can be configured to pull the data it needs out of your existing DB.
 
 ## Downloading the server
 
@@ -17,8 +17,8 @@ By default this server uses a config file named `federation.cfg` in the current 
   * `dsn` - The DSN (data source name) used to connect to the database connection.  This value should be appropriate for the database type chosen.
     * for `postgres`: `postgres://user:password@host/dbname?sslmode=sslmode` ([more info](https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters))
 * `queries`
-  * `federation` - Implementation dependent query to fetch federation results, should return either 1 or 3 columns. These columns should be labeled `id`,`memo`,`memo_type`. Memo and memo_type are optional - see [Federation](https://developers.stellar.org/docs/glossary/federation/) docs for more detail).  When executed, this query will be provided with two input parameters, the first will be the name portion of a stellar address and the second will be the domain portion of a stellar address.  For example, a request for `scott*stellar.org` would trigger a query with two input parameters, `scott` and `stellar.org` respectively. 
-  * `reverse-federation` - A SQL query to fetch reverse federation results that should return two columns, labeled `name` and `domain`.   When executed, this query will be provided with one input parameter, a [stellar account ID](https://developers.stellar.org/docs/glossary/accounts/#account-id) used to lookup the name and domain mapping.
+  * `federation` - Implementation dependent query to fetch federation results, should return either 1 or 3 columns. These columns should be labeled `id`,`memo`,`memo_type`. Memo and memo_type are optional - see [Federation](https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/federation) docs for more detail).  When executed, this query will be provided with two input parameters, the first will be the name portion of a stellar address and the second will be the domain portion of a stellar address.  For example, a request for `scott*stellar.org` would trigger a query with two input parameters, `scott` and `stellar.org` respectively.
+  * `reverse-federation` - A SQL query to fetch reverse federation results that should return two columns, labeled `name` and `domain`.   When executed, this query will be provided with one input parameter, a [stellar account ID](https://developers.stellar.org/docs/learn/glossary#account-id) used to lookup the name and domain mapping.
 
     If reverse-lookup isn't supported (e.g. you have a single Stellar account for all users), leave this entry out.
 

--- a/services/horizon/README.md
+++ b/services/horizon/README.md
@@ -1,7 +1,7 @@
 # Horizon
 [![Build Status](https://circleci.com/gh/stellar/go.svg?style=shield)](https://circleci.com/gh/stellar/go)
 
-Horizon is the client facing API server for the [Stellar ecosystem](https://developers.stellar.org/docs/start/introduction/).  It acts as the interface between [Stellar Core](https://developers.stellar.org/docs/run-core-node/) and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.
+Horizon is the client facing API server for the [Stellar ecosystem](https://developers.stellar.org).  It acts as the interface between [Stellar Core](https://developers.stellar.org/docs/validators) and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.
 
 Check out the following resources to get started:
 - [Horizon Development Guide](internal/docs/GUIDE_FOR_DEVELOPERS.md): Instructions for building and developing Horizon. Covers setup, building, testing, and contributing. Also contains some helpful notes and context for Horizon developers.
@@ -10,7 +10,7 @@ Check out the following resources to get started:
 - [Horizon SDK and API Guide](internal/docs/SDK_API_GUIDE.md): Documentation on the Horizon SDKs, APIs, resources, and examples. Useful for developers building on top of Horizon.
 
 ## Run a production server
-If you're an administrator planning to run a production instance of Horizon as part of the public Stellar network, you should check out the instructions on our public developer docs - [Run an API Server](https://developers.stellar.org/docs/run-api-server/). It covers installation, monitoring, error scenarios and more.
+If you're an administrator planning to run a production instance of Horizon as part of the public Stellar network, you should check out the instructions on our public developer docs - [Run an API Server](https://developers.stellar.org/docs/data/horizon/admin-guide). It covers installation, monitoring, error scenarios and more.
 
 ## Contributing
 As an open source project, development of Horizon is public, and you can help! We welcome new issue reports, documentation and bug fixes, and contributions that further the project roadmap. The [Development Guide](internal/docs/GUIDE_FOR_DEVELOPERS.md) will show you how to build Horizon, see what's going on behind the scenes, and set up an effective develop-test-push cycle so that you can get your work incorporated quickly.

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -21,7 +21,7 @@ var (
 			"and applications that want to access the Stellar network. It allows you to submit transactions to the " +
 			"network, check the status of accounts, subscribe to event streams and more.\n" +
 			"DEPRECATED - the use of command-line flags has been deprecated in favor of environment variables. Please" +
-			"consult our Configuring section in the developer documentation on how to use them - https://developers.stellar.org/docs/run-api-server/configuring",
+			"consult our Configuring section in the developer documentation on how to use them - https://developers.stellar.org/docs/data/horizon/admin-guide/configuring",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app, err := horizon.NewAppFromFlags(globalConfig, globalFlags)
 			if err != nil {

--- a/services/horizon/internal/actions/submit_transaction.go
+++ b/services/horizon/internal/actions/submit_transaction.go
@@ -142,7 +142,7 @@ func (handler SubmitTransactionHandler) response(r *http.Request, info envelopeI
 			Detail: "The transaction failed when submitted to the stellar network. " +
 				"The `extras.result_codes` field on this response contains further " +
 				"details.  Descriptions of each code can be found at: " +
-				"https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/transaction-failed/",
+				"https://developers.stellar.org/docs/data/horizon/api-reference/errors/http-status-codes/horizon-specific/transaction-failed",
 			Extras: extras,
 		}
 	}

--- a/services/horizon/internal/actions/submit_transaction_async.go
+++ b/services/horizon/internal/actions/submit_transaction_async.go
@@ -81,7 +81,7 @@ func (handler AsyncSubmitTransactionHandler) GetResource(_ HeaderWriter, r *http
 			Detail: "Could not submit transaction to stellar-core. " +
 				"The `extras.error` field on this response contains further " +
 				"details.  Descriptions of each code can be found at: " +
-				"https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/transaction-submission-async/transaction_submission_failed",
+				"https://developers.stellar.org/docs/data/horizon/api-reference/errors/http-status-codes/horizon-specific/transaction-failed",
 			Extras: map[string]interface{}{
 				"envelope_xdr": raw,
 				"error":        err,
@@ -98,7 +98,7 @@ func (handler AsyncSubmitTransactionHandler) GetResource(_ HeaderWriter, r *http
 			Detail: "Received exception from stellar-core." +
 				"The `extras.error` field on this response contains further " +
 				"details.  Descriptions of each code can be found at: " +
-				"https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/transaction-submission-async/transaction_submission_exception",
+				"https://developers.stellar.org/docs/data/horizon/api-reference/errors/http-status-codes/horizon-specific/transaction-malformed",
 			Extras: map[string]interface{}{
 				"envelope_xdr": raw,
 				"error":        resp.Exception,
@@ -127,7 +127,7 @@ func (handler AsyncSubmitTransactionHandler) GetResource(_ HeaderWriter, r *http
 			Detail: "Received invalid status from stellar-core." +
 				"The `extras.error` field on this response contains further " +
 				"details.  Descriptions of each code can be found at: " +
-				"https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/transaction-submission-async/transaction_submission_invalid_status",
+				"https://developers.stellar.org/docs/data/horizon/api-reference/errors/http-status-codes/horizon-specific/timeout",
 			Extras: map[string]interface{}{
 				"envelope_xdr": raw,
 				"error":        resp.Error,

--- a/services/horizon/internal/docs/GUIDE_FOR_DEVELOPERS.md
+++ b/services/horizon/internal/docs/GUIDE_FOR_DEVELOPERS.md
@@ -17,8 +17,8 @@ git clone https://github.com/stellar/go.git
 If you want to contribute to the project, consider forking the repository and cloning the fork instead.
 
 ## Getting Started with Running Horizon
-The [start.sh](/services/horizon/docker/start.sh) script builds horizon from current source, and then runs docker-compose to start the docker containers with runtime configs for horizon, postgres, and optionally core if the optional `standalone` network parameter was included. 
-The script takes one optional parameter which configures the Stellar network used by the docker containers. If no parameter is supplied, the containers will run on the Stellar test network. Read more about the public and private networks in the [public documentation](https://developers.stellar.org/docs/fundamentals-and-concepts/testnet-and-pubnet#testnet)
+The [start.sh](/services/horizon/docker/start.sh) script builds horizon from current source, and then runs docker-compose to start the docker containers with runtime configs for horizon, postgres, and optionally core if the optional `standalone` network parameter was included.
+The script takes one optional parameter which configures the Stellar network used by the docker containers. If no parameter is supplied, the containers will run on the Stellar test network. Read more about the public and private networks in the [public documentation](https://developers.stellar.org/docs/learn/fundamentals/networks#testnet)
 
 `./services/horizon/docker/start.sh pubnet` will run the containers on the Stellar public network.
 
@@ -32,9 +32,9 @@ The following ports will be exposed:
 - Stellar-Core (If `standalone` specified): **11626**
 - Stellar-Core-Postgres (If `standalone` specified): **5641**
 
-Note that when you switch between different networks you will need to clear the Stellar Core and Stellar Horizon databases. You can wipe out the databases by running `docker-compose down --remove-orphans -v`. 
+Note that when you switch between different networks you will need to clear the Stellar Core and Stellar Horizon databases. You can wipe out the databases by running `docker-compose down --remove-orphans -v`.
 
-This script is helpful to spin up the services quickly and play around with them. However, for code development it's important to build and install everything locally 
+This script is helpful to spin up the services quickly and play around with them. However, for code development it's important to build and install everything locally
 
 ## Developing Horizon Locally
 We will now configure a development environment to run Horizon service locally without Docker.
@@ -75,7 +75,7 @@ Add a debug configuration in your IDE to attach a debugger to the local Horizon 
      "args": []
  }
 ```
-If all is well, you should see ingest logs written to standard out. You can read more about configuring the different environment variables in [Configuring](https://developers.stellar.org/docs/run-api-server/configuring) section of our public documentation.
+If all is well, you should see ingest logs written to standard out. You can read more about configuring the different environment variables in [Configuring](https://developers.stellar.org/docs/data/horizon/admin-guide/configuring) section of our public documentation.
 
 ### Building Horizon Binary
 
@@ -87,7 +87,7 @@ Open a new terminal. Confirm everything worked by running `stellar-horizon --hel
 
 ### Run tests
 
-Once you have [installed stellar-core](#building-stellar-core) on your machine and have the 
+Once you have [installed stellar-core](#building-stellar-core) on your machine and have the
 [Horizon database](#database-setup) up and running, you should be able to run Horizon's unit tests:
 
 ```bash
@@ -98,7 +98,7 @@ go test ./...
 To run the integration tests, you need to set some environment variables:
 
 ```bash
-export HORIZON_INTEGRATION_TESTS_ENABLED=true 
+export HORIZON_INTEGRATION_TESTS_ENABLED=true
 export HORIZON_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL=21
 export HORIZON_INTEGRATION_TESTS_DOCKER_IMG=stellar/stellar-core:21
 go test -race -timeout 25m -v ./services/horizon/internal/integration/...
@@ -161,8 +161,8 @@ And finally setting the checkpoint frequency for horizon:
 export CHECKPOINT_FREQUENCY=8
 ```
 
-This modification causes the standalone network to close ledgers every 1 second and create a checkpoint once every 8 ledgers, 
-deviating from the default timing of ledger closing after 5 seconds and creating a checkpoint once every 64 ledgers. Please note that 
+This modification causes the standalone network to close ledgers every 1 second and create a checkpoint once every 8 ledgers,
+deviating from the default timing of ledger closing after 5 seconds and creating a checkpoint once every 64 ledgers. Please note that
 this customization is only applicable when running a standalone network, as it requires changes to the captive-core configuration.
 
 ## Using a specific version of Stellar Core
@@ -170,7 +170,7 @@ this customization is only applicable when running a standalone network, as it r
 By default, the Docker Compose file is configured to use version 21 of Protocol and Stellar Core. You can specify optional environment variables from the command shell for stating version overrides for either the docker-compose or start.sh invocations.
 ```bash
 export PROTOCOL_VERSION="21"
-export CORE_IMAGE="stellar/stellar-core:21" 
+export CORE_IMAGE="stellar/stellar-core:21"
 export STELLAR_CORE_VERSION="21.0.0-1872.c6f474133.focal"
 ```
 

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -986,7 +986,7 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 	flagsPassedByUser := flags.GetCommandLineFlagsPassedByUser()
 	if len(flagsPassedByUser) > 0 {
 		result := fmt.Sprintf("DEPRECATED - the use of command-line flags: [%s], has been deprecated in favor of environment variables. "+
-			"Please consult our Configuring section in the developer documentation on how to use them - https://developers.stellar.org/docs/run-api-server/configuring", "--"+strings.Join(flagsPassedByUser, ",--"))
+			"Please consult our Configuring section in the developer documentation on how to use them - https://developers.stellar.org/docs/data/horizon/admin-guide/overview/configuring", "--"+strings.Join(flagsPassedByUser, ",--"))
 		stdLog.Println(result)
 	}
 

--- a/services/horizon/internal/httpx/static/txsub_async_oapi.yaml
+++ b/services/horizon/internal/httpx/static/txsub_async_oapi.yaml
@@ -27,7 +27,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AsyncTransactionSubmissionResponse'
-              example: 
+              example:
                   tx_status: "PENDING"
                   hash: "6cbb7f714bd08cea7c30cab7818a35c510cbbfc0a6aa06172a1e94146ecf0165"
 
@@ -36,7 +36,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf: 
+                oneOf:
                   - $ref: '#/components/schemas/AsyncTransactionSubmissionResponse'
                   - $ref: '#/components/schemas/Problem'
               examples:
@@ -77,7 +77,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AsyncTransactionSubmissionResponse'
-              example: 
+              example:
                   errorResultXdr: ""
                   tx_status: "DUPLICATE"
                   hash: "6cbb7f714bd08cea7c30cab7818a35c510cbbfc0a6aa06172a1e94146ecf0165"
@@ -94,7 +94,7 @@ paths:
                     type: "transaction_submission_failed"
                     title: "Transaction Submission Failed"
                     status: 500
-                    detail: "Could not submit transaction to stellar-core. The `extras.error` field on this response contains further details. Descriptions of each code can be found at: https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/transaction-submission-async/transaction_submission_failed"
+                    detail: "Could not submit transaction to stellar-core. The `extras.error` field on this response contains further details. Descriptions of each code can be found at: https://developers.stellar.org/docs/data/horizon/api-reference/errors/http-status-codes/horizon-specific/transaction-failed"
                     extras:
                       envelope_xdr: ""
                       error: "Error details here"
@@ -104,7 +104,7 @@ paths:
                     type: "transaction_submission_exception"
                     title: "Transaction Submission Exception"
                     status: 500
-                    detail: "Received exception from stellar-core. The `extras.error` field on this response contains further details. Descriptions of each code can be found at: https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/transaction-submission-async/transaction_submission_exception"
+                    detail: "Received exception from stellar-core. The `extras.error` field on this response contains further details. Descriptions of each code can be found at: https://developers.stellar.org/docs/data/horizon/api-reference/errors/http-status-codes/horizon-specific/transaction-malformed"
                     extras:
                       envelope_xdr: ""
                       error: "Exception details here"
@@ -130,7 +130,7 @@ paths:
                     tx_status: "TRY_AGAIN_LATER"
                     hash: "6cbb7f714bd08cea7c30cab7818a35c510cbbfc0a6aa06172a1e94146ecf0165"
 
-                  
+
 components:
   schemas:
     AsyncTransactionSubmissionResponse:

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -496,7 +496,7 @@ func TestDeprecatedOutputs(t *testing.T) {
 		assert.Contains(t, string(outputBytes), "DEPRECATED - the use of command-line flags: "+
 			"[--disable-tx-sub], has been deprecated in favor of environment variables. Please consult our "+
 			"Configuring section in the developer documentation on how to use them - "+
-			"https://developers.stellar.org/docs/run-api-server/configuring")
+			"https://developers.stellar.org/docs/data/horizon/admin-guide/configuring")
 	})
 	t.Run("deprecated output for --captive-core-use-db", func(t *testing.T) {
 		originalStderr := os.Stderr

--- a/services/ticker/docs/API.md
+++ b/services/ticker/docs/API.md
@@ -118,7 +118,7 @@ GET `https://ticker.stellar.org/markets.json`
 }
 ```
 ## Asset (Currency) Data
-Lists all the valid assets within the Stellar network. The provided fields are based on the [Currency Documentation of SEP-0001](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md#currency-documentation) and the [Asset fields from Horizon](https://developers.stellar.org/api/resources/assets/).
+Lists all the valid assets within the Stellar network. The provided fields are based on the [Currency Documentation of SEP-0001](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md#currency-documentation) and the [Asset fields from Horizon](https://developers.stellar.org/docs/data/horizon/api-reference/resources/assets).
 ### Response Fields
 
 * `generated_at`: UNIX timestamp of when data was generated
@@ -234,7 +234,7 @@ Apart from the orderbook data provided by `markets.json`, orderbook data can be 
 The `type`, `code` and `issuer` parameters for any given asset can be found in the Ticker's `assets.json` endpoint described in the previous section.
 
 
-Full documentation on Horizon's Orderbook endpoint can be found [here](https://developers.stellar.org/api/aggregations/order-books/).
+Full documentation on Horizon's Orderbook endpoint can be found [here](https://developers.stellar.org/docs/data/horizon/api-reference/aggregations/order-books).
 
 ### Example
 #### Endpoint

--- a/services/ticker/internal/scraper/orderbook_scraper.go
+++ b/services/ticker/internal/scraper/orderbook_scraper.go
@@ -121,7 +121,7 @@ func createOrderbookRequest(bType, bCode, bIssuer, cType, cCode, cIssuer string)
 	// when an Asset is native. As we store "XLM" as the asset code for native,
 	// we should only add Code and Issuer info in case we're dealing with
 	// non-native assets.
-	// See: https://developers.stellar.org/api/aggregations/order-books/single/
+	// See: https://developers.stellar.org/docs/data/horizon/api-reference/aggregations/order-books/single
 	if bType != string(horizonclient.AssetTypeNative) {
 		r.SellingAssetCode = bCode
 		r.SellingAssetIssuer = bIssuer

--- a/txnbuild/CHANGELOG.md
+++ b/txnbuild/CHANGELOG.md
@@ -51,7 +51,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
   * Rename `SetOpSourceMuxedAccount()` to (pre-existing) `SetOpSourceAccount()` which now accepts
     both `G` and `M` (muxed) account strkeys.
 * Use xdr.Price to represent prices in txnbuild instead of strings ([#4167](https://github.com/stellar/go/pull/4167)).
-  
+
 ## [8.0.0-beta.0](https://github.com/stellar/go/releases/tag/horizonclient-v8.0.0-beta.0) - 2021-10-04
 
 **This release adds support for Protocol 18.**
@@ -59,7 +59,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 ### New features
 * `GenericTransaction`, `Transaction`, and `FeeBumpTransaction` now implement
 `encoding.TextMarshaler` and `encoding.TextUnmarshaler`.
-* New asset structures that conform to the new ChangeTrust and New assets: 
+* New asset structures that conform to the new ChangeTrust and New assets:
 * Support for the core liquidity pool XDR types: `LiquidityPoolId`, `LiquidityPoolParameters`, `LiquidityPoolDeposit`, and `LiquidityPoolWithdraw`.
 * Support for the new asset structures: `ChangeTrustAsset` and `TrustLineAsset`.
 
@@ -153,7 +153,7 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Add helper function `ParseAssetString()`, making it easier to build an `Asset` structure from a string in [canonical form](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md#asset) and check its various properties ([#3105](https://github.com/stellar/go/pull/3105)).
 
-* Add helper function `Transaction.ClaimableBalanceID()`, making it easier to calculate balance IDs for [claimable balances](https://developers.stellar.org/docs/glossary/claimable-balance/) without actually submitting the transaction ([#3122](https://github.com/stellar/go/pull/3122)).
+* Add helper function `Transaction.ClaimableBalanceID()`, making it easier to calculate balance IDs for [claimable balances](https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/claimable-balances) without actually submitting the transaction ([#3122](https://github.com/stellar/go/pull/3122)).
 
 * Add support for SEP-10 v2.1.0.
   * Remove verification of home domain. (Will be reintroduced and changed in a future release.)

--- a/txnbuild/README.md
+++ b/txnbuild/README.md
@@ -1,22 +1,22 @@
 # txnbuild
 
-`txnbuild` is a [Stellar SDK](https://developers.stellar.org/docs/software-and-sdks/), implemented in [Go](https://golang.org/). It provides a reference implementation of the complete [set of operations](https://developers.stellar.org/docs/start/list-of-operations/) that compose [transactions](https://developers.stellar.org/docs/glossary/transactions/) for the Stellar distributed ledger.
+`txnbuild` is a [Stellar SDK](https://developers.stellar.org/docs/tools/sdks/library), implemented in [Go](https://golang.org/). It provides a reference implementation of the complete [set of operations](https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations) that compose [transactions](https://developers.stellar.org/docs/learn/glossary#transaction) for the Stellar distributed ledger.
 
 This project is maintained by the Stellar Development Foundation.
 
 ```golang
     import (
         "log"
-        
+
         "github.com/stellar/go/clients/horizonclient"
         "github.com/stellar/go/keypair"
         "github.com/stellar/go/network"
         "github.com/stellar/go/txnbuild"
     )
-    
+
     // Make a keypair for a known account from a secret seed
     kp, _ := keypair.Parse("SBPQUZ6G4FZNWFHKUWC5BEYWF6R52E3SEP7R3GWYSM2XTKGF5LNTWW4R")
-    
+
     // Get the current state of the account from the network
     client := horizonclient.DefaultTestNetClient
     ar := horizonclient.AccountRequest{AccountID: kp.Address()}
@@ -24,13 +24,13 @@ This project is maintained by the Stellar Development Foundation.
     if err != nil {
         log.Fatalln(err)
     }
-    
+
     // Build an operation to create and fund a new account
     op := txnbuild.CreateAccount{
         Destination: "GCCOBXW2XQNUSL467IEILE6MMCNRR66SSVL4YQADUNYYNUVREF3FIV2Z",
         Amount:      "10",
     }
-    
+
     // Construct the transaction that holds the operations to execute on the network
     tx, err := txnbuild.NewTransaction(
         txnbuild.TransactionParams{
@@ -44,19 +44,19 @@ This project is maintained by the Stellar Development Foundation.
     if err != nil {
         log.Fatalln(err)
     )
-    
+
     // Sign the transaction
     tx, err = tx.Sign(network.TestNetworkPassphrase, kp.(*keypair.Full))
     if err != nil {
         log.Fatalln(err)
     )
-    
+
     // Get the base 64 encoded transaction envelope
     txe, err := tx.Base64()
     if err != nil {
         log.Fatalln(err)
     }
-    
+
     // Send the transaction to the network
     resp, err := client.SubmitTransactionXDR(txe)
     if err != nil {

--- a/txnbuild/account_merge.go
+++ b/txnbuild/account_merge.go
@@ -6,7 +6,7 @@ import (
 )
 
 // AccountMerge represents the Stellar merge account operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type AccountMerge struct {
 	Destination   string
 	SourceAccount string

--- a/txnbuild/allow_trust.go
+++ b/txnbuild/allow_trust.go
@@ -10,7 +10,7 @@ import (
 
 // Deprecated: use SetTrustLineFlags instead.
 // AllowTrust represents the Stellar allow trust operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type AllowTrust struct {
 	Trustor                        string
 	Type                           Asset

--- a/txnbuild/begin_sponsoring_future_reserves.go
+++ b/txnbuild/begin_sponsoring_future_reserves.go
@@ -8,7 +8,7 @@ import (
 )
 
 // BeginSponsoringFutureReserves represents the Stellar begin sponsoring future reserves operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type BeginSponsoringFutureReserves struct {
 	SponsoredID   string
 	SourceAccount string

--- a/txnbuild/bump_sequence.go
+++ b/txnbuild/bump_sequence.go
@@ -6,7 +6,7 @@ import (
 )
 
 // BumpSequence represents the Stellar bump sequence operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type BumpSequence struct {
 	BumpTo        int64
 	SourceAccount string

--- a/txnbuild/change_trust.go
+++ b/txnbuild/change_trust.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ChangeTrust represents the Stellar change trust operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 // If Limit is omitted, it defaults to txnbuild.MaxTrustlineLimit.
 type ChangeTrust struct {
 	Line          ChangeTrustAsset

--- a/txnbuild/claim_claimable_balance.go
+++ b/txnbuild/claim_claimable_balance.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ClaimClaimableBalance represents the Stellar claim claimable balance operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type ClaimClaimableBalance struct {
 	BalanceID     string
 	SourceAccount string

--- a/txnbuild/clawback.go
+++ b/txnbuild/clawback.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Clawback represents the Stellar clawback operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type Clawback struct {
 	From          string
 	Amount        string

--- a/txnbuild/clawback_claimable_balance.go
+++ b/txnbuild/clawback_claimable_balance.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ClawbackClaimableBalance represents the Stellar clawback claimable balance operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type ClawbackClaimableBalance struct {
 	BalanceID     string
 	SourceAccount string

--- a/txnbuild/cmd/demo/operations/demo.go
+++ b/txnbuild/cmd/demo/operations/demo.go
@@ -86,7 +86,7 @@ func Reset(client *horizonclient.Client, keys []Account) {
 		}
 
 		// It exists - so we will proceed to deconstruct any existing account entries, and then merge it
-		// See https://developers.stellar.org/docs/glossary/ledger/#ledger-entries
+		// See https://developers.stellar.org/docs/learn/fundamentals/stellar-data-structures/ledgers
 		log.Info("Found testnet account with ID:", k.HAccount.ID)
 
 		// Find any offers that need deleting...

--- a/txnbuild/create_account.go
+++ b/txnbuild/create_account.go
@@ -7,7 +7,7 @@ import (
 )
 
 // CreateAccount represents the Stellar create account operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type CreateAccount struct {
 	Destination   string
 	Amount        string

--- a/txnbuild/create_claimable_balance.go
+++ b/txnbuild/create_claimable_balance.go
@@ -9,7 +9,7 @@ import (
 )
 
 // CreateClaimableBalance represents the Stellar create claimable balance operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type CreateClaimableBalance struct {
 	Amount        string
 	Asset         Asset

--- a/txnbuild/create_passive_offer.go
+++ b/txnbuild/create_passive_offer.go
@@ -7,7 +7,7 @@ import (
 )
 
 // CreatePassiveSellOffer represents the Stellar create passive offer operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type CreatePassiveSellOffer struct {
 	Selling       Asset
 	Buying        Asset

--- a/txnbuild/end_sponsoring_future_reserves.go
+++ b/txnbuild/end_sponsoring_future_reserves.go
@@ -8,7 +8,7 @@ import (
 )
 
 // EndSponsoringFutureReserves represents the Stellar begin sponsoring future reserves operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type EndSponsoringFutureReserves struct {
 	SourceAccount string
 }

--- a/txnbuild/inflation.go
+++ b/txnbuild/inflation.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Inflation represents the Stellar inflation operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type Inflation struct {
 	SourceAccount string
 }

--- a/txnbuild/liquidity_pool_deposit.go
+++ b/txnbuild/liquidity_pool_deposit.go
@@ -8,7 +8,7 @@ import (
 )
 
 // LiquidityPoolDeposit represents the Stellar liquidity pool deposit operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type LiquidityPoolDeposit struct {
 	SourceAccount   string
 	LiquidityPoolID LiquidityPoolId

--- a/txnbuild/liquidity_pool_withdraw.go
+++ b/txnbuild/liquidity_pool_withdraw.go
@@ -8,7 +8,7 @@ import (
 )
 
 // LiquidityPoolWithdraw represents the Stellar liquidity pool withdraw operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type LiquidityPoolWithdraw struct {
 	SourceAccount   string
 	LiquidityPoolID LiquidityPoolId

--- a/txnbuild/manage_buy_offer.go
+++ b/txnbuild/manage_buy_offer.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ManageBuyOffer represents the Stellar manage buy offer operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type ManageBuyOffer struct {
 	Selling       Asset
 	Buying        Asset

--- a/txnbuild/manage_data.go
+++ b/txnbuild/manage_data.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ManageData represents the Stellar manage data operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type ManageData struct {
 	Name          string
 	Value         []byte

--- a/txnbuild/manage_offer.go
+++ b/txnbuild/manage_offer.go
@@ -74,7 +74,7 @@ func DeleteOfferOp(offerID int64, sourceAccount ...string) (ManageSellOffer, err
 }
 
 // ManageSellOffer represents the Stellar manage offer operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type ManageSellOffer struct {
 	Selling       Asset
 	Buying        Asset

--- a/txnbuild/path_payment.go
+++ b/txnbuild/path_payment.go
@@ -13,7 +13,7 @@ import (
 type PathPayment = PathPaymentStrictReceive
 
 // PathPaymentStrictReceive represents the Stellar path_payment_strict_receive operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type PathPaymentStrictReceive struct {
 	SendAsset     Asset
 	SendMax       string

--- a/txnbuild/path_payment_strict_send.go
+++ b/txnbuild/path_payment_strict_send.go
@@ -7,7 +7,7 @@ import (
 )
 
 // PathPaymentStrictSend represents the Stellar path_payment_strict_send operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type PathPaymentStrictSend struct {
 	SendAsset     Asset
 	SendAmount    string

--- a/txnbuild/payment.go
+++ b/txnbuild/payment.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Payment represents the Stellar payment operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type Payment struct {
 	Destination   string
 	Amount        string

--- a/txnbuild/set_options.go
+++ b/txnbuild/set_options.go
@@ -51,7 +51,7 @@ func NewInflationDestination(ai string) *string {
 }
 
 // SetOptions represents the Stellar set options operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type SetOptions struct {
 	InflationDestination *string
 	SetFlags             []AccountFlag
@@ -122,7 +122,7 @@ func (so *SetOptions) handleInflationXDR(account *xdr.AccountId) {
 }
 
 // handleSetFlags for SetOptions sets XDR account flags (represented as a bitmask).
-// See https://developers.stellar.org/docs/glossary/accounts/#flags
+// See https://developers.stellar.org/docs/learn/glossary#flags
 func (so *SetOptions) handleSetFlags() {
 	var flags xdr.Uint32
 	for _, flag := range so.SetFlags {
@@ -134,7 +134,7 @@ func (so *SetOptions) handleSetFlags() {
 }
 
 // handleSetFlagsXDR for SetOptions sets account flags from XDR object (represented as a bitmask).
-// See https://developers.stellar.org/docs/glossary/accounts/#flags
+// See https://developers.stellar.org/docs/learn/glossary#flags
 func (so *SetOptions) handleSetFlagsXDR(flags *xdr.Uint32) {
 	if flags != nil {
 		for _, f := range []AccountFlag{AuthRequired, AuthRevocable, AuthImmutable, AuthClawbackEnabled} {
@@ -146,7 +146,7 @@ func (so *SetOptions) handleSetFlagsXDR(flags *xdr.Uint32) {
 }
 
 // handleClearFlags for SetOptions unsets XDR account flags (represented as a bitmask).
-// See https://developers.stellar.org/docs/glossary/accounts/#flags
+// See https://developers.stellar.org/docs/learn/glossary#flags
 func (so *SetOptions) handleClearFlags() {
 	var flags xdr.Uint32
 	for _, flag := range so.ClearFlags {
@@ -158,7 +158,7 @@ func (so *SetOptions) handleClearFlags() {
 }
 
 // handleClearFlagsXDR for SetOptions unsets account flags (represented as a bitmask).
-// See https://developers.stellar.org/docs/glossary/accounts/#flags
+// See https://developers.stellar.org/docs/learn/glossary#flags
 func (so *SetOptions) handleClearFlagsXDR(flags *xdr.Uint32) {
 	if flags != nil {
 		for _, f := range []AccountFlag{AuthRequired, AuthRevocable, AuthImmutable, AuthClawbackEnabled} {
@@ -170,7 +170,7 @@ func (so *SetOptions) handleClearFlagsXDR(flags *xdr.Uint32) {
 }
 
 // handleMasterWeight for SetOptions sets the XDR weight of the master signing key.
-// See https://developers.stellar.org/docs/glossary/multisig/
+// See https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig
 func (so *SetOptions) handleMasterWeight() {
 	if so.MasterWeight != nil {
 		xdrWeight := xdr.Uint32(*so.MasterWeight)
@@ -179,7 +179,7 @@ func (so *SetOptions) handleMasterWeight() {
 }
 
 // handleMasterWeightXDR for SetOptions sets the weight of the master signing key.
-// See https://developers.stellar.org/docs/glossary/multisig/
+// See https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig
 func (so *SetOptions) handleMasterWeightXDR(weight *xdr.Uint32) {
 	if weight != nil {
 		mw := Threshold(uint32(*weight))
@@ -188,7 +188,7 @@ func (so *SetOptions) handleMasterWeightXDR(weight *xdr.Uint32) {
 }
 
 // handleLowThreshold for SetOptions sets the XDR value of the account's "low" threshold.
-// See https://developers.stellar.org/docs/glossary/multisig/
+// See https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig
 func (so *SetOptions) handleLowThreshold() {
 	if so.LowThreshold != nil {
 		xdrThreshold := xdr.Uint32(*so.LowThreshold)
@@ -197,7 +197,7 @@ func (so *SetOptions) handleLowThreshold() {
 }
 
 // handleLowThresholdXDR for SetOptions sets value of the account's "low" threshold.
-// See https://developers.stellar.org/docs/glossary/multisig/
+// See https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig
 func (so *SetOptions) handleLowThresholdXDR(weight *xdr.Uint32) {
 	if weight != nil {
 		lt := Threshold(uint32(*weight))
@@ -206,7 +206,7 @@ func (so *SetOptions) handleLowThresholdXDR(weight *xdr.Uint32) {
 }
 
 // handleMediumThreshold for SetOptions sets the XDR value of the account's "medium" threshold.
-// See https://developers.stellar.org/docs/glossary/multisig/
+// See https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig
 func (so *SetOptions) handleMediumThreshold() {
 	if so.MediumThreshold != nil {
 		xdrThreshold := xdr.Uint32(*so.MediumThreshold)
@@ -215,7 +215,7 @@ func (so *SetOptions) handleMediumThreshold() {
 }
 
 // handleLowMediumXDR for SetOptions sets value of the account's "medium" threshold.
-// See https://developers.stellar.org/docs/glossary/multisig/
+// See https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig
 func (so *SetOptions) handleMediumThresholdXDR(weight *xdr.Uint32) {
 	if weight != nil {
 		mt := Threshold(uint32(*weight))
@@ -224,7 +224,7 @@ func (so *SetOptions) handleMediumThresholdXDR(weight *xdr.Uint32) {
 }
 
 // handleHighThreshold for SetOptions sets the XDR value of the account's "high" threshold.
-// See https://developers.stellar.org/docs/glossary/multisig/
+// See https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig
 func (so *SetOptions) handleHighThreshold() {
 	if so.HighThreshold != nil {
 		xdrThreshold := xdr.Uint32(*so.HighThreshold)
@@ -233,7 +233,7 @@ func (so *SetOptions) handleHighThreshold() {
 }
 
 // handleHighThresholdXDR for SetOptions sets value of the account's "high" threshold.
-// See https://developers.stellar.org/docs/glossary/multisig/
+// See https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig
 func (so *SetOptions) handleHighThresholdXDR(weight *xdr.Uint32) {
 	if weight != nil {
 		ht := Threshold(uint32(*weight))
@@ -242,7 +242,7 @@ func (so *SetOptions) handleHighThresholdXDR(weight *xdr.Uint32) {
 }
 
 // handleHomeDomain for SetOptions sets the XDR value of the account's home domain.
-// https://developers.stellar.org/docs/glossary/federation/
+// https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/federation
 func (so *SetOptions) handleHomeDomain() error {
 	if so.HomeDomain != nil {
 		if len(*so.HomeDomain) > 32 {
@@ -256,7 +256,7 @@ func (so *SetOptions) handleHomeDomain() error {
 }
 
 // handleHomeDomainXDR for SetOptions sets the value of the account's home domain.
-// https://developers.stellar.org/docs/glossary/federation/
+// https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/federation
 func (so *SetOptions) handleHomeDomainXDR(xDomain *xdr.String32) {
 	if xDomain != nil {
 		domain := string(*xDomain)
@@ -265,7 +265,7 @@ func (so *SetOptions) handleHomeDomainXDR(xDomain *xdr.String32) {
 }
 
 // handleSigner for SetOptions sets the XDR value of a signer for the account.
-// See https://developers.stellar.org/docs/glossary/multisig/
+// See https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig
 func (so *SetOptions) handleSigner() (err error) {
 	if so.Signer != nil {
 		var xdrSigner xdr.Signer
@@ -282,7 +282,7 @@ func (so *SetOptions) handleSigner() (err error) {
 }
 
 // handleSignerXDR for SetOptions sets the value of a signer for the account.
-// See https://developers.stellar.org/docs/glossary/multisig/
+// See https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig
 func (so *SetOptions) handleSignerXDR(xSigner *xdr.Signer) {
 	if xSigner != nil {
 		newSigner := Signer{}

--- a/txnbuild/set_trust_line_flags.go
+++ b/txnbuild/set_trust_line_flags.go
@@ -19,7 +19,7 @@ const TrustLineAuthorizedToMaintainLiabilities = TrustLineFlag(xdr.TrustLineFlag
 const TrustLineClawbackEnabled = TrustLineFlag(xdr.TrustLineFlagsTrustlineClawbackEnabledFlag)
 
 // SetTrustLineFlags represents the Stellar set trust line flags operation. See
-// https://developers.stellar.org/docs/start/list-of-operations/
+// https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations/
 type SetTrustLineFlags struct {
 	Trustor       string
 	Asset         Asset

--- a/txnbuild/transaction.go
+++ b/txnbuild/transaction.go
@@ -33,7 +33,7 @@ import (
 const MinBaseFee = 100
 
 // Account represents the aspects of a Stellar account necessary to construct transactions. See
-// https://developers.stellar.org/docs/glossary/accounts/
+// https://developers.stellar.org/docs/learn/glossary#account
 type Account interface {
 	GetAccountID() string
 	IncrementSequenceNumber() (int64, error)
@@ -202,7 +202,7 @@ func marshallBase64Bytes(e xdr.TransactionEnvelope, signatures []xdr.DecoratedSi
 }
 
 // Transaction represents a Stellar transaction. See
-// https://developers.stellar.org/docs/glossary/transactions/
+// https://developers.stellar.org/docs/learn/glossary#transaction
 // A Transaction may be wrapped by a FeeBumpTransaction in which case
 // the account authorizing the FeeBumpTransaction will pay for the transaction fees
 // instead of the Transaction's source account.
@@ -314,7 +314,7 @@ func (t *Transaction) SignWithKeyString(network string, keys ...string) (*Transa
 
 // SignHashX returns a new Transaction instance which extends the current instance
 // with HashX signature type.
-// See description here: https://developers.stellar.org/docs/glossary/multisig/#hashx
+// See description here: https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#hashx
 func (t *Transaction) SignHashX(preimage []byte) (*Transaction, error) {
 	extendedSignatures, err := concatHashX(t.Signatures(), preimage)
 	if err != nil {
@@ -516,7 +516,7 @@ func (t *FeeBumpTransaction) SignWithKeyString(network string, keys ...string) (
 
 // SignHashX returns a new FeeBumpTransaction instance which extends the current instance
 // with HashX signature type.
-// See description here: https://developers.stellar.org/docs/glossary/multisig/#hashx
+// See description here: https://developers.stellar.org/docs/learn/encyclopedia/security/signatures-multisig#hashx
 func (t *FeeBumpTransaction) SignHashX(preimage []byte) (*FeeBumpTransaction, error) {
 	extendedSignatures, err := concatHashX(t.Signatures(), preimage)
 	if err != nil {


### PR DESCRIPTION
The [stellar-docs](https://github.com/stellar/stellar-docs) site has undergone some structural updates/changes. Among other areas, the Horizon API documentation has been affected. This PR aims to make current all references to the developers documentation.