### PR TITLE
services/horizon: update failed transaction error message

### DIFF
--- a/services/horizon/internal/actions/submit_transaction.go
+++ b/services/horizon/internal/actions/submit_transaction.go
@@ -142,7 +142,7 @@ func (handler SubmitTransactionHandler) response(r *http.Request, info envelopeI
 			Detail: "The transaction failed when submitted to the stellar network. " +
 				"The `extras.result_codes` field on this response contains further " +
 				"details.  Descriptions of each code can be found at: " +
-				"https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/transaction-failed/",
+				"https://developers.stellar.org/docs/data/horizon/api-reference/errors/result-codes/transactions",
 			Extras: extras,
 		}
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next release branch if it's not a patch change.
</details>

### What

Changed the url mentioned in the error message from [old url](https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/transaction-failed/) to [new url](https://developers.stellar.org/docs/data/horizon/api-reference/errors/result-codes/transactions")

### Why

The [old url](https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/transaction-failed/) answers with a 404

### Known limitations

It would firstly be seen as a patch change since no API is changed.
But it may (or not) break related tests in other repos where this url appears : see [this search query](https://github.com/search?q=org%3Astellar+%22https%3A%2F%2Fdevelopers.stellar.org%2Fapi%2Ferrors%2Fhttp-status-codes%2Fhorizon-specific%2Ftransaction-failed%2F%22&type=code)

