### PR TITLE
services/friendbot: support funding existing accounts

### DIFF
--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -66,8 +66,7 @@ func initFriendbot(
 }
 
 func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full, networkPassphrase, newAccountBalance, minionBalance string,
-	numMinions, minionBatchSize, submitTxRetriesAllowed int, baseFee int64, hclient horizonclient.ClientInterface,
-) ([]internal.Minion, error) {
+	numMinions, minionBatchSize, submitTxRetriesAllowed int, baseFee int64, hclient horizonclient.ClientInterface) ([]internal.Minion, error) {
 	var minions []internal.Minion
 	numRemainingMinions := numMinions
 	// Allow retries to account for testnet congestion

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -66,8 +66,8 @@ func initFriendbot(
 }
 
 func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full, networkPassphrase, newAccountBalance, minionBalance string,
-	numMinions, minionBatchSize, submitTxRetriesAllowed int, baseFee int64, hclient horizonclient.ClientInterface) ([]internal.Minion, error) {
-
+	numMinions, minionBatchSize, submitTxRetriesAllowed int, baseFee int64, hclient horizonclient.ClientInterface,
+) ([]internal.Minion, error) {
 	var minions []internal.Minion
 	numRemainingMinions := numMinions
 	// Allow retries to account for testnet congestion
@@ -104,6 +104,7 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 				StartingBalance:      newAccountBalance,
 				SubmitTransaction:    internal.SubmitTransaction,
 				CheckSequenceRefresh: internal.CheckSequenceRefresh,
+				CheckAccountExists:   internal.CheckAccountExists,
 				BaseFee:              baseFee,
 			})
 

--- a/services/friendbot/init_friendbot.go
+++ b/services/friendbot/init_friendbot.go
@@ -67,6 +67,7 @@ func initFriendbot(
 
 func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full, networkPassphrase, newAccountBalance, minionBalance string,
 	numMinions, minionBatchSize, submitTxRetriesAllowed int, baseFee int64, hclient horizonclient.ClientInterface) ([]internal.Minion, error) {
+
 	var minions []internal.Minion
 	numRemainingMinions := numMinions
 	// Allow retries to account for testnet congestion

--- a/services/friendbot/internal/friendbot_test.go
+++ b/services/friendbot/internal/friendbot_test.go
@@ -190,25 +190,6 @@ func TestFriendbot_Pay_accountExistsAlreadyFunded(t *testing.T) {
 	fb := &Bot{Minions: []Minion{minion}}
 
 	recipientAddress := "GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z"
-	txSuccess, err := fb.Pay(recipientAddress)
-	if !assert.NoError(t, err) {
-		return
-	}
-	expectedTxn := "AAAAAgAAAAD4Az3jKU6lbzq/L5HG9/GzBT+FYusOz71oyYMbZkP+GAAAAGQAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAPXQ8gjyrVHa47a6JDPkVHwPPDKxNRE2QBcamA4JvlOGAAAAAQAAAADShvreeub1LWzv6W93J+BROl6MxA6GAyXFy86/NQWGFAAAAAAAAAAXSHboAAAAAAAAAAACZkP+GAAAAEBAwm/hWuu/ZHHQWRD9oF/cnSwQyTZpHQoTlPlVSFH4g12HR2nbzOI9wC5Z5bt0ueXny4UNFS5QhUvnzdb2FMsDCb5ThgAAAED1HzWPW6lKBxBi6MTSwM/POytPSfL87taiarpTIk5naoqXPLpM0YBBaf5uH8de5Id1KSCP/g8tdeCxvrT053kJ"
-	assert.Equal(t, expectedTxn, txSuccess.EnvelopeXdr)
-
-	// Don't assert on tx values below, since the completion order is unknown.
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		_, err := fb.Pay(recipientAddress)
-		assert.NoError(t, err)
-		wg.Done()
-	}()
-	go func() {
-		_, err := fb.Pay(recipientAddress)
-		assert.NoError(t, err)
-		wg.Done()
-	}()
-	wg.Wait()
+	_, err = fb.Pay(recipientAddress)
+	assert.ErrorIs(t, err, ErrAccountFunded)
 }

