### PR TITLE
Add General purpose API wrapper util

### DIFF
--- a/support/http/httptest/client_expectation.go
+++ b/support/http/httptest/client_expectation.go
@@ -1,6 +1,7 @@
 package httptest
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -83,6 +84,37 @@ func (ce *ClientExpectation) ReturnStringWithHeader(
 	}
 
 	return ce.Return(httpmock.ResponderFromResponse(&cResp))
+}
+
+// ReturnMultipleResults registers multiple sequential responses for a given client expectation.
+// Useful for testing retries
+func (ce *ClientExpectation) ReturnMultipleResults(responseSets []ResponseData) *ClientExpectation {
+	var allResponses []httpmock.Responder
+	for _, response := range responseSets {
+		resp := http.Response{
+			Status:     strconv.Itoa(response.Status),
+			StatusCode: response.Status,
+			Body:       httpmock.NewRespBodyFromString(response.Body),
+			Header:     response.Header,
+		}
+		allResponses = append(allResponses, httpmock.ResponderFromResponse(&resp))
+	}
+	responseIndex := 0
+	ce.Client.MockTransport.RegisterResponder(
+		ce.Method,
+		ce.URL,
+		func(req *http.Request) (*http.Response, error) {
+			if responseIndex >= len(allResponses) {
+				panic(fmt.Sprintf("no responses available"))
+			}
+
+			resp := allResponses[responseIndex]
+			responseIndex++
+			return resp(req)
+		},
+	)
+
+	return ce
 }
 
 // ReturnJSONWithHeader causes this expectation to resolve to a json-based body with the provided

--- a/support/http/httptest/client_expectation.go
+++ b/support/http/httptest/client_expectation.go
@@ -105,7 +105,7 @@ func (ce *ClientExpectation) ReturnMultipleResults(responseSets []ResponseData) 
 		ce.URL,
 		func(req *http.Request) (*http.Response, error) {
 			if responseIndex >= len(allResponses) {
-				panic(fmt.Sprintf("no responses available"))
+				panic(fmt.Errorf("no responses available"))
 			}
 
 			resp := allResponses[responseIndex]

--- a/support/http/httptest/main.go
+++ b/support/http/httptest/main.go
@@ -67,3 +67,9 @@ func NewServer(t *testing.T, handler http.Handler) *Server {
 		Expect: httpexpect.New(t, server.URL),
 	}
 }
+
+type ResponseData struct {
+	Status int
+	Body   string
+	Header http.Header
+}

--- a/utils/apiclient/client.go
+++ b/utils/apiclient/client.go
@@ -1,98 +1,85 @@
 package apiclient
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/pkg/errors"
 )
 
-func (c *APIClient) createRequestBody(endpoint string, queryParams url.Values) (*http.Request, error) {
-	fullURL := c.url(endpoint, queryParams)
-	req, err := http.NewRequest("GET", fullURL, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "http GET request creation failed")
-	}
-	return req, nil
+const (
+	maxRetries     = 5
+	initialBackoff = 1 * time.Second
+)
+
+func isRetryableStatusCode(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable
 }
 
-func (c *APIClient) callAPI(req *http.Request) (interface{}, error) {
+func (c *APIClient) GetURL(endpoint string, qstr url.Values) string {
+	return fmt.Sprintf("%s/%s?%s", c.BaseURL, endpoint, qstr.Encode())
+}
+
+func (c *APIClient) CallAPI(reqParams RequestParams) (interface{}, error) {
+	if reqParams.QueryParams == nil {
+		reqParams.QueryParams = url.Values{}
+	}
+
+	if reqParams.Headers == nil {
+		reqParams.Headers = map[string]interface{}{}
+	}
+
+	url := c.GetURL(reqParams.Endpoint, reqParams.QueryParams)
+	reqBody, err := CreateRequestBody(reqParams.RequestType, url)
+	if err != nil {
+		return nil, errors.Wrap(err, "http request creation failed")
+	}
+
+	SetAuthHeaders(reqBody, c.authType, c.authHeaders)
+	SetHeaders(reqBody, reqParams.Headers)
 	client := c.HTTP
 	if client == nil {
 		client = &http.Client{}
 	}
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, errors.Wrap(err, "http GET request failed")
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API request failed with status %d", resp.StatusCode)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
 	var result interface{}
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	retries := 0
+
+	for retries <= maxRetries {
+		resp, err := client.Do(reqBody)
+		if err != nil {
+			return nil, errors.Wrap(err, "http request failed")
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read response body: %w", err)
+			}
+
+			if err := json.Unmarshal(body, &result); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+			}
+
+			return result, nil
+		} else if isRetryableStatusCode(resp.StatusCode) {
+			retries++
+			backoffDuration := initialBackoff * time.Duration(1<<retries)
+			if retries <= maxRetries {
+				fmt.Printf("Received retryable status %d. Retrying in %v...\n", resp.StatusCode, backoffDuration)
+				time.Sleep(backoffDuration)
+			} else {
+				return nil, fmt.Errorf("Maximum retries reached after receiving status %d", resp.StatusCode)
+			}
+		} else {
+			return nil, fmt.Errorf("API request failed with status %d", resp.StatusCode)
+		}
 	}
 
