### PR TITLE
ingest/cdp: Update the default config for BufferedStorageBackend.

### DIFF
--- a/ingest/cdp/producer.go
+++ b/ingest/cdp/producer.go
@@ -34,13 +34,9 @@ func DefaultBufferedStorageBackendConfig(ledgersPerFile uint32) ledgerbackend.Bu
 	}
 
 	switch {
-	case ledgersPerFile < 2:
-		config.BufferSize = 500
-		config.NumWorkers = 5
-		return config
-	case ledgersPerFile < 101:
-		config.BufferSize = 10
-		config.NumWorkers = 5
+	case ledgersPerFile < 64:
+		config.BufferSize = 100
+		config.NumWorkers = 10
 		return config
 	default:
 		config.BufferSize = 10

--- a/ingest/cdp/producer_test.go
+++ b/ingest/cdp/producer_test.go
@@ -24,15 +24,8 @@ func TestDefaultBSBConfigs(t *testing.T) {
 	smallConfig := ledgerbackend.BufferedStorageBackendConfig{
 		RetryLimit: 5,
 		RetryWait:  30 * time.Second,
-		BufferSize: 500,
-		NumWorkers: 5,
-	}
-
-	mediumConfig := ledgerbackend.BufferedStorageBackendConfig{
-		RetryLimit: 5,
-		RetryWait:  30 * time.Second,
-		BufferSize: 10,
-		NumWorkers: 5,
+		BufferSize: 100,
+		NumWorkers: 10,
 	}
 
 	largeConfig := ledgerbackend.BufferedStorageBackendConfig{
@@ -43,10 +36,8 @@ func TestDefaultBSBConfigs(t *testing.T) {
 	}
 
 	assert.Equal(t, DefaultBufferedStorageBackendConfig(1), smallConfig)
-	assert.Equal(t, DefaultBufferedStorageBackendConfig(2), mediumConfig)
-	assert.Equal(t, DefaultBufferedStorageBackendConfig(100), mediumConfig)
-	assert.Equal(t, DefaultBufferedStorageBackendConfig(101), largeConfig)
-	assert.Equal(t, DefaultBufferedStorageBackendConfig(1000), largeConfig)
+	assert.Equal(t, DefaultBufferedStorageBackendConfig(64), largeConfig)
+	assert.Equal(t, DefaultBufferedStorageBackendConfig(512), largeConfig)
 }
 
 func TestBSBProducerFn(t *testing.T) {


### PR DESCRIPTION


<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update the default configuration for BufferedStorageBackend based on the results from running tests in #5497
### Why

#5497
 
### Known limitations
The tests were conducted locally and the results may vary depending on the network capacity.