--- a/services/friendbot/internal/friendbot_test.go
+++ b/services/friendbot/internal/friendbot_test.go
@@ -12,11 +12,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFriendbot_Pay(t *testing.T) {
+func TestFriendbot_Pay_accountDoesNotExist(t *testing.T) {
 	mockSubmitTransaction := func(minion *Minion, hclient horizonclient.ClientInterface, tx string) (*hProtocol.Transaction, error) {
 		// Instead of submitting the tx, we emulate a success.
 		txSuccess := hProtocol.Transaction{EnvelopeXdr: tx, Successful: true}
 		return &txSuccess, nil
+	}
+
+	mockCheckAccountExists := func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, error) {
+		return false, nil
 	}
 
 	// Public key: GD25B4QI6KWVDWXDW25CIM7EKR6A6PBSWE2RCNSAC4NJQDQJXZJYMMKR
@@ -46,6 +50,7 @@ func TestFriendbot_Pay(t *testing.T) {
 		StartingBalance:      "10000.00",
 		SubmitTransaction:    mockSubmitTransaction,
 		CheckSequenceRefresh: CheckSequenceRefresh,
+		CheckAccountExists:   mockCheckAccountExists,
 		BaseFee:              txnbuild.MinBaseFee,
 	}
 	fb := &Bot{Minions: []Minion{minion}}
@@ -56,6 +61,73 @@ func TestFriendbot_Pay(t *testing.T) {
 		return
 	}
 	expectedTxn := "AAAAAgAAAAD4Az3jKU6lbzq/L5HG9/GzBT+FYusOz71oyYMbZkP+GAAAAGQAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAPXQ8gjyrVHa47a6JDPkVHwPPDKxNRE2QBcamA4JvlOGAAAAAAAAAADShvreeub1LWzv6W93J+BROl6MxA6GAyXFy86/NQWGFAAAABdIdugAAAAAAAAAAAJmQ/4YAAAAQDRLEljDVYALnTk9mDceQEd5PrjQyE3LUAjstIyTWH5t/TP909F66TgEfBFKMxSKF6fka7ZuPcSs40ix4AomEgoJvlOGAAAAQPSGs88OwXubz7UT6nFhvhF47EQfaOsmiIsOkjgzUrmBoypJQTmMMbgeix0kdbfHqS75+iefJpdXLNFDreGnxgE="
+	assert.Equal(t, expectedTxn, txSuccess.EnvelopeXdr)
+
+	// Don't assert on tx values below, since the completion order is unknown.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		_, err := fb.Pay(recipientAddress)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+	go func() {
+		_, err := fb.Pay(recipientAddress)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+	wg.Wait()
+}
+
+func TestFriendbot_Pay_accountExists(t *testing.T) {
+	mockSubmitTransaction := func(minion *Minion, hclient horizonclient.ClientInterface, tx string) (*hProtocol.Transaction, error) {
+		// Instead of submitting the tx, we emulate a success.
+		txSuccess := hProtocol.Transaction{EnvelopeXdr: tx, Successful: true}
+		return &txSuccess, nil
+	}
+
+	mockCheckAccountExists := func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, error) {
+		return true, nil
+	}
+
+	// Public key: GD25B4QI6KWVDWXDW25CIM7EKR6A6PBSWE2RCNSAC4NJQDQJXZJYMMKR
+	botSeed := "SCWNLYELENPBXN46FHYXETT5LJCYBZD5VUQQVW4KZPHFO2YTQJUWT4D5"
+	botKeypair, err := keypair.Parse(botSeed)
+	if !assert.NoError(t, err) {
+		return
+	}
+	botAccount := Account{AccountID: botKeypair.Address()}
+
+	// Public key: GD4AGPPDFFHKK3Z2X4XZDRXX6GZQKP4FMLVQ5T55NDEYGG3GIP7BQUHM
+	minionSeed := "SDTNSEERJPJFUE2LSDNYBFHYGVTPIWY7TU2IOJZQQGLWO2THTGB7NU5A"
+	minionKeypair, err := keypair.Parse(minionSeed)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	minion := Minion{
+		Account: Account{
+			AccountID: minionKeypair.Address(),
+			Sequence:  1,
+		},
+		Keypair:              minionKeypair.(*keypair.Full),
+		BotAccount:           botAccount,
+		BotKeypair:           botKeypair.(*keypair.Full),
+		Network:              "Test SDF Network ; September 2015",
+		StartingBalance:      "10000.00",
+		SubmitTransaction:    mockSubmitTransaction,
+		CheckSequenceRefresh: CheckSequenceRefresh,
+		CheckAccountExists:   mockCheckAccountExists,
+		BaseFee:              txnbuild.MinBaseFee,
+	}
+	fb := &Bot{Minions: []Minion{minion}}
+
+	recipientAddress := "GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z"
+	txSuccess, err := fb.Pay(recipientAddress)
+	if !assert.NoError(t, err) {
+		return
+	}
+	expectedTxn := "AAAAAgAAAAD4Az3jKU6lbzq/L5HG9/GzBT+FYusOz71oyYMbZkP+GAAAAGQAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAPXQ8gjyrVHa47a6JDPkVHwPPDKxNRE2QBcamA4JvlOGAAAAAQAAAADShvreeub1LWzv6W93J+BROl6MxA6GAyXFy86/NQWGFAAAAAAAAAAXSHboAAAAAAAAAAACZkP+GAAAAEBAwm/hWuu/ZHHQWRD9oF/cnSwQyTZpHQoTlPlVSFH4g12HR2nbzOI9wC5Z5bt0ueXny4UNFS5QhUvnzdb2FMsDCb5ThgAAAED1HzWPW6lKBxBi6MTSwM/POytPSfL87taiarpTIk5naoqXPLpM0YBBaf5uH8de5Id1KSCP/g8tdeCxvrT053kJ"
 	assert.Equal(t, expectedTxn, txSuccess.EnvelopeXdr)
 
 	// Don't assert on tx values below, since the completion order is unknown.

