### PR TITLE
fix CI failures due to race condition in recoverysigner unit tests

### DIFF
--- a/support/db/dbtest/db.go
+++ b/support/db/dbtest/db.go
@@ -128,8 +128,8 @@ func checkReadOnly(t testing.TB, DSN string) {
 	if !rows.Next() {
 		_, err = tx.Exec("CREATE ROLE user_ro WITH LOGIN PASSWORD 'user_ro';")
 		if err != nil {
-			// Handle race condition by ignoring the error if it's a duplicate key violation
-			if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "23505" {
+			// Handle race condition by ignoring the error if it's a duplicate key violation or duplicate object error
+			if pqErr, ok := err.(*pq.Error); ok && (pqErr.Code == "23505" || pqErr.Code == "42710") {
 				return
 			}
 		}

--- a/support/db/dbtest/db.go
+++ b/support/db/dbtest/db.go
@@ -131,6 +131,8 @@ func checkReadOnly(t testing.TB, DSN string) {
 			// Handle race condition by ignoring the error if it's a duplicate key violation or duplicate object error
 			if pqErr, ok := err.(*pq.Error); ok && (pqErr.Code == "23505" || pqErr.Code == "42710") {
 				return
+			} else if ok {
+				t.Logf("pq error code: %s", pqErr.Code)
 			}
 		}
 		require.NoError(t, err)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Fix a race condition in unit tests that causes  `pq: role 'user_ro' already exists` error.  The error happens when another transaction creates the role at the same time. Handle this by ignoring the error if the role already exists. This is similar to what was done in https://github.com/stellar/go/pull/5398 for fixing CI failures in RecoverySigner unit tests.

### Why
Fixes [CI error ](https://github.com/stellar/go/actions/runs/10893140510/job/30227451493) seen in RecoverySigner unit tests 

### Known limitations
N/A
