### PR TITLE
updates to horizon docker builds

### DIFF
--- a/services/horizon/docker/Dockerfile
+++ b/services/horizon/docker/Dockerfile
@@ -1,3 +1,4 @@
+# install Core from apt "stable" or "unstable" pool, and horizon from apt "testing" pool
 FROM ubuntu:focal
 
 ARG VERSION

--- a/services/horizon/docker/Dockerfile.core-testing
+++ b/services/horizon/docker/Dockerfile.core-testing
@@ -1,0 +1,19 @@
+# install both horizon and core from apt "testing" pool
+FROM ubuntu:focal
+
+ARG VERSION
+ARG STELLAR_CORE_VERSION
+ARG DEBIAN_FRONTEND=noninteractive
+ARG ALLOW_CORE_UNSTABLE=no
+
+RUN apt-get update && apt-get install -y wget apt-transport-https gnupg2 && \
+    wget -qO /etc/apt/trusted.gpg.d/SDF.asc https://apt.stellar.org/SDF.asc && \
+    echo "deb https://apt.stellar.org focal testing" | tee -a /etc/apt/sources.list.d/SDF.list && \
+    cat /etc/apt/sources.list.d/SDF.list && \
+    apt-get update && \
+    apt-cache madison stellar-core && eval "apt-get install -y stellar-core${STELLAR_CORE_VERSION+=$STELLAR_CORE_VERSION}" && \
+    apt-cache madison stellar-horizon && apt-get install -y stellar-horizon=${VERSION} && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /var/log/*.log /var/log/*/*.log
+
+EXPOSE 8000
+ENTRYPOINT ["/usr/bin/stellar-horizon"]

--- a/services/horizon/docker/Dockerfile.stable
+++ b/services/horizon/docker/Dockerfile.stable
@@ -1,0 +1,18 @@
+# install Core from apt "stable"and horizon from apt "stable" pool
+FROM ubuntu:focal
+
+ARG VERSION
+ARG STELLAR_CORE_VERSION
+ARG DEBIAN_FRONTEND=noninteractive
+ARG ALLOW_CORE_UNSTABLE=no
+
+RUN apt-get update && apt-get install -y wget apt-transport-https gnupg2 && \
+    wget -qO /etc/apt/trusted.gpg.d/SDF.asc https://apt.stellar.org/SDF.asc && \
+    echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list && \
+    cat /etc/apt/sources.list.d/SDF.list && \
+    apt-get update && apt-cache madison stellar-core && eval "apt-get install -y stellar-core${STELLAR_CORE_VERSION+=$STELLAR_CORE_VERSION}" && \
+    apt-cache madison stellar-horizon && apt-get install -y stellar-horizon=${VERSION} && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /var/log/*.log /var/log/*/*.log
+
+EXPOSE 8000
+ENTRYPOINT ["/usr/bin/stellar-horizon"]

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -29,11 +29,23 @@ ifndef VERSION
 	$(error VERSION environment variable must be set. For example VERSION=2.4.1-101 )
 endif
 ifndef STELLAR_CORE_VERSION
+	$(error STELLAR_CORE_VERSION environment variable must be set. )
+else
 	$(SUDO) docker build --file ./Dockerfile.core-testing --pull $(DOCKER_OPTS) \
 	--label org.opencontainers.image.created="$(BUILD_DATE)" \
-	--build-arg VERSION=$(VERSION) -t $(TAG) .
+	--build-arg VERSION=$(VERSION) --build-arg STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION) \
+	-t $(TAG) .
+endif
+
+# build Core and Horizon from apt "stable"
+docker-build-core-stable:
+ifndef VERSION
+	$(error VERSION environment variable must be set. For example VERSION=2.4.1-101 )
+endif
+ifndef STELLAR_CORE_VERSION
+	$(error STELLAR_CORE_VERSION environment variable must be set. )
 else
-	$(SUDO) docker build --pull $(DOCKER_OPTS) \
+	$(SUDO) docker build --file ./Dockerfile.stable --pull $(DOCKER_OPTS) \
 	--label org.opencontainers.image.created="$(BUILD_DATE)" \
 	--build-arg VERSION=$(VERSION) --build-arg STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION) \
 	-t $(TAG) .

--- a/services/horizon/docker/Makefile
+++ b/services/horizon/docker/Makefile
@@ -5,6 +5,7 @@ BUILD_DATE := $(shell date -u +%FT%TZ)
 
 TAG ?= stellar/stellar-horizon:$(VERSION)
 
+# build with Core from apt "stable" or "unstable", and horizon from apt "testing"
 docker-build:
 ifndef VERSION
 	$(error VERSION environment variable must be set. For example VERSION=2.4.1-101 )
@@ -19,6 +20,22 @@ else
 	--label org.opencontainers.image.created="$(BUILD_DATE)" \
 	--build-arg VERSION=$(VERSION) --build-arg STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION) \
         --build-arg ALLOW_CORE_UNSTABLE=$(ALLOW_CORE_UNSTABLE) \
+	-t $(TAG) .
+endif
+
+# build Core and Horizon from apt "testing"
+docker-build-core-testing:
+ifndef VERSION
+	$(error VERSION environment variable must be set. For example VERSION=2.4.1-101 )
+endif
+ifndef STELLAR_CORE_VERSION
+	$(SUDO) docker build --file ./Dockerfile.core-testing --pull $(DOCKER_OPTS) \
+	--label org.opencontainers.image.created="$(BUILD_DATE)" \
+	--build-arg VERSION=$(VERSION) -t $(TAG) .
+else
+	$(SUDO) docker build --pull $(DOCKER_OPTS) \
+	--label org.opencontainers.image.created="$(BUILD_DATE)" \
+	--build-arg VERSION=$(VERSION) --build-arg STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION) \
 	-t $(TAG) .
 endif
 


### PR DESCRIPTION
### What
- a new Dockerfile to install Core from the "testing" pool an update to the Makefile specifically for this case
- a new Dockerfile to install Core and Horizon from their "stable" pools
- additional comments to clarify what the different files do

### Why
this is needed to support Horizon's new workflow

### Testing
this has been tested successfully

### Issue addressed by this PR
https://github.com/stellar/ops/issues/3124