--- a/services/friendbot/internal/friendbot_test.go
+++ b/services/friendbot/internal/friendbot_test.go
@@ -19,8 +19,8 @@ func TestFriendbot_Pay_accountDoesNotExist(t *testing.T) {
 		return &txSuccess, nil
 	}
 
-	mockCheckAccountExists := func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, error) {
-		return false, nil
+	mockCheckAccountExists := func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, string, error) {
+		return false, "0", nil
 	}
 
 	// Public key: GD25B4QI6KWVDWXDW25CIM7EKR6A6PBSWE2RCNSAC4NJQDQJXZJYMMKR
@@ -86,8 +86,75 @@ func TestFriendbot_Pay_accountExists(t *testing.T) {
 		return &txSuccess, nil
 	}
 
-	mockCheckAccountExists := func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, error) {
-		return true, nil
+	mockCheckAccountExists := func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, string, error) {
+		return true, "0", nil
+	}
+
+	// Public key: GD25B4QI6KWVDWXDW25CIM7EKR6A6PBSWE2RCNSAC4NJQDQJXZJYMMKR
+	botSeed := "SCWNLYELENPBXN46FHYXETT5LJCYBZD5VUQQVW4KZPHFO2YTQJUWT4D5"
+	botKeypair, err := keypair.Parse(botSeed)
+	if !assert.NoError(t, err) {
+		return
+	}
+	botAccount := Account{AccountID: botKeypair.Address()}
+
+	// Public key: GD4AGPPDFFHKK3Z2X4XZDRXX6GZQKP4FMLVQ5T55NDEYGG3GIP7BQUHM
+	minionSeed := "SDTNSEERJPJFUE2LSDNYBFHYGVTPIWY7TU2IOJZQQGLWO2THTGB7NU5A"
+	minionKeypair, err := keypair.Parse(minionSeed)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	minion := Minion{
+		Account: Account{
+			AccountID: minionKeypair.Address(),
+			Sequence:  1,
+		},
+		Keypair:              minionKeypair.(*keypair.Full),
+		BotAccount:           botAccount,
+		BotKeypair:           botKeypair.(*keypair.Full),
+		Network:              "Test SDF Network ; September 2015",
+		StartingBalance:      "10000.00",
+		SubmitTransaction:    mockSubmitTransaction,
+		CheckSequenceRefresh: CheckSequenceRefresh,
+		CheckAccountExists:   mockCheckAccountExists,
+		BaseFee:              txnbuild.MinBaseFee,
+	}
+	fb := &Bot{Minions: []Minion{minion}}
+
+	recipientAddress := "GDJIN6W6PLTPKLLM57UW65ZH4BITUXUMYQHIMAZFYXF45PZVAWDBI77Z"
+	txSuccess, err := fb.Pay(recipientAddress)
+	if !assert.NoError(t, err) {
+		return
+	}
+	expectedTxn := "AAAAAgAAAAD4Az3jKU6lbzq/L5HG9/GzBT+FYusOz71oyYMbZkP+GAAAAGQAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAPXQ8gjyrVHa47a6JDPkVHwPPDKxNRE2QBcamA4JvlOGAAAAAQAAAADShvreeub1LWzv6W93J+BROl6MxA6GAyXFy86/NQWGFAAAAAAAAAAXSHboAAAAAAAAAAACZkP+GAAAAEBAwm/hWuu/ZHHQWRD9oF/cnSwQyTZpHQoTlPlVSFH4g12HR2nbzOI9wC5Z5bt0ueXny4UNFS5QhUvnzdb2FMsDCb5ThgAAAED1HzWPW6lKBxBi6MTSwM/POytPSfL87taiarpTIk5naoqXPLpM0YBBaf5uH8de5Id1KSCP/g8tdeCxvrT053kJ"
+	assert.Equal(t, expectedTxn, txSuccess.EnvelopeXdr)
+
+	// Don't assert on tx values below, since the completion order is unknown.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		_, err := fb.Pay(recipientAddress)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+	go func() {
+		_, err := fb.Pay(recipientAddress)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+	wg.Wait()
+}
+
+func TestFriendbot_Pay_accountExistsAlreadyFunded(t *testing.T) {
+	mockSubmitTransaction := func(minion *Minion, hclient horizonclient.ClientInterface, tx string) (*hProtocol.Transaction, error) {
+		// Instead of submitting the tx, we emulate a success.
+		txSuccess := hProtocol.Transaction{EnvelopeXdr: tx, Successful: true}
+		return &txSuccess, nil
+	}
+
+	mockCheckAccountExists := func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, string, error) {
+		return true, "10000.00", nil
 	}
 
 	// Public key: GD25B4QI6KWVDWXDW25CIM7EKR6A6PBSWE2RCNSAC4NJQDQJXZJYMMKR

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 
+	"github.com/stellar/go/amount"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	hProtocol "github.com/stellar/go/protocols/horizon"
@@ -28,7 +29,7 @@ type Minion struct {
 	// Mockable functions
 	SubmitTransaction    func(minion *Minion, hclient horizonclient.ClientInterface, tx string) (*hProtocol.Transaction, error)
 	CheckSequenceRefresh func(minion *Minion, hclient horizonclient.ClientInterface) error
-	CheckAccountExists   func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, error)
+	CheckAccountExists   func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, string, error)
 
 	// Uninitialized.
 	forceRefreshSequence bool
