### PR TITLE
historyarchive: Update bucket list hash validation for protocol 23

### DIFF
--- a/historyarchive/history_archive_state_test.go
+++ b/historyarchive/history_archive_state_test.go
@@ -7,6 +7,7 @@ package historyarchive
 import (
 	"encoding/hex"
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,112 +48,36 @@ func TestUnmarshalState(t *testing.T) {
 }
 
 func TestHashValidation(t *testing.T) {
-	// This is real bucket hash list for pubnet's ledger: 24088895
-	// https://horizon.stellar.org/ledgers/24088895
-	// http://history.stellar.org/prd/core-live/core_live_001/history/01/6f/91/history-016f913f.json
-	var jsonBlob = []byte(`{
-    "version": 1,
-    "server": "v11.1.0",
-    "currentLedger": 24088895,
-    "currentBuckets": [
-        {
-            "curr": "2a4416e7f3e301c2fc1078dce0e1dd109b8ae6d3958942b91b447f24014a7b5c",
-            "next": {
-                "state": 0
-            },
-            "snap": "7ff95a98838dfd39a36858f15c8d503641560f02a52aa15335559e1183ce2ca1"
-        },
-        {
-            "curr": "2c7e74c4c5555e41b39a5fc04e77e77852c35e7769e32b486e07a072b9b3177c",
-            "next": {
-                "state": 1,
-                "output": "7ff95a98838dfd39a36858f15c8d503641560f02a52aa15335559e1183ce2ca1"
-            },
-            "snap": "5f0bc7d0bd9e8ed6530fc270339b7dd2fbcedf0d80235f5ef64daa90b84259f4"
-        },
-        {
-            "curr": "068f2a1ece2817c98c0d21d5ac20817637c331df6793d0ff3e874e29da5d65b1",
-            "next": {
-                "state": 1,
-                "output": "e93d50365d74d8a8dc2ff7631dfb506b7e6b2245f7f46556d407e82f197a6c59"
-            },
-            "snap": "875cbdf9ab03c488c075a36ee3ee1e02aef9d5fe9d253a2b1f99b92fe64598b8"
-        },
-        {
-            "curr": "f413ff9d27e2cad12754ff84ca905f8c309ca7b68a6fbe8e9b01ecd18f5d3759",
-            "next": {
-                "state": 1,
-                "output": "ffbb6cd3a4170dbf547ab0783fea90c1a57a28e562db7bcd3a079374f1e63464"
-            },
-            "snap": "5d198cdc5a2139d92fe74f6541a098c27aba61e8aee543a6a551814aae9adb5a"
-        },
-        {
-            "curr": "1c6f9ec76b06aac2aac77e9a0da2224d120dc25c1cf10211ce33475db4d66f13",
-            "next": {
-                "state": 1,
-                "output": "6473d4a3ff5b6448fc6dfd279ef33bf0b1524d8361b758dbde49fc84691cadbe"
-            },
-            "snap": "6dd30650a7c8cadad545561d732828cf55cefdf5f70c615fbdc33e01c647907b"
-        },
-        {
-            "curr": "b3b3c9b54db9e08f3994a17a40e5be7583c546488e88523ebf8b444ee53f4aec",
-            "next": {
-                "state": 1,
-                "output": "ed452df8b803190b7a1cf07894c27c03415029272e9c4a3171e7f3ad6e67c90a"
-            },
-            "snap": "7d84d34019975b37758278e858e86265323ddbb7b46f6d679433c93bbae693ee"
-        },
-        {
-            "curr": "a6c20a247ed2afc2cea7f4dc5856efa61a51b4e4b0318877eebdf8ad47be83b7",
-            "next": {
-                "state": 1,
-                "output": "ce9a7c779d0873ff364a9abd20007bbf7e41646ac4662eb87f89a5c39b69f70d"
-            },
-            "snap": "285ac930ee2bd358d3202666c545fd3b94ee973d1a0cd2569de357042ec12b3d"
-        },
-        {
-            "curr": "2e779b37b97052a1141a65a92c4ca14a7bd28f7c2d646749b1d584f45d50fa7b",
-            "next": {
-                "state": 1,
-                "output": "e4dba3994ad576489880eee38db2d8c0f8889585e932b7192dd7af168d79b43f"
-            },
-            "snap": "37094a837769dbae5783dca9831be463b895f1b07d1cd24e271966e10503fdfc"
-        },
-        {
-            "curr": "48f435285dd96511d0822f7ae1a20e28c6c28019e385313713655fc76fe3bc03",
-            "next": {
-                "state": 1,
-                "output": "11f8c2f8e1cb0d47576f74d9e2fa838f5f3a37180907a24a85d0ad8b647862e4"
-            },
-            "snap": "96e0d8bf7d7eb775299edf285b6324499a1a05122d95eed9289c6477cf6a01cb"
-        },
-        {
-            "curr": "4100ad3b1085bd14d1c808ece3b38db97171532d0d11ed5edd57aff0e416e06a",
-            "next": {
-                "state": 1,
-                "output": "5f351041761b45f3e725f98bb8b6713873e30ab6c8aee56ba0823d357c7ebd0d"
-            },
-            "snap": "23669fa3d310ca8ac8dbe9dcce7e4e4361b1c3334da1dda2fb6447a30c67422f"
-        },
-        {
-            "curr": "14cc632ab181396418fc761503105047e3b63d0455d0a4e9480578129ea8e9dc",
-            "next": {
-                "state": 1,
-                "output": "a4811c9ba9505e421f0015e5fcfd9f5d204ae85b584766759e844ef85db10d47"
-            },
-            "snap": "0000000000000000000000000000000000000000000000000000000000000000"
-        }
-    ]
-}`)
+	for _, testCase := range []struct {
+		inputFile    string
+		expectedHash string
+	}{
+		{
+			// This is real bucket hash list for pubnet's ledger: 24088895
+			// https://horizon.stellar.org/ledgers/24088895
+			// http://history.stellar.org/prd/core-live/core_live_001/history/01/6f/91/history-016f913f.json
+			inputFile:    "testdata/historyV1.json",
+			expectedHash: "fc5fe47af3f5a9b18b278f2a7edbbc641e1934bf68131d9aa5ab7aebb4aa8aa3",
+		},
+		{
+			// taken from https://github.com/stellar/stellar-core/pull/4623/files#diff-f0bf7c78e09501debc1cd55b61977f9328f7f7b872138ccbd7e0e0a2b1cb91bc
+			inputFile:    "testdata/historyV2.json",
+			expectedHash: "136fa2ef979150e7d5fdbeeaf36f61c9af6016fe5b0f34ebc842301dfca95ebc",
+		},
+	} {
+		t.Run(testCase.inputFile, func(t *testing.T) {
+			inputBytes, err := os.ReadFile(testCase.inputFile)
+			require.NoError(t, err)
 
-	var state HistoryArchiveState
-	err := json.Unmarshal(jsonBlob, &state)
-	require.NoError(t, err)
+			var state HistoryArchiveState
+			require.NoError(t, json.Unmarshal(inputBytes, &state))
 
-	expectedHash, err := hex.DecodeString("fc5fe47af3f5a9b18b278f2a7edbbc641e1934bf68131d9aa5ab7aebb4aa8aa3")
-	require.NoError(t, err)
+			expectedHash, err := hex.DecodeString(testCase.expectedHash)
+			require.NoError(t, err)
 
-	hash, err := state.BucketListHash()
-	require.NoError(t, err)
-	assert.Equal(t, expectedHash, hash[:])
+			hash, err := state.BucketListHash()
+			require.NoError(t, err)
+			assert.Equal(t, expectedHash, hash[:])
+		})
+	}
 }

--- a/historyarchive/testdata/historyV1.json
+++ b/historyarchive/testdata/historyV1.json
@@ -1,0 +1,94 @@
+{
+  "version": 1,
+  "server": "v11.1.0",
+  "currentLedger": 24088895,
+  "currentBuckets": [
+    {
+      "curr": "2a4416e7f3e301c2fc1078dce0e1dd109b8ae6d3958942b91b447f24014a7b5c",
+      "next": {
+        "state": 0
+      },
+      "snap": "7ff95a98838dfd39a36858f15c8d503641560f02a52aa15335559e1183ce2ca1"
+    },
+    {
+      "curr": "2c7e74c4c5555e41b39a5fc04e77e77852c35e7769e32b486e07a072b9b3177c",
+      "next": {
+        "state": 1,
+        "output": "7ff95a98838dfd39a36858f15c8d503641560f02a52aa15335559e1183ce2ca1"
+      },
+      "snap": "5f0bc7d0bd9e8ed6530fc270339b7dd2fbcedf0d80235f5ef64daa90b84259f4"
+    },
+    {
+      "curr": "068f2a1ece2817c98c0d21d5ac20817637c331df6793d0ff3e874e29da5d65b1",
+      "next": {
+        "state": 1,
+        "output": "e93d50365d74d8a8dc2ff7631dfb506b7e6b2245f7f46556d407e82f197a6c59"
+      },
+      "snap": "875cbdf9ab03c488c075a36ee3ee1e02aef9d5fe9d253a2b1f99b92fe64598b8"
+    },
+    {
+      "curr": "f413ff9d27e2cad12754ff84ca905f8c309ca7b68a6fbe8e9b01ecd18f5d3759",
+      "next": {
+        "state": 1,
+        "output": "ffbb6cd3a4170dbf547ab0783fea90c1a57a28e562db7bcd3a079374f1e63464"
+      },
+      "snap": "5d198cdc5a2139d92fe74f6541a098c27aba61e8aee543a6a551814aae9adb5a"
+    },
+    {
+      "curr": "1c6f9ec76b06aac2aac77e9a0da2224d120dc25c1cf10211ce33475db4d66f13",
+      "next": {
+        "state": 1,
+        "output": "6473d4a3ff5b6448fc6dfd279ef33bf0b1524d8361b758dbde49fc84691cadbe"
+      },
+      "snap": "6dd30650a7c8cadad545561d732828cf55cefdf5f70c615fbdc33e01c647907b"
+    },
+    {
+      "curr": "b3b3c9b54db9e08f3994a17a40e5be7583c546488e88523ebf8b444ee53f4aec",
+      "next": {
+        "state": 1,
+        "output": "ed452df8b803190b7a1cf07894c27c03415029272e9c4a3171e7f3ad6e67c90a"
+      },
+      "snap": "7d84d34019975b37758278e858e86265323ddbb7b46f6d679433c93bbae693ee"
+    },
+    {
+      "curr": "a6c20a247ed2afc2cea7f4dc5856efa61a51b4e4b0318877eebdf8ad47be83b7",
+      "next": {
+        "state": 1,
+        "output": "ce9a7c779d0873ff364a9abd20007bbf7e41646ac4662eb87f89a5c39b69f70d"
+      },
+      "snap": "285ac930ee2bd358d3202666c545fd3b94ee973d1a0cd2569de357042ec12b3d"
+    },
+    {
+      "curr": "2e779b37b97052a1141a65a92c4ca14a7bd28f7c2d646749b1d584f45d50fa7b",
+      "next": {
+        "state": 1,
+        "output": "e4dba3994ad576489880eee38db2d8c0f8889585e932b7192dd7af168d79b43f"
+      },
+      "snap": "37094a837769dbae5783dca9831be463b895f1b07d1cd24e271966e10503fdfc"
+    },
+    {
+      "curr": "48f435285dd96511d0822f7ae1a20e28c6c28019e385313713655fc76fe3bc03",
+      "next": {
+        "state": 1,
+        "output": "11f8c2f8e1cb0d47576f74d9e2fa838f5f3a37180907a24a85d0ad8b647862e4"
+      },
+      "snap": "96e0d8bf7d7eb775299edf285b6324499a1a05122d95eed9289c6477cf6a01cb"
+    },
+    {
+      "curr": "4100ad3b1085bd14d1c808ece3b38db97171532d0d11ed5edd57aff0e416e06a",
+      "next": {
+        "state": 1,
+        "output": "5f351041761b45f3e725f98bb8b6713873e30ab6c8aee56ba0823d357c7ebd0d"
+      },
+      "snap": "23669fa3d310ca8ac8dbe9dcce7e4e4361b1c3334da1dda2fb6447a30c67422f"
+    },
+    {
+      "curr": "14cc632ab181396418fc761503105047e3b63d0455d0a4e9480578129ea8e9dc",
+      "next": {
+        "state": 1,
+        "output": "a4811c9ba9505e421f0015e5fcfd9f5d204ae85b584766759e844ef85db10d47"
+      },
+      "snap": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  ]
+}

--- a/historyarchive/testdata/historyV2.json
+++ b/historyarchive/testdata/historyV2.json
@@ -1,0 +1,184 @@
+{
+  "version": 2,
+  "server": "v9.0.1-dirty",
+  "currentLedger": 6714239,
+  "networkPassphrase": "(V) (;,,;) (V)",
+  "currentBuckets": [
+    {
+      "curr": "0000000000000000000000000000000000000000000000000000000000000000",
+      "next": {
+        "state": 0
+      },
+      "snap": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "curr": "c3131b946b5cadf713ca88d299505fe16572ffeefa083b2858a674452fd8ba76",
+      "next": {
+        "state": 1,
+        "output": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "snap": "e08d65b07ca3cb0999a340247afcf0fedbe1d1e1df6ada0c34422e2d3b905735"
+    },
+    {
+      "curr": "b767206bf07e3dbbe14cff681234b7ccfd4dab5957ce6d440f692409498ff909",
+      "next": {
+        "state": 1,
+        "output": "e08d65b07ca3cb0999a340247afcf0fedbe1d1e1df6ada0c34422e2d3b905735"
+      },
+      "snap": "0bdeee425d0b4c3458353b7b20901e60eb8b5289dd8a714e59f910a47b49d66e"
+    },
+    {
+      "curr": "7a1132e7566dea51a35f6981181ad3f108256bb5f9470f0e9df3222c138c6446",
+      "next": {
+        "state": 1,
+        "output": "0bdeee425d0b4c3458353b7b20901e60eb8b5289dd8a714e59f910a47b49d66e"
+      },
+      "snap": "1863067ae6d91218c589b2ccc40a983edc144196ca3a2cd43c7426275a8a3f40"
+    },
+    {
+      "curr": "f4e99dd7c25206f6766911dc812502f0ec2cd5469f4742b7848523aa6e0da03e",
+      "next": {
+        "state": 1,
+        "output": "dd9bcfba61bf17be7093f56eb6e1392d5f25981282d4331cb51961852c11ee16"
+      },
+      "snap": "04a5699bb688ef82e8a352b2ccfa134458c794a0365dddfac00f2e6fc7c159f9"
+    },
+    {
+      "curr": "f9de28d23c53d1affe871a97a5c9747bbc9a208754388dc88cdea96852977471",
+      "next": {
+        "state": 1,
+        "output": "b6d012ce7af5624c24d4ff386ae172516ff0cd13f70cd030edbb503b87ad196b"
+      },
+      "snap": "1fd4b80ec5278fc08269f96728206fcfbf5d3f5efe1bf7f93d4a3d79a75eeca8"
+    },
+    {
+      "curr": "71f4453669ec84632afcdd1f2a97685121cef52a01db58c8d4c810310c07c0d8",
+      "next": {
+        "state": 1,
+        "output": "c0992883bd5f4631f736c5287538342c08e00f80be16b36a5a794772114a3db9"
+      },
+      "snap": "b8913fa01d3b58b763fc04ee1528317c0ec71f250500758e09d0a839ca405be4"
+    },
+    {
+      "curr": "a113930757a7ff48a8898dad74c1446a942b5e5b5f443626a8f943768432ec41",
+      "next": {
+        "state": 1,
+        "output": "9b6feec6e7e366b898a59ad562b31ce3305d7e1545f92bf5fda5c13e032bc0f9"
+      },
+      "snap": "d3b1a36290f39d4cd09e7ef80b7cb871df9a3a5b1e40d8e5cfd26c754914ca84"
+    },
+    {
+      "curr": "e57d1c6342f6e47c2ac0305cd5251bb0fb2cdd40923af87c4657e896e33acdc5",
+      "next": {
+        "state": 1,
+        "output": "de8805e4232fe81c04f5536487e586ab6d3ef38eff93bad5bf6872a3e53ced6b"
+      },
+      "snap": "fcddef737957961d828023a081b84449dc0ab20524e5155837bae12a3b18ac64"
+    },
+    {
+      "curr": "5c3387bcaad3139bb48ff2a99010d6f075cc9b20ba2f22c194fcda2a97926f55",
+      "next": {
+        "state": 1,
+        "output": "3373185b0eb537b909c56e6e16e76e33d966dc7ee1e7168123cfe1114d444e88"
+      },
+      "snap": "2958d66f083ca13ca97a184a5be3a03b3c2e494f832b1ac1a3e16d7b02e9f50c"
+    },
+    {
+      "curr": "ae7e4814b50e176d8e3532e462e2e9db02f218adebd74603d7e349cc19f489e1",
+      "next": {
+        "state": 1,
+        "output": "50abed8a9d86c072cfe8388246b7a378dc355fe996fd7384a5ee57e8da2ad51d"
+      },
+      "snap": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  ],
+  "hotArchiveBuckets": [
+    {
+      "curr": "0000000000000000000000000000000000000000000000000000000000000000",
+      "next": {
+        "state": 0
+      },
+      "snap": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "curr": "c3131b946b5cadf713ca88d299505fe16572ffeefa083b2858a674452fd8ba74",
+      "next": {
+        "state": 1,
+        "output": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "snap": "e08d65b07ca3cb0999a340247afcf0fedbe1d1e1df6ada0c34422e2d3b905732"
+    },
+    {
+      "curr": "b767206bf07e3dbbe14cff681234b7ccfd4dab5957ce6d440f692409498ff901",
+      "next": {
+        "state": 1,
+        "output": "e08d65b07ca3cb0999a340247afcf0fedbe1d1e1df6ada0c34422e2d3b905732"
+      },
+      "snap": "0bdeee425d0b4c3458353b7b20901e60eb8b5289dd8a714e59f910a47b49d661"
+    },
+    {
+      "curr": "7a1132e7566dea51a35f6981181ad3f108256bb5f9470f0e9df3222c138c6442",
+      "next": {
+        "state": 1,
+        "output": "0bdeee425d0b4c3458353b7b20901e60eb8b5289dd8a714e59f910a47b49d661"
+      },
+      "snap": "1863067ae6d91218c589b2ccc40a983edc144196ca3a2cd43c7426275a8a3f42"
+    },
+    {
+      "curr": "f4e99dd7c25206f6766911dc812502f0ec2cd5469f4742b7848523aa6e0da031",
+      "next": {
+        "state": 1,
+        "output": "dd9bcfba61bf17be7093f56eb6e1392d5f25981282d4331cb51961852c11ee12"
+      },
+      "snap": "04a5699bb688ef82e8a352b2ccfa134458c794a0365dddfac00f2e6fc7c159f1"
+    },
+    {
+      "curr": "f9de28d23c53d1affe871a97a5c9747bbc9a208754388dc88cdea96852977472",
+      "next": {
+        "state": 1,
+        "output": "b6d012ce7af5624c24d4ff386ae172516ff0cd13f70cd030edbb503b87ad1961"
+      },
+      "snap": "1fd4b80ec5278fc08269f96728206fcfbf5d3f5efe1bf7f93d4a3d79a75eeca2"
+    },
+    {
+      "curr": "71f4453669ec84632afcdd1f2a97685121cef52a01db58c8d4c810310c07c0d1",
+      "next": {
+        "state": 1,
+        "output": "c0992883bd5f4631f736c5287538342c08e00f80be16b36a5a794772114a3db2"
+      },
+      "snap": "b8913fa01d3b58b763fc04ee1528317c0ec71f250500758e09d0a839ca405be1"
+    },
+    {
+      "curr": "a113930757a7ff48a8898dad74c1446a942b5e5b5f443626a8f943768432ec42",
+      "next": {
+        "state": 1,
+        "output": "9b6feec6e7e366b898a59ad562b31ce3305d7e1545f92bf5fda5c13e032bc0f1"
+      },
+      "snap": "d3b1a36290f39d4cd09e7ef80b7cb871df9a3a5b1e40d8e5cfd26c754914ca24"
+    },
+    {
+      "curr": "e57d1c6342f6e47c2ac0305cd5251bb0fb2cdd40923af87c4657e896e33acdc1",
+      "next": {
+        "state": 1,
+        "output": "de8805e4232fe81c04f5536487e586ab6d3ef38eff93bad5bf6872a3e53ced62"
+      },
+      "snap": "fcddef737957961d828023a081b84449dc0ab20524e5155837bae12a3b18ac61"
+    },
+    {
+      "curr": "5c3387bcaad3139bb48ff2a99010d6f075cc9b20ba2f22c194fcda2a97926f52",
+      "next": {
+        "state": 1,
+        "output": "3373185b0eb537b909c56e6e16e76e33d966dc7ee1e7168123cfe1114d444e81"
+      },
+      "snap": "2958d66f083ca13ca97a184a5be3a03b3c2e494f832b1ac1a3e16d7b02e9f502"
+    },
+    {
+      "curr": "ae7e4814b50e176d8e3532e462e2e9db02f218adebd74603d7e349cc19f489e2",
+      "next": {
+        "state": 1,
+        "output": "50abed8a9d86c072cfe8388246b7a378dc355fe996fd7384a5ee57e8da2ad52"
+      },
+      "snap": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  ]
+}

--- a/ingest/checkpoint_change_reader_test.go
+++ b/ingest/checkpoint_change_reader_test.go
@@ -18,11 +18,11 @@ import (
 	"github.com/stellar/go/xdr"
 )
 
-func TestSingleLedgerStateReaderTestSuite(t *testing.T) {
-	suite.Run(t, new(SingleLedgerStateReaderTestSuite))
+func TestCheckpointChangeReaderTestSuite(t *testing.T) {
+	suite.Run(t, new(CheckpointChangeReaderTestSuite))
 }
 
-type SingleLedgerStateReaderTestSuite struct {
+type CheckpointChangeReaderTestSuite struct {
 	suite.Suite
 	mockArchive          *historyarchive.MockArchive
 	reader               *CheckpointChangeReader
@@ -31,7 +31,7 @@ type SingleLedgerStateReaderTestSuite struct {
 	mockBucketSizeCall   *mock.Call
 }
 
-func (s *SingleLedgerStateReaderTestSuite) SetupTest() {
+func (s *CheckpointChangeReaderTestSuite) SetupTest() {
 	s.mockArchive = &historyarchive.MockArchive{}
 
 	err := json.Unmarshal([]byte(hasExample), &s.has)
@@ -71,14 +71,20 @@ func (s *SingleLedgerStateReaderTestSuite) SetupTest() {
 	s.reader.disableBucketListHashValidation = true
 }
 
-func (s *SingleLedgerStateReaderTestSuite) TearDownTest() {
+func (s *CheckpointChangeReaderTestSuite) TearDownTest() {
 	s.mockArchive.AssertExpectations(s.T())
 }
 
 // TestSimple test reading buckets with a single live entry.
-func (s *SingleLedgerStateReaderTestSuite) TestSimple() {
+func (s *CheckpointChangeReaderTestSuite) TestSimple() {
+	meta := metaEntry(23)
+	liveArchiveType := xdr.BucketListTypeLive
+	meta.MetaEntry.Ext = xdr.BucketMetadataExt{
+		V:              1,
+		BucketListType: &liveArchiveType,
+	}
 	curr1 := createXdrStream(
-		metaEntry(11),
+		meta,
 		entryAccount(xdr.BucketEntryTypeLiveentry, "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", 1),
 	)
 
@@ -109,7 +115,7 @@ func (s *SingleLedgerStateReaderTestSuite) TestSimple() {
 }
 
 // TestRemoved test reading buckets with a single live entry that was removed.
-func (s *SingleLedgerStateReaderTestSuite) TestRemoved() {
+func (s *CheckpointChangeReaderTestSuite) TestRemoved() {
 	curr1 := createXdrStream(
 		entryAccount(xdr.BucketEntryTypeDeadentry, "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", 1),
 	)
@@ -141,7 +147,7 @@ func (s *SingleLedgerStateReaderTestSuite) TestRemoved() {
 }
 
 // TestConcurrentRead test concurrent reads for race conditions
-func (s *SingleLedgerStateReaderTestSuite) TestConcurrentRead() {
+func (s *CheckpointChangeReaderTestSuite) TestConcurrentRead() {
 	curr1 := createXdrStream(
 		entryAccount(xdr.BucketEntryTypeDeadentry, "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", 1),
 	)
@@ -191,7 +197,7 @@ func (s *SingleLedgerStateReaderTestSuite) TestConcurrentRead() {
 }
 
 // TestEnsureLatestLiveEntry tests if a live entry overrides an older initentry
-func (s *SingleLedgerStateReaderTestSuite) TestEnsureLatestLiveEntry() {
+func (s *CheckpointChangeReaderTestSuite) TestEnsureLatestLiveEntry() {
 	curr1 := createXdrStream(
 		metaEntry(11),
 		entryAccount(xdr.BucketEntryTypeLiveentry, "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", 1),
@@ -221,7 +227,7 @@ func (s *SingleLedgerStateReaderTestSuite) TestEnsureLatestLiveEntry() {
 	s.Require().Equal(err, io.EOF)
 }
 
-func (s *SingleLedgerStateReaderTestSuite) TestUniqueInitEntryOptimization() {
+func (s *CheckpointChangeReaderTestSuite) TestUniqueInitEntryOptimization() {
 	curr1 := createXdrStream(
 		metaEntry(20),
 		entryAccount(xdr.BucketEntryTypeLiveentry, "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", 1),
@@ -349,7 +355,7 @@ func (s *SingleLedgerStateReaderTestSuite) TestUniqueInitEntryOptimization() {
 	s.Require().Equal(err, io.EOF)
 }
 
-func (s *SingleLedgerStateReaderTestSuite) assertVisitedLedgerKeysContains(key xdr.LedgerKey) {
+func (s *CheckpointChangeReaderTestSuite) assertVisitedLedgerKeysContains(key xdr.LedgerKey) {
 	encodingBuffer := xdr.NewEncodingBuffer()
 	keyBytes, err := encodingBuffer.LedgerKeyUnsafeMarshalBinaryCompress(key)
 	s.Require().NoError(err)
@@ -357,7 +363,7 @@ func (s *SingleLedgerStateReaderTestSuite) assertVisitedLedgerKeysContains(key x
 }
 
 // TestMalformedProtocol11Bucket tests a buggy protocol 11 bucket (meta not the first entry)
-func (s *SingleLedgerStateReaderTestSuite) TestMalformedProtocol11Bucket() {
+func (s *CheckpointChangeReaderTestSuite) TestMalformedProtocol11Bucket() {
 	curr1 := createXdrStream(
 		entryAccount(xdr.BucketEntryTypeLiveentry, "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", 1),
 		metaEntry(11),
@@ -381,7 +387,7 @@ func (s *SingleLedgerStateReaderTestSuite) TestMalformedProtocol11Bucket() {
 }
 
 // TestMalformedProtocol11BucketNoMeta tests a buggy protocol 11 bucket (no meta entry)
-func (s *SingleLedgerStateReaderTestSuite) TestMalformedProtocol11BucketNoMeta() {
+func (s *CheckpointChangeReaderTestSuite) TestMalformedProtocol11BucketNoMeta() {
 	curr1 := createXdrStream(
 		entryAccount(xdr.BucketEntryTypeInitentry, "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", 1),
 	)
@@ -397,6 +403,32 @@ func (s *SingleLedgerStateReaderTestSuite) TestMalformedProtocol11BucketNoMeta()
 	_, err := s.reader.Read()
 	s.Require().NotNil(err)
 	s.Assert().Equal("Error while reading from buckets: Read INITENTRY from version <11 bucket: 0@517bea4c6627a688a8ce501febd8c562e737e3d86b29689d9956217640f3c74b", err.Error())
+}
+
+// TestMalformedProtocol11Bucket ensures the checkpoint change reader asserts its reading from the live bucketlist
+func (s *CheckpointChangeReaderTestSuite) TestMalformedBucketListType() {
+	meta := metaEntry(23)
+	hotArchiveType := xdr.BucketListTypeHotArchive
+	meta.MetaEntry.Ext = xdr.BucketMetadataExt{
+		V:              1,
+		BucketListType: &hotArchiveType,
+	}
+	curr1 := createXdrStream(
+		meta,
+		entryAccount(xdr.BucketEntryTypeLiveentry, "GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML", 1),
+	)
+
+	nextBucket := s.getNextBucketChannel()
+
+	// Return curr1 stream, rest won't be read due to an error
+	s.mockArchive.
+		On("GetXdrStreamForHash", <-nextBucket).
+		Return(curr1, nil).Once()
+
+	// Meta entry
+	_, err := s.reader.Read()
+	s.Require().NotNil(err)
+	s.Assert().EqualError(err, "Error while reading from buckets: expected bucket list type to be live (instead got BucketListTypeHotArchive) in the bucket hash '517bea4c6627a688a8ce501febd8c562e737e3d86b29689d9956217640f3c74b'")
 }
 
 func TestBucketExistsTestSuite(t *testing.T) {
@@ -984,7 +1016,7 @@ func xdrStreamFromBuffer(b *bytes.Buffer) *historyarchive.XdrStream {
 // getNextBucket is a helper that returns next bucket hash in the order of processing.
 // This allows to write simpler test code that ensures that mocked calls are in a
 // correct order.
-func (s *SingleLedgerStateReaderTestSuite) getNextBucketChannel() <-chan (historyarchive.Hash) {
+func (s *CheckpointChangeReaderTestSuite) getNextBucketChannel() <-chan (historyarchive.Hash) {
 	// 11 levels with 2 buckets each = buffer of 22
 	c := make(chan (historyarchive.Hash), 22)
 

--- a/ingest/checkpoint_change_reader_test.go
+++ b/ingest/checkpoint_change_reader_test.go
@@ -405,7 +405,7 @@ func (s *CheckpointChangeReaderTestSuite) TestMalformedProtocol11BucketNoMeta() 
 	s.Assert().Equal("Error while reading from buckets: Read INITENTRY from version <11 bucket: 0@517bea4c6627a688a8ce501febd8c562e737e3d86b29689d9956217640f3c74b", err.Error())
 }
 
-// TestMalformedProtocol11Bucket ensures the checkpoint change reader asserts its reading from the live bucketlist
+// TestMalformedBucketListType ensures the checkpoint change reader asserts its reading from the live bucketlist
 func (s *CheckpointChangeReaderTestSuite) TestMalformedBucketListType() {
 	meta := metaEntry(23)
 	hotArchiveType := xdr.BucketListTypeHotArchive


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Close https://github.com/stellar/go/issues/5425

In protocol 23 there will be two bucketlists: one for the live ledger entries and one for evicted archived ledger entries. Consequently the bucketlist hash in the ledger header will change to (see [CAP-62](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0062.md#changes-to-ledgerheader)):

```
header.bucketListHash = SHA256(liveStateBucketListHash, hotArchiveHash)
```

The checkpoint change reader will need to be updated to calculate the bucket list hash in this way. The [live bucketlist](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0062.md#live-state-bucketlist) will still be the same as the current bucketlist we ingest in the checkpoint change reader so there will not be any changes required there. However, I did add an assertion to ensure the checkpoint change reader is ingesting from the live bucket list instead of the bucket list for evicted ledger entries.

### Known limitations

[N/A]
