### PR TITLE
services/horizon/internal/ingest: Add more fine-grained reap metrics

### DIFF
--- a/services/horizon/internal/db2/history/reap_test.go
+++ b/services/horizon/internal/db2/history/reap_test.go
@@ -52,7 +52,7 @@ func TestReapLookupTables(t *testing.T) {
 	err = q.Begin(tt.Ctx)
 	tt.Require.NoError(err)
 
-	deletedCount, newOffsets, err := q.ReapLookupTables(tt.Ctx, nil)
+	results, err := q.ReapLookupTables(tt.Ctx, nil)
 	tt.Require.NoError(err)
 
 	err = q.Commit()
@@ -77,23 +77,23 @@ func TestReapLookupTables(t *testing.T) {
 
 	tt.Assert.Equal(25, prevAccounts, "prevAccounts")
 	tt.Assert.Equal(1, curAccounts, "curAccounts")
-	tt.Assert.Equal(int64(24), deletedCount["history_accounts"], `deletedCount["history_accounts"]`)
+	tt.Assert.Equal(int64(24), results["history_accounts"].RowsDeleted, `deletedCount["history_accounts"]`)
 
 	tt.Assert.Equal(7, prevAssets, "prevAssets")
 	tt.Assert.Equal(0, curAssets, "curAssets")
-	tt.Assert.Equal(int64(7), deletedCount["history_assets"], `deletedCount["history_assets"]`)
+	tt.Assert.Equal(int64(7), results["history_assets"].RowsDeleted, `deletedCount["history_assets"]`)
 
 	tt.Assert.Equal(1, prevClaimableBalances, "prevClaimableBalances")
 	tt.Assert.Equal(0, curClaimableBalances, "curClaimableBalances")
-	tt.Assert.Equal(int64(1), deletedCount["history_claimable_balances"], `deletedCount["history_claimable_balances"]`)
+	tt.Assert.Equal(int64(1), results["history_claimable_balances"].RowsDeleted, `deletedCount["history_claimable_balances"]`)
 
 	tt.Assert.Equal(1, prevLiquidityPools, "prevLiquidityPools")
 	tt.Assert.Equal(0, curLiquidityPools, "curLiquidityPools")
-	tt.Assert.Equal(int64(1), deletedCount["history_liquidity_pools"], `deletedCount["history_liquidity_pools"]`)
+	tt.Assert.Equal(int64(1), results["history_liquidity_pools"].RowsDeleted, `deletedCount["history_liquidity_pools"]`)
 
-	tt.Assert.Len(newOffsets, 4)
-	tt.Assert.Equal(int64(0), newOffsets["history_accounts"])
-	tt.Assert.Equal(int64(0), newOffsets["history_assets"])
-	tt.Assert.Equal(int64(0), newOffsets["history_claimable_balances"])
-	tt.Assert.Equal(int64(0), newOffsets["history_liquidity_pools"])
+	tt.Assert.Len(results, 4)
+	tt.Assert.Equal(int64(0), results["history_accounts"].Offset)
+	tt.Assert.Equal(int64(0), results["history_assets"].Offset)
+	tt.Assert.Equal(int64(0), results["history_claimable_balances"].Offset)
+	tt.Assert.Equal(int64(0), results["history_liquidity_pools"].Offset)
 }

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -145,9 +145,8 @@ type Metrics struct {
 	// duration of rebuilding trade aggregation buckets.
 	LedgerIngestionTradeAggregationDuration prometheus.Summary
 
-	// LedgerIngestionReapLookupTablesDuration exposes timing metrics about the rate and
-	// duration of reaping lookup tables.
-	LedgerIngestionReapLookupTablesDuration prometheus.Summary
+	ReapDurationByLookupTable *prometheus.SummaryVec
+	RowsReapedByLookupTable   *prometheus.SummaryVec
 
 	// StateVerifyDuration exposes timing metrics about the rate and
 	// duration of state verification.
@@ -367,11 +366,17 @@ func (s *system) initMetrics() {
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	})
 
-	s.metrics.LedgerIngestionReapLookupTablesDuration = prometheus.NewSummary(prometheus.SummaryOpts{
-		Namespace: "horizon", Subsystem: "ingest", Name: "ledger_ingestion_reap_lookup_tables_duration_seconds",
-		Help:       "ledger ingestion reap lookup tables durations, sliding window = 10m",
+	s.metrics.ReapDurationByLookupTable = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace: "horizon", Subsystem: "ingest", Name: "reap_lookup_tables_duration_seconds",
+		Help:       "reap lookup tables durations, sliding window = 10m",
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
-	})
+	}, []string{"table"})
+
+	s.metrics.RowsReapedByLookupTable = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace: "horizon", Subsystem: "ingest", Name: "reap_lookup_tables_rows_reaped",
+		Help:       "rows delated during lookup tables reap, sliding window = 10m",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	}, []string{"table"})
 
 	s.metrics.StateVerifyDuration = prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: "horizon", Subsystem: "ingest", Name: "state_verify_duration_seconds",