@@ -45,11 +46,19 @@ func (minion *Minion) Run(destAddress string, resultChan chan SubmitResult) {
 		}
 		return
 	}
-	exists, err := minion.CheckAccountExists(minion, minion.Horizon, destAddress)
+	exists, balance, err := minion.CheckAccountExists(minion, minion.Horizon, destAddress)
 	if err != nil {
 		resultChan <- SubmitResult{
 			maybeTransactionSuccess: nil,
 			maybeErr:                errors.Wrap(err, "checking account exists"),
+		}
+		return
+	}
+	err = minion.checkBalance(balance)
+	if err != nil {
+		resultChan <- SubmitResult{
+			maybeTransactionSuccess: nil,
+			maybeErr:                errors.Wrap(err, "account already funded"),
 		}
 		return
 	}
@@ -114,19 +123,27 @@ func CheckSequenceRefresh(minion *Minion, hclient horizonclient.ClientInterface)
 }
 
 // CheckAccountExists checks if the specified address exists as a Stellar account.
+// And returns the current native balance of the account also.
 // This should also be passed to the minion.
-func CheckAccountExists(minion *Minion, hclient horizonclient.ClientInterface, address string) (bool, error) {
+func CheckAccountExists(minion *Minion, hclient horizonclient.ClientInterface, address string) (bool, string, error) {
 	accountRequest := horizonclient.AccountRequest{AccountID: address}
-	_, err := hclient.AccountDetail(accountRequest)
+	accountDetails, err := hclient.AccountDetail(accountRequest)
 	switch e := err.(type) {
 	case nil:
-		return true, nil
+		balance := "0"
+		for _, b := range accountDetails.Balances {
+			if b.Type == "native" {
+				balance = b.Balance
+				break
+			}
+		}
+		return true, balance, nil
 	case *horizonclient.Error:
 		if e.Response.StatusCode == 404 {
-			return false, nil
+			return false, "0", nil
 		}
 	}
-	return false, err
+	return false, "0", err
 }
 
 func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
@@ -136,6 +153,21 @@ func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
 		return
 	}
 	minion.forceRefreshSequence = true
