### PR TITLE
services/horizon/internal/db2/history: Optimize query for reaping lookup tables

### DIFF
--- a/services/horizon/internal/db2/history/key_value.go
+++ b/services/horizon/internal/db2/history/key_value.go
@@ -3,9 +3,12 @@ package history
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strconv"
+	"strings"
 
 	sq "github.com/Masterminds/squirrel"
+
 	"github.com/stellar/go/support/errors"
 )
 
@@ -18,6 +21,7 @@ const (
 	stateInvalid                    = "exp_state_invalid"
 	offerCompactionSequence         = "offer_compaction_sequence"
 	liquidityPoolCompactionSequence = "liquidity_pool_compaction_sequence"
+	lookupTableReapOffsetSuffix     = "_reap_offset"
 )
 
 // GetLastLedgerIngestNonBlocking works like GetLastLedgerIngest but
@@ -201,6 +205,42 @@ func (q *Q) getValueFromStore(ctx context.Context, key string, forUpdate bool) (
 	}
 
 	return value, nil
+}
+
+type KeyValuePair struct {
+	Key   string `db:"key"`
+	Value string `db:"value"`
+}
+
+func (q *Q) getLookupTableReapOffsets(ctx context.Context) (map[string]int64, error) {
+	keys := make([]string, 0, len(historyLookupTables))
+	for table := range historyLookupTables {
+		keys = append(keys, table+lookupTableReapOffsetSuffix)
+	}
+	offsets := map[string]int64{}
+	var pairs []KeyValuePair
+	query := sq.Select("key", "value").
+		From("key_value_store").
+		Where(map[string]interface{}{
+			"key": keys,
+		})
+	err := q.Select(ctx, &pairs, query)
+	for _, pair := range pairs {
+		table := strings.TrimSuffix(pair.Key, lookupTableReapOffsetSuffix)
+		if _, ok := historyLookupTables[table]; !ok {
+			return nil, fmt.Errorf("invalid key: %s", pair.Key)
+		}
+		offset, err := strconv.ParseInt(pair.Value, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid offset: %s", pair.Value)
+		}
+		offsets[table] = offset
+	}
+	return offsets, err
+}
+
+func (q *Q) updateLookupTableReapOffset(ctx context.Context, table string, offset int64) error {
+	return q.updateValueInStore(ctx, table+lookupTableReapOffsetSuffix, strconv.FormatInt(offset, 10))
 }
 
 // updateValueInStore updates a value for a given key in KV store

--- a/services/horizon/internal/db2/history/key_value.go
+++ b/services/horizon/internal/db2/history/key_value.go
@@ -225,12 +225,17 @@ func (q *Q) getLookupTableReapOffsets(ctx context.Context) (map[string]int64, er
 			"key": keys,
 		})
 	err := q.Select(ctx, &pairs, query)
