### PR TITLE
services/horizon: migrate to docker compose v2

### DIFF
--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -224,6 +224,7 @@ func (i *Test) runComposeCommand(args ...string) {
 		cmdline = append([]string{"-f", integrationSorobanRPCYaml}, cmdline...)
 	}
 	cmdline = append([]string{"-f", integrationYaml}, cmdline...)
+	//lint:ignore SA1005 commands with spaces!
 	cmd := exec.Command("docker compose", cmdline...)
 	coreImageOverride := ""
 	if i.config.CoreDockerImage != "" {

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -224,8 +224,8 @@ func (i *Test) runComposeCommand(args ...string) {
 		cmdline = append([]string{"-f", integrationSorobanRPCYaml}, cmdline...)
 	}
 	cmdline = append([]string{"-f", integrationYaml}, cmdline...)
-	//lint:ignore SA1005 commands with spaces!
-	cmd := exec.Command("docker compose", cmdline...)
+	cmdline = append([]string{"compose"}, cmdline...)
+	cmd := exec.Command("docker", cmdline...)
 	coreImageOverride := ""
 	if i.config.CoreDockerImage != "" {
 		coreImageOverride = i.config.CoreDockerImage

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -224,7 +224,7 @@ func (i *Test) runComposeCommand(args ...string) {
 		cmdline = append([]string{"-f", integrationSorobanRPCYaml}, cmdline...)
 	}
 	cmdline = append([]string{"-f", integrationYaml}, cmdline...)
-	cmd := exec.Command("docker-compose", cmdline...)
+	cmd := exec.Command("docker compose", cmdline...)
 	coreImageOverride := ""
 	if i.config.CoreDockerImage != "" {
 		coreImageOverride = i.config.CoreDockerImage


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Migrate to [Docker Compose v2](https://docs.docker.com/compose/migrate/), which requires changing the docker compose invocation from `docker-compose` to `docker compose`. 

The `exec.Command` in Go doesn’t support commands with spaces in them, so passing `compose` as a separate argument to the `docker` command.

### Why
[GitHub Ubuntu runners](https://github.com/actions/runner-images/issues/9692) for CI removed support for Docker Compose v1, causing our CI to fail. 

### Known limitations