+}
+
+func (minion *Minion) checkBalance(balance string) error {
+	bal, err := amount.ParseInt64(balance)
+	if err != nil {
+		return errors.Wrap(err, "cannot parse account balance")
+	}
+	starting, err := amount.ParseInt64(minion.StartingBalance)
+	if err != nil {
+		return errors.Wrap(err, "cannot parse starting balance")
+	}
+	if bal > starting {
+		return errors.New("account already funded up to the starting balance")
+	}
+	return nil
 }
 
 func (minion *Minion) makeTx(destAddress string, exists bool) ([32]byte, string, error) {

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -15,6 +15,8 @@ const createAccountAlreadyExistXDR = "AAAAAAAAAGT/////AAAAAQAAAAAAAAAA/////AAAAA
 
 var ErrAccountExists error = errors.New(fmt.Sprintf("createAccountAlreadyExist (%s)", createAccountAlreadyExistXDR))
 
+var ErrAccountFunded error = errors.New("account already funded to starting balance")
+
 // Minion contains a Stellar channel account and Go channels to communicate with friendbot.
 type Minion struct {
 	Account         Account
@@ -164,8 +166,8 @@ func (minion *Minion) checkBalance(balance string) error {
 	if err != nil {
 		return errors.Wrap(err, "cannot parse starting balance")
 	}
-	if bal > starting {
-		return errors.New("account already funded up to the starting balance")
+	if bal >= starting {
+		return ErrAccountFunded
 	}
 	return nil
 }

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -217,10 +217,5 @@ func (minion *Minion) makePaymentTx(destAddress string) ([32]byte, string, error
 		return [32]byte{}, "", errors.Wrap(err, "unable to hash")
 	}
 
-	// Increment the in-memory sequence number, since the tx will be submitted.
-	_, err = minion.Account.IncrementSequenceNumber()
-	if err != nil {
-		return [32]byte{}, "", errors.Wrap(err, "incrementing minion seq")
-	}
 	return txh, txe, err
 }

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -146,6 +146,42 @@ func (minion *Minion) makeTx(destAddress string, exists bool) ([32]byte, string,
 	}
 }
 
+func (minion *Minion) makeCreateTx(destAddress string) ([32]byte, string, error) {
+	createAccountOp := txnbuild.CreateAccount{
+		Destination:   destAddress,
+		SourceAccount: minion.BotAccount.GetAccountID(),
+		Amount:        minion.StartingBalance,
+	}
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        minion.Account,
+			IncrementSequenceNum: true,
+			Operations:           []txnbuild.Operation{&createAccountOp},
+			BaseFee:              minion.BaseFee,
+			Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()},
+		},
+	)
+	if err != nil {
+		return [32]byte{}, "", errors.Wrap(err, "unable to build tx")
+	}
+
+	tx, err = tx.Sign(minion.Network, minion.Keypair, minion.BotKeypair)
+	if err != nil {
+		return [32]byte{}, "", errors.Wrap(err, "unable to sign tx")
+	}
+
+	txe, err := tx.Base64()
+	if err != nil {
+		return [32]byte{}, "", errors.Wrap(err, "unable to serialize")
+	}
+
+	txh, err := tx.Hash(minion.Network)
+	if err != nil {
+		return [32]byte{}, "", errors.Wrap(err, "unable to hash")
+	}
+	return txh, txe, err
+}
+
 func (minion *Minion) makePaymentTx(destAddress string) ([32]byte, string, error) {
 	createAccountOp := txnbuild.Payment{
 		SourceAccount: minion.BotAccount.GetAccountID(),
@@ -185,42 +221,6 @@ func (minion *Minion) makePaymentTx(destAddress string) ([32]byte, string, error
 	_, err = minion.Account.IncrementSequenceNumber()
 	if err != nil {
 		return [32]byte{}, "", errors.Wrap(err, "incrementing minion seq")
-	}
-	return txh, txe, err
-}
-
-func (minion *Minion) makeCreateTx(destAddress string) ([32]byte, string, error) {
-	createAccountOp := txnbuild.CreateAccount{
-		Destination:   destAddress,
-		SourceAccount: minion.BotAccount.GetAccountID(),
-		Amount:        minion.StartingBalance,
-	}
-	tx, err := txnbuild.NewTransaction(
-		txnbuild.TransactionParams{
-			SourceAccount:        minion.Account,
-			IncrementSequenceNum: true,
-			Operations:           []txnbuild.Operation{&createAccountOp},
-			BaseFee:              minion.BaseFee,
-			Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()},
-		},
-	)
-	if err != nil {
-		return [32]byte{}, "", errors.Wrap(err, "unable to build tx")
-	}
-
-	tx, err = tx.Sign(minion.Network, minion.Keypair, minion.BotKeypair)
-	if err != nil {
-		return [32]byte{}, "", errors.Wrap(err, "unable to sign tx")
-	}
-
-	txe, err := tx.Base64()
-	if err != nil {
-		return [32]byte{}, "", errors.Wrap(err, "unable to serialize")
-	}
-
-	txh, err := tx.Hash(minion.Network)
-	if err != nil {
-		return [32]byte{}, "", errors.Wrap(err, "unable to hash")
 	}
 	return txh, txe, err
 }

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -28,6 +28,7 @@ type Minion struct {
 	// Mockable functions
 	SubmitTransaction    func(minion *Minion, hclient horizonclient.ClientInterface, tx string) (*hProtocol.Transaction, error)
 	CheckSequenceRefresh func(minion *Minion, hclient horizonclient.ClientInterface) error
+	CheckAccountExists   func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, error)
 
 	// Uninitialized.
 	forceRefreshSequence bool
@@ -44,11 +45,27 @@ func (minion *Minion) Run(destAddress string, resultChan chan SubmitResult) {
 		}
 		return
 	}