-	return result, nil
-}
-
-func setHeaders(req *http.Request, args map[string]interface{}) {
-	for key, value := range args {
-		strValue, ok := value.(string)
-		if !ok {
-			fmt.Printf("Skipping non-string value for header %s\n", key)
-			continue
-		}
-
-		req.Header.Set(key, strValue)
-	}
-}
-
-func setAuthHeaders(req *http.Request, authType string, args map[string]interface{}) error {
-	switch authType {
-	case "basic":
-		username, ok := args["username"].(string)
-		if !ok {
-			return fmt.Errorf("missing or invalid username")
-		}
-		password, ok := args["password"].(string)
-		if !ok {
-			return fmt.Errorf("missing or invalid password")
-		}
-
-		authHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
-		setHeaders(req, map[string]interface{}{
-			"Authorization": authHeader,
-		})
-
-	case "api_key":
-		apiKey, ok := args["api_key"].(string)
-		if !ok {
-			return fmt.Errorf("missing or invalid API key")
-		}
-		setHeaders(req, map[string]interface{}{
-			"Authorization": apiKey,
-		})
-
-	default:
-		return fmt.Errorf("unsupported auth type: %s", authType)
-	}
-	return nil
-}
-
-func (c *APIClient) url(endpoint string, qstr url.Values) string {
-	return fmt.Sprintf("%s/%s?%s", c.BaseURL, endpoint, qstr.Encode())
+	return nil, fmt.Errorf("API request failed after %d retries", retries)
 }

--- a/utils/apiclient/client.go
+++ b/utils/apiclient/client.go
@@ -1,0 +1,34 @@
+package apiclient
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+func (c *APIClient) getRequest(endpoint string, queryParams url.Values) error {
+	fullURL := c.url(endpoint, queryParams)
+	req, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return errors.Wrap(err, "http GET request creation failed")
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "http GET request failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("API request failed with status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (c *APIClient) url(endpoint string, qstr url.Values) string {
+	return fmt.Sprintf("%s/%s?%s", c.BaseURL, endpoint, qstr.Encode())
+}

--- a/utils/apiclient/client.go
+++ b/utils/apiclient/client.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stellar/go/support/log"
 )
 
