### PR TITLE
clients: Update Stellar Core client to latest state archival API

### DIFF
--- a/clients/stellarcore/client_test.go
+++ b/clients/stellarcore/client_test.go
@@ -2,6 +2,7 @@ package stellarcore
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"net/http"
@@ -143,23 +144,54 @@ func TestGetLedgerEntries(t *testing.T) {
 	hmock := httptest.NewClient()
 	c := &Client{HTTP: hmock, URL: "http://localhost:11626"}
 
-	// build a fake response body
-	mockResp := proto.GetLedgerEntryResponse{
-		Ledger: 1215, // checkpoint align on expected request
-		Entries: []proto.LedgerEntryResponse{{
-			Entry: "pretend this is XDR lol",
-			State: "live",
-			Ttl:   1234,
-		}, {
-			Entry: "pretend this is another XDR lol",
-			State: "archived",
-		}},
+	var hash xdr.Hash
+	_, err := rand.Read(hash[:])
+	require.NoError(t, err)
+
+	tr, err := xdr.NewScVal(xdr.ScValTypeScvBool, true)
+	require.NoError(t, err)
+	fl, err := xdr.NewScVal(xdr.ScValTypeScvBool, false)
+	require.NoError(t, err)
+
+	rawEntry := xdr.ContractDataEntry{
+		Ext:        xdr.ExtensionPoint{},
+		Contract:   xdr.ScAddress{Type: xdr.ScAddressTypeScAddressTypeContract, ContractId: &hash},
+		Key:        tr,
+		Durability: xdr.ContractDataDurabilityPersistent,
+		Val:        fl,
 	}
+	entry := xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 1210,
+		Data: xdr.LedgerEntryData{
+			Type:         xdr.LedgerEntryTypeContractData,
+			ContractData: &rawEntry,
+		},
+	}
+	entryB64, err := xdr.MarshalBase64(entry)
+	require.NoError(t, err)
 
 	var key xdr.LedgerKey
 	acc, err := xdr.AddressToAccountId(keypair.MustRandom().Address())
 	require.NoError(t, err)
 	key.SetAccount(acc)
+	keyB64, err := key.MarshalBinaryBase64()
+	require.NoError(t, err)
+
+	// build a fake response body
+	mockResp := proto.GetLedgerEntryResponse{
+		Ledger: 1215, // checkpoint align on expected request
+		Entries: []proto.LedgerEntryResponse{{
+			Entry: entryB64,
+			State: "live",
+			Ttl:   1234,
+		}, {
+			Entry: entryB64,
+			State: "archived",
+		}, {
+			Entry: keyB64,
+			State: "new",
+		}},
+	}
 
 	// happy path - fetch an entry
 	ce := hmock.On("POST", "http://localhost:11626/getledgerentry")
@@ -187,12 +219,14 @@ func TestGetLedgerEntries(t *testing.T) {
 	require.NotNil(t, resp)
 
 	require.EqualValues(t, 1215, resp.Ledger)
-	require.Len(t, resp.Entries, 2)
-	require.Equal(t, "pretend this is XDR lol", resp.Entries[0].Entry)
-	require.Equal(t, "pretend this is another XDR lol", resp.Entries[1].Entry)
+	require.Len(t, resp.Entries, 3)
+	require.Equal(t, entryB64, resp.Entries[0].Entry)
+	require.Equal(t, entryB64, resp.Entries[1].Entry)
+	require.Equal(t, keyB64, resp.Entries[2].Entry)
 	require.EqualValues(t, 1234, resp.Entries[0].Ttl)
 	require.EqualValues(t, "live", resp.Entries[0].State)
 	require.EqualValues(t, "archived", resp.Entries[1].State)
+	require.EqualValues(t, "new", resp.Entries[2].State)
 
 	key.Type = xdr.LedgerEntryTypeTtl
 	_, err = c.GetLedgerEntries(context.Background(), 1234, key)

--- a/clients/stellarcore/client_test.go
+++ b/clients/stellarcore/client_test.go
@@ -203,8 +203,6 @@ func TestGetLedgerEntries(t *testing.T) {
 			requestData, ierr := io.ReadAll(r.Body)
 			require.NoError(t, ierr)
 
-			keyB64, ierr := key.MarshalBinaryBase64()
-			require.NoError(t, ierr)
 			expected := fmt.Sprintf("key=%s&ledgerSeq=1234", url.QueryEscape(keyB64))
 			require.Equal(t, expected, string(requestData))
 

--- a/clients/stellarcore/client_test.go
+++ b/clients/stellarcore/client_test.go
@@ -203,7 +203,11 @@ func TestGetLedgerEntries(t *testing.T) {
 			requestData, ierr := io.ReadAll(r.Body)
 			require.NoError(t, ierr)
 
-			expected := fmt.Sprintf("key=%s&ledgerSeq=1234", url.QueryEscape(keyB64))
+			expected := fmt.Sprintf(
+				"key=%s&key=%s&key=%s&ledgerSeq=1234",
+				url.QueryEscape(keyB64),
+				url.QueryEscape(keyB64),
+				url.QueryEscape(keyB64))
 			require.Equal(t, expected, string(requestData))
 
 			resp, ierr := httpmock.NewJsonResponse(http.StatusOK, &mockResp)
@@ -212,7 +216,7 @@ func TestGetLedgerEntries(t *testing.T) {
 			return resp, nil
 		})
 
-	resp, err := c.GetLedgerEntries(context.Background(), 1234, key)
+	resp, err := c.GetLedgerEntries(context.Background(), 1234, key, key, key)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 

--- a/ingest/processors/asset_processor/asset_test.go
+++ b/ingest/processors/asset_processor/asset_test.go
@@ -31,9 +31,6 @@ var genericBumpOperationEnvelope = xdr.TransactionV1Envelope{
 		Ext: xdr.TransactionExt{
 			V: 0,
 			SorobanData: &xdr.SorobanTransactionData{
-				Ext: xdr.ExtensionPoint{
-					V: 0,
-				},
 				Resources: xdr.SorobanResources{
 					Footprint: xdr.LedgerFootprint{
 						ReadOnly:  []xdr.LedgerKey{},

--- a/ingest/processors/operation_processor/operation_test.go
+++ b/ingest/processors/operation_processor/operation_test.go
@@ -70,9 +70,6 @@ var genericBumpOperationEnvelope = xdr.TransactionV1Envelope{
 		Ext: xdr.TransactionExt{
 			V: 0,
 			SorobanData: &xdr.SorobanTransactionData{
-				Ext: xdr.ExtensionPoint{
-					V: 0,
-				},
 				Resources: xdr.SorobanResources{
 					Footprint: xdr.LedgerFootprint{
 						ReadOnly:  []xdr.LedgerKey{},

--- a/ingest/processors/trade_processor/trade_test.go
+++ b/ingest/processors/trade_processor/trade_test.go
@@ -33,9 +33,6 @@ var genericBumpOperationEnvelope = xdr.TransactionV1Envelope{
 		Ext: xdr.TransactionExt{
 			V: 0,
 			SorobanData: &xdr.SorobanTransactionData{
-				Ext: xdr.ExtensionPoint{
-					V: 0,
-				},
 				Resources: xdr.SorobanResources{
 					Footprint: xdr.LedgerFootprint{
 						ReadOnly:  []xdr.LedgerKey{},

--- a/ingest/processors/transaction_processor/transaction_test.go
+++ b/ingest/processors/transaction_processor/transaction_test.go
@@ -61,9 +61,6 @@ var genericBumpOperationEnvelope = xdr.TransactionV1Envelope{
 		Ext: xdr.TransactionExt{
 			V: 0,
 			SorobanData: &xdr.SorobanTransactionData{
-				Ext: xdr.ExtensionPoint{
-					V: 0,
-				},
 				Resources: xdr.SorobanResources{
 					Footprint: xdr.LedgerFootprint{
 						ReadOnly:  []xdr.LedgerKey{},

--- a/protocols/stellarcore/getledgerentry_response.go
+++ b/protocols/stellarcore/getledgerentry_response.go
@@ -7,8 +7,8 @@ const (
 	// current state when created. In this case, the `Entry` field will be an
 	// xdr.LedgerKey matching the one requested rather than an xdr.LedgerEntry.
 	LedgerEntryStateNew = "new"
-	// Indicates that the entry has been archived due to its TTL but still lives
-	// in the live state
+	// Indicates that the entry has been archived to the hot archive due to its
+	// TTL expiring
 	LedgerEntryStateArchived = "archived"
 )
 

--- a/protocols/stellarcore/getledgerentry_response.go
+++ b/protocols/stellarcore/getledgerentry_response.go
@@ -10,14 +10,11 @@ const (
 	// Indicates that the entry has been archived due to its TTL but still lives
 	// in the live state
 	LedgerEntryStateArchived = "archived"
-	// Indicates that the entry has been evicted from the live state and now
-	// lives in the "hot archive" state.
-	LedgerEntryStateEvicted = "evicted"
 )
 
 // GetLedgerEntryResponse is the structure of Stellar Core's /getledgerentry
 type GetLedgerEntryResponse struct {
-	Ledger  uint32                `json:"ledger"`
+	Ledger  uint32                `json:"ledgerSeq"`
 	Entries []LedgerEntryResponse `json:"entries"`
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [x] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [x] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Update the API to reflect its latest schema and enhance testing by building real ledger keys and entries.

### Why
The API has been updated, see [Slack thread](https://stellarfoundation.slack.com/archives/C07ET021CA2/p1739921403806869?thread_ts=1739921155.418029&cid=C07ET021CA2) and [the CAP](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0066.md#getledgerentry-endpoint).