-	txHash, txStr, err := minion.makeTx(destAddress)
+	exists, err := minion.CheckAccountExists(minion, minion.Horizon, destAddress)
+	if err != nil {
+		resultChan <- SubmitResult{
+			maybeTransactionSuccess: nil,
+			maybeErr:                errors.Wrap(err, "checking account exists"),
+		}
+		return
+	}
+	txHash, txStr, err := minion.makeTx(destAddress, exists)
 	if err != nil {
 		resultChan <- SubmitResult{
 			maybeTransactionSuccess: nil,
 			maybeErr:                errors.Wrap(err, "making payment tx"),
+		}
+		return
+	}
+	_, err = minion.Account.IncrementSequenceNumber()
+	if err != nil {
+		resultChan <- SubmitResult{
+			maybeTransactionSuccess: nil,
+			maybeErr:                errors.Wrap(err, "incrementing submitters sequence number"),
 		}
 		return
 	}
@@ -96,6 +113,22 @@ func CheckSequenceRefresh(minion *Minion, hclient horizonclient.ClientInterface)
 	return nil
 }
 
+// CheckAccountExists checks if the specified address exists as a Stellar account.
+// This should also be passed to the minion.
+func CheckAccountExists(minion *Minion, hclient horizonclient.ClientInterface, address string) (bool, error) {
+	accountRequest := horizonclient.AccountRequest{AccountID: address}
+	_, err := hclient.AccountDetail(accountRequest)
+	switch e := err.(type) {
+	case nil:
+		return true, nil
+	case *horizonclient.Error:
+		if e.Response.StatusCode == 404 {
+			return false, nil
+		}
+	}
+	return false, err
+}
+
 func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
 	resCode, e := err.ResultCodes()
 	isTxBadSeqCode := e == nil && resCode.TransactionCode == "tx_bad_seq"
@@ -105,10 +138,19 @@ func (minion *Minion) checkHandleBadSequence(err *horizonclient.Error) {
 	minion.forceRefreshSequence = true
 }
 
-func (minion *Minion) makeTx(destAddress string) ([32]byte, string, error) {
-	createAccountOp := txnbuild.CreateAccount{
-		Destination:   destAddress,
+func (minion *Minion) makeTx(destAddress string, exists bool) ([32]byte, string, error) {
+	if exists {
+		return minion.makePaymentTx(destAddress)
+	} else {
+		return minion.makeCreateTx(destAddress)
+	}
+}
+
+func (minion *Minion) makePaymentTx(destAddress string) ([32]byte, string, error) {
+	createAccountOp := txnbuild.Payment{
 		SourceAccount: minion.BotAccount.GetAccountID(),
+		Destination:   destAddress,
+		Asset:         txnbuild.NativeAsset{},
 		Amount:        minion.StartingBalance,
 	}
 	tx, err := txnbuild.NewTransaction(
@@ -143,6 +185,42 @@ func (minion *Minion) makeTx(destAddress string) ([32]byte, string, error) {
 	_, err = minion.Account.IncrementSequenceNumber()
 	if err != nil {
 		return [32]byte{}, "", errors.Wrap(err, "incrementing minion seq")
+	}
+	return txh, txe, err
+}
+
+func (minion *Minion) makeCreateTx(destAddress string) ([32]byte, string, error) {
+	createAccountOp := txnbuild.CreateAccount{
+		Destination:   destAddress,
+		SourceAccount: minion.BotAccount.GetAccountID(),
+		Amount:        minion.StartingBalance,
+	}
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        minion.Account,
+			IncrementSequenceNum: true,
+			Operations:           []txnbuild.Operation{&createAccountOp},
+			BaseFee:              minion.BaseFee,
+			Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()},
+		},
+	)
+	if err != nil {
+		return [32]byte{}, "", errors.Wrap(err, "unable to build tx")
+	}
+
+	tx, err = tx.Sign(minion.Network, minion.Keypair, minion.BotKeypair)
+	if err != nil {
+		return [32]byte{}, "", errors.Wrap(err, "unable to sign tx")
+	}
+
+	txe, err := tx.Base64()
+	if err != nil {
+		return [32]byte{}, "", errors.Wrap(err, "unable to serialize")
+	}
+
+	txh, err := tx.Hash(minion.Network)
+	if err != nil {
+		return [32]byte{}, "", errors.Wrap(err, "unable to hash")
 	}
 	return txh, txe, err
 }

--- a/services/friendbot/internal/minion.go
+++ b/services/friendbot/internal/minion.go
@@ -217,7 +217,7 @@ func (minion *Minion) makeCreateTx(destAddress string) ([32]byte, string, error)
 }
 
 func (minion *Minion) makePaymentTx(destAddress string) ([32]byte, string, error) {
-	createAccountOp := txnbuild.Payment{
+	paymentOp := txnbuild.Payment{
 		SourceAccount: minion.BotAccount.GetAccountID(),
 		Destination:   destAddress,
 		Asset:         txnbuild.NativeAsset{},
@@ -227,7 +227,7 @@ func (minion *Minion) makePaymentTx(destAddress string) ([32]byte, string, error
 		txnbuild.TransactionParams{
 			SourceAccount:        minion.Account,
 			IncrementSequenceNum: true,
-			Operations:           []txnbuild.Operation{&createAccountOp},
+			Operations:           []txnbuild.Operation{&paymentOp},
 			BaseFee:              minion.BaseFee,
 			Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()},
 		},

--- a/services/friendbot/internal/minion_test.go
+++ b/services/friendbot/internal/minion_test.go
@@ -24,8 +24,8 @@ func TestMinion_NoChannelErrors(t *testing.T) {
 		return errors.New("could not refresh sequence")
 	}
 
-	mockCheckAccountExists := func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, error) {
-		return false, nil
+	mockCheckAccountExists := func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, string, error) {
+		return false, "0", nil
 	}
 
 	// Public key: GD25B4QI6KWVDWXDW25CIM7EKR6A6PBSWE2RCNSAC4NJQDQJXZJYMMKR
@@ -94,8 +94,8 @@ func TestMinion_CorrectNumberOfTxSubmissions(t *testing.T) {
 		return nil
 	}
 
-	mockCheckAccountExists := func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, error) {
-		return false, nil
+	mockCheckAccountExists := func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, string, error) {
+		return false, "0", nil
 	}
 
 	// Public key: GD25B4QI6KWVDWXDW25CIM7EKR6A6PBSWE2RCNSAC4NJQDQJXZJYMMKR

--- a/services/friendbot/internal/minion_test.go
+++ b/services/friendbot/internal/minion_test.go
@@ -24,6 +24,10 @@ func TestMinion_NoChannelErrors(t *testing.T) {
 		return errors.New("could not refresh sequence")
 	}
 
+	mockCheckAccountExists := func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, error) {
+		return false, nil
+	}
+
 	// Public key: GD25B4QI6KWVDWXDW25CIM7EKR6A6PBSWE2RCNSAC4NJQDQJXZJYMMKR
 	botSeed := "SCWNLYELENPBXN46FHYXETT5LJCYBZD5VUQQVW4KZPHFO2YTQJUWT4D5"
 	botKeypair, err := keypair.Parse(botSeed)
@@ -51,6 +55,7 @@ func TestMinion_NoChannelErrors(t *testing.T) {
 		StartingBalance:      "10000.00",
 		SubmitTransaction:    mockSubmitTransaction,
 		CheckSequenceRefresh: mockCheckSequenceRefresh,
+		CheckAccountExists:   mockCheckAccountExists,
 		BaseFee:              txnbuild.MinBaseFee,
 	}
 	fb := &Bot{Minions: []Minion{minion}}
@@ -89,6 +94,10 @@ func TestMinion_CorrectNumberOfTxSubmissions(t *testing.T) {
 		return nil
 	}
 
+	mockCheckAccountExists := func(minion *Minion, hclient horizonclient.ClientInterface, destAddress string) (bool, error) {
+		return false, nil
+	}
+
 	// Public key: GD25B4QI6KWVDWXDW25CIM7EKR6A6PBSWE2RCNSAC4NJQDQJXZJYMMKR
 	botSeed := "SCWNLYELENPBXN46FHYXETT5LJCYBZD5VUQQVW4KZPHFO2YTQJUWT4D5"
 	botKeypair, err := keypair.Parse(botSeed)
@@ -116,6 +125,7 @@ func TestMinion_CorrectNumberOfTxSubmissions(t *testing.T) {
 		StartingBalance:      "10000.00",
 		SubmitTransaction:    mockSubmitTransaction,
 		CheckSequenceRefresh: mockCheckSequenceRefresh,
+		CheckAccountExists:   mockCheckAccountExists,
 		BaseFee:              txnbuild.MinBaseFee,
 	}
 	fb := &Bot{Minions: []Minion{minion}}

--- a/services/friendbot/main.go
+++ b/services/friendbot/main.go
@@ -34,7 +34,6 @@ type Config struct {
 }
 
 func main() {
-
 	rootCmd := &cobra.Command{
 		Use:   "friendbot",
 		Short: "friendbot for the Stellar Test Network",
@@ -114,4 +113,8 @@ func registerProblems() {
 	accountExistsProblem := problem.BadRequest
 	accountExistsProblem.Detail = internal.ErrAccountExists.Error()
 	problem.RegisterError(internal.ErrAccountExists, accountExistsProblem)
+
+	accountFundedProblem := problem.BadRequest
+	accountFundedProblem.Detail = internal.ErrAccountFunded.Error()
+	problem.RegisterError(internal.ErrAccountFunded, accountFundedProblem)
 }


### PR DESCRIPTION
### What
Support funding existing accounts in Friendbot.

If an account does not exist, do as done today, create the account with the starting balance.

If an account exists, and balance is equal to or above the starting balance, error as the account is funded sufficiently.

If an account exists, and balance is below the starting balance, send a payment to the account of the starting balance.

### Why
The stellar-cli supports funding accounts and there's a request to support funding to top up existing accounts that have spent funds (https://github.com/stellar/stellar-cli/issues/1389).

There are reasons why this shouldn't be done. It's possible for someone to more easily exhaust the testnet native balance available. However, it is really already very easy to do that by simply passing random addresses. And because this change doesn't allow unlimited funding of a single account without moving funds out of the account the same amount of friction will exist as it does today to someone wishing to accumulate lots of testnet native.

Close https://github.com/stellar/stellar-cli/issues/1389