### PR TITLE
protocols/horizon: Reinstate errorResultXdr with deprecation warning

### DIFF
--- a/protocols/horizon/main.go
+++ b/protocols/horizon/main.go
@@ -175,16 +175,20 @@ type AssetStat struct {
 	} `json:"_links"`
 
 	base.Asset
-	PT                      string            `json:"paging_token"`
-	ContractID              string            `json:"contract_id,omitempty"`
-	NumClaimableBalances    int32             `json:"num_claimable_balances"`
-	NumLiquidityPools       int32             `json:"num_liquidity_pools"`
-	NumContracts            int32             `json:"num_contracts"`
+	PT                   string `json:"paging_token"`
+	ContractID           string `json:"contract_id,omitempty"`
+	NumClaimableBalances int32  `json:"num_claimable_balances"`
+	NumLiquidityPools    int32  `json:"num_liquidity_pools"`
+	NumContracts         int32  `json:"num_contracts"`
+	// NumArchivedContracts is deprecated and will be removed in the v23 release
+	// Action needed in release: horizon-v23.0.0: remove field
 	NumArchivedContracts    int32             `json:"num_archived_contracts"`
 	Accounts                AssetStatAccounts `json:"accounts"`
 	ClaimableBalancesAmount string            `json:"claimable_balances_amount"`
 	LiquidityPoolsAmount    string            `json:"liquidity_pools_amount"`
 	ContractsAmount         string            `json:"contracts_amount"`
+	// ArchivedContractsAmount is deprecated and will be removed in the v23 release
+	// Action needed in release: horizon-v23.0.0: remove field
 	ArchivedContractsAmount string            `json:"archived_contracts_amount"`
 	Balances                AssetStatBalances `json:"balances"`
 	Flags                   AccountFlags      `json:"flags"`
@@ -576,6 +580,10 @@ type AsyncTransactionSubmissionResponse struct {
 	// ErrorResultXDR is a TransactionResult xdr string which contains details on why
 	// the transaction could not be accepted by stellar-core.
 	ErrorResultXDR string `json:"error_result_xdr,omitempty"`
+	// DeprecatedErrorResultXDR is a deprecated field equivalent to ErrorResultXDR
+	// which will be removed in the  v23 release. Use ErrorResultXDR instead of
+	// DeprecatedErrorResultXDR
+	DeprecatedErrorResultXDR string `json:"errorResultXdr,omitempty"`
 	// TxStatus represents the status of the transaction submission returned by stellar-core.
 	// It can be one of: proto.TXStatusPending, proto.TXStatusDuplicate,
 	// proto.TXStatusTryAgainLater, or proto.TXStatusError.

--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this
 file. This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 22.0.0-rc
+## 22.0.0-rc2
+
+
+### Deprecations
+
+- The `errorResultXdr` field from the response of the async transaction submission endpoint has been temporarily reinstated. However it will be removed in the v23 release. ([5496](https://github.com/stellar/go/pull/5496))
+- The `num_archived_contracts` and `archived_contracts_amount` fields from the `/assets` response have been deprecated and will be removed in the v23 Horizon release. ([5496](https://github.com/stellar/go/pull/5496))
+
+## 22.0.0-rc1
 
 **This release adds support for Protocol 22**
 

--- a/services/horizon/internal/actions/submit_transaction_async.go
+++ b/services/horizon/internal/actions/submit_transaction_async.go
@@ -115,6 +115,8 @@ func (handler AsyncSubmitTransactionHandler) GetResource(_ HeaderWriter, r *http
 
 		if resp.Status == proto.TXStatusError {
 			response.ErrorResultXDR = resp.Error
+			// Action needed in release: horizon-v23.0.0: remove deprecated field
+			response.DeprecatedErrorResultXDR = resp.Error
 		}
 
 		return response, nil

--- a/services/horizon/internal/actions/submit_transaction_async_test.go
+++ b/services/horizon/internal/actions/submit_transaction_async_test.go
@@ -164,9 +164,10 @@ func TestAsyncSubmitTransactionHandler_TransactionStatusResponse(t *testing.T) {
 				DiagnosticEvents: "test-diagnostic-events",
 			},
 			expectedResponse: horizon.AsyncTransactionSubmissionResponse{
-				ErrorResultXDR: "test-error",
-				TxStatus:       proto.TXStatusError,
-				Hash:           TxHash,
+				ErrorResultXDR:           "test-error",
+				DeprecatedErrorResultXDR: "test-error",
+				TxStatus:                 proto.TXStatusError,
+				Hash:                     TxHash,
 			},
 		},
 		{

--- a/services/horizon/internal/httpx/static/txsub_async_oapi.yaml
+++ b/services/horizon/internal/httpx/static/txsub_async_oapi.yaml
@@ -140,6 +140,10 @@ components:
           type: string
           nullable: true
           description: TransactionResult XDR string which is present only if the submission status from core is an ERROR.
+        errorResultXdr:
+          type: string
+          nullable: true
+          description: This field is deprecated, use error_result_xdr instead.
         tx_status:
           type: string
           enum: ["ERROR", "PENDING", "DUPLICATE", "TRY_AGAIN_LATER"]

--- a/services/horizon/internal/integration/txsub_async_test.go
+++ b/services/horizon/internal/integration/txsub_async_test.go
@@ -87,9 +87,10 @@ func TestAsyncTxSub_SubmissionError(t *testing.T) {
 	txResp, err := itest.AsyncSubmitTransaction(master, txParams)
 	assert.NoError(t, err)
 	assert.Equal(t, txResp, horizon.AsyncTransactionSubmissionResponse{
-		ErrorResultXDR: "AAAAAAAAAGT////7AAAAAA==",
-		TxStatus:       "ERROR",
-		Hash:           "0684df00f20efd5876f1b8d17bc6d3a68d8b85c06bb41e448815ecaa6307a251",
+		ErrorResultXDR:           "AAAAAAAAAGT////7AAAAAA==",
+		DeprecatedErrorResultXDR: "AAAAAAAAAGT////7AAAAAA==",
+		TxStatus:                 "ERROR",
+		Hash:                     "0684df00f20efd5876f1b8d17bc6d3a68d8b85c06bb41e448815ecaa6307a251",
 	})
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

In https://github.com/stellar/go/pull/5445 , `errorResultXdr` was renamed to `error_result_xdr`. Although the v22 is a major release, we should provide a pathway for horizon clients to upgrade without incurring any downtime. So, will still include the field in the async txsub response and in the v23 release we can remove `errorResultXdr` entirely.

This commit also includes deprecation warnings in the changelog for `num_archived_contracts` and `archived_contracts_amount` from the `/assets` response. From protocol 23 onwards it will be difficult to track archived contract balances because archived balances will eventually be evicted and horizon will not be able to determine how many archived balances live outside the bucketlist. 
