### PR TITLE
Change `ErrorResultXDR` to `error_result_xdr` in `AsyncTransactionSubmissionResponse`

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -582,7 +582,7 @@ type AsyncTransactionSubmissionResponse struct {
 	// ErrorResultXDR is present only if Status is equal to proto.TXStatusError.
 	// ErrorResultXDR is a TransactionResult xdr string which contains details on why
 	// the transaction could not be accepted by stellar-core.
-	ErrorResultXDR string `json:"errorResultXdr,omitempty"`
+	ErrorResultXDR string `json:"error_result_xdr,omitempty"`
 	// TxStatus represents the status of the transaction submission returned by stellar-core.
 	// It can be one of: proto.TXStatusPending, proto.TXStatusDuplicate,
 	// proto.TXStatusTryAgainLater, or proto.TXStatusError.

--- a/services/horizon/internal/httpx/static/txsub_async_oapi.yaml
+++ b/services/horizon/internal/httpx/static/txsub_async_oapi.yaml
@@ -52,7 +52,7 @@ paths:
                 ErrorStatusExample:
                   summary: ERROR Status from core
                   value:
-                    errorResultXdr: "AAAAAAAAAGT////7AAAAAA=="
+                    error_result_xdr: "AAAAAAAAAGT////7AAAAAA=="
                     tx_status: "ERROR"
                     hash: "6cbb7f714bd08cea7c30cab7818a35c510cbbfc0a6aa06172a1e94146ecf0165"
         '405':
@@ -78,7 +78,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AsyncTransactionSubmissionResponse'
               example: 
-                  errorResultXdr: ""
+                  error_result_xdr: ""
                   tx_status: "DUPLICATE"
                   hash: "6cbb7f714bd08cea7c30cab7818a35c510cbbfc0a6aa06172a1e94146ecf0165"
         '500':
@@ -136,7 +136,7 @@ components:
     AsyncTransactionSubmissionResponse:
       type: object
       properties:
-        errorResultXdr:
+        error_result_xdr:
           type: string
           nullable: true
           description: TransactionResult XDR string which is present only if the submission status from core is an ERROR.


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Closes #5441 

### Why

This change makes it uniform with the snake-case naming in other endpoints.

### Known limitations

NA
