### PR TITLE
Fix CI test workflow errors in RecoverySigner unit tests 

### DIFF
--- a/support/db/dbtest/db.go
+++ b/support/db/dbtest/db.go
@@ -127,6 +127,12 @@ func checkReadOnly(t testing.TB, DSN string) {
 
 	if !rows.Next() {
 		_, err = tx.Exec("CREATE ROLE user_ro WITH LOGIN PASSWORD 'user_ro';")
+		if err != nil {
+			// Handle race condition by ignoring the error if it's a duplicate key violation
+			if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "23505" {
+				return
+			}
+		}
 		require.NoError(t, err)
 	}
 

--- a/support/db/dbtest/db.go
+++ b/support/db/dbtest/db.go
@@ -118,7 +118,7 @@ func checkReadOnly(t testing.TB, DSN string) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	tx, err := conn.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
+	tx, err := conn.BeginTx(context.Background(), &sql.TxOptions{})
 	require.NoError(t, err)
 	defer tx.Rollback()
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Recently, we've been seeing the following error in the test workflow `Received unexpected error: pq: duplicate key value violates unique constraint 'pg_authid_rolname_index'` in the RecoverySigner unit test. The first occurrence of this error in recent history was [here](https://github.com/stellar/go/commit/01dc1762d6be40d84829476ee154834d88490155). After committing the [PR](https://github.com/stellar/go/commit/a3fae02c3b634b353dc4c37597ccc1da78f46317) that moves Galexie out of experimental, the issue became exacerbated and started failing every time. The RecoverySigner unit test always fails, but not always in the same test, though the error remains the same.

This issue arises because multiple concurrent tests are trying to create the same role, resulting in a race condition. It is unclear why we consistently see this issue now; it may be due to the order in which the tests are executed changing after the relocation of Galexie out of experimental.

The solution is to check for the specific error and if it is a duplicate key violation, we know that the role has been created by another concurrent transaction in which case we ignore the error. Any other type of error during role creation will result in the tests failing.

### Why
Resolve CI test workflow errors.

### Known limitations

