### PR TITLE
Remove CLA reference from contributing document

### DIFF
--- a/services/horizon/CONTRIBUTING.md
+++ b/services/horizon/CONTRIBUTING.md
@@ -1,6 +1,3 @@
 # How to contribute
 
 Please read the [Contribution Guide](https://github.com/stellar/docs/blob/master/CONTRIBUTING.md).
-
-Then please [sign the Contributor License Agreement](https://docs.google.com/forms/d/1g7EF6PERciwn7zfmfke5Sir2n10yddGGSXyZsq98tVY/viewform?usp=send_form).
-

--- a/services/horizon/CONTRIBUTING.md
+++ b/services/horizon/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # How to contribute
 
-Please read the [Contribution Guide](https://github.com/stellar/docs/blob/master/CONTRIBUTING.md).
+Please read the [Contribution Guide](https://github.com/stellar/.github/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION

### What

Remove CLA reference from contributing document.

### Why

The CLA was deprecated at some point and this reference remained.