@@ -49,7 +48,7 @@ func (c *APIClient) CallAPI(reqParams RequestParams) (interface{}, error) {
 	url := c.GetURL(reqParams.Endpoint, reqParams.QueryParams)
 	reqBody, err := CreateRequestBody(reqParams.RequestType, url)
 	if err != nil {
-		return nil, errors.Wrap(err, "http request creation failed")
+		return nil, fmt.Errorf("http request creation failed")
 	}
 
 	SetAuthHeaders(reqBody, c.AuthType, c.AuthHeaders)
@@ -65,18 +64,18 @@ func (c *APIClient) CallAPI(reqParams RequestParams) (interface{}, error) {
 	for retries <= c.MaxRetries {
 		resp, err := client.Do(reqBody)
 		if err != nil {
-			return nil, errors.Wrap(err, "http request failed")
+			return nil, fmt.Errorf("http request failed: %w", err)
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode == http.StatusOK {
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
-				return nil, errors.Wrap(err, "failed to read response body")
+				return nil, fmt.Errorf("failed to read response body: %w", err)
 			}
 
 			if err := json.Unmarshal(body, &result); err != nil {
-				return nil, errors.Wrap(err, "failed to unmarshal JSON")
+				return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
 			}
 
 			return result, nil

--- a/utils/apiclient/client.go
+++ b/utils/apiclient/client.go
@@ -1,32 +1,48 @@
 package apiclient
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 
 	"github.com/pkg/errors"
 )
 
-func (c *APIClient) getRequest(endpoint string, queryParams url.Values) error {
+func (c *APIClient) getRequest(endpoint string, queryParams url.Values) (interface{}, error) {
+	client := c.HTTP
+	if client == nil {
+		client = &http.Client{}
+	}
+
 	fullURL := c.url(endpoint, queryParams)
 	req, err := http.NewRequest("GET", fullURL, nil)
 	if err != nil {
-		return errors.Wrap(err, "http GET request creation failed")
+		return nil, errors.Wrap(err, "http GET request creation failed")
 	}
 
-	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "http GET request failed")
+		return nil, errors.Wrap(err, "http GET request failed")
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("API request failed with status %d", resp.StatusCode)
+		return nil, fmt.Errorf("API request failed with status %d", resp.StatusCode)
 	}
 
-	return nil
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var result interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return result, nil
 }
 
 func (c *APIClient) url(endpoint string, qstr url.Values) string {

--- a/utils/apiclient/client.go
+++ b/utils/apiclient/client.go
@@ -39,7 +39,7 @@ func (c *APIClient) CallAPI(reqParams RequestParams) (interface{}, error) {
 		return nil, errors.Wrap(err, "http request creation failed")
 	}
 
-	SetAuthHeaders(reqBody, c.authType, c.authHeaders)
+	SetAuthHeaders(reqBody, c.AuthType, c.AuthHeaders)
 	SetHeaders(reqBody, reqParams.Headers)
 	client := c.HTTP
 	if client == nil {
@@ -74,7 +74,7 @@ func (c *APIClient) CallAPI(reqParams RequestParams) (interface{}, error) {
 				fmt.Printf("Received retryable status %d. Retrying in %v...\n", resp.StatusCode, backoffDuration)
 				time.Sleep(backoffDuration)
 			} else {
-				return nil, fmt.Errorf("Maximum retries reached after receiving status %d", resp.StatusCode)
+				return nil, fmt.Errorf("maximum retries reached after receiving status %d", resp.StatusCode)
 			}
 		} else {
 			return nil, fmt.Errorf("API request failed with status %d", resp.StatusCode)

--- a/utils/apiclient/client.go
+++ b/utils/apiclient/client.go
@@ -21,8 +21,8 @@ func isRetryableStatusCode(statusCode int) bool {
 	return statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable
 }
 
-func (c *APIClient) GetURL(endpoint string, qstr url.Values) string {
-	return fmt.Sprintf("%s/%s?%s", c.BaseURL, endpoint, qstr.Encode())
+func (c *APIClient) GetURL(endpoint string, queryParams url.Values) string {
+	return fmt.Sprintf("%s/%s?%s", c.BaseURL, endpoint, queryParams.Encode())
 }
 
 func (c *APIClient) CallAPI(reqParams RequestParams) (interface{}, error) {

--- a/utils/apiclient/client.go
+++ b/utils/apiclient/client.go
@@ -1,6 +1,7 @@
 package apiclient
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,16 +11,19 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (c *APIClient) getRequest(endpoint string, queryParams url.Values) (interface{}, error) {
-	client := c.HTTP
-	if client == nil {
-		client = &http.Client{}
-	}
-
+func (c *APIClient) createRequestBody(endpoint string, queryParams url.Values) (*http.Request, error) {
 	fullURL := c.url(endpoint, queryParams)
 	req, err := http.NewRequest("GET", fullURL, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "http GET request creation failed")
+	}
+	return req, nil
+}
+
+func (c *APIClient) callAPI(req *http.Request) (interface{}, error) {
+	client := c.HTTP
+	if client == nil {
+		client = &http.Client{}
 	}
 
 	resp, err := client.Do(req)
@@ -43,6 +47,50 @@ func (c *APIClient) getRequest(endpoint string, queryParams url.Values) (interfa
 	}
 
 	return result, nil
+}
+
+func setHeaders(req *http.Request, args map[string]interface{}) {
+	for key, value := range args {
+		strValue, ok := value.(string)
+		if !ok {
+			fmt.Printf("Skipping non-string value for header %s\n", key)
+			continue
+		}
+
+		req.Header.Set(key, strValue)
+	}
+}
+
+func setAuthHeaders(req *http.Request, authType string, args map[string]interface{}) error {
+	switch authType {
+	case "basic":
+		username, ok := args["username"].(string)
+		if !ok {
+			return fmt.Errorf("missing or invalid username")
+		}
+		password, ok := args["password"].(string)
+		if !ok {
+			return fmt.Errorf("missing or invalid password")
+		}
+
+		authHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+		setHeaders(req, map[string]interface{}{
+			"Authorization": authHeader,
+		})
+
+	case "api_key":
+		apiKey, ok := args["api_key"].(string)
+		if !ok {
+			return fmt.Errorf("missing or invalid API key")
+		}
+		setHeaders(req, map[string]interface{}{
+			"Authorization": apiKey,
+		})
+
+	default:
+		return fmt.Errorf("unsupported auth type: %s", authType)
+	}
+	return nil
 }
 
 func (c *APIClient) url(endpoint string, qstr url.Values) string {

--- a/utils/apiclient/client_test.go
+++ b/utils/apiclient/client_test.go
@@ -23,13 +23,15 @@ func TestGetURL(t *testing.T) {
 	assert.Equal(t, "https://stellar.org/federation?acct=2382376&federation_type=bank_account&swift=BOPBPHMM&type=forward", furl)
 }
 
+type testCase struct {
+	name          string
+	mockResponses []httptest.ResponseData
+	expected      interface{}
+	expectedError string
+}
+
 func TestCallAPI(t *testing.T) {
-	testCases := []struct {
-		name          string
-		mockResponses []httptest.ResponseData
-		expected      interface{}
-		expectedError string
-	}{
+	testCases := []testCase{
 		{
 			name: "status 200 - Success",
 			mockResponses: []httptest.ResponseData{
@@ -90,14 +92,9 @@ func TestCallAPI(t *testing.T) {
 			result, err := c.CallAPI(reqParams)
 
 			if tc.expectedError != "" {
-				if err == nil {
-					t.Fatalf("expected error %q, got nil", tc.expectedError)
-				}
-				if err.Error() != tc.expectedError {
-					t.Fatalf("expected error %q, got %q", tc.expectedError, err.Error())
-				}
-			} else if err != nil {
-				t.Fatal(err)
+				assert.EqualError(t, err, tc.expectedError)
+			} else {
+				assert.NoError(t, err)
 			}
 
 			if tc.expected != nil {

--- a/utils/apiclient/client_test.go
+++ b/utils/apiclient/client_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/stellar/go/support/http/httptest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,4 +20,31 @@ func Test_url(t *testing.T) {
 	qstr.Add("acct", "2382376")
 	furl := c.url("federation", qstr)
 	assert.Equal(t, "https://stellar.org/federation?acct=2382376&federation_type=bank_account&swift=BOPBPHMM&type=forward", furl)
+}
+
+func Test_getRequest(t *testing.T) {
+	friendbotFundResponse := `{"key": "value"}`
+
+	hmock := httptest.NewClient()
+	c := &APIClient{
+		BaseURL: "https://stellar.org",
+		HTTP:    hmock,
+	}
+	hmock.On(
+		"GET",
+		"https://stellar.org/federation?acct=2382376&federation_type=bank_account&swift=BOPBPHMM&type=forward",
+	).ReturnString(200, friendbotFundResponse)
+	qstr := url.Values{}
+
+	qstr.Add("type", "forward")
+	qstr.Add("federation_type", "bank_account")
+	qstr.Add("swift", "BOPBPHMM")
+	qstr.Add("acct", "2382376")
+
+	result, err := c.getRequest("federation", qstr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := map[string]interface{}{"key": "value"}
+	assert.Equal(t, expected, result)
 }

--- a/utils/apiclient/client_test.go
+++ b/utils/apiclient/client_test.go
@@ -22,7 +22,7 @@ func Test_url(t *testing.T) {
 	assert.Equal(t, "https://stellar.org/federation?acct=2382376&federation_type=bank_account&swift=BOPBPHMM&type=forward", furl)
 }
 
-func Test_getRequest(t *testing.T) {
+func Test_callAPI(t *testing.T) {
 	friendbotFundResponse := `{"key": "value"}`
 
 	hmock := httptest.NewClient()
@@ -41,10 +41,18 @@ func Test_getRequest(t *testing.T) {
 	qstr.Add("swift", "BOPBPHMM")
 	qstr.Add("acct", "2382376")
 
-	result, err := c.getRequest("federation", qstr)
+	req, err := c.createRequestBody("federation", qstr)
 	if err != nil {
 		t.Fatal(err)
 	}
+	setAuthHeaders(req, "api_key", map[string]interface{}{"api_key": "test_api_key"})
+	assert.Equal(t, "test_api_key", req.Header.Get("Authorization"))
+
+	result, err := c.callAPI(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	expected := map[string]interface{}{"key": "value"}
 	assert.Equal(t, expected, result)
 }

--- a/utils/apiclient/client_test.go
+++ b/utils/apiclient/client_test.go
@@ -1,0 +1,22 @@
+package apiclient
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_url(t *testing.T) {
+	c := &APIClient{
+		BaseURL: "https://stellar.org",
+	}
+
+	qstr := url.Values{}
+	qstr.Add("type", "forward")
+	qstr.Add("federation_type", "bank_account")
+	qstr.Add("swift", "BOPBPHMM")
+	qstr.Add("acct", "2382376")
+	furl := c.url("federation", qstr)
+	assert.Equal(t, "https://stellar.org/federation?acct=2382376&federation_type=bank_account&swift=BOPBPHMM&type=forward", furl)
+}

--- a/utils/apiclient/client_test.go
+++ b/utils/apiclient/client_test.go
@@ -1,6 +1,7 @@
 package apiclient
 
 import (
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -8,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_url(t *testing.T) {
+func Test_GetURL(t *testing.T) {
 	c := &APIClient{
 		BaseURL: "https://stellar.org",
 	}
@@ -18,41 +19,95 @@ func Test_url(t *testing.T) {
 	qstr.Add("federation_type", "bank_account")
 	qstr.Add("swift", "BOPBPHMM")
 	qstr.Add("acct", "2382376")
-	furl := c.url("federation", qstr)
+	furl := c.GetURL("federation", qstr)
 	assert.Equal(t, "https://stellar.org/federation?acct=2382376&federation_type=bank_account&swift=BOPBPHMM&type=forward", furl)
 }
 
-func Test_callAPI(t *testing.T) {
-	friendbotFundResponse := `{"key": "value"}`
-
-	hmock := httptest.NewClient()
-	c := &APIClient{
-		BaseURL: "https://stellar.org",
-		HTTP:    hmock,
+func Test_CallAPI(t *testing.T) {
+	testCases := []struct {
+		name          string
+		mockResponses []httptest.ResponseData
+		expected      interface{}
+		expectedError string
+		retries       bool
+	}{
+		{
+			name: "status 200 - Success",
+			mockResponses: []httptest.ResponseData{
+				{Status: http.StatusOK, Body: `{"data": "Okay Response"}`, Header: nil},
+			},
+			expected:      map[string]interface{}{"data": "Okay Response"},
+			expectedError: "",
+			retries:       false,
+		},
+		{
+			name: "success with retries - status 429 and 503 then 200",
+			mockResponses: []httptest.ResponseData{
+				{Status: http.StatusTooManyRequests, Body: `{"data": "First Response"}`, Header: nil},
+				{Status: http.StatusServiceUnavailable, Body: `{"data": "Second Response"}`, Header: nil},
+				{Status: http.StatusOK, Body: `{"data": "Third Response"}`, Header: nil},
+				{Status: http.StatusOK, Body: `{"data": "Fourth Response"}`, Header: nil},
+			},
+			expected:      map[string]interface{}{"data": "Third Response"},
+			expectedError: "",
+			retries:       true,
+		},
+		{
+			name: "failure - status 500",
+			mockResponses: []httptest.ResponseData{
+				{Status: http.StatusInternalServerError, Body: `{"error": "Internal Server Error"}`, Header: nil},
+			},
+			expected:      nil,
+			expectedError: "API request failed with status 500",
+			retries:       false,
+		},
+		{
+			name: "failure - status 401",
+			mockResponses: []httptest.ResponseData{
+				{Status: http.StatusUnauthorized, Body: `{"error": "Bad authorization"}`, Header: nil},
+			},
+			expected:      nil,
+			expectedError: "API request failed with status 401",
+			retries:       false,
+		},
 	}
-	hmock.On(
-		"GET",
-		"https://stellar.org/federation?acct=2382376&federation_type=bank_account&swift=BOPBPHMM&type=forward",
-	).ReturnString(200, friendbotFundResponse)
-	qstr := url.Values{}
 
-	qstr.Add("type", "forward")
-	qstr.Add("federation_type", "bank_account")
-	qstr.Add("swift", "BOPBPHMM")
-	qstr.Add("acct", "2382376")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hmock := httptest.NewClient()
+			hmock.On("GET", "https://stellar.org/federation?acct=2382376").
+				ReturnMultipleResults(tc.mockResponses)
 
-	req, err := c.createRequestBody("federation", qstr)
-	if err != nil {
-		t.Fatal(err)
+			c := &APIClient{
+				BaseURL: "https://stellar.org",
+				HTTP:    hmock,
+			}
+
+			qstr := url.Values{}
+			qstr.Add("acct", "2382376")
+
+			reqParams := RequestParams{
+				RequestType: "GET",
+				Endpoint:    "federation",
+				QueryParams: qstr,
+			}
+
+			result, err := c.CallAPI(reqParams)
+
+			if tc.expectedError != "" {
+				if err == nil {
+					t.Fatalf("expected error %q, got nil", tc.expectedError)
+				}
+				if err.Error() != tc.expectedError {
+					t.Fatalf("expected error %q, got %q", tc.expectedError, err.Error())
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.expected != nil {
+				assert.Equal(t, tc.expected, result)
+			}
+		})
 	}
-	setAuthHeaders(req, "api_key", map[string]interface{}{"api_key": "test_api_key"})
-	assert.Equal(t, "test_api_key", req.Header.Get("Authorization"))
-
-	result, err := c.callAPI(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expected := map[string]interface{}{"key": "value"}
-	assert.Equal(t, expected, result)
 }

--- a/utils/apiclient/client_test.go
+++ b/utils/apiclient/client_test.go
@@ -14,12 +14,12 @@ func TestGetURL(t *testing.T) {
 		BaseURL: "https://stellar.org",
 	}
 
-	qstr := url.Values{}
-	qstr.Add("type", "forward")
-	qstr.Add("federation_type", "bank_account")
-	qstr.Add("swift", "BOPBPHMM")
-	qstr.Add("acct", "2382376")
-	furl := c.GetURL("federation", qstr)
+	queryParams := url.Values{}
+	queryParams.Add("type", "forward")
+	queryParams.Add("federation_type", "bank_account")
+	queryParams.Add("swift", "BOPBPHMM")
+	queryParams.Add("acct", "2382376")
+	furl := c.GetURL("federation", queryParams)
 	assert.Equal(t, "https://stellar.org/federation?acct=2382376&federation_type=bank_account&swift=BOPBPHMM&type=forward", furl)
 }
 
@@ -80,13 +80,13 @@ func TestCallAPI(t *testing.T) {
 				HTTP:    hmock,
 			}
 
-			qstr := url.Values{}
-			qstr.Add("acct", "2382376")
+			queryParams := url.Values{}
+			queryParams.Add("acct", "2382376")
 
 			reqParams := RequestParams{
 				RequestType: "GET",
 				Endpoint:    "federation",
-				QueryParams: qstr,
+				QueryParams: queryParams,
 			}
 
 			result, err := c.CallAPI(reqParams)

--- a/utils/apiclient/client_test.go
+++ b/utils/apiclient/client_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_GetURL(t *testing.T) {
+func TestGetURL(t *testing.T) {
 	c := &APIClient{
 		BaseURL: "https://stellar.org",
 	}
@@ -23,13 +23,12 @@ func Test_GetURL(t *testing.T) {
 	assert.Equal(t, "https://stellar.org/federation?acct=2382376&federation_type=bank_account&swift=BOPBPHMM&type=forward", furl)
 }
 
-func Test_CallAPI(t *testing.T) {
+func TestCallAPI(t *testing.T) {
 	testCases := []struct {
 		name          string
 		mockResponses []httptest.ResponseData
 		expected      interface{}
 		expectedError string
-		retries       bool
 	}{
 		{
 			name: "status 200 - Success",
@@ -38,7 +37,6 @@ func Test_CallAPI(t *testing.T) {
 			},
 			expected:      map[string]interface{}{"data": "Okay Response"},
 			expectedError: "",
-			retries:       false,
 		},
 		{
 			name: "success with retries - status 429 and 503 then 200",
@@ -50,7 +48,6 @@ func Test_CallAPI(t *testing.T) {
 			},
 			expected:      map[string]interface{}{"data": "Third Response"},
 			expectedError: "",
-			retries:       true,
 		},
 		{
 			name: "failure - status 500",
@@ -59,7 +56,6 @@ func Test_CallAPI(t *testing.T) {
 			},
 			expected:      nil,
 			expectedError: "API request failed with status 500",
-			retries:       false,
 		},
 		{
 			name: "failure - status 401",
@@ -68,7 +64,6 @@ func Test_CallAPI(t *testing.T) {
 			},
 			expected:      nil,
 			expectedError: "API request failed with status 401",
-			retries:       false,
 		},
 	}
 

--- a/utils/apiclient/main.go
+++ b/utils/apiclient/main.go
@@ -3,6 +3,7 @@ package apiclient
 import (
 	"net/http"
 	"net/url"
+	"time"
 )
 
 type HTTP interface {
@@ -12,10 +13,12 @@ type HTTP interface {
 }
 
 type APIClient struct {
-	BaseURL     string
-	HTTP        HTTP
-	AuthType    string
-	AuthHeaders map[string]interface{}
+	BaseURL            string
+	HTTP               HTTP
+	AuthType           string
+	AuthHeaders        map[string]interface{}
+	MaxRetries         int
+	InitialBackoffTime time.Duration
 }
 
 type RequestParams struct {

--- a/utils/apiclient/main.go
+++ b/utils/apiclient/main.go
@@ -12,7 +12,6 @@ type HTTP interface {
 }
 
 type APIClient struct {
-	BaseURL   string
-	AuthToken string
-	HTTP      HTTP
+	BaseURL string
+	HTTP    HTTP
 }

--- a/utils/apiclient/main.go
+++ b/utils/apiclient/main.go
@@ -1,6 +1,18 @@
 package apiclient
 
+import (
+	"net/http"
+	"net/url"
+)
+
+type HTTP interface {
+	Do(req *http.Request) (resp *http.Response, err error)
+	Get(url string) (resp *http.Response, err error)
+	PostForm(url string, data url.Values) (resp *http.Response, err error)
+}
+
 type APIClient struct {
 	BaseURL   string
 	AuthToken string
+	HTTP      HTTP
 }

--- a/utils/apiclient/main.go
+++ b/utils/apiclient/main.go
@@ -12,6 +12,15 @@ type HTTP interface {
 }
 
 type APIClient struct {
-	BaseURL string
-	HTTP    HTTP
+	BaseURL     string
+	HTTP        HTTP
+	authType    string
+	authHeaders map[string]interface{}
+}
+
+type RequestParams struct {
+	RequestType string
+	Endpoint    string
+	QueryParams url.Values
+	Headers     map[string]interface{}
 }

--- a/utils/apiclient/main.go
+++ b/utils/apiclient/main.go
@@ -14,8 +14,8 @@ type HTTP interface {
 type APIClient struct {
 	BaseURL     string
 	HTTP        HTTP
-	authType    string
-	authHeaders map[string]interface{}
+	AuthType    string
+	AuthHeaders map[string]interface{}
 }
 
 type RequestParams struct {

--- a/utils/apiclient/main.go
+++ b/utils/apiclient/main.go
@@ -1,0 +1,6 @@
+package apiclient
+
+type APIClient struct {
+	BaseURL   string
+	AuthToken string
+}

--- a/utils/apiclient/request.go
+++ b/utils/apiclient/request.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
+	"github.com/stellar/go/support/log"
 )
 
 func CreateRequestBody(requestType string, url string) (*http.Request, error) {
@@ -20,7 +21,7 @@ func SetHeaders(req *http.Request, args map[string]interface{}) {
 	for key, value := range args {
 		strValue, ok := value.(string)
 		if !ok {
-			fmt.Printf("Skipping non-string value for header %s\n", key)
+			log.Debugf("Skipping non-string value for header %s\n", key)
 			continue
 		}
 

--- a/utils/apiclient/request.go
+++ b/utils/apiclient/request.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
 	"github.com/stellar/go/support/log"
 )
 
 func CreateRequestBody(requestType string, url string) (*http.Request, error) {
 	req, err := http.NewRequest(requestType, url, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "http GET request creation failed")
+		return nil, fmt.Errorf("http GET request creation failed: %w", err)
 	}
 	return req, nil
 }

--- a/utils/apiclient/request.go
+++ b/utils/apiclient/request.go
@@ -1,0 +1,61 @@
+package apiclient
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+func CreateRequestBody(requestType string, url string) (*http.Request, error) {
+	req, err := http.NewRequest(requestType, url, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "http GET request creation failed")
+	}
+	return req, nil
+}
+
+func SetHeaders(req *http.Request, args map[string]interface{}) {
+	for key, value := range args {
+		strValue, ok := value.(string)
+		if !ok {
+			fmt.Printf("Skipping non-string value for header %s\n", key)
+			continue
+		}
+
+		req.Header.Set(key, strValue)
+	}
+}
+
+func SetAuthHeaders(req *http.Request, authType string, args map[string]interface{}) error {
+	switch authType {
+	case "basic":
+		username, ok := args["username"].(string)
+		if !ok {
+			return fmt.Errorf("missing or invalid username")
+		}
+		password, ok := args["password"].(string)
+		if !ok {
+			return fmt.Errorf("missing or invalid password")
+		}
+
+		authHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+		SetHeaders(req, map[string]interface{}{
+			"Authorization": authHeader,
+		})
+
+	case "api_key":
+		apiKey, ok := args["api_key"].(string)
+		if !ok {
+			return fmt.Errorf("missing or invalid API key")
+		}
+		SetHeaders(req, map[string]interface{}{
+			"Authorization": apiKey,
+		})
+
+	default:
+		return fmt.Errorf("unsupported auth type: %s", authType)
+	}
+	return nil
+}

--- a/utils/apiclient/request_test.go
+++ b/utils/apiclient/request_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_CreateRequestBody_ValidURL(t *testing.T) {
+func TestCreateRequestBodyValidURL(t *testing.T) {
 	// Valid case
 	req, err := CreateRequestBody("GET", "http://stellar.org")
 	assert.NotNil(t, req)
 	assert.NoError(t, err)
 }
 
-func Test_CreateRequestBody_InvalidURL(t *testing.T) {
+func TestCreateRequestBodyInvalidURL(t *testing.T) {
 	invalidURL := "://invalid-url"
 	req, err := CreateRequestBody("GET", invalidURL)
 	assert.Nil(t, req)
@@ -21,7 +21,7 @@ func Test_CreateRequestBody_InvalidURL(t *testing.T) {
 	assert.Contains(t, err.Error(), "http GET request creation failed")
 }
 
-func Test_SetHeaders_ValidHeaders(t *testing.T) {
+func TestSetHeadersValidHeaders(t *testing.T) {
 	req, err := CreateRequestBody("GET", "http://stellar.org")
 	assert.NoError(t, err)
 
@@ -34,7 +34,7 @@ func Test_SetHeaders_ValidHeaders(t *testing.T) {
 	assert.Equal(t, "GoClient/1.0", req.Header.Get("User-Agent"))
 }
 
-func Test_SetHeaders_InvalidHeaders(t *testing.T) {
+func TestSetHeadersInvalidHeaders(t *testing.T) {
 	req, err := CreateRequestBody("GET", "http://stellar.org")
 	assert.NoError(t, err)
 
@@ -51,15 +51,15 @@ func Test_SetHeaders_InvalidHeaders(t *testing.T) {
 	assert.Equal(t, "Bearer token123", req.Header.Get("Authorization")) // Set correctly
 }
 
-type SetAuthHeadersTestCase struct {
+type setAuthHeadersTestCase struct {
 	authType       string
 	args           map[string]interface{}
 	expectedHeader string
 	expectedError  string
 }
 
-func Test_SetAuthHeaders(t *testing.T) {
-	testCases := []SetAuthHeadersTestCase{
+func TestSetAuthHeaders(t *testing.T) {
+	testCases := []setAuthHeadersTestCase{
 		{
 			authType: "basic",
 			args: map[string]interface{}{

--- a/utils/apiclient/request_test.go
+++ b/utils/apiclient/request_test.go
@@ -1,0 +1,130 @@
+package apiclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_CreateRequestBody_ValidURL(t *testing.T) {
+	// Valid case
+	req, err := CreateRequestBody("GET", "http://stellar.org")
+	assert.NotNil(t, req)
+	assert.NoError(t, err)
+}
+
+func Test_CreateRequestBody_InvalidURL(t *testing.T) {
+	invalidURL := "://invalid-url"
+	req, err := CreateRequestBody("GET", invalidURL)
+	assert.Nil(t, req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "http GET request creation failed")
+}
+
+func Test_SetHeaders_ValidHeaders(t *testing.T) {
+	req, err := CreateRequestBody("GET", "http://stellar.org")
+	assert.NoError(t, err)
+
+	headers := map[string]interface{}{
+		"Content-Type": "application/json",
+		"User-Agent":   "GoClient/1.0",
+	}
+	SetHeaders(req, headers)
+	assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
+	assert.Equal(t, "GoClient/1.0", req.Header.Get("User-Agent"))
+}
+
+func Test_SetHeaders_InvalidHeaders(t *testing.T) {
+	req, err := CreateRequestBody("GET", "http://stellar.org")
+	assert.NoError(t, err)
+
+	headers := map[string]interface{}{
+		"Content-Type":  123,               // Invalid: integer
+		"User-Agent":    true,              // Invalid: boolean
+		"Authorization": "Bearer token123", // Valid: string
+	}
+	SetHeaders(req, headers)
+
+	// Assertions to check that the invalid headers were skipped
+	assert.Equal(t, "", req.Header.Get("Content-Type"))                 // Skipped because it's not a string
+	assert.Equal(t, "", req.Header.Get("User-Agent"))                   // Skipped because it's not a string
+	assert.Equal(t, "Bearer token123", req.Header.Get("Authorization")) // Set correctly
+}
+
+type SetAuthHeadersTestCase struct {
+	authType       string
+	args           map[string]interface{}
+	expectedHeader string
+	expectedError  string
+}
+
+func Test_SetAuthHeaders(t *testing.T) {
+	testCases := []SetAuthHeadersTestCase{
+		{
+			authType: "basic",
+			args: map[string]interface{}{
+				"username": "user",
+				"password": "pass",
+			},
+			expectedHeader: "Basic dXNlcjpwYXNz", // base64 of "user:pass"
+			expectedError:  "",
+		},
+		{
+			authType: "basic",
+			args: map[string]interface{}{
+				"password": "pass", // Missing "username"
+			},
+			expectedHeader: "",
+			expectedError:  "missing or invalid username",
+		},
+		{
+			authType: "basic",
+			args: map[string]interface{}{
+				"username": "user", // Missing "password"
+			},
+			expectedHeader: "",
+			expectedError:  "missing or invalid password",
+		},
+		{
+			authType: "api_key",
+			args: map[string]interface{}{
+				"api_key": "my-api-key-123",
+			},
+			expectedHeader: "my-api-key-123",
+			expectedError:  "",
+		},
+		{
+			authType:       "api_key",
+			args:           map[string]interface{}{}, // Missing "api_key"
+			expectedHeader: "",
+			expectedError:  "missing or invalid API key",
+		},
+		{
+			authType: "oauth", // Unsupported auth type
+			args: map[string]interface{}{
+				"username": "user",
+				"password": "pass",
+			},
+			expectedHeader: "",
+			expectedError:  "unsupported auth type: oauth",
+		},
+	}
+
+	// Loop over each test case
+	for _, tc := range testCases {
+		t.Run(tc.authType, func(t *testing.T) {
+			req, err := CreateRequestBody("GET", "http://stellar.org")
+			assert.NoError(t, err)
+
+			err = SetAuthHeaders(req, tc.authType, tc.args)
+
+			if tc.expectedError != "" {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expectedError, err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedHeader, req.Header.Get("Authorization"))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR adds a general purpose API wrapper which could be used to call any API endpoint with given query params and headers.
There are two modules added:
- Client: Contains function to call an API. This supports retries in case there are throttling or service unavailable.
- Request: Contains function to build requestBody with given inputs such request type, headers etc

Also updated httptest library to support mocking http request when we want to see multiple results on subsequent api calls. This is particularly helpful when we want to test whether API retries work as expected or not.

### Why

This will be used in stellar-etl to invoke various APIs-retool, github etc to fetch data and store in bigquery for analytics.

### Known limitations

I did not add support for pagination as we don't have a use case as of now. However, this util can be extended in future as needed.

### Questions

I am not sure if this is right place to add this library. I am open to relocating it where it finds better fit.