### PR TITLE
services/horizon: Skip captive-core configuration when reingesting from datastore

### DIFF
--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -270,6 +270,11 @@ var (
 	ledgerBackendType        ingest.LedgerBackendType
 )
 
+type StorageBackendConfig struct {
+	DataStoreConfig              datastore.DataStoreConfig                  `toml:"datastore_config"`
+	BufferedStorageBackendConfig ledgerbackend.BufferedStorageBackendConfig `toml:"buffered_storage_backend_config"`
+}
+
 func ingestRangeCmdOpts() support.ConfigOptions {
 	return support.ConfigOptions{
 		{

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -270,11 +270,6 @@ var (
 	ledgerBackendType        ingest.LedgerBackendType
 )
 
-type StorageBackendConfig struct {
-	DataStoreConfig              datastore.DataStoreConfig                  `toml:"datastore_config"`
-	BufferedStorageBackendConfig ledgerbackend.BufferedStorageBackendConfig `toml:"buffered_storage_backend_config"`
-}
-
 func ingestRangeCmdOpts() support.ConfigOptions {
 	return support.ConfigOptions{
 		{
@@ -385,6 +380,7 @@ var dbReingestRangeCmd = &cobra.Command{
 		}
 
 		var storageBackendConfig ingest.StorageBackendConfig
+		options := horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false, AlwaysIngest: false}
 		if ledgerBackendType == ingest.BufferedStorageBackend {
 			cfg, err := toml.LoadFile(storageBackendConfigPath)
 			if err != nil {
@@ -395,9 +391,10 @@ var dbReingestRangeCmd = &cobra.Command{
 			}
 			storageBackendConfig.BufferedStorageBackendFactory = ledgerbackend.NewBufferedStorageBackend
 			storageBackendConfig.DataStoreFactory = datastore.NewDataStore
+			options.NoCaptiveCore = true
 		}
 
-		err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false, AlwaysIngest: false})
+		err := horizon.ApplyFlags(globalConfig, globalFlags, options)
 		if err != nil {
 			return err
 		}
@@ -447,6 +444,7 @@ var dbFillGapsCmd = &cobra.Command{
 		}
 
 		var storageBackendConfig ingest.StorageBackendConfig
+		options := horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false, AlwaysIngest: false}
 		if ledgerBackendType == ingest.BufferedStorageBackend {
 			cfg, err := toml.LoadFile(storageBackendConfigPath)
 			if err != nil {
@@ -457,9 +455,10 @@ var dbFillGapsCmd = &cobra.Command{
 			}
 			storageBackendConfig.BufferedStorageBackendFactory = ledgerbackend.NewBufferedStorageBackend
 			storageBackendConfig.DataStoreFactory = datastore.NewDataStore
+			options.NoCaptiveCore = true
 		}
 
-		err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false, AlwaysIngest: false})
+		err := horizon.ApplyFlags(globalConfig, globalFlags, options)
 		if err != nil {
 			return err
 		}

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -225,7 +225,7 @@ var dbReapCmd = &cobra.Command{
 	Long:  "reap removes any historical data that is earlier than the configured retention cutoff",
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false, AlwaysIngest: false})
+		err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false})
 		if err != nil {
 			return err
 		}
@@ -380,7 +380,7 @@ var dbReingestRangeCmd = &cobra.Command{
 		}
 
 		var storageBackendConfig ingest.StorageBackendConfig
-		options := horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false, AlwaysIngest: false}
+		options := horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}
 		if ledgerBackendType == ingest.BufferedStorageBackend {
 			cfg, err := toml.LoadFile(storageBackendConfigPath)
 			if err != nil {
@@ -444,7 +444,7 @@ var dbFillGapsCmd = &cobra.Command{
 		}
 
 		var storageBackendConfig ingest.StorageBackendConfig
-		options := horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false, AlwaysIngest: false}
+		options := horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}
 		if ledgerBackendType == ingest.BufferedStorageBackend {
 			cfg, err := toml.LoadFile(storageBackendConfigPath)
 			if err != nil {

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
 	"github.com/stellar/go/historyarchive"
 	horizon "github.com/stellar/go/services/horizon/internal"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -94,7 +95,7 @@ var ingestVerifyRangeCmd = &cobra.Command{
 			co.SetValue()
 		}
 
-		if err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false, AlwaysIngest: true}); err != nil {
+		if err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}); err != nil {
 			return err
 		}
 
