### PR TITLE
Send an error response for Horizon.Problem

### DIFF
--- a/clients/horizonclient/internal.go
+++ b/clients/horizonclient/internal.go
@@ -70,10 +70,7 @@ func decodeAsyncTxSubResponse(resp *http.Response, object interface{}) error {
 	// the hash of the transaction. If the response was not a valid AsyncTransactionSubmissionResponse object,
 	// the hash of the converted object will be empty.
 	asyncRespDecoder := json.NewDecoder(bytes.NewReader(bodyBytes))
-	err = asyncRespDecoder.Decode(&object)
-	if err != nil {
-		return errors.Wrap(err, "error decoding response")
-	}
+	asyncRespDecoder.Decode(&object)
 	if asyncResp, ok := object.(*horizon.AsyncTransactionSubmissionResponse); ok && asyncResp.Hash != "" {
 		return nil
 	}

--- a/clients/horizonclient/internal.go
+++ b/clients/horizonclient/internal.go
@@ -67,7 +67,8 @@ func decodeAsyncTxSubResponse(resp *http.Response, object interface{}) error {
 	}
 
 	// The first decoder converts the response to AsyncTransactionSubmissionResponse and checks
-	// the hash of the transaction. If the response was not a valid one, the hash will be empty.
+	// the hash of the transaction. If the response was not a valid AsyncTransactionSubmissionResponse object,
+	// the hash of the converted object will be empty.
 	decoder1 := json.NewDecoder(bytes.NewReader(bodyBytes))
 	err = decoder1.Decode(&object)
 	if err != nil {

--- a/clients/horizonclient/internal.go
+++ b/clients/horizonclient/internal.go
@@ -71,7 +71,7 @@ func decodeAsyncTxSubResponse(resp *http.Response, object interface{}) error {
 	// the hash of the converted object will be empty.
 	asyncRespDecoder := json.NewDecoder(bytes.NewReader(bodyBytes))
 	err = asyncRespDecoder.Decode(&object)
-	if asyncResp, ok := object.(*horizon.AsyncTransactionSubmissionResponse); err != nil && ok && asyncResp.Hash != "" {
+	if asyncResp, ok := object.(*horizon.AsyncTransactionSubmissionResponse); err == nil && ok && asyncResp.Hash != "" {
 		return nil
 	}
 

--- a/clients/horizonclient/internal.go
+++ b/clients/horizonclient/internal.go
@@ -69,8 +69,8 @@ func decodeAsyncTxSubResponse(resp *http.Response, object interface{}) error {
 	// The first decoder converts the response to AsyncTransactionSubmissionResponse and checks
 	// the hash of the transaction. If the response was not a valid AsyncTransactionSubmissionResponse object,
 	// the hash of the converted object will be empty.
-	decoder1 := json.NewDecoder(bytes.NewReader(bodyBytes))
-	err = decoder1.Decode(&object)
+	asyncRespDecoder := json.NewDecoder(bytes.NewReader(bodyBytes))
+	err = asyncRespDecoder.Decode(&object)
 	if err != nil {
 		return errors.Wrap(err, "error decoding response")
 	}
@@ -79,15 +79,15 @@ func decodeAsyncTxSubResponse(resp *http.Response, object interface{}) error {
 	}
 
 	// Create a new reader for the second decoding. The second decoder decodes to Horizon.Problem object.
-	decoder2 := json.NewDecoder(bytes.NewReader(bodyBytes))
-	horizonErr := Error{
+	errorDecoder := json.NewDecoder(bytes.NewReader(bodyBytes))
+	horizonError := Error{
 		Response: resp,
 	}
-	err = decoder2.Decode(&horizonErr.Problem)
+	err = errorDecoder.Decode(&horizonError.Problem)
 	if err != nil {
 		return errors.Wrap(err, "error decoding horizon error")
 	}
-	return horizonErr
+	return horizonError
 }
 
 // countParams counts the number of parameters provided

--- a/clients/horizonclient/internal.go
+++ b/clients/horizonclient/internal.go
@@ -1,13 +1,16 @@
 package horizonclient
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/clock"
 	"github.com/stellar/go/support/errors"
 )
@@ -27,10 +30,11 @@ func decodeResponse(resp *http.Response, object interface{}, horizonUrl string, 
 	}
 	setCurrentServerTime(u.Hostname(), resp.Header["Date"], clock)
 
-	// While this part of code assumes that any error < 200 or error >= 300 is a Horizon problem, it is not
-	// true for the response from /transactions_async endpoint which does give these codes for certain responses
-	// from core.
-	if !(resp.StatusCode >= 200 && resp.StatusCode < 300) && (resp.Request == nil || resp.Request.URL == nil || resp.Request.URL.Path != "/transactions_async") {
+	if isStatusCodeAnError(resp.StatusCode) {
+		if isAsyncTxSubRequest(resp) {
+			return decodeAsyncTxSubResponse(resp, object)
+		}
+
 		horizonError := &Error{
 			Response: resp,
 		}
@@ -45,6 +49,44 @@ func decodeResponse(resp *http.Response, object interface{}, horizonUrl string, 
 		return errors.Wrap(err, "error decoding response")
 	}
 	return
+}
+
+func isStatusCodeAnError(statusCode int) bool {
+	return !(statusCode >= 200 && statusCode < 300)
+}
+
+func isAsyncTxSubRequest(resp *http.Response) bool {
+	return resp.Request != nil && resp.Request.URL != nil && resp.Request.URL.Path == "/transactions_async"
+}
+
+func decodeAsyncTxSubResponse(resp *http.Response, object interface{}) error {
+	// We need to read the entire body in order to create 2 decoders later.
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "error reading response body")
+	}
+
+	// The first decoder converts the response to AsyncTransactionSubmissionResponse and checks
+	// the hash of the transaction. If the response was not a valid one, the hash will be empty.
+	decoder1 := json.NewDecoder(bytes.NewReader(bodyBytes))
+	err = decoder1.Decode(&object)
+	if err != nil {
+		return errors.Wrap(err, "error decoding response")
+	}
+	if asyncResp, ok := object.(*horizon.AsyncTransactionSubmissionResponse); ok && asyncResp.Hash != "" {
+		return nil
+	}
+
+	// Create a new reader for the second decoding. The second decoder decodes to Horizon.Problem object.
+	decoder2 := json.NewDecoder(bytes.NewReader(bodyBytes))
+	horizonErr := Error{
+		Response: resp,
+	}
+	err = decoder2.Decode(&horizonErr.Problem)
+	if err != nil {
+		return errors.Wrap(err, "error decoding horizon error")
+	}
+	return horizonErr
 }
 
 // countParams counts the number of parameters provided

--- a/clients/horizonclient/internal.go
+++ b/clients/horizonclient/internal.go
@@ -70,8 +70,8 @@ func decodeAsyncTxSubResponse(resp *http.Response, object interface{}) error {
 	// the hash of the transaction. If the response was not a valid AsyncTransactionSubmissionResponse object,
 	// the hash of the converted object will be empty.
 	asyncRespDecoder := json.NewDecoder(bytes.NewReader(bodyBytes))
-	asyncRespDecoder.Decode(&object)
-	if asyncResp, ok := object.(*horizon.AsyncTransactionSubmissionResponse); ok && asyncResp.Hash != "" {
+	err = asyncRespDecoder.Decode(&object)
+	if asyncResp, ok := object.(*horizon.AsyncTransactionSubmissionResponse); err != nil && ok && asyncResp.Hash != "" {
 		return nil
 	}
 

--- a/clients/horizonclient/internal.go
+++ b/clients/horizonclient/internal.go
@@ -76,11 +76,11 @@ func decodeAsyncTxSubResponse(resp *http.Response, object interface{}) error {
 	}
 
 	// Create a new reader for the second decoding. The second decoder decodes to Horizon.Problem object.
-	errorDecoder := json.NewDecoder(bytes.NewReader(bodyBytes))
+	problemDecoder := json.NewDecoder(bytes.NewReader(bodyBytes))
 	horizonError := Error{
 		Response: resp,
 	}
-	err = errorDecoder.Decode(&horizonError.Problem)
+	err = problemDecoder.Decode(&horizonError.Problem)
 	if err != nil {
 		return errors.Wrap(err, "error decoding horizon error")
 	}

--- a/services/horizon/internal/integration/txsub_async_test.go
+++ b/services/horizon/internal/integration/txsub_async_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/protocols/horizon"
@@ -129,6 +130,31 @@ func TestAsyncTxSub_SubmissionTryAgainLater(t *testing.T) {
 		TxStatus:       "TRY_AGAIN_LATER",
 		Hash:           "d5eb72a4c1832b89965850fff0bd9bba4b6ca102e7c89099dcaba5e7d7d2e049",
 	})
+}
+
+func TestAsyncTxSub_TransactionMalformed(t *testing.T) {
+	itest := integration.NewTest(t, integration.Config{
+		EnableSorobanRPC: true,
+		HorizonEnvironment: map[string]string{
+			"MAX_HTTP_REQUEST_SIZE": "1800",
+		},
+	})
+	master := itest.Master()
+
+	// establish which account will be contract owner, and load it's current seq
+	sourceAccount, err := itest.Client().AccountDetail(horizonclient.AccountRequest{
+		AccountID: itest.Master().Address(),
+	})
+	require.NoError(t, err)
+
+	installContractOp := assembleInstallContractCodeOp(t, master.Address(), "soroban_sac_test.wasm")
+	preFlightOp, minFee := itest.PreflightHostFunctions(&sourceAccount, *installContractOp)
+	txParams := integration.GetBaseTransactionParamsWithFee(&sourceAccount, minFee+txnbuild.MinBaseFee, &preFlightOp)
+	_, err = itest.AsyncSubmitTransaction(master, txParams)
+	assert.EqualError(
+		t, err,
+		"horizon error: \"Transaction Malformed\" - check horizon.Error.Problem for more information",
+	)
 }
 
 func TestAsyncTxSub_GetOpenAPISpecResponse(t *testing.T) {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Change the decoding method for non-2xx codes in `async-txsub` endpoint. Current code decodes all error responses to `horizon.Problem` object. This change adds a separate decoding method specific for the async-txsub endpoint responses.

### Why

For non-2xx codes, the `async-txsub` endpoint not only sends a `horizon.Problem` response, but also sends `AsyncTransactionSubmissionResponse` object depending on certain core responses.

### Known limitations

NA
