### PR TITLE
services/horizon/internal/actions: populate default cursor value for history endpoints

### DIFF
--- a/services/horizon/internal/actions/effects.go
+++ b/services/horizon/internal/actions/effects.go
@@ -51,7 +51,7 @@ type GetEffectsHandler struct {
 }
 
 func (handler GetEffectsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
-	pq, err := GetPageQuery(handler.LedgerState, r)
+	pq, err := GetPageQuery(handler.LedgerState, r, DefaultTOID)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -226,7 +226,7 @@ func GetPageQuery(ledgerState *ledger.State, r *http.Request, opts ...Opt) (db2.
 	if cursor == "" && defaultTOID {
 		if pageQuery.Order == db2.OrderAscending {
 			pageQuery.Cursor = toid.AfterLedger(
-				ordered.Max(1, ledgerState.CurrentStatus().HistoryElder-1),
+				ordered.Max(0, ledgerState.CurrentStatus().HistoryElder-1),
 			).String()
 		} else if pageQuery.Order == db2.OrderDescending {
 			pageQuery.Cursor = toid.AfterLedger(

--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stellar/go/services/horizon/internal/ledger"
 	hProblem "github.com/stellar/go/services/horizon/internal/render/problem"
 	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/ordered"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/toid"
 	"github.com/stellar/go/xdr"
@@ -44,6 +45,10 @@ type Opt int
 const (
 	// DisableCursorValidation disables cursor validation in GetPageQuery
 	DisableCursorValidation Opt = iota
+	// DefaultTOID sets a default cursor value in GetPageQuery based on the ledger state
+	DefaultTOID Opt = iota
+
+	defaultLedgerCursorBuffer = 100
 )
 
 // HeaderWriter is an interface for setting HTTP response headers
@@ -182,9 +187,13 @@ func getLimit(r *http.Request, name string, def uint64, max uint64) (uint64, err
 // using the results from a call to GetPagingParams()
 func GetPageQuery(ledgerState *ledger.State, r *http.Request, opts ...Opt) (db2.PageQuery, error) {
 	disableCursorValidation := false
+	defaultTOID := false
 	for _, opt := range opts {
 		if opt == DisableCursorValidation {
 			disableCursorValidation = true
+		}
+		if opt == DefaultTOID {
+			defaultTOID = true
 		}
 	}
 
@@ -213,6 +222,21 @@ func GetPageQuery(ledgerState *ledger.State, r *http.Request, opts ...Opt) (db2.
 		}
 
 		return db2.PageQuery{}, err
+	}
+	if cursor == "" && defaultTOID {
+		if pageQuery.Order == db2.OrderAscending {
+			pageQuery.Cursor = toid.AfterLedger(
+				ordered.Max(1, ledgerState.CurrentStatus().HistoryElder-1),
+			).String()
+		} else if pageQuery.Order == db2.OrderDescending {
+			pageQuery.Cursor = toid.AfterLedger(
+				// add an extra amount to the latest ledger in case the
+				// ledger state is out of date
+				ledgerState.CurrentStatus().HistoryLatest + defaultLedgerCursorBuffer,
+			).String()
+		} else {
+			return db2.PageQuery{}, problem.BadRequest
+		}
 	}
 
 	return pageQuery, nil

--- a/services/horizon/internal/actions/helpers.go
+++ b/services/horizon/internal/actions/helpers.go
@@ -47,8 +47,6 @@ const (
 	DisableCursorValidation Opt = iota
 	// DefaultTOID sets a default cursor value in GetPageQuery based on the ledger state
 	DefaultTOID Opt = iota
-
-	defaultLedgerCursorBuffer = 100
 )
 
 // HeaderWriter is an interface for setting HTTP response headers
@@ -228,14 +226,6 @@ func GetPageQuery(ledgerState *ledger.State, r *http.Request, opts ...Opt) (db2.
 			pageQuery.Cursor = toid.AfterLedger(
 				ordered.Max(0, ledgerState.CurrentStatus().HistoryElder-1),
 			).String()
-		} else if pageQuery.Order == db2.OrderDescending {
-			pageQuery.Cursor = toid.AfterLedger(
-				// add an extra amount to the latest ledger in case the
-				// ledger state is out of date
-				ledgerState.CurrentStatus().HistoryLatest + defaultLedgerCursorBuffer,
-			).String()
-		} else {
-			return db2.PageQuery{}, problem.BadRequest
 		}
 	}
 

--- a/services/horizon/internal/actions/helpers_test.go
+++ b/services/horizon/internal/actions/helpers_test.go
@@ -311,7 +311,7 @@ func TestGetPageQueryCursorDefaultTOID(t *testing.T) {
 
 	pq, err = GetPageQuery(ledgerState, descReq, DefaultTOID)
 	assert.NoError(t, err)
-	assert.Equal(t, toid.AfterLedger(7000+defaultLedgerCursorBuffer).String(), pq.Cursor)
+	assert.Equal(t, "", pq.Cursor)
 	assert.Equal(t, uint64(2), pq.Limit)
 	assert.Equal(t, "desc", pq.Order)
 
@@ -324,7 +324,7 @@ func TestGetPageQueryCursorDefaultTOID(t *testing.T) {
 	pq, err = GetPageQuery(ledgerState, descReq)
 	assert.NoError(t, err)
 	assert.Empty(t, pq.Cursor)
-	assert.Equal(t, uint64(2), pq.Limit)
+	assert.Equal(t, "", pq.Cursor)
 	assert.Equal(t, "desc", pq.Order)
 
 	ledgerState.SetHorizonStatus(ledger.HorizonStatus{
@@ -342,7 +342,7 @@ func TestGetPageQueryCursorDefaultTOID(t *testing.T) {
 
 	pq, err = GetPageQuery(ledgerState, descReq, DefaultTOID)
 	assert.NoError(t, err)
-	assert.Equal(t, toid.AfterLedger(7000+defaultLedgerCursorBuffer).String(), pq.Cursor)
+	assert.Equal(t, "", pq.Cursor)
 	assert.Equal(t, uint64(2), pq.Limit)
 	assert.Equal(t, "desc", pq.Order)
 

--- a/services/horizon/internal/actions/helpers_test.go
+++ b/services/horizon/internal/actions/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/assert"
@@ -288,6 +289,63 @@ func TestGetPageQuery(t *testing.T) {
 	r = makeTestActionRequest("/?limit=0", nil)
 	_, err = GetPageQuery(ledgerState, r)
 	tt.Assert.Error(err)
+}
+
+func TestGetPageQueryCursorDefaultTOID(t *testing.T) {
+	ascReq := makeTestActionRequest("/foo-bar/blah?limit=2", testURLParams())
+	descReq := makeTestActionRequest("/foo-bar/blah?limit=2&order=desc", testURLParams())
+
+	ledgerState := &ledger.State{}
+	ledgerState.SetHorizonStatus(ledger.HorizonStatus{
+		HistoryLatest:         7000,
+		HistoryLatestClosedAt: time.Now(),
+		HistoryElder:          300,
+		ExpHistoryLatest:      7000,
+	})
+
+	pq, err := GetPageQuery(ledgerState, ascReq, DefaultTOID)
+	assert.NoError(t, err)
+	assert.Equal(t, toid.AfterLedger(299).String(), pq.Cursor)
+	assert.Equal(t, uint64(2), pq.Limit)
+	assert.Equal(t, "asc", pq.Order)
+
+	pq, err = GetPageQuery(ledgerState, descReq, DefaultTOID)
+	assert.NoError(t, err)
+	assert.Equal(t, toid.AfterLedger(7000+defaultLedgerCursorBuffer).String(), pq.Cursor)
+	assert.Equal(t, uint64(2), pq.Limit)
+	assert.Equal(t, "desc", pq.Order)
+
+	pq, err = GetPageQuery(ledgerState, ascReq)
+	assert.NoError(t, err)
+	assert.Empty(t, pq.Cursor)
+	assert.Equal(t, uint64(2), pq.Limit)
+	assert.Equal(t, "asc", pq.Order)
+
+	pq, err = GetPageQuery(ledgerState, descReq)
+	assert.NoError(t, err)
+	assert.Empty(t, pq.Cursor)
+	assert.Equal(t, uint64(2), pq.Limit)
+	assert.Equal(t, "desc", pq.Order)
+
+	ledgerState.SetHorizonStatus(ledger.HorizonStatus{
+		HistoryLatest:         7000,
+		HistoryLatestClosedAt: time.Now(),
+		HistoryElder:          0,
+		ExpHistoryLatest:      7000,
+	})
+
+	pq, err = GetPageQuery(ledgerState, ascReq, DefaultTOID)
+	assert.NoError(t, err)
+	assert.Equal(t, toid.AfterLedger(1).String(), pq.Cursor)
+	assert.Equal(t, uint64(2), pq.Limit)
+	assert.Equal(t, "asc", pq.Order)
+
+	pq, err = GetPageQuery(ledgerState, descReq, DefaultTOID)
+	assert.NoError(t, err)
+	assert.Equal(t, toid.AfterLedger(7000+defaultLedgerCursorBuffer).String(), pq.Cursor)
+	assert.Equal(t, uint64(2), pq.Limit)
+	assert.Equal(t, "desc", pq.Order)
+
 }
 
 func TestGetString(t *testing.T) {

--- a/services/horizon/internal/actions/helpers_test.go
+++ b/services/horizon/internal/actions/helpers_test.go
@@ -336,7 +336,7 @@ func TestGetPageQueryCursorDefaultTOID(t *testing.T) {
 
 	pq, err = GetPageQuery(ledgerState, ascReq, DefaultTOID)
 	assert.NoError(t, err)
-	assert.Equal(t, toid.AfterLedger(1).String(), pq.Cursor)
+	assert.Equal(t, toid.AfterLedger(0).String(), pq.Cursor)
 	assert.Equal(t, uint64(2), pq.Limit)
 	assert.Equal(t, "asc", pq.Order)
 

--- a/services/horizon/internal/actions/ledger.go
+++ b/services/horizon/internal/actions/ledger.go
@@ -17,7 +17,7 @@ type GetLedgersHandler struct {
 }
 
 func (handler GetLedgersHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
-	pq, err := GetPageQuery(handler.LedgerState, r)
+	pq, err := GetPageQuery(handler.LedgerState, r, DefaultTOID)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/operation.go
+++ b/services/horizon/internal/actions/operation.go
@@ -72,7 +72,7 @@ type GetOperationsHandler struct {
 func (handler GetOperationsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
 	ctx := r.Context()
 
-	pq, err := GetPageQuery(handler.LedgerState, r)
+	pq, err := GetPageQuery(handler.LedgerState, r, DefaultTOID)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -185,10 +185,12 @@ func TestInvokeHostFnDetailsInPaymentOperations(t *testing.T) {
 func TestGetOperationsWithoutFilter(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
-	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{
+		LedgerState: &ledger.State{},
+	}
+	handler.LedgerState.SetStatus(tt.Scenario("base"))
 
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
@@ -203,10 +205,12 @@ func TestGetOperationsWithoutFilter(t *testing.T) {
 func TestGetOperationsExclusiveFilters(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
-	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{
+		LedgerState: &ledger.State{},
+	}
+	handler.LedgerState.SetStatus(tt.Scenario("base"))
 
 	testCases := []struct {
 		desc  string
@@ -262,10 +266,12 @@ func TestGetOperationsByLiquidityPool(t *testing.T) {
 func TestGetOperationsFilterByAccountID(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
-	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{
+		LedgerState: &ledger.State{},
+	}
+	handler.LedgerState.SetStatus(tt.Scenario("base"))
 
 	testCases := []struct {
 		accountID string
@@ -303,10 +309,12 @@ func TestGetOperationsFilterByAccountID(t *testing.T) {
 func TestGetOperationsFilterByTxID(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
-	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{
+		LedgerState: &ledger.State{},
+	}
+	handler.LedgerState.SetStatus(tt.Scenario("base"))
 
 	testCases := []struct {
 		desc          string
@@ -377,10 +385,12 @@ func TestGetOperationsFilterByTxID(t *testing.T) {
 func TestGetOperationsIncludeFailed(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
-	tt.Scenario("failed_transactions")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{
+		LedgerState: &ledger.State{},
+	}
+	handler.LedgerState.SetStatus(tt.Scenario("failed_transactions"))
 
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
@@ -507,10 +517,12 @@ func TestGetOperationsIncludeFailed(t *testing.T) {
 func TestGetOperationsFilterByLedgerID(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
-	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{
+		LedgerState: &ledger.State{},
+	}
+	handler.LedgerState.SetStatus(tt.Scenario("base"))
 
 	testCases := []struct {
 		ledgerID    string
@@ -578,12 +590,13 @@ func TestGetOperationsFilterByLedgerID(t *testing.T) {
 func TestGetOperationsOnlyPayments(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
-	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
 	handler := GetOperationsHandler{
+		LedgerState:  &ledger.State{},
 		OnlyPayments: true,
 	}
+	handler.LedgerState.SetStatus(tt.Scenario("base"))
 
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
@@ -627,7 +640,7 @@ func TestGetOperationsOnlyPayments(t *testing.T) {
 	tt.Assert.NoError(err)
 	tt.Assert.Len(records, 1)
 
-	tt.Scenario("pathed_payment")
+	handler.LedgerState.SetStatus(tt.Scenario("pathed_payment"))
 
 	records, err = handler.GetResourcePage(
 		httptest.NewRecorder(),
@@ -658,10 +671,12 @@ func TestGetOperationsOnlyPayments(t *testing.T) {
 func TestOperation_CreatedAt(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
-	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{
+		LedgerState: &ledger.State{},
+	}
+	handler.LedgerState.SetStatus(tt.Scenario("base"))
 
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
@@ -683,12 +698,12 @@ func TestOperation_CreatedAt(t *testing.T) {
 func TestGetOperationsPagination(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
-	tt.Scenario("base")
 
 	q := &history.Q{tt.HorizonSession()}
 	handler := GetOperationsHandler{
 		LedgerState: &ledger.State{},
 	}
+	handler.LedgerState.SetStatus(tt.Scenario("base"))
 
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
@@ -742,10 +757,12 @@ func TestGetOperationsPagination(t *testing.T) {
 func TestGetOperations_IncludeTransactions(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
-	tt.Scenario("failed_transactions")
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{}
+	handler := GetOperationsHandler{
+		LedgerState: &ledger.State{},
+	}
+	handler.LedgerState.SetStatus(tt.Scenario("failed_transactions"))
 
 	_, err := handler.GetResourcePage(
 		httptest.NewRecorder(),
@@ -835,11 +852,12 @@ func TestGetOperation(t *testing.T) {
 func TestOperation_IncludeTransaction(t *testing.T) {
 	tt := test.Start(t)
 	defer tt.Finish()
-	tt.Scenario("kahuna")
 
 	handler := GetOperationByIDHandler{
 		LedgerState: &ledger.State{},
 	}
+	handler.LedgerState.SetStatus(tt.Scenario("kahuna"))
+
 	record, err := handler.GetResource(
 		httptest.NewRecorder(),
 		makeRequest(

--- a/services/horizon/internal/actions/operation_test.go
+++ b/services/horizon/internal/actions/operation_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/guregu/null"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/protocols/horizon/operations"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
@@ -19,7 +21,6 @@ import (
 	supportProblem "github.com/stellar/go/support/render/problem"
 	"github.com/stellar/go/toid"
 	"github.com/stellar/go/xdr"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestInvokeHostFnDetailsInPaymentOperations(t *testing.T) {
@@ -28,8 +29,14 @@ func TestInvokeHostFnDetailsInPaymentOperations(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetOperationsHandler{OnlyPayments: true}
-
+	handler := GetOperationsHandler{OnlyPayments: true,
+		LedgerState: &ledger.State{},
+	}
+	handler.LedgerState.SetHorizonStatus(ledger.HorizonStatus{
+		HistoryLatest:    56,
+		HistoryElder:     56,
+		ExpHistoryLatest: 56,
+	})
 	txIndex := int32(1)
 	sequence := int32(56)
 	txID := toid.New(sequence, txIndex, 0).ToInt64()

--- a/services/horizon/internal/actions/trade.go
+++ b/services/horizon/internal/actions/trade.go
@@ -159,7 +159,7 @@ type GetTradesHandler struct {
 func (handler GetTradesHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
 	ctx := r.Context()
 
-	pq, err := GetPageQuery(handler.LedgerState, r)
+	pq, err := GetPageQuery(handler.LedgerState, r, DefaultTOID)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/transaction.go
+++ b/services/horizon/internal/actions/transaction.go
@@ -98,7 +98,7 @@ type GetTransactionsHandler struct {
 func (handler GetTransactionsHandler) GetResourcePage(w HeaderWriter, r *http.Request) ([]hal.Pageable, error) {
 	ctx := r.Context()
 
-	pq, err := GetPageQuery(handler.LedgerState, r)
+	pq, err := GetPageQuery(handler.LedgerState, r, DefaultTOID)
 	if err != nil {
 		return nil, err
 	}

--- a/services/horizon/internal/actions/transaction_test.go
+++ b/services/horizon/internal/actions/transaction_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/ledger"
 	"github.com/stellar/go/services/horizon/internal/test"
 	supportProblem "github.com/stellar/go/support/render/problem"
 )
@@ -16,7 +17,10 @@ func TestGetTransactionsHandler(t *testing.T) {
 	defer tt.Finish()
 
 	q := &history.Q{tt.HorizonSession()}
-	handler := GetTransactionsHandler{}
+	handler := GetTransactionsHandler{
+		LedgerState: &ledger.State{},
+	}
+	handler.LedgerState.SetStatus(tt.Scenario("base"))
 
 	// filter by account
 	records, err := handler.GetResourcePage(
@@ -155,7 +159,14 @@ func TestFeeBumpTransactionPage(t *testing.T) {
 	test.ResetHorizonDB(t, tt.HorizonDB)
 	q := &history.Q{tt.HorizonSession()}
 	fixture := history.FeeBumpScenario(tt, q, true)
-	handler := GetTransactionsHandler{}
+	handler := GetTransactionsHandler{
+		LedgerState: &ledger.State{},
+	}
+	handler.LedgerState.SetHorizonStatus(ledger.HorizonStatus{
+		HistoryLatest:    fixture.Ledger.Sequence,
+		HistoryElder:     fixture.Ledger.Sequence,
+		ExpHistoryLatest: uint32(fixture.Ledger.Sequence),
+	})
 
 	records, err := handler.GetResourcePage(
 		httptest.NewRecorder(),


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The following endpoints use a [TOID](https://github.com/stellar/go/blob/master/toid/main.go#L8) cursor value derived from the ledger sequence number:

/effects
/operations
/transactions
/ledgers
/trades
/payments

When a cursor is omitted the query to fetch the history data will look like:

`select * from history_transactions order by id asc` (if the order is asc which is by default))

or 

`select * from history_transactions order by id desc` (if the order is desc)

However, the query performs better with a paging clause, eg:

`select * from history_transactions where id >= 200076760811839488 order by id asc`

 
This commit sets a default cursor value based on the paging order. If order is set to asc, we will use the oldest ledger -1 to create the default cursor value. Similarly, if the order is set to desc, we will use the latest ledger + 100 to create the default cursor value.
 
### Known limitations

We obtain the oldest and latest ledger using `ledgerState *ledger.State` which is refreshed periodically. It is possible that `ledgerState` is out of date but that is why we add a buffer of 100 extra ledgers to `ledgerState.CurrentStatus().HistoryLatest`. 