@@ -189,7 +190,7 @@ var ingestStressTestCmd = &cobra.Command{
 			co.SetValue()
 		}
 
-		if err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false, AlwaysIngest: true}); err != nil {
+		if err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}); err != nil {
 			return err
 		}
 
@@ -239,7 +240,7 @@ var ingestTriggerStateRebuildCmd = &cobra.Command{
 	Short: "updates a database to trigger state rebuild, state will be rebuilt by a running Horizon instance, DO NOT RUN production DB, some endpoints will be unavailable until state is rebuilt",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
-		if err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false, AlwaysIngest: true}); err != nil {
+		if err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}); err != nil {
 			return err
 		}
 
@@ -263,7 +264,7 @@ var ingestInitGenesisStateCmd = &cobra.Command{
 	Short: "ingests genesis state (ledger 1)",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
-		if err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false, AlwaysIngest: true}); err != nil {
+		if err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}); err != nil {
 			return err
 		}
 
@@ -320,7 +321,7 @@ var ingestBuildStateCmd = &cobra.Command{
 			co.SetValue()
 		}
 
-		if err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false, AlwaysIngest: true}); err != nil {
+		if err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}); err != nil {
 			return err
 		}
 

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -832,7 +832,7 @@ func Flags() (*Config, support.ConfigOptions) {
 
 // NewAppFromFlags constructs a new Horizon App from the given command line flags
 func NewAppFromFlags(config *Config, flags support.ConfigOptions) (*App, error) {
-	err := ApplyFlags(config, flags, ApplyOptions{RequireCaptiveCoreFullConfig: true, AlwaysIngest: false})
+	err := ApplyFlags(config, flags, ApplyOptions{RequireCaptiveCoreFullConfig: true})
 	if err != nil {
 		return nil, err
 	}
@@ -850,7 +850,6 @@ func NewAppFromFlags(config *Config, flags support.ConfigOptions) (*App, error) 
 }
 
 type ApplyOptions struct {
-	AlwaysIngest                 bool
 	RequireCaptiveCoreFullConfig bool
 	NoCaptiveCore                bool
 }
@@ -946,10 +945,6 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 	// Validate options that should be provided together
 	if err := validateBothOrNeither("tls-cert", "tls-key"); err != nil {
 		return err
-	}
-
-	if options.AlwaysIngest {
-		config.Ingest = true
 	}
 
 	if config.Ingest {

--- a/services/horizon/internal/flags.go
+++ b/services/horizon/internal/flags.go
@@ -852,27 +852,8 @@ func NewAppFromFlags(config *Config, flags support.ConfigOptions) (*App, error) 
 type ApplyOptions struct {
 	AlwaysIngest                 bool
 	RequireCaptiveCoreFullConfig bool
+	NoCaptiveCore                bool
 }
-
-type networkConfig struct {
-	defaultConfig      []byte
-	HistoryArchiveURLs []string
-	NetworkPassphrase  string
-}
-
-var (
-	PubnetConf = networkConfig{
-		defaultConfig:      ledgerbackend.PubnetDefaultConfig,
-		HistoryArchiveURLs: network.PublicNetworkhistoryArchiveURLs,
-		NetworkPassphrase:  network.PublicNetworkPassphrase,
-	}
-
-	TestnetConf = networkConfig{
-		defaultConfig:      ledgerbackend.TestnetDefaultConfig,
-		HistoryArchiveURLs: network.TestNetworkhistoryArchiveURLs,
-		NetworkPassphrase:  network.TestNetworkPassphrase,
-	}
-)
 
 // getCaptiveCoreBinaryPath retrieves the path of the Captive Core binary
 // Returns the path or an error if the binary is not found
@@ -884,69 +865,32 @@ func getCaptiveCoreBinaryPath() (string, error) {
 	return result, nil
 }
 
-// getCaptiveCoreConfigFromNetworkParameter returns the default Captive Core configuration based on the network.
-func getCaptiveCoreConfigFromNetworkParameter(config *Config) (networkConfig, error) {
-	var defaultNetworkConfig networkConfig
-
-	if config.NetworkPassphrase != "" {
-		return defaultNetworkConfig, fmt.Errorf("invalid config: %s parameter not allowed with the %s parameter",
-			NetworkPassphraseFlagName, NetworkFlagName)
-	}
-
-	if len(config.HistoryArchiveURLs) > 0 {
-		return defaultNetworkConfig, fmt.Errorf("invalid config: %s parameter not allowed with the %s parameter",
-			HistoryArchiveURLsFlagName, NetworkFlagName)
-	}
-
-	switch config.Network {
-	case StellarPubnet:
-		defaultNetworkConfig = PubnetConf
-	case StellarTestnet:
-		defaultNetworkConfig = TestnetConf
-	default:
-		return defaultNetworkConfig, fmt.Errorf("no default configuration found for network %s", config.Network)
-	}
-
-	return defaultNetworkConfig, nil
-}
-
 // setCaptiveCoreConfiguration prepares configuration for the Captive Core
 func setCaptiveCoreConfiguration(config *Config, options ApplyOptions) error {
 	stdLog.Println("Preparing captive core...")
 
+	var err error
 	// If the user didn't specify a Stellar Core binary, we can check the
 	// $PATH and possibly fill it in for them.
 	if config.CaptiveCoreBinaryPath == "" {
-		var err error
 		if config.CaptiveCoreBinaryPath, err = getCaptiveCoreBinaryPath(); err != nil {
 			return fmt.Errorf("captive core requires %s", StellarCoreBinaryPathName)
 		}
 	}
 
-	var defaultNetworkConfig networkConfig
-	if config.Network != "" {
-		var err error
-		defaultNetworkConfig, err = getCaptiveCoreConfigFromNetworkParameter(config)
-		if err != nil {
-			return err
-		}
-		config.NetworkPassphrase = defaultNetworkConfig.NetworkPassphrase
-		config.HistoryArchiveURLs = defaultNetworkConfig.HistoryArchiveURLs
-	} else {
-		if config.NetworkPassphrase == "" {
-			return fmt.Errorf("%s must be set", NetworkPassphraseFlagName)
-		}
+	var defaultCaptiveCoreConfig []byte
+	switch config.Network {
+	case StellarPubnet:
+		defaultCaptiveCoreConfig = ledgerbackend.PubnetDefaultConfig
+	case StellarTestnet:
 
-		if len(config.HistoryArchiveURLs) == 0 {
-			return fmt.Errorf("%s must be set", HistoryArchiveURLsFlagName)
-		}
+		defaultCaptiveCoreConfig = ledgerbackend.TestnetDefaultConfig
 	}
 
 	config.CaptiveCoreTomlParams.CoreBinaryPath = config.CaptiveCoreBinaryPath
 	config.CaptiveCoreTomlParams.HistoryArchiveURLs = config.HistoryArchiveURLs
 	config.CaptiveCoreTomlParams.NetworkPassphrase = config.NetworkPassphrase
 
-	var err error
 	if config.CaptiveCoreConfigPath != "" {
 		config.CaptiveCoreToml, err = ledgerbackend.NewCaptiveCoreTomlFromFile(config.CaptiveCoreConfigPath,
 			config.CaptiveCoreTomlParams)
@@ -960,8 +904,8 @@ func setCaptiveCoreConfiguration(config *Config, options ApplyOptions) error {
 		if err != nil {
 			return errors.Wrap(err, "invalid captive core toml file")
 		}
-	} else if len(defaultNetworkConfig.defaultConfig) != 0 {
-		config.CaptiveCoreToml, err = ledgerbackend.NewCaptiveCoreTomlFromData(defaultNetworkConfig.defaultConfig,
+	} else if len(defaultCaptiveCoreConfig) != 0 {
+		config.CaptiveCoreToml, err = ledgerbackend.NewCaptiveCoreTomlFromData(defaultCaptiveCoreConfig,
 			config.CaptiveCoreTomlParams)
 		if err != nil {
 			return errors.Wrap(err, "invalid captive core toml file")
@@ -1023,9 +967,15 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 			return err
 		}
 
-		err := setCaptiveCoreConfiguration(config, options)
-		if err != nil {
-			return errors.Wrap(err, "error generating captive core configuration")
+		if err := setNetworkConfiguration(config); err != nil {
+			return err
+		}
+
+		if !options.NoCaptiveCore {
+			err := setCaptiveCoreConfiguration(config, options)
+			if err != nil {
+				return errors.Wrap(err, "error generating captive core configuration")
+			}
 		}
 	}
 
@@ -1059,5 +1009,39 @@ func ApplyFlags(config *Config, flags support.ConfigOptions, options ApplyOption
 		config.ClientQueryTimeout = config.ConnectionTimeout * 2
 	}
 
+	return nil
+}
+
+func setNetworkConfiguration(config *Config) error {
+	if config.Network != "" {
+		if config.NetworkPassphrase != "" {
+			return fmt.Errorf("invalid config: %s parameter not allowed with the %s parameter",
+				NetworkPassphraseFlagName, NetworkFlagName)
+		}
+
+		if len(config.HistoryArchiveURLs) > 0 {
+			return fmt.Errorf("invalid config: %s parameter not allowed with the %s parameter",
+				HistoryArchiveURLsFlagName, NetworkFlagName)
+		}
+
+		switch config.Network {
+		case StellarPubnet:
+			config.NetworkPassphrase = network.PublicNetworkPassphrase
+			config.HistoryArchiveURLs = network.PublicNetworkhistoryArchiveURLs
+		case StellarTestnet:
+			config.NetworkPassphrase = network.TestNetworkPassphrase
+			config.HistoryArchiveURLs = network.TestNetworkhistoryArchiveURLs
+		default:
+			return fmt.Errorf("no default configuration found for network %s", config.Network)
+		}
+	}
+
+	if config.NetworkPassphrase == "" {
+		return fmt.Errorf("%s must be set", NetworkPassphraseFlagName)
+	}
+
+	if len(config.HistoryArchiveURLs) == 0 {
+		return fmt.Errorf("%s must be set", HistoryArchiveURLsFlagName)
+	}
 	return nil
 }

--- a/services/horizon/internal/flags_test.go
+++ b/services/horizon/internal/flags_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stellar/go/network"
 	"github.com/stellar/go/services/horizon/internal/test"
 
 	"github.com/stretchr/testify/assert"
@@ -29,16 +30,16 @@ func Test_createCaptiveCoreDefaultConfig(t *testing.T) {
 			config: Config{Network: StellarTestnet,
 				CaptiveCoreBinaryPath: "/path/to/captive-core/binary",
 			},
-			networkPassphrase:  TestnetConf.NetworkPassphrase,
-			historyArchiveURLs: TestnetConf.HistoryArchiveURLs,
+			networkPassphrase:  network.TestNetworkPassphrase,
+			historyArchiveURLs: network.TestNetworkhistoryArchiveURLs,
 		},
 		{
 			name: "pubnet default config",
 			config: Config{Network: StellarPubnet,
 				CaptiveCoreBinaryPath: "/path/to/captive-core/binary",
 			},
-			networkPassphrase:  PubnetConf.NetworkPassphrase,
-			historyArchiveURLs: PubnetConf.HistoryArchiveURLs,
+			networkPassphrase:  network.PublicNetworkPassphrase,
+			historyArchiveURLs: network.PublicNetworkhistoryArchiveURLs,
 		},
 		{
 			name: "testnet validation; history archive urls supplied",
@@ -83,18 +84,41 @@ func Test_createCaptiveCoreDefaultConfig(t *testing.T) {
 			},
 			errStr: "no default configuration found for network unknown",
 		},
+		{
+			name: "no network specified; passphrase not supplied",
+			config: Config{
+				HistoryArchiveURLs:    []string{"HistoryArchiveURLs"},
+				CaptiveCoreBinaryPath: "/path/to/captive-core/binary",
+			},
+			errStr: fmt.Sprintf("%s must be set", NetworkPassphraseFlagName),
+		},
+		{
+			name: "no network specified; history archive urls not supplied",
+			config: Config{
+				NetworkPassphrase:     "NetworkPassphrase",
+				CaptiveCoreBinaryPath: "/path/to/captive-core/binary",
+			},
+			errStr: fmt.Sprintf("%s must be set", HistoryArchiveURLsFlagName),
+		},
+
+		{
+			name: "unknown network specified",
+			config: Config{Network: "unknown",
+				NetworkPassphrase:     "",
+				HistoryArchiveURLs:    []string{},
+				CaptiveCoreBinaryPath: "/path/to/captive-core/binary",
+			},
+			errStr: "no default configuration found for network unknown",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.config.CaptiveCoreTomlParams.UseDB = true
-			e := setCaptiveCoreConfiguration(&tt.config,
-				ApplyOptions{RequireCaptiveCoreFullConfig: true})
+			e := setNetworkConfiguration(&tt.config)
 			if tt.errStr == "" {
 				assert.NoError(t, e)
 				assert.Equal(t, tt.networkPassphrase, tt.config.NetworkPassphrase)
 				assert.Equal(t, tt.historyArchiveURLs, tt.config.HistoryArchiveURLs)
-				assert.Equal(t, tt.networkPassphrase, tt.config.CaptiveCoreTomlParams.NetworkPassphrase)
-				assert.Equal(t, tt.historyArchiveURLs, tt.config.CaptiveCoreTomlParams.HistoryArchiveURLs)
 			} else {
 				assert.Equal(t, tt.errStr, e.Error())
 			}
@@ -102,53 +126,50 @@ func Test_createCaptiveCoreDefaultConfig(t *testing.T) {
 	}
 }
 
-func Test_createCaptiveCoreConfig(t *testing.T) {
-
-	var errorMsgConfig = "%s must be set"
+func TestSetCaptiveCoreConfig(t *testing.T) {
 	tests := []struct {
 		name                     string
 		requireCaptiveCoreConfig bool
 		config                   Config
-		networkPassphrase        string
-		historyArchiveURLs       []string
 		errStr                   string
 	}{
+		{
+			name:                     "testnet default config",
+			requireCaptiveCoreConfig: true,
+			config: Config{
+				Network:               StellarTestnet,
+				NetworkPassphrase:     network.TestNetworkPassphrase,
+				HistoryArchiveURLs:    network.TestNetworkhistoryArchiveURLs,
+				CaptiveCoreBinaryPath: "/path/to/captive-core/binary",
+			},
+		},
+		{
+			name:                     "pubnet default config",
+			requireCaptiveCoreConfig: true,
+			config: Config{
+				Network:               StellarPubnet,
+				NetworkPassphrase:     network.PublicNetworkPassphrase,
+				HistoryArchiveURLs:    network.PublicNetworkhistoryArchiveURLs,
+				CaptiveCoreBinaryPath: "/path/to/captive-core/binary",
+			},
+		},
 		{
 			name:                     "no network specified; valid parameters",
 			requireCaptiveCoreConfig: true,
 			config: Config{
-				NetworkPassphrase:     PubnetConf.NetworkPassphrase,
-				HistoryArchiveURLs:    PubnetConf.HistoryArchiveURLs,
+				NetworkPassphrase:     network.PublicNetworkPassphrase,
+				HistoryArchiveURLs:    network.PublicNetworkhistoryArchiveURLs,
 				CaptiveCoreConfigPath: "../../../ingest/ledgerbackend/configs/captive-core-pubnet.cfg",
 				CaptiveCoreBinaryPath: "/path/to/captive-core/binary",
 			},
-			networkPassphrase:  PubnetConf.NetworkPassphrase,
-			historyArchiveURLs: PubnetConf.HistoryArchiveURLs,
 		},
-		{
-			name:                     "no network specified; passphrase not supplied",
-			requireCaptiveCoreConfig: true,
-			config: Config{
-				HistoryArchiveURLs:    []string{"HistoryArchiveURLs"},
-				CaptiveCoreBinaryPath: "/path/to/captive-core/binary",
-			},
-			errStr: fmt.Sprintf(errorMsgConfig, NetworkPassphraseFlagName),
-		},
-		{
-			name:                     "no network specified; history archive urls not supplied",
-			requireCaptiveCoreConfig: true,
-			config: Config{
-				NetworkPassphrase:     "NetworkPassphrase",
-				CaptiveCoreBinaryPath: "/path/to/captive-core/binary",
-			},
-			errStr: fmt.Sprintf(errorMsgConfig, HistoryArchiveURLsFlagName),
-		},
+
 		{
 			name:                     "no network specified; captive-core-config-path not supplied",
 			requireCaptiveCoreConfig: true,
 			config: Config{
-				NetworkPassphrase:     PubnetConf.NetworkPassphrase,
-				HistoryArchiveURLs:    PubnetConf.HistoryArchiveURLs,
+				NetworkPassphrase:     network.PublicNetworkPassphrase,
+				HistoryArchiveURLs:    network.PublicNetworkhistoryArchiveURLs,
 				CaptiveCoreBinaryPath: "/path/to/captive-core/binary",
 			},
 			errStr: fmt.Sprintf("invalid config: captive core requires that --%s is set or "+
@@ -158,8 +179,8 @@ func Test_createCaptiveCoreConfig(t *testing.T) {
 			name:                     "no network specified; captive-core-config-path invalid file",
 			requireCaptiveCoreConfig: true,
 			config: Config{
-				NetworkPassphrase:     PubnetConf.NetworkPassphrase,
-				HistoryArchiveURLs:    PubnetConf.HistoryArchiveURLs,
+				NetworkPassphrase:     network.PublicNetworkPassphrase,
+				HistoryArchiveURLs:    network.PublicNetworkhistoryArchiveURLs,
 				CaptiveCoreConfigPath: "xyz.cfg",
 				CaptiveCoreBinaryPath: "/path/to/captive-core/binary",
 			},
@@ -170,25 +191,21 @@ func Test_createCaptiveCoreConfig(t *testing.T) {
 			name:                     "no network specified; captive-core-config-path incorrect config",
 			requireCaptiveCoreConfig: true,
 			config: Config{
-				NetworkPassphrase:     PubnetConf.NetworkPassphrase,
-				HistoryArchiveURLs:    PubnetConf.HistoryArchiveURLs,
+				NetworkPassphrase:     network.PublicNetworkPassphrase,
+				HistoryArchiveURLs:    network.PublicNetworkhistoryArchiveURLs,
 				CaptiveCoreConfigPath: "../../../ingest/ledgerbackend/configs/captive-core-testnet.cfg",
 				CaptiveCoreBinaryPath: "/path/to/captive-core/binary",
 			},
 			errStr: fmt.Sprintf("invalid captive core toml file: invalid captive core toml: "+
 				"NETWORK_PASSPHRASE in captive core config file: %s does not match Horizon "+
-				"network-passphrase flag: %s", TestnetConf.NetworkPassphrase, PubnetConf.NetworkPassphrase),
+				"network-passphrase flag: %s", network.TestNetworkPassphrase, network.PublicNetworkPassphrase),
 		},
 		{
-			name:                     "no network specified; captive-core-config not required",
+			name:                     "no network specified; full captive-core-config not required",
 			requireCaptiveCoreConfig: false,
 			config: Config{
-				NetworkPassphrase:     PubnetConf.NetworkPassphrase,
-				HistoryArchiveURLs:    PubnetConf.HistoryArchiveURLs,
 				CaptiveCoreBinaryPath: "/path/to/captive-core/binary",
 			},
-			networkPassphrase:  PubnetConf.NetworkPassphrase,
-			historyArchiveURLs: PubnetConf.HistoryArchiveURLs,
 		},
 	}
 	for _, tt := range tests {
@@ -198,10 +215,6 @@ func Test_createCaptiveCoreConfig(t *testing.T) {
 				ApplyOptions{RequireCaptiveCoreFullConfig: tt.requireCaptiveCoreConfig})
 			if tt.errStr == "" {
 				assert.NoError(t, e)
-				assert.Equal(t, tt.networkPassphrase, tt.config.NetworkPassphrase)
-				assert.Equal(t, tt.historyArchiveURLs, tt.config.HistoryArchiveURLs)
-				assert.Equal(t, tt.networkPassphrase, tt.config.CaptiveCoreTomlParams.NetworkPassphrase)
-				assert.Equal(t, tt.historyArchiveURLs, tt.config.CaptiveCoreTomlParams.HistoryArchiveURLs)
 			} else {
 				require.Error(t, e)
 				assert.Equal(t, tt.errStr, e.Error())

--- a/services/horizon/internal/flags_test.go
+++ b/services/horizon/internal/flags_test.go
@@ -274,7 +274,7 @@ func TestClientQueryTimeoutFlag(t *testing.T) {
 			if err := flags.Init(horizonCmd); err != nil {
 				require.NoError(t, err)
 			}
-			if err := ApplyFlags(config, flags, ApplyOptions{RequireCaptiveCoreFullConfig: true, AlwaysIngest: false}); err != nil {
+			if err := ApplyFlags(config, flags, ApplyOptions{RequireCaptiveCoreFullConfig: true}); err != nil {
 				require.EqualError(t, err, testCase.err)
 			} else {
 				require.Empty(t, testCase.err)
@@ -306,7 +306,7 @@ func TestEnvironmentVariables(t *testing.T) {
 	if err := flags.Init(horizonCmd); err != nil {
 		fmt.Println(err)
 	}
-	if err := ApplyFlags(config, flags, ApplyOptions{RequireCaptiveCoreFullConfig: true, AlwaysIngest: false}); err != nil {
+	if err := ApplyFlags(config, flags, ApplyOptions{RequireCaptiveCoreFullConfig: true}); err != nil {
 		fmt.Println(err)
 	}
 	assert.Equal(t, config.Ingest, false)

--- a/services/horizon/internal/integration/parameters_test.go
+++ b/services/horizon/internal/integration/parameters_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stellar/go/network"
 	"github.com/stellar/go/services/horizon/internal/paths"
 	"github.com/stellar/go/services/horizon/internal/simplepath"
 
@@ -186,13 +187,13 @@ func TestNetworkParameter(t *testing.T) {
 	}{
 		{
 			networkValue:       horizon.StellarTestnet,
-			networkPassphrase:  horizon.TestnetConf.NetworkPassphrase,
-			historyArchiveURLs: horizon.TestnetConf.HistoryArchiveURLs,
+			networkPassphrase:  network.TestNetworkPassphrase,
+			historyArchiveURLs: network.TestNetworkhistoryArchiveURLs,
 		},
 		{
 			networkValue:       horizon.StellarPubnet,
-			networkPassphrase:  horizon.PubnetConf.NetworkPassphrase,
-			historyArchiveURLs: horizon.PubnetConf.HistoryArchiveURLs,
+			networkPassphrase:  network.PublicNetworkPassphrase,
+			historyArchiveURLs: network.PublicNetworkhistoryArchiveURLs,
 		},
 	}
 	for _, tt := range testCases {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

- Skip captive-core configuration when reingesting from the datastore.
- Remove the AlwaysIngest option, as Ingest is always true by default.
- Refactor code to separate captive-core config from stellar network config, since network config is required even when ingesting from the datastore.

### Why

#4911 

### Known limitations
N/A