+	if err != nil {
+		return nil, err
+	}
 	for _, pair := range pairs {
 		table := strings.TrimSuffix(pair.Key, lookupTableReapOffsetSuffix)
 		if _, ok := historyLookupTables[table]; !ok {
 			return nil, fmt.Errorf("invalid key: %s", pair.Key)
 		}
-		offset, err := strconv.ParseInt(pair.Value, 10, 64)
+
+		var offset int64
+		offset, err = strconv.ParseInt(pair.Value, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("invalid offset: %s", pair.Value)
 		}

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -972,9 +972,9 @@ type tableObjectFieldPair struct {
 }
 
 type LookupTableReapResult struct {
-	Offset      int64
-	RowsDeleted int64
-	Duration    time.Duration
+	Offset      int64         `json:"offset"`
+	RowsDeleted int64         `json:"rowsDeleted"`
+	Duration    time.Duration `json:"duration"`
 }
 
 // ReapLookupTables removes rows from lookup tables like history_claimable_balances

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -1094,24 +1094,17 @@ func (q Q) ReapLookupTables(ctx context.Context, offsets map[string]int64) (
 // constructReapLookupTablesQuery creates a query like (using history_claimable_balances
 // as an example):
 //
-// delete from history_claimable_balances where id in
+// delete from history_claimable_balances where id in (
 //
-//	(SELECT e1.id FROM (
-//			SELECT id FROM history_claimable_balances
+//		WITH ha_batch AS (
+//			SELECT   id
+//			FROM     history_claimable_balances
 //			WHERE id >= 1000
-//			ORDER BY id LIMIT 1000
-//		) e1 LEFT JOIN LATERAL (
-//			SELECT 1 AS row
-//			FROM history_transaction_claimable_balances
-//			where history_transaction_claimable_balances.history_claimable_balance_id = e1.id
-//			LIMIT 1
-//		) e2 ON true LEFT JOIN LATERAL (
-//			SELECT 1 AS row
-//			FROM history_operation_claimable_balances
-//			where history_operation_claimable_balances.history_claimable_balance_id = e1.id
-//			LIMIT 1
-//		) e3 ON true
-//	WHERE e2.row IS NULL AND e3.row IS NULL);
+//			ORDER BY id limit 1000
+//		) SELECT e1.id as id FROM ha_batch e1
+//		WHERE NOT EXISTS (SELECT 1 FROM history_transaction_claimable_balances WHERE history_transaction_claimable_balances.history_claimable_balance_id = id limit 1)
+//		AND NOT EXISTS (SELECT 1 FROM history_operation_claimable_balances WHERE history_operation_claimable_balances.history_claimable_balance_id = id limit 1)
+//	 )
 //
 // In short it checks the 1000 rows omitting 1000 row of history_claimable_balances
 // and counts occurrences of each row in corresponding history tables.
@@ -1124,31 +1117,28 @@ func (q Q) ReapLookupTables(ctx context.Context, offsets map[string]int64) (
 // when it reaches the table size so eventually all orphaned rows are
 // deleted.
 func constructReapLookupTablesQuery(table string, historyTables []tableObjectFieldPair, batchSize, offset int64) string {
-	index := 2
-	var joins []string
 	var conditions []string
 
 	for _, historyTable := range historyTables {
-		joins = append(
-			joins,
+		conditions = append(
+			conditions,
 			fmt.Sprintf(
-				` LEFT JOIN LATERAL ( SELECT 1 as row FROM %s WHERE %s.%s = e1.id LIMIT 1) e%d ON true`,
+				"NOT EXISTS ( SELECT 1 as row FROM %s WHERE %s.%s = id LIMIT 1)",
 				historyTable.name,
 				historyTable.name, historyTable.objectField,
-				index,
 			),
 		)
-		conditions = append(conditions, fmt.Sprintf("e%d.row IS NULL", index))
-		index++
 	}
 
 	return fmt.Sprintf(
-		"DELETE FROM %s WHERE id IN (SELECT e1.id FROM (SELECT id FROM %s WHERE id >= %d ORDER BY id LIMIT %d) e1",
+		"DELETE FROM %s WHERE id IN ("+
+			"WITH ha_batch AS (SELECT id FROM %s WHERE id >= %d ORDER BY id limit %d) "+
+			"SELECT e1.id as id FROM ha_batch e1 WHERE ",
 		table,
 		table,
 		offset,
 		batchSize,
-	) + strings.Join(joins, "") + fmt.Sprintf(" WHERE %s);", strings.Join(conditions, " AND "))
+	) + strings.Join(conditions, " AND ") + ")"
 }
 
 // DeleteRangeAll deletes a range of rows from all history tables between

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -282,7 +282,7 @@ type IngestionQ interface {
 	NewTradeBatchInsertBuilder() TradeBatchInsertBuilder
 	RebuildTradeAggregationTimes(ctx context.Context, from, to strtime.Millis, roundingSlippageFilter int) error
 	RebuildTradeAggregationBuckets(ctx context.Context, fromLedger, toLedger uint32, roundingSlippageFilter int) error
-	ReapLookupTables(ctx context.Context) (map[string]LookupTableReapResult, error)
+	ReapLookupTables(ctx context.Context, batchSize int) (map[string]LookupTableReapResult, error)
 	CreateAssets(ctx context.Context, assets []xdr.Asset, batchSize int) (map[string]Asset, error)
 	QTransactions
 	QTrustLines
@@ -981,7 +981,7 @@ type LookupTableReapResult struct {
 // which aren't used (orphaned), i.e. history entries for them were reaped.
 // This method must be executed inside ingestion transaction. Otherwise it may
 // create invalid state in lookup and history tables.
-func (q *Q) ReapLookupTables(ctx context.Context) (
+func (q *Q) ReapLookupTables(ctx context.Context, batchSize int) (
 	map[string]LookupTableReapResult,
 	error,
 ) {
@@ -993,8 +993,6 @@ func (q *Q) ReapLookupTables(ctx context.Context) (
 	if err != nil {
 		return nil, fmt.Errorf("could not obtain offsets: %w", err)
 	}
-
-	const batchSize = 1000
 
 	results := map[string]LookupTableReapResult{}
 	for table, historyTables := range historyLookupTables {
@@ -1127,7 +1125,7 @@ var historyLookupTables = map[string][]tableObjectFieldPair{
 // possible that rows will be skipped from deletion. But offset is reset
 // when it reaches the table size so eventually all orphaned rows are
 // deleted.
-func constructReapLookupTablesQuery(table string, historyTables []tableObjectFieldPair, batchSize, offset int64) string {
+func constructReapLookupTablesQuery(table string, historyTables []tableObjectFieldPair, batchSize int, offset int64) string {
 	var conditions []string
 
 	for _, historyTable := range historyTables {

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -995,6 +995,11 @@ func (q Q) ReapLookupTables(ctx context.Context, offsets map[string]int64) (
 	for table, historyTables := range map[string][]tableObjectFieldPair{
 		"history_accounts": {
 			{
+				name:        "history_transaction_participants",
+				objectField: "history_account_id",
+			},
+
+			{
 				name:        "history_effects",
 				objectField: "history_account_id",
 			},
@@ -1009,10 +1014,6 @@ func (q Q) ReapLookupTables(ctx context.Context, offsets map[string]int64) (
 			{
 				name:        "history_trades",
 				objectField: "counter_account_id",
-			},
-			{
-				name:        "history_transaction_participants",
-				objectField: "history_account_id",
 			},
 		},
 		"history_assets": {
@@ -1035,34 +1036,31 @@ func (q Q) ReapLookupTables(ctx context.Context, offsets map[string]int64) (
 		},
 		"history_claimable_balances": {
 			{
-				name:        "history_operation_claimable_balances",
+				name:        "history_transaction_claimable_balances",
 				objectField: "history_claimable_balance_id",
 			},
 			{
-				name:        "history_transaction_claimable_balances",
+				name:        "history_operation_claimable_balances",
 				objectField: "history_claimable_balance_id",
 			},
 		},
 		"history_liquidity_pools": {
 			{
-				name:        "history_operation_liquidity_pools",
+				name:        "history_transaction_liquidity_pools",
 				objectField: "history_liquidity_pool_id",
 			},
 			{
-				name:        "history_transaction_liquidity_pools",
+				name:        "history_operation_liquidity_pools",
 				objectField: "history_liquidity_pool_id",
 			},
 		},
 	} {
 		startTime := time.Now()
-		query, err := constructReapLookupTablesQuery(table, historyTables, batchSize, offsets[table])
-		if err != nil {
-			return nil, errors.Wrap(err, "error constructing a query")
-		}
+		query := constructReapLookupTablesQuery(table, historyTables, batchSize, offsets[table])
 
 		// Find new offset before removing the rows
 		var newOffset int64
-		err = q.GetRaw(ctx, &newOffset, fmt.Sprintf("SELECT id FROM %s where id >= %d limit 1 offset %d", table, offsets[table], batchSize))
+		err := q.GetRaw(ctx, &newOffset, fmt.Sprintf("SELECT id FROM %s where id >= %d limit 1 offset %d", table, offsets[table], batchSize))
 		if err != nil {
 			if q.NoRows(err) {
 				newOffset = 0
@@ -1098,17 +1096,24 @@ func (q Q) ReapLookupTables(ctx context.Context, offsets map[string]int64) (
 //
 // delete from history_claimable_balances where id in
 //
-//	 (select id from
-//	   (select id,
-//			(select 1 from history_operation_claimable_balances
-//			 where history_claimable_balance_id = hcb.id limit 1) as c1,
-//			(select 1 from history_transaction_claimable_balances
-//			 where history_claimable_balance_id = hcb.id limit 1) as c2,
-//			1 as cx,
-//	     from history_claimable_balances hcb where id > 1000 order by id limit 100)
-//	 as sub where c1 IS NULL and c2 IS NULL and 1=1);
+//	(SELECT e1.id FROM (
+//			SELECT id FROM history_claimable_balances
+//			WHERE id >= 1000
+//			ORDER BY id LIMIT 1000
+//		) e1 LEFT JOIN LATERAL (
+//			SELECT 1 AS row
+//			FROM history_transaction_claimable_balances
+//			where history_transaction_claimable_balances.history_claimable_balance_id = e1.id
+//			LIMIT 1
+//		) e2 ON true LEFT JOIN LATERAL (
+//			SELECT 1 AS row
+//			FROM history_operation_claimable_balances
+//			where history_operation_claimable_balances.history_claimable_balance_id = e1.id
+//			LIMIT 1
+//		) e3 ON true
+//	WHERE e2.row IS NULL AND e3.row IS NULL);
 //
-// In short it checks the 100 rows omitting 1000 row of history_claimable_balances
+// In short it checks the 1000 rows omitting 1000 row of history_claimable_balances
 // and counts occurrences of each row in corresponding history tables.
 // If there are no history rows for a given id, the row in
 // history_claimable_balances is removed.
@@ -1118,45 +1123,32 @@ func (q Q) ReapLookupTables(ctx context.Context, offsets map[string]int64) (
 // possible that rows will be skipped from deletion. But offset is reset
 // when it reaches the table size so eventually all orphaned rows are
 // deleted.
-func constructReapLookupTablesQuery(table string, historyTables []tableObjectFieldPair, batchSize, offset int64) (string, error) {
-	var sb strings.Builder
-	var err error
-	_, err = fmt.Fprintf(&sb, "delete from %s where id IN (select id from (select id, ", table)
-	if err != nil {
-		return "", err
-	}
+func constructReapLookupTablesQuery(table string, historyTables []tableObjectFieldPair, batchSize, offset int64) string {
+	index := 2
+	var joins []string
+	var conditions []string
 
-	for i, historyTable := range historyTables {
-		_, err = fmt.Fprintf(
-			&sb,
-			`(select 1 from %s where %s = hcb.id limit 1) as c%d, `,
-			historyTable.name,
-			historyTable.objectField,
-			i,
+	for _, historyTable := range historyTables {
+		joins = append(
+			joins,
+			fmt.Sprintf(
+				` LEFT JOIN LATERAL ( SELECT 1 as row FROM %s WHERE %s.%s = e1.id LIMIT 1) e%d ON true`,
+				historyTable.name,
+				historyTable.name, historyTable.objectField,
+				index,
+			),
 		)
-		if err != nil {
-			return "", err
-		}
+		conditions = append(conditions, fmt.Sprintf("e%d.row IS NULL", index))
+		index++
 	}
 
-	_, err = fmt.Fprintf(&sb, "1 as cx from %s hcb where id >= %d order by id limit %d) as sub where ", table, offset, batchSize)
-	if err != nil {
-		return "", err
-	}
-
-	for i := range historyTables {
-		_, err = fmt.Fprintf(&sb, "c%d IS NULL and ", i)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	_, err = sb.WriteString("1=1);")
-	if err != nil {
-		return "", err
-	}
-
-	return sb.String(), nil
+	return fmt.Sprintf(
+		"DELETE FROM %s WHERE id IN (SELECT e1.id FROM (SELECT id FROM %s WHERE id >= %d ORDER BY id LIMIT %d) e1",
+		table,
+		table,
+		offset,
+		batchSize,
+	) + strings.Join(joins, "") + fmt.Sprintf(" WHERE %s);", strings.Join(conditions, " AND "))
 }
 
 // DeleteRangeAll deletes a range of rows from all history tables between

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -282,7 +282,7 @@ type IngestionQ interface {
 	NewTradeBatchInsertBuilder() TradeBatchInsertBuilder
 	RebuildTradeAggregationTimes(ctx context.Context, from, to strtime.Millis, roundingSlippageFilter int) error
 	RebuildTradeAggregationBuckets(ctx context.Context, fromLedger, toLedger uint32, roundingSlippageFilter int) error
-	ReapLookupTables(ctx context.Context, offsets map[string]int64) (map[string]LookupTableReapResult, error)
+	ReapLookupTables(ctx context.Context) (map[string]LookupTableReapResult, error)
 	CreateAssets(ctx context.Context, assets []xdr.Asset, batchSize int) (map[string]Asset, error)
 	QTransactions
 	QTrustLines
@@ -981,7 +981,7 @@ type LookupTableReapResult struct {
 // which aren't used (orphaned), i.e. history entries for them were reaped.
 // This method must be executed inside ingestion transaction. Otherwise it may
 // create invalid state in lookup and history tables.
-func (q Q) ReapLookupTables(ctx context.Context, offsets map[string]int64) (
+func (q *Q) ReapLookupTables(ctx context.Context) (
 	map[string]LookupTableReapResult,
 	error,
 ) {
@@ -989,72 +989,15 @@ func (q Q) ReapLookupTables(ctx context.Context, offsets map[string]int64) (
 		return nil, errors.New("cannot be called outside of an ingestion transaction")
 	}
 
+	offsets, err := q.getLookupTableReapOffsets(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not obtain offsets: %w", err)
+	}
+
 	const batchSize = 1000
 
 	results := map[string]LookupTableReapResult{}
-	for table, historyTables := range map[string][]tableObjectFieldPair{
-		"history_accounts": {
-			{
-				name:        "history_transaction_participants",
-				objectField: "history_account_id",
-			},
-
-			{
-				name:        "history_effects",
-				objectField: "history_account_id",
-			},
-			{
-				name:        "history_operation_participants",
-				objectField: "history_account_id",
-			},
-			{
-				name:        "history_trades",
-				objectField: "base_account_id",
-			},
-			{
-				name:        "history_trades",
-				objectField: "counter_account_id",
-			},
-		},
-		"history_assets": {
-			{
-				name:        "history_trades",
-				objectField: "base_asset_id",
-			},
-			{
-				name:        "history_trades",
-				objectField: "counter_asset_id",
-			},
-			{
-				name:        "history_trades_60000",
-				objectField: "base_asset_id",
-			},
-			{
-				name:        "history_trades_60000",
-				objectField: "counter_asset_id",
-			},
-		},
-		"history_claimable_balances": {
-			{
-				name:        "history_transaction_claimable_balances",
-				objectField: "history_claimable_balance_id",
-			},
-			{
-				name:        "history_operation_claimable_balances",
-				objectField: "history_claimable_balance_id",
-			},
-		},
-		"history_liquidity_pools": {
-			{
-				name:        "history_transaction_liquidity_pools",
-				objectField: "history_liquidity_pool_id",
-			},
-			{
-				name:        "history_operation_liquidity_pools",
-				objectField: "history_liquidity_pool_id",
-			},
-		},
-	} {
+	for table, historyTables := range historyLookupTables {
 		startTime := time.Now()
 		query := constructReapLookupTablesQuery(table, historyTables, batchSize, offsets[table])
 
@@ -1077,6 +1020,10 @@ func (q Q) ReapLookupTables(ctx context.Context, offsets map[string]int64) (
 			return nil, errors.Wrapf(err, "error running query: %s", query)
 		}
 
+		if err = q.updateLookupTableReapOffset(ctx, table, newOffset); err != nil {
+			return nil, fmt.Errorf("error updating offset: %w", err)
+		}
+
 		rows, err := res.RowsAffected()
 		if err != nil {
 			return nil, errors.Wrapf(err, "error running RowsAffected after query: %s", query)
@@ -1089,6 +1036,70 @@ func (q Q) ReapLookupTables(ctx context.Context, offsets map[string]int64) (
 		}
 	}
 	return results, nil
+}
+
+var historyLookupTables = map[string][]tableObjectFieldPair{
+	"history_accounts": {
+		{
+			name:        "history_transaction_participants",
+			objectField: "history_account_id",
+		},
+
+		{
+			name:        "history_effects",
+			objectField: "history_account_id",
+		},
+		{
+			name:        "history_operation_participants",
+			objectField: "history_account_id",
+		},
+		{
+			name:        "history_trades",
+			objectField: "base_account_id",
+		},
+		{
+			name:        "history_trades",
+			objectField: "counter_account_id",
+		},
+	},
+	"history_assets": {
+		{
+			name:        "history_trades",
+			objectField: "base_asset_id",
+		},
+		{
+			name:        "history_trades",
+			objectField: "counter_asset_id",
+		},
+		{
+			name:        "history_trades_60000",
+			objectField: "base_asset_id",
+		},
+		{
+			name:        "history_trades_60000",
+			objectField: "counter_asset_id",
+		},
+	},
+	"history_claimable_balances": {
+		{
+			name:        "history_transaction_claimable_balances",
+			objectField: "history_claimable_balance_id",
+		},
+		{
+			name:        "history_operation_claimable_balances",
+			objectField: "history_claimable_balance_id",
+		},
+	},
+	"history_liquidity_pools": {
+		{
+			name:        "history_transaction_liquidity_pools",
+			objectField: "history_liquidity_pool_id",
+		},
+		{
+			name:        "history_operation_liquidity_pools",
+			objectField: "history_liquidity_pool_id",
+		},
+	},
 }
 
 // constructReapLookupTablesQuery creates a query like (using history_claimable_balances

--- a/services/horizon/internal/db2/history/main.go
+++ b/services/horizon/internal/db2/history/main.go
@@ -972,9 +972,9 @@ type tableObjectFieldPair struct {
 }
 
 type LookupTableReapResult struct {
-	Offset      int64         `json:"offset"`
-	RowsDeleted int64         `json:"rowsDeleted"`
-	Duration    time.Duration `json:"duration"`
+	Offset      int64
+	RowsDeleted int64
+	Duration    time.Duration
 }
 
 // ReapLookupTables removes rows from lookup tables like history_claimable_balances

--- a/services/horizon/internal/db2/history/main_test.go
+++ b/services/horizon/internal/db2/history/main_test.go
@@ -72,28 +72,7 @@ func TestElderLedger(t *testing.T) {
 func TestConstructReapLookupTablesQuery(t *testing.T) {
 	query := constructReapLookupTablesQuery(
 		"history_accounts",
-		[]tableObjectFieldPair{
-			{
-				name:        "history_transaction_participants",
-				objectField: "history_account_id",
-			},
-			{
-				name:        "history_effects",
-				objectField: "history_account_id",
-			},
-			{
-				name:        "history_operation_participants",
-				objectField: "history_account_id",
-			},
-			{
-				name:        "history_trades",
-				objectField: "base_account_id",
-			},
-			{
-				name:        "history_trades",
-				objectField: "counter_account_id",
-			},
-		},
+		historyLookupTables["history_accounts"],
 		10,
 		0,
 	)
@@ -105,5 +84,5 @@ func TestConstructReapLookupTablesQuery(t *testing.T) {
 			"AND NOT EXISTS ( SELECT 1 as row FROM history_effects WHERE history_effects.history_account_id = id LIMIT 1) "+
 			"AND NOT EXISTS ( SELECT 1 as row FROM history_operation_participants WHERE history_operation_participants.history_account_id = id LIMIT 1) "+
 			"AND NOT EXISTS ( SELECT 1 as row FROM history_trades WHERE history_trades.base_account_id = id LIMIT 1) "+
-			"AND NOT EXISTS ( SELECT 1 as row FROM history_trades WHERE history_trades.counter_account_id = id LIMIT 1)", query)
+			"AND NOT EXISTS ( SELECT 1 as row FROM history_trades WHERE history_trades.counter_account_id = id LIMIT 1))", query)
 }

--- a/services/horizon/internal/db2/history/main_test.go
+++ b/services/horizon/internal/db2/history/main_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stellar/go/services/horizon/internal/test"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go/services/horizon/internal/test"
 )
 
 func TestLatestLedger(t *testing.T) {
@@ -70,9 +70,13 @@ func TestElderLedger(t *testing.T) {
 }
 
 func TestConstructReapLookupTablesQuery(t *testing.T) {
-	query, err := constructReapLookupTablesQuery(
+	query := constructReapLookupTablesQuery(
 		"history_accounts",
 		[]tableObjectFieldPair{
+			{
+				name:        "history_transaction_participants",
+				objectField: "history_account_id",
+			},
 			{
 				name:        "history_effects",
 				objectField: "history_account_id",
@@ -89,24 +93,25 @@ func TestConstructReapLookupTablesQuery(t *testing.T) {
 				name:        "history_trades",
 				objectField: "counter_account_id",
 			},
-			{
-				name:        "history_transaction_participants",
-				objectField: "history_account_id",
-			},
 		},
 		10,
 		0,
 	)
 
-	require.NoError(t, err)
 	assert.Equal(t,
-		"delete from history_accounts where id IN "+
-			"(select id from "+
-			"(select id, (select 1 from history_effects where history_account_id = hcb.id limit 1) as c0, "+
-			"(select 1 from history_operation_participants where history_account_id = hcb.id limit 1) as c1, "+
-			"(select 1 from history_trades where base_account_id = hcb.id limit 1) as c2, "+
-			"(select 1 from history_trades where counter_account_id = hcb.id limit 1) as c3, "+
-			"(select 1 from history_transaction_participants where history_account_id = hcb.id limit 1) as c4, "+
-			"1 as cx from history_accounts hcb where id >= 0 order by id limit 10) as sub "+
-			"where c0 IS NULL and c1 IS NULL and c2 IS NULL and c3 IS NULL and c4 IS NULL and 1=1);", query)
+		"DELETE FROM history_accounts WHERE id IN ("+
+			"SELECT e1.id FROM ("+
+			"SELECT id FROM history_accounts WHERE id >= 0 ORDER BY id LIMIT 10) e1 "+
+			"LEFT JOIN LATERAL ( "+
+			"SELECT 1 as row FROM history_transaction_participants WHERE history_transaction_participants.history_account_id = e1.id LIMIT 1"+
+			") e2 ON true LEFT JOIN LATERAL ( "+
+			"SELECT 1 as row FROM history_effects WHERE history_effects.history_account_id = e1.id LIMIT 1"+
+			") e3 ON true LEFT JOIN LATERAL ( "+
+			"SELECT 1 as row FROM history_operation_participants WHERE history_operation_participants.history_account_id = e1.id LIMIT 1"+
+			") e4 ON true LEFT JOIN LATERAL ( "+
+			"SELECT 1 as row FROM history_trades WHERE history_trades.base_account_id = e1.id LIMIT 1"+
+			") e5 ON true LEFT JOIN LATERAL ( "+
+			"SELECT 1 as row FROM history_trades WHERE history_trades.counter_account_id = e1.id LIMIT 1"+
+			") e6 ON true "+
+			"WHERE e2.row IS NULL AND e3.row IS NULL AND e4.row IS NULL AND e5.row IS NULL AND e6.row IS NULL);", query)
 }

--- a/services/horizon/internal/db2/history/main_test.go
+++ b/services/horizon/internal/db2/history/main_test.go
@@ -100,18 +100,10 @@ func TestConstructReapLookupTablesQuery(t *testing.T) {
 
 	assert.Equal(t,
 		"DELETE FROM history_accounts WHERE id IN ("+
-			"SELECT e1.id FROM ("+
-			"SELECT id FROM history_accounts WHERE id >= 0 ORDER BY id LIMIT 10) e1 "+
-			"LEFT JOIN LATERAL ( "+
-			"SELECT 1 as row FROM history_transaction_participants WHERE history_transaction_participants.history_account_id = e1.id LIMIT 1"+
-			") e2 ON true LEFT JOIN LATERAL ( "+
-			"SELECT 1 as row FROM history_effects WHERE history_effects.history_account_id = e1.id LIMIT 1"+
-			") e3 ON true LEFT JOIN LATERAL ( "+
-			"SELECT 1 as row FROM history_operation_participants WHERE history_operation_participants.history_account_id = e1.id LIMIT 1"+
-			") e4 ON true LEFT JOIN LATERAL ( "+
-			"SELECT 1 as row FROM history_trades WHERE history_trades.base_account_id = e1.id LIMIT 1"+
-			") e5 ON true LEFT JOIN LATERAL ( "+
-			"SELECT 1 as row FROM history_trades WHERE history_trades.counter_account_id = e1.id LIMIT 1"+
-			") e6 ON true "+
-			"WHERE e2.row IS NULL AND e3.row IS NULL AND e4.row IS NULL AND e5.row IS NULL AND e6.row IS NULL);", query)
+			"WITH ha_batch AS (SELECT id FROM history_accounts WHERE id >= 0 ORDER BY id limit 10) SELECT e1.id as id FROM ha_batch e1 "+
+			"WHERE NOT EXISTS ( SELECT 1 as row FROM history_transaction_participants WHERE history_transaction_participants.history_account_id = id LIMIT 1) "+
+			"AND NOT EXISTS ( SELECT 1 as row FROM history_effects WHERE history_effects.history_account_id = id LIMIT 1) "+
+			"AND NOT EXISTS ( SELECT 1 as row FROM history_operation_participants WHERE history_operation_participants.history_account_id = id LIMIT 1) "+
+			"AND NOT EXISTS ( SELECT 1 as row FROM history_trades WHERE history_trades.base_account_id = id LIMIT 1) "+
+			"AND NOT EXISTS ( SELECT 1 as row FROM history_trades WHERE history_trades.counter_account_id = id LIMIT 1)", query)
 }

--- a/services/horizon/internal/db2/history/reap_test.go
+++ b/services/horizon/internal/db2/history/reap_test.go
@@ -52,7 +52,7 @@ func TestReapLookupTables(t *testing.T) {
 	err = q.Begin(tt.Ctx)
 	tt.Require.NoError(err)
 
-	results, err := q.ReapLookupTables(tt.Ctx)
+	results, err := q.ReapLookupTables(tt.Ctx, 5)
 	tt.Require.NoError(err)
 
 	err = q.Commit()
@@ -76,12 +76,12 @@ func TestReapLookupTables(t *testing.T) {
 	tt.Assert.Equal(1, curLedgers, "curLedgers")
 
 	tt.Assert.Equal(25, prevAccounts, "prevAccounts")
-	tt.Assert.Equal(1, curAccounts, "curAccounts")
-	tt.Assert.Equal(int64(24), results["history_accounts"].RowsDeleted, `deletedCount["history_accounts"]`)
+	tt.Assert.Equal(21, curAccounts, "curAccounts")
+	tt.Assert.Equal(int64(4), results["history_accounts"].RowsDeleted, `deletedCount["history_accounts"]`)
 
 	tt.Assert.Equal(7, prevAssets, "prevAssets")
-	tt.Assert.Equal(0, curAssets, "curAssets")
-	tt.Assert.Equal(int64(7), results["history_assets"].RowsDeleted, `deletedCount["history_assets"]`)
+	tt.Assert.Equal(2, curAssets, "curAssets")
+	tt.Assert.Equal(int64(5), results["history_assets"].RowsDeleted, `deletedCount["history_assets"]`)
 
 	tt.Assert.Equal(1, prevClaimableBalances, "prevClaimableBalances")
 	tt.Assert.Equal(0, curClaimableBalances, "curClaimableBalances")
@@ -90,6 +90,66 @@ func TestReapLookupTables(t *testing.T) {
 	tt.Assert.Equal(1, prevLiquidityPools, "prevLiquidityPools")
 	tt.Assert.Equal(0, curLiquidityPools, "curLiquidityPools")
 	tt.Assert.Equal(int64(1), results["history_liquidity_pools"].RowsDeleted, `deletedCount["history_liquidity_pools"]`)
+
+	tt.Assert.Len(results, 4)
+	tt.Assert.Equal(int64(6), results["history_accounts"].Offset)
+	tt.Assert.Equal(int64(6), results["history_assets"].Offset)
+	tt.Assert.Equal(int64(0), results["history_claimable_balances"].Offset)
+	tt.Assert.Equal(int64(0), results["history_liquidity_pools"].Offset)
+
+	err = q.Begin(tt.Ctx)
+	tt.Require.NoError(err)
+
+	results, err = q.ReapLookupTables(tt.Ctx, 5)
+	tt.Require.NoError(err)
+
+	err = q.Commit()
+	tt.Require.NoError(err)
+
+	err = db.GetRaw(tt.Ctx, &curAccounts, `SELECT COUNT(*) FROM history_accounts`)
+	tt.Require.NoError(err)
+	err = db.GetRaw(tt.Ctx, &curAssets, `SELECT COUNT(*) FROM history_assets`)
+	tt.Require.NoError(err)
+
+	tt.Assert.Equal(16, curAccounts, "curAccounts")
+	tt.Assert.Equal(int64(5), results["history_accounts"].RowsDeleted, `deletedCount["history_accounts"]`)
+
+	tt.Assert.Equal(0, curAssets, "curAssets")
+	tt.Assert.Equal(int64(2), results["history_assets"].RowsDeleted, `deletedCount["history_assets"]`)
+
+	tt.Assert.Equal(int64(0), results["history_claimable_balances"].RowsDeleted, `deletedCount["history_claimable_balances"]`)
+
+	tt.Assert.Equal(int64(0), results["history_liquidity_pools"].RowsDeleted, `deletedCount["history_liquidity_pools"]`)
+
+	tt.Assert.Len(results, 4)
+	tt.Assert.Equal(int64(11), results["history_accounts"].Offset)
+	tt.Assert.Equal(int64(0), results["history_assets"].Offset)
+	tt.Assert.Equal(int64(0), results["history_claimable_balances"].Offset)
+	tt.Assert.Equal(int64(0), results["history_liquidity_pools"].Offset)
+
+	err = q.Begin(tt.Ctx)
+	tt.Require.NoError(err)
+
+	results, err = q.ReapLookupTables(tt.Ctx, 1000)
+	tt.Require.NoError(err)
+
+	err = q.Commit()
+	tt.Require.NoError(err)
+
+	err = db.GetRaw(tt.Ctx, &curAccounts, `SELECT COUNT(*) FROM history_accounts`)
+	tt.Require.NoError(err)
+	err = db.GetRaw(tt.Ctx, &curAssets, `SELECT COUNT(*) FROM history_assets`)
+	tt.Require.NoError(err)
+
+	tt.Assert.Equal(1, curAccounts, "curAccounts")
+	tt.Assert.Equal(int64(15), results["history_accounts"].RowsDeleted, `deletedCount["history_accounts"]`)
+
+	tt.Assert.Equal(0, curAssets, "curAssets")
+	tt.Assert.Equal(int64(0), results["history_assets"].RowsDeleted, `deletedCount["history_assets"]`)
+
+	tt.Assert.Equal(int64(0), results["history_claimable_balances"].RowsDeleted, `deletedCount["history_claimable_balances"]`)
+
+	tt.Assert.Equal(int64(0), results["history_liquidity_pools"].RowsDeleted, `deletedCount["history_liquidity_pools"]`)
 
 	tt.Assert.Len(results, 4)
 	tt.Assert.Equal(int64(0), results["history_accounts"].Offset)

--- a/services/horizon/internal/db2/history/reap_test.go
+++ b/services/horizon/internal/db2/history/reap_test.go
@@ -52,7 +52,7 @@ func TestReapLookupTables(t *testing.T) {
 	err = q.Begin(tt.Ctx)
 	tt.Require.NoError(err)
 
-	results, err := q.ReapLookupTables(tt.Ctx, nil)
+	results, err := q.ReapLookupTables(tt.Ctx)
 	tt.Require.NoError(err)
 
 	err = q.Commit()

--- a/services/horizon/internal/db2/history/reap_test.go
+++ b/services/horizon/internal/db2/history/reap_test.go
@@ -30,21 +30,18 @@ func TestReapLookupTables(t *testing.T) {
 		prevLiquidityPools, curLiquidityPools       int
 	)
 
-	// Prev
-	{
-		err := db.GetRaw(tt.Ctx, &prevLedgers, `SELECT COUNT(*) FROM history_ledgers`)
-		tt.Require.NoError(err)
-		err = db.GetRaw(tt.Ctx, &prevAccounts, `SELECT COUNT(*) FROM history_accounts`)
-		tt.Require.NoError(err)
-		err = db.GetRaw(tt.Ctx, &prevAssets, `SELECT COUNT(*) FROM history_assets`)
-		tt.Require.NoError(err)
-		err = db.GetRaw(tt.Ctx, &prevClaimableBalances, `SELECT COUNT(*) FROM history_claimable_balances`)
-		tt.Require.NoError(err)
-		err = db.GetRaw(tt.Ctx, &prevLiquidityPools, `SELECT COUNT(*) FROM history_liquidity_pools`)
-		tt.Require.NoError(err)
-	}
+	err := db.GetRaw(tt.Ctx, &prevLedgers, `SELECT COUNT(*) FROM history_ledgers`)
+	tt.Require.NoError(err)
+	err = db.GetRaw(tt.Ctx, &prevAccounts, `SELECT COUNT(*) FROM history_accounts`)
+	tt.Require.NoError(err)
+	err = db.GetRaw(tt.Ctx, &prevAssets, `SELECT COUNT(*) FROM history_assets`)
+	tt.Require.NoError(err)
+	err = db.GetRaw(tt.Ctx, &prevClaimableBalances, `SELECT COUNT(*) FROM history_claimable_balances`)
+	tt.Require.NoError(err)
+	err = db.GetRaw(tt.Ctx, &prevLiquidityPools, `SELECT COUNT(*) FROM history_liquidity_pools`)
+	tt.Require.NoError(err)
 
-	err := reaper.DeleteUnretainedHistory(tt.Ctx)
+	err = reaper.DeleteUnretainedHistory(tt.Ctx)
 	tt.Require.NoError(err)
 
 	q := &history.Q{tt.HorizonSession()}
@@ -58,19 +55,16 @@ func TestReapLookupTables(t *testing.T) {
 	err = q.Commit()
 	tt.Require.NoError(err)
 
-	// cur
-	{
-		err := db.GetRaw(tt.Ctx, &curLedgers, `SELECT COUNT(*) FROM history_ledgers`)
-		tt.Require.NoError(err)
-		err = db.GetRaw(tt.Ctx, &curAccounts, `SELECT COUNT(*) FROM history_accounts`)
-		tt.Require.NoError(err)
-		err = db.GetRaw(tt.Ctx, &curAssets, `SELECT COUNT(*) FROM history_assets`)
-		tt.Require.NoError(err)
-		err = db.GetRaw(tt.Ctx, &curClaimableBalances, `SELECT COUNT(*) FROM history_claimable_balances`)
-		tt.Require.NoError(err)
-		err = db.GetRaw(tt.Ctx, &curLiquidityPools, `SELECT COUNT(*) FROM history_liquidity_pools`)
-		tt.Require.NoError(err)
-	}
+	err = db.GetRaw(tt.Ctx, &curLedgers, `SELECT COUNT(*) FROM history_ledgers`)
+	tt.Require.NoError(err)
+	err = db.GetRaw(tt.Ctx, &curAccounts, `SELECT COUNT(*) FROM history_accounts`)
+	tt.Require.NoError(err)
+	err = db.GetRaw(tt.Ctx, &curAssets, `SELECT COUNT(*) FROM history_assets`)
+	tt.Require.NoError(err)
+	err = db.GetRaw(tt.Ctx, &curClaimableBalances, `SELECT COUNT(*) FROM history_claimable_balances`)
+	tt.Require.NoError(err)
+	err = db.GetRaw(tt.Ctx, &curLiquidityPools, `SELECT COUNT(*) FROM history_liquidity_pools`)
+	tt.Require.NoError(err)
 
 	tt.Assert.Equal(61, prevLedgers, "prevLedgers")
 	tt.Assert.Equal(1, curLedgers, "curLedgers")

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -253,7 +253,6 @@ type system struct {
 
 	runStateVerificationOnLedger func(uint32) bool
 
-	reapOffsetByTable map[string]int64
 	maxLedgerPerFlush uint32
 
 	reaper *Reaper
@@ -369,7 +368,6 @@ func NewSystem(config Config) (System, error) {
 			config.ReapConfig,
 			config.HistorySession,
 		),
-		reapOffsetByTable: map[string]int64{},
 	}
 
 	system.initMetrics()
@@ -843,7 +841,7 @@ func (s *system) maybeReapLookupTables(lastIngestedLedger uint32) {
 	defer cancel()
 
 	reapStart := time.Now()
-	results, err := s.historyQ.ReapLookupTables(ctx, s.reapOffsetByTable)
+	results, err := s.historyQ.ReapLookupTables(ctx)
 	if err != nil {
 		log.WithError(err).Warn("Error reaping lookup tables")
 		return
@@ -860,7 +858,6 @@ func (s *system) maybeReapLookupTables(lastIngestedLedger uint32) {
 	for table, result := range results {
 		totalDeleted += result.RowsDeleted
 		reapLog = reapLog.WithField(table, result)
-		s.reapOffsetByTable[table] = result.Offset
 		s.Metrics().RowsReapedByLookupTable.With(prometheus.Labels{"table": table}).Observe(float64(result.RowsDeleted))
 		s.Metrics().ReapDurationByLookupTable.With(prometheus.Labels{"table": table}).Observe(result.Duration.Seconds())
 	}

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -73,12 +73,13 @@ const (
 	//  * Reaping (requires 2 connections, the extra connection is used for holding the advisory lock)
 	MaxDBConnections = 5
 
-	defaultCoreCursorName           = "HORIZON"
 	stateVerificationErrorThreshold = 3
 
 	// 100 ledgers per flush has shown in stress tests
 	// to be best point on performance curve, default to that.
 	MaxLedgersPerFlush uint32 = 100
+
+	reapLookupTablesBatchSize = 1000
 )
 
 var log = logpkg.DefaultLogger.WithField("service", "ingest")
@@ -841,7 +842,7 @@ func (s *system) maybeReapLookupTables(lastIngestedLedger uint32) {
 	defer cancel()
 
 	reapStart := time.Now()
-	results, err := s.historyQ.ReapLookupTables(ctx)
+	results, err := s.historyQ.ReapLookupTables(ctx, reapLookupTablesBatchSize)
 	if err != nil {
 		log.WithError(err).Warn("Error reaping lookup tables")
 		return

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -857,7 +857,9 @@ func (s *system) maybeReapLookupTables(lastIngestedLedger uint32) {
 	reapLog := log
 	for table, result := range results {
 		totalDeleted += result.RowsDeleted
-		reapLog = reapLog.WithField(table, result)
+		reapLog = reapLog.WithField(table+"_offset", result.Offset)
+		reapLog = reapLog.WithField(table+"_duration", result.Duration)
+		reapLog = reapLog.WithField(table+"_rows_deleted", result.RowsDeleted)
 		s.Metrics().RowsReapedByLookupTable.With(prometheus.Labels{"table": table}).Observe(float64(result.RowsDeleted))
 		s.Metrics().ReapDurationByLookupTable.With(prometheus.Labels{"table": table}).Observe(result.Duration.Seconds())
 	}

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -562,8 +562,8 @@ func (m *mockDBQ) NewTradeBatchInsertBuilder() history.TradeBatchInsertBuilder {
 	return args.Get(0).(history.TradeBatchInsertBuilder)
 }
 
-func (m *mockDBQ) ReapLookupTables(ctx context.Context, offsets map[string]int64) (map[string]history.LookupTableReapResult, error) {
-	args := m.Called(ctx, offsets)
+func (m *mockDBQ) ReapLookupTables(ctx context.Context) (map[string]history.LookupTableReapResult, error) {
+	args := m.Called(ctx)
 	var r1 map[string]history.LookupTableReapResult
 	if args.Get(0) != nil {
 		r1 = args.Get(0).(map[string]history.LookupTableReapResult)

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -562,8 +562,8 @@ func (m *mockDBQ) NewTradeBatchInsertBuilder() history.TradeBatchInsertBuilder {
 	return args.Get(0).(history.TradeBatchInsertBuilder)
 }
 
-func (m *mockDBQ) ReapLookupTables(ctx context.Context) (map[string]history.LookupTableReapResult, error) {
-	args := m.Called(ctx)
+func (m *mockDBQ) ReapLookupTables(ctx context.Context, batchSize int) (map[string]history.LookupTableReapResult, error) {
+	args := m.Called(ctx, batchSize)
 	var r1 map[string]history.LookupTableReapResult
 	if args.Get(0) != nil {
 		r1 = args.Get(0).(map[string]history.LookupTableReapResult)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Previously the sql queries to fined orphaned history lookup table rows looked like:

```sql
SELECT id
FROM   (SELECT id,
               (SELECT 1
                FROM   history_effects
                WHERE  history_account_id = hcb.id
                LIMIT  1) AS c0,
               (SELECT 1
                FROM   history_operation_participants
                WHERE  history_account_id = hcb.id
                LIMIT  1) AS c1,
               (SELECT 1
                FROM   history_trades
                WHERE  base_account_id = hcb.id
                LIMIT  1) AS c2,
               (SELECT 1
                FROM   history_trades
                WHERE  counter_account_id = hcb.id
                LIMIT  1) AS c3,
               (SELECT 1
                FROM   history_transaction_participants
                WHERE  history_account_id = hcb.id
                LIMIT  1) AS c4,
               1          AS cx
        FROM   history_accounts hcb
        WHERE  id >= 3183878982
        ORDER  BY id
        LIMIT  1000) AS sub
WHERE  c0 IS NULL
       AND c1 IS NULL
       AND c2 IS NULL
       AND c3 IS NULL
       AND c4 IS NULL
       AND 1 = 1 
```

The idea behind this query is to iterate over rows from the `history_accounts` table in batches of 1000. For each row in the batch we check if the account id is referenced in any of the history tables. If there are no references then we know we have identified an orphaned row which can be deleted. 

Here is the explain analyze output on that query:
```
                                                                                            QUERY PLAN                                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Subquery Scan on sub  (cost=0.43..3559.46 rows=1 width=8) (actual time=93780.856..93780.858 rows=0 loops=1)
   Filter: ((sub.c0 IS NULL) AND (sub.c1 IS NULL) AND (sub.c2 IS NULL) AND (sub.c3 IS NULL) AND (sub.c4 IS NULL))
   Rows Removed by Filter: 1000
   ->  Limit  (cost=0.43..3549.46 rows=1000 width=32) (actual time=8.656..93780.428 rows=1000 loops=1)
         ->  Index Only Scan using index_history_accounts_on_id on history_accounts hcb  (cost=0.43..11756323.12 rows=3312542 width=32) (actual time=8.655..93780.174 rows=1000 loops=1)
               Index Cond: (id >= '3183878982'::bigint)
               Heap Fetches: 5
               SubPlan 1
                 ->  Limit  (cost=0.71..0.77 rows=1 width=4) (actual time=46.704..46.704 rows=1 loops=1000)
                       ->  Index Only Scan using hist_e_id on history_effects  (cost=0.71..46809.94 rows=775981 width=4) (actual time=46.701..46.701 rows=1 loops=1000)
                             Index Cond: (history_account_id = hcb.id)
                             Heap Fetches: 84730
               SubPlan 2
                 ->  Limit  (cost=0.71..0.74 rows=1 width=4) (actual time=42.713..42.713 rows=1 loops=1000)
                       ->  Index Only Scan using hist_op_p_id on history_operation_participants  (cost=0.71..18835.15 rows=516039 width=4) (actual time=42.710..42.710 rows=1 loops=1000)
                             Index Cond: (history_account_id = hcb.id)
                             Heap Fetches: 125718
               SubPlan 3
                 ->  Limit  (cost=0.57..0.61 rows=1 width=4) (actual time=0.038..0.038 rows=0 loops=1000)
                       ->  Index Only Scan using htrd_by_base_account on history_trades  (cost=0.57..6013.19 rows=200418 width=4) (actual time=0.037..0.037 rows=0 loops=1000)
                             Index Cond: (base_account_id = hcb.id)
                             Heap Fetches: 0
               SubPlan 4
                 ->  Limit  (cost=0.57..0.61 rows=1 width=4) (actual time=0.038..0.038 rows=0 loops=1000)
                       ->  Index Only Scan using htrd_by_counter_account on history_trades history_trades_1  (cost=0.57..5581.26 rows=186019 width=4) (actual time=0.037..0.037 rows=0 loops=1000)
                             Index Cond: (counter_account_id = hcb.id)
                             Heap Fetches: 3
               SubPlan 5
                 ->  Limit  (cost=0.70..0.79 rows=1 width=4) (actual time=4.278..4.278 rows=1 loops=1000)
                       ->  Index Only Scan using hist_tx_p_id on history_transaction_participants  (cost=0.70..11259.16 rows=135159 width=4) (actual time=4.276..4.276 rows=1 loops=1000)
                             Index Cond: (history_account_id = hcb.id)
                             Heap Fetches: 1853
 Planning Time: 50.173 ms
 Execution Time: 93780.903 ms
(34 rows)
```

This PR changes the query to use [LATERAL joins](https://www.heap.io/blog/postgresqls-powerful-new-join-type-lateral):

```sql
SELECT    e1.id
FROM      (
                   SELECT   id
                   FROM     history_accounts
                   WHERE    id >= 4632128084
                   ORDER BY id limit 1000) e1
LEFT JOIN lateral
          (
                 SELECT 1 AS row
                 FROM   history_transaction_participants
                 WHERE  history_transaction_participants.history_account_id = e1.id limit 1) e2
ON        true
LEFT JOIN lateral
          (
                 SELECT 1 AS row
                 FROM   history_effects
                 WHERE  history_effects.history_account_id = e1.id limit 1) e3
ON        true
LEFT JOIN lateral
          (
                 SELECT 1 AS row
                 FROM   history_operation_participants
                 WHERE  history_operation_participants.history_account_id = e1.id limit 1) e4
ON        true
LEFT JOIN lateral
          (
                 SELECT 1 AS row
                 FROM   history_trades
                 WHERE  history_trades.base_account_id = e1.id limit 1) e5
ON        true
LEFT JOIN lateral
          (
                 SELECT 1 AS row
                 FROM   history_trades
                 WHERE  history_trades.counter_account_id = e1.id limit 1) e6
ON        true
WHERE     e2.row IS NULL
AND       e3.row IS NULL
AND       e4.row IS NULL
AND       e5.row IS NULL
AND       e6.row IS NULL
```
The new query is often faster because if it detects that an account id is referenced in one history table it aborts the search and does not query the remaining history tables in the subsequent lateral joins.

```
                                                                                              QUERY PLAN                                                                                              
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop Left Join  (cost=3.70..864.09 rows=1 width=8) (actual time=10615.471..10615.475 rows=0 loops=1)
   Filter: ((1) IS NULL)
   ->  Nested Loop Left Join  (cost=3.12..863.47 rows=1 width=8) (actual time=10615.470..10615.473 rows=0 loops=1)
         Filter: ((1) IS NULL)
         ->  Nested Loop Left Join  (cost=2.55..862.84 rows=1 width=8) (actual time=10615.470..10615.472 rows=0 loops=1)
               Filter: ((1) IS NULL)
               ->  Nested Loop Left Join  (cost=1.84..862.08 rows=1 width=8) (actual time=10615.470..10615.472 rows=0 loops=1)
                     Filter: ((1) IS NULL)
                     ->  Nested Loop Left Join  (cost=1.14..858.14 rows=5 width=8) (actual time=10615.469..10615.471 rows=0 loops=1)
                           Filter: ((1) IS NULL)
                           Rows Removed by Filter: 1000
                           ->  Limit  (cost=0.43..39.84 rows=1000 width=8) (actual time=1.183..2.864 rows=1000 loops=1)
                                 ->  Index Only Scan using index_history_accounts_on_id on history_accounts  (cost=0.43..122615.46 rows=3111337 width=8) (actual time=1.182..2.733 rows=1000 loops=1)
                                       Index Cond: (id >= '4632128084'::bigint)
                                       Heap Fetches: 25
                           ->  Limit  (cost=0.70..0.79 rows=1 width=4) (actual time=10.612..10.612 rows=1 loops=1000)
                                 ->  Index Only Scan using hist_tx_p_id on history_transaction_participants  (cost=0.70..11259.16 rows=135159 width=4) (actual time=10.609..10.609 rows=1 loops=1000)
                                       Index Cond: (history_account_id = history_accounts.id)
                                       Heap Fetches: 7358
                     ->  Limit  (cost=0.71..0.77 rows=1 width=4) (never executed)
                           ->  Index Only Scan using hist_e_id on history_effects  (cost=0.71..46809.94 rows=775981 width=4) (never executed)
                                 Index Cond: (history_account_id = history_accounts.id)
                                 Heap Fetches: 0
               ->  Limit  (cost=0.71..0.74 rows=1 width=4) (never executed)
                     ->  Index Only Scan using hist_op_p_id on history_operation_participants  (cost=0.71..18835.15 rows=516039 width=4) (never executed)
                           Index Cond: (history_account_id = history_accounts.id)
                           Heap Fetches: 0
         ->  Limit  (cost=0.57..0.61 rows=1 width=4) (never executed)
               ->  Index Only Scan using htrd_by_base_account on history_trades  (cost=0.57..6013.19 rows=200418 width=4) (never executed)
                     Index Cond: (base_account_id = history_accounts.id)
                     Heap Fetches: 0
   ->  Limit  (cost=0.57..0.61 rows=1 width=4) (never executed)
         ->  Index Only Scan using htrd_by_counter_account on history_trades history_trades_1  (cost=0.57..5581.26 rows=186019 width=4) (never executed)
               Index Cond: (counter_account_id = history_accounts.id)
               Heap Fetches: 0
 Planning Time: 0.246 ms
 Execution Time: 10615.520 ms
(37 rows)
```

This change was deployed on staging on 7/18 at approximately 11am UTC. We can see that the duration of reaping lookup tables has decreased significantly:

<img width="838" alt="Screenshot 2024-07-23 at 9 15 15 AM" src="https://github.com/user-attachments/assets/5173add8-0a49-4280-bb1b-2cd8274833d1">

We also observed a decrease in the number of timeout errors when reaping lookup tables:

<img width="1720" alt="Screenshot 2024-07-23 at 9 16 35 AM" src="https://github.com/user-attachments/assets/ccbfa721-c327-4e1f-912d-d6874baba3df">

### Known limitations

[N/A]