@@ -490,7 +495,8 @@ func (s *system) RegisterMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(s.metrics.LocalLatestLedger)
 	registry.MustRegister(s.metrics.LedgerIngestionDuration)
 	registry.MustRegister(s.metrics.LedgerIngestionTradeAggregationDuration)
-	registry.MustRegister(s.metrics.LedgerIngestionReapLookupTablesDuration)
+	registry.MustRegister(s.metrics.ReapDurationByLookupTable)
+	registry.MustRegister(s.metrics.RowsReapedByLookupTable)
 	registry.MustRegister(s.metrics.StateVerifyDuration)
 	registry.MustRegister(s.metrics.StateInvalidGauge)
 	registry.MustRegister(s.metrics.LedgerStatsCounter)
@@ -793,7 +799,7 @@ func (s *system) maybeReapLookupTables(lastIngestedLedger uint32) {
 	defer cancel()
 
 	reapStart := time.Now()
-	deletedCount, newOffsets, err := s.historyQ.ReapLookupTables(ctx, s.reapOffsets)
+	results, err := s.historyQ.ReapLookupTables(ctx, s.reapOffsets)
 	if err != nil {
 		log.WithError(err).Warn("Error reaping lookup tables")
 		return
@@ -807,18 +813,20 @@ func (s *system) maybeReapLookupTables(lastIngestedLedger uint32) {
 
 	totalDeleted := int64(0)
 	reapLog := log
-	for table, c := range deletedCount {
-		totalDeleted += c
-		reapLog = reapLog.WithField(table, c)
+	for table, result := range results {
+		totalDeleted += result.RowsDeleted
+		reapLog = reapLog.WithField(table, result)
+		s.reapOffsets[table] = result.Offset
+		s.Metrics().RowsReapedByLookupTable.With(prometheus.Labels{"table": table}).Observe(float64(result.RowsDeleted))
+		s.Metrics().ReapDurationByLookupTable.With(prometheus.Labels{"table": table}).Observe(result.Duration.Seconds())
 	}
 
 	if totalDeleted > 0 {
 		reapLog.Info("Reaper deleted rows from lookup tables")
 	}
 
-	s.reapOffsets = newOffsets
-	reapDuration := time.Since(reapStart).Seconds()
-	s.Metrics().LedgerIngestionReapLookupTablesDuration.Observe(float64(reapDuration))
+	s.Metrics().RowsReapedByLookupTable.With(prometheus.Labels{"table": "total"}).Observe(float64(totalDeleted))
+	s.Metrics().ReapDurationByLookupTable.With(prometheus.Labels{"table": "total"}).Observe(time.Since(reapStart).Seconds())
 }
 
 func (s *system) incrementStateVerificationErrors() int {

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -326,6 +326,7 @@ func NewSystem(config Config) (System, error) {
 			config.ReapConfig,
 			config.HistorySession,
 		),
+		reapOffsets: map[string]int64{},
 	}
 
 	system.initMetrics()

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -227,7 +227,7 @@ type system struct {
 
 	runStateVerificationOnLedger func(uint32) bool
 
-	reapOffsets       map[string]int64
+	reapOffsetByTable map[string]int64
 	maxLedgerPerFlush uint32
 
 	reaper *Reaper
@@ -326,7 +326,7 @@ func NewSystem(config Config) (System, error) {
 			config.ReapConfig,
 			config.HistorySession,
 		),
-		reapOffsets: map[string]int64{},
+		reapOffsetByTable: map[string]int64{},
 	}
 
 	system.initMetrics()
@@ -375,7 +375,7 @@ func (s *system) initMetrics() {
 
 	s.metrics.RowsReapedByLookupTable = prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: "horizon", Subsystem: "ingest", Name: "reap_lookup_tables_rows_reaped",
-		Help:       "rows delated during lookup tables reap, sliding window = 10m",
+		Help:       "rows deleted during lookup tables reap, sliding window = 10m",
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, []string{"table"})
 
@@ -800,7 +800,7 @@ func (s *system) maybeReapLookupTables(lastIngestedLedger uint32) {
 	defer cancel()
 
 	reapStart := time.Now()
-	results, err := s.historyQ.ReapLookupTables(ctx, s.reapOffsets)
+	results, err := s.historyQ.ReapLookupTables(ctx, s.reapOffsetByTable)
 	if err != nil {
 		log.WithError(err).Warn("Error reaping lookup tables")
 		return
@@ -817,7 +817,7 @@ func (s *system) maybeReapLookupTables(lastIngestedLedger uint32) {
 	for table, result := range results {
 		totalDeleted += result.RowsDeleted
 		reapLog = reapLog.WithField(table, result)
-		s.reapOffsets[table] = result.Offset
+		s.reapOffsetByTable[table] = result.Offset
 		s.Metrics().RowsReapedByLookupTable.With(prometheus.Labels{"table": table}).Observe(float64(result.RowsDeleted))
 		s.Metrics().ReapDurationByLookupTable.With(prometheus.Labels{"table": table}).Observe(result.Duration.Seconds())
 	}

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -562,16 +562,13 @@ func (m *mockDBQ) NewTradeBatchInsertBuilder() history.TradeBatchInsertBuilder {
 	return args.Get(0).(history.TradeBatchInsertBuilder)
 }
 
-func (m *mockDBQ) ReapLookupTables(ctx context.Context, offsets map[string]int64) (map[string]int64, map[string]int64, error) {
+func (m *mockDBQ) ReapLookupTables(ctx context.Context, offsets map[string]int64) (map[string]history.LookupTableReapResult, error) {
 	args := m.Called(ctx, offsets)
-	var r1, r2 map[string]int64
+	var r1 map[string]history.LookupTableReapResult
 	if args.Get(0) != nil {
-		r1 = args.Get(0).(map[string]int64)
+		r1 = args.Get(0).(map[string]history.LookupTableReapResult)
 	}
-	if args.Get(1) != nil {
-		r1 = args.Get(1).(map[string]int64)
-	}
-	return r1, r2, args.Error(2)
+	return r1, args.Error(2)
 }
 
 func (m *mockDBQ) RebuildTradeAggregationTimes(ctx context.Context, from, to strtime.Millis, roundingSlippageFilter int) error {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Add duration metrics for reaping of lookup tables where we can see how much time is spent reaping each table. See link below which displays the new metrics on staging:

https://grafana.stellar-ops.com/d/x8xDSQQIk/stellar-horizon?orgId=1&viewPanel=2531


Also, add metrics which count how many rows were deleted from each lookup table. See link below which displays the new metrics on staging:

https://grafana.stellar-ops.com/d/x8xDSQQIk/stellar-horizon?orgId=1&viewPanel=2541
 
### Why

These fine-grained metrics are required so that we can analyze which tables are the most expensive to reap.

### Known limitations

[N/A]
