### PR TITLE
exp/orderbook: Fix bug in CalculatePoolExpectation()

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this
 file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Pending
+
+### Fixed
+- Fix liquidity pool bug which resulted in invalid paths being included in the `/paths/strict-receive` response ([5541](https://github.com/stellar/go/pull/5541)).
+
 ## 22.0.1
 
 ### Fixed


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Fixes https://github.com/stellar/go/issues/5143

This commit fixes three inconsistencies with how liquidity pool payouts / expectations are calculated in core vs horizon:

1. When calculating how much we need to deposit into a pool in order to receive a desired payout we need to consider that the calculated deposit may overflow the reserves, see https://github.com/stellar/stellar-core/blob/fdd833d57c86cfe0c5057da5b2319953ab841de0/src/transactions/OfferExchange.cpp#L1361-L1363
2. We should rule out trades that will result in a payout of 0, see https://github.com/stellar/stellar-core/blob/fdd833d57c86cfe0c5057da5b2319953ab841de0/src/transactions/OfferExchange.cpp#L1325-L1327
3. Fees that are greater than or equal to 100% are illegal, see https://github.com/stellar/stellar-core/blob/fdd833d57c86cfe0c5057da5b2319953ab841de0/src/transactions/OfferExchange.cpp#L1254-L1259

(2) and (3) do not affect the output of the horizon path finding endpoint because those corner cases are excluded from consideration in the path finding algorithm.

However, (1) results in horizon returning incorrect paths which attempt to trade against liquidity pools in a way that would overflow the liquidity pool reserves.  When users try to submit path payments using these incorrect paths, core is not able to execute the trades and that results in a [`op_too_few_offers`](https://developers.stellar.org/docs/data/horizon/api-reference/errors/result-codes/operation-specific/path-payment-strict-receive) error.

### Known limitations

[N/A]
