### PR TITLE
.github: fix OS version for galexie CI

### DIFF
--- a/.github/workflows/galexie-release.yml
+++ b/.github/workflows/galexie-release.yml
@@ -8,7 +8,7 @@ jobs:
 
   publish-docker:
     name: Test and push docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GALEXIE_INTEGRATION_TESTS_ENABLED: "true"
       GALEXIE_INTEGRATION_TESTS_CAPTIVE_CORE_BIN: /usr/bin/stellar-core

--- a/.github/workflows/galexie.yml
+++ b/.github/workflows/galexie.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   galexie:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CAPTIVE_CORE_DEBIAN_PKG_VERSION: 22.1.0-2194.0241e79f7.focal
       GALEXIE_INTEGRATION_TESTS_ENABLED: "true"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

The github action which tests galexie functionality started failing:

https://github.com/stellar/go/actions/runs/12483719925/job/35064750830

Configuring the OS version to `ubuntu-22.04`, which is what we use in the Horizon github actions, instead of `latest` has fixed the test failures.

### Known limitations

[N/A]
