### PR TITLE
[WIP] Change reference to stellar-rpc

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -35,7 +35,7 @@ jobs:
       HORIZON_INTEGRATION_TESTS_CAPTIVE_CORE_USE_DB: true
       PROTOCOL_21_CORE_DEBIAN_PKG_VERSION: 21.3.1-2007.4ede19620.focal
       PROTOCOL_21_CORE_DOCKER_IMG: stellar/stellar-core:21.3.1-2007.4ede19620.focal
-      PROTOCOL_21_SOROBAN_RPC_DOCKER_IMG: stellar/soroban-rpc:21.5.0
+      PROTOCOL_21_SOROBAN_RPC_DOCKER_IMG: stellar/stellar-rpc:21.5.0
       PGHOST: localhost
       PGPORT: 5432
       PGUSER: postgres

--- a/services/horizon/docker/docker-compose.integration-tests.soroban-rpc.yml
+++ b/services/horizon/docker/docker-compose.integration-tests.soroban-rpc.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   soroban-rpc:
     platform: linux/amd64
-    image: ${SOROBAN_RPC_IMAGE:-stellar/soroban-rpc}
+    image: ${SOROBAN_RPC_IMAGE:-stellar/stellar-rpc}
     depends_on:
       - core
     restart: on-failure


### PR DESCRIPTION

### What

Rename the reference of soroban-rpc

### Why

We are renaming soroban-rpc repository to stellar-rpc

### Known limitations

Note: Not changing any internal env or variable names related to soroban-rpc in order to keep this change minimal for now.