### PR TITLE
services/horizon/internal/ingest/processors: Fix ingestContractAssetBalance() restore case

### DIFF
--- a/services/horizon/internal/ingest/processors/asset_stats_processor.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor.go
@@ -196,7 +196,7 @@ func (p *AssetStatsProcessor) updateDB(
 		// When ingesting from the history archives we can take advantage of the fact
 		// that there are only created ledger entries. We don't need to execute any
 		// updates or removals on the asset stats tables. And we can also skip
-		// ingesting restored contract balances and expired contract balances.
+		// deleting expired contract balances.
 		assetStatsDeltas := p.assetStatSet.All()
 		if len(assetStatsDeltas) > 0 {
 			var err error

--- a/services/horizon/internal/ingest/processors/asset_stats_processor.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor.go
@@ -59,13 +59,6 @@ func (p *AssetStatsProcessor) ProcessChange(ctx context.Context, change ingest.C
 		return nil
 	}
 
-	// We don't need to handle evictions because we immediately delete contract balances
-	// upon expiration. So by the time an archived ledger entry is evicted it will already
-	// be deleted from the horizon DB.
-	if change.Reason == ingest.LedgerEntryChangeReasonEviction {
-		return nil
-	}
-
 	var err error
 	switch change.Type {
 	case xdr.LedgerEntryTypeLiquidityPool:
@@ -84,6 +77,14 @@ func (p *AssetStatsProcessor) ProcessChange(ctx context.Context, change ingest.C
 		asset := AssetFromContractData(*ledgerEntry, p.networkPassphrase)
 		_, _, balanceFound := ContractBalanceFromContractData(*ledgerEntry, p.networkPassphrase)
 		if asset == nil && !balanceFound {
+			return nil
+		}
+		// We don't need to handle evictions for contract balances because we immediately delete
+		// contract balances upon expiration. So by the time an archived ledger entry is evicted
+		// it will already be deleted from the horizon DB.
+		// However, we do handle evictions if the asset contract itself is evicted. In that
+		// scenario we will omit contract asset stats for that asset in the /assets response.
+		if change.Reason == ingest.LedgerEntryChangeReasonEviction && asset == nil {
 			return nil
 		}
 		p.contractDataChanges = append(p.contractDataChanges, change)

--- a/services/horizon/internal/ingest/processors/asset_stats_processor.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor.go
@@ -147,11 +147,14 @@ func (p *AssetStatsProcessor) addExpirationChange(change ingest.Change) error {
 				post.LiveUntilLedgerSeq,
 			)
 		}
-		// also the new expiration ledger must always be greater than or equal
-		// to the current ledger
-		if uint32(post.LiveUntilLedgerSeq) < p.currentLedger {
+
+		// The previous expiration ledger must always be greater than or equal to the current ledger
+		// because if the previous expiration ledger is less than the current ledger then it implies
+		// the ledger entry was archived. However, an archived ledger entry cannot be updated without
+		// first being restored.
+		if uint32(pre.LiveUntilLedgerSeq) < p.currentLedger {
 			return errors.Errorf(
-				"post expiration ledger is less than current ledger."+
+				"pre expiration ledger is less than current ledger."+
 					" Pre: %v Post: %v current ledger: %v",
 				pre.LiveUntilLedgerSeq,
 				post.LiveUntilLedgerSeq,

--- a/services/horizon/internal/ingest/processors/asset_stats_processor_test.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor_test.go
@@ -720,16 +720,6 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestUpdateContractBalance() {
 	s.mockQ.On("GetContractAssetStat", s.ctx, usdID[:]).
 		Return(usdAssetContractStat, nil).Once()
 
-	s.mockQ.On("GetContractAssetBalances", s.ctx, []xdr.Hash{keyHash}).
-		Return([]history.ContractAssetBalance{
-			{
-				KeyHash:          keyHash[:],
-				ContractID:       usdID[:],
-				Amount:           "100",
-				ExpirationLedger: 2234,
-			},
-		}, nil).Once()
-
 	usdAssetContractStat.Stat.ActiveBalance = "350"
 	s.mockQ.On("UpdateContractAssetStat", s.ctx, mock.MatchedBy(func(row history.ContractAssetStatRow) bool {
 		return bytes.Equal(usdID[:], row.ContractID) &&
@@ -1253,12 +1243,12 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestExpirationLedgerCannotBeLessTha
 				Type: xdr.LedgerEntryTypeTtl,
 				Ttl: &xdr.TtlEntry{
 					KeyHash:            keyHash,
-					LiveUntilLedgerSeq: 1234,
+					LiveUntilLedgerSeq: 1236,
 				},
 			},
 		},
 	}),
-		"post expiration ledger is less than current ledger. Pre: 1230 Post: 1234 current ledger: 1235",
+		"pre expiration ledger is less than current ledger. Pre: 1230 Post: 1236 current ledger: 1235",
 	)
 }
 

--- a/services/horizon/internal/ingest/processors/asset_stats_processor_test.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor_test.go
@@ -2113,7 +2113,8 @@ func (s *AssetStatsProcessorTestSuiteLedger) TestRemoveContractID() {
 	s.Assert().NoError(err)
 
 	err = s.processor.ProcessChange(s.ctx, ingest.Change{
-		Type: xdr.LedgerEntryTypeContractData,
+		Reason: ingest.LedgerEntryChangeReasonEviction,
+		Type:   xdr.LedgerEntryTypeContractData,
 		Pre: &xdr.LedgerEntry{
 			LastModifiedLedgerSeq: lastModifiedLedgerSeq,
 			Data:                  eurContractData,

--- a/services/horizon/internal/ingest/processors/contract_asset_stats.go
+++ b/services/horizon/internal/ingest/processors/contract_asset_stats.go
@@ -169,23 +169,7 @@ func (s *ContractAssetStatSet) ingestContractAssetBalance(ctx context.Context, c
 			return err
 		}
 		expirationLedger, ok := s.createdExpirationEntries[keyHash]
-		if !ok {
-			// when restoring a contract balance which is archived but not yet evicted,
-			// the restoration meta for the ttl entry will appear like an update because
-			// it will include the previous state
-			if expirationUpdate, ok := s.updatedExpirationEntries[keyHash]; ok {
-				expirationLedger = expirationUpdate[1]
-			} else {
-				return nil
-			}
-			if expirationLedger < s.currentLedger {
-				return errors.Errorf(
-					"contract balance has invalid expiration ledger keyhash %v expiration ledger %v",
-					keyHash,
-					expirationLedger,
-				)
-			}
-		} else if expirationLedger < s.currentLedger {
+		if !ok || expirationLedger < s.currentLedger {
 			return nil
 		}
 		s.createdBalances = append(s.createdBalances, history.ContractAssetBalance{

--- a/services/horizon/internal/ingest/processors/contract_asset_stats.go
+++ b/services/horizon/internal/ingest/processors/contract_asset_stats.go
@@ -29,7 +29,6 @@ func (v assetContractStatValue) ConvertToHistoryObject() history.ContractAssetSt
 }
 
 type contractAssetBalancesQ interface {
-	GetContractAssetBalances(ctx context.Context, keys []xdr.Hash) ([]history.ContractAssetBalance, error)
 	DeleteContractAssetBalancesExpiringAt(ctx context.Context, ledger uint32) ([]history.ContractAssetBalance, error)
 }
 
@@ -242,38 +241,6 @@ func (s *ContractAssetStatSet) ingestContractAssetBalance(ctx context.Context, c
 		keyHash, err := getKeyHash(*change.Post)
 		if err != nil {
 			return err
-		}
-
-		var preExpiration, postExpiration uint32
-		if expirationUpdate, ok := s.updatedExpirationEntries[keyHash]; ok {
-			preExpiration, postExpiration = expirationUpdate[0], expirationUpdate[1]
-		} else {
-			rows, err := s.assetStatsQ.GetContractAssetBalances(ctx, []xdr.Hash{keyHash})
-			if err != nil {
-				return errors.Wrapf(err, "could not query contract asset balance for %v", keyHash)
-			}
-			if len(rows) == 0 {
-				return nil
-			}
-			if len(rows) != 1 {
-				return errors.Wrapf(
-					err,
-					"expected 1 contract asset balance for %v but got %v",
-					keyHash,
-					len(rows),
-				)
-			}
-			preExpiration = rows[0].ExpirationLedger
-			postExpiration = preExpiration
-		}
-		for _, expiration := range []uint32{preExpiration, postExpiration} {
-			if expiration < s.currentLedger {
-				return errors.Errorf(
-					"contract balance has invalid expiration ledger keyhash %v expiration ledger %v",
-					keyHash,
-					expiration,
-				)
-			}
 		}
 
 		s.updatedBalances[keyHash] = postAmt

--- a/services/horizon/internal/ingest/processors/contract_asset_stats_test.go
+++ b/services/horizon/internal/ingest/processors/contract_asset_stats_test.go
@@ -215,16 +215,6 @@ func TestUpdateContractBalance(t *testing.T) {
 	assert.NoError(t, err)
 
 	keyHash = getKeyHashForBalance(t, usdcID, [32]byte{2})
-	ctx := context.Background()
-	mockQ.On("GetContractAssetBalances", ctx, []xdr.Hash{keyHash}).
-		Return([]history.ContractAssetBalance{
-			{
-				KeyHash:          keyHash[:],
-				ContractID:       usdcID[:],
-				Amount:           "30",
-				ExpirationLedger: 180,
-			},
-		}, nil).Once()
 	expectedBalances[keyHash] = "100"
 	err = set.AddContractData(context.Background(), ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
@@ -237,31 +227,7 @@ func TestUpdateContractBalance(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	keyHash = getKeyHashForBalance(t, usdcID, [32]byte{4})
-	// balances which don't exist in the db will be ignored
-	mockQ.On("GetContractAssetBalances", ctx, []xdr.Hash{keyHash}).
-		Return([]history.ContractAssetBalance{}, nil).Once()
-	err = set.AddContractData(context.Background(), ingest.Change{
-		Type: xdr.LedgerEntryTypeContractData,
-		Pre: &xdr.LedgerEntry{
-			Data: BalanceToContractData(usdcID, [32]byte{4}, 0),
-		},
-		Post: &xdr.LedgerEntry{
-			Data: BalanceToContractData(usdcID, [32]byte{4}, 100),
-		},
-	})
-	assert.NoError(t, err)
-
 	keyHash = getKeyHashForBalance(t, etherID, [32]byte{})
-	mockQ.On("GetContractAssetBalances", ctx, []xdr.Hash{keyHash}).
-		Return([]history.ContractAssetBalance{
-			{
-				KeyHash:          keyHash[:],
-				ContractID:       etherID[:],
-				Amount:           "200",
-				ExpirationLedger: 200,
-			},
-		}, nil).Once()
 	expectedBalances[keyHash] = "50"
 	err = set.AddContractData(context.Background(), ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
@@ -309,40 +275,6 @@ func TestUpdateContractBalance(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-
-	keyHash = getKeyHashForBalance(t, btcID, [32]byte{5})
-	mockQ.On("GetContractAssetBalances", ctx, []xdr.Hash{keyHash}).
-		Return([]history.ContractAssetBalance{
-			{
-				KeyHash:          keyHash[:],
-				ContractID:       btcID[:],
-				Amount:           "10",
-				ExpirationLedger: 20,
-			},
-		}, nil).Once()
-	err = set.AddContractData(context.Background(), ingest.Change{
-		Type: xdr.LedgerEntryTypeContractData,
-		Pre: &xdr.LedgerEntry{
-			Data: BalanceToContractData(btcID, [32]byte{5}, 10),
-		},
-		Post: &xdr.LedgerEntry{
-			Data: BalanceToContractData(btcID, [32]byte{5}, 15),
-		},
-	})
-	assert.ErrorContains(t, err, "contract balance has invalid expiration ledger keyhash")
-
-	keyHash = getKeyHashForBalance(t, btcID, [32]byte{6})
-	set.updatedExpirationEntries[keyHash] = [2]uint32{100, 110}
-	err = set.AddContractData(context.Background(), ingest.Change{
-		Type: xdr.LedgerEntryTypeContractData,
-		Pre: &xdr.LedgerEntry{
-			Data: BalanceToContractData(btcID, [32]byte{6}, 120),
-		},
-		Post: &xdr.LedgerEntry{
-			Data: BalanceToContractData(btcID, [32]byte{6}, 135),
-		},
-	})
-	assert.ErrorContains(t, err, "contract balance has invalid expiration ledger keyhash")
 
 	keyHash = getKeyHashForBalance(t, uniID, [32]byte{4})
 	set.updatedExpirationEntries[keyHash] = [2]uint32{150, 170}

--- a/services/horizon/internal/ingest/processors/contract_asset_stats_test.go
+++ b/services/horizon/internal/ingest/processors/contract_asset_stats_test.go
@@ -106,7 +106,7 @@ func TestAddContractData(t *testing.T) {
 	assert.NoError(t, err)
 
 	otherEtherBalanceKeyHash := getKeyHashForBalance(t, etherID, [32]byte{1})
-	set.updatedExpirationEntries[otherEtherBalanceKeyHash] = [2]uint32{100, 150}
+	set.createdExpirationEntries[otherEtherBalanceKeyHash] = 150
 	err = set.AddContractData(context.Background(), ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Post: &xdr.LedgerEntry{
@@ -135,16 +135,6 @@ func TestAddContractData(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-
-	invalidBTCBalanceKeyHash := getKeyHashForBalance(t, btcID, [32]byte{3})
-	set.updatedExpirationEntries[invalidBTCBalanceKeyHash] = [2]uint32{100, 120}
-	err = set.AddContractData(context.Background(), ingest.Change{
-		Type: xdr.LedgerEntryTypeContractData,
-		Post: &xdr.LedgerEntry{
-			Data: BalanceToContractData(btcID, [32]byte{3}, 90),
-		},
-	})
-	assert.ErrorContains(t, err, "contract balance has invalid expiration ledger")
 
 	assert.Empty(t, set.updatedBalances)
 	assert.Empty(t, set.removedBalances)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

This PR is a follow up to https://github.com/stellar/go/pull/5611

In https://github.com/stellar/go/pull/5611 , I assumed that the structure of the restoration meta differed depending on whether the restoration was for an evicted ledger entry or a ledger entry which was archived but not yet evicted. But in the latest revision of [CAP-66](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0066.md#meta) it explicitly states that:

> Whenever an entry is restored, the data/code entry will be emitted as a LedgerEntryChangeType of type LEDGER_ENTRY_RESTORE. This will include the complete LedgerEntry of the restored entry. It does not matter if the entry has been evicted or not, the meta produced will be the same. Additionally, the corresponding TTL entry will also be emitted as a LedgerEntryChangeType of type LEDGER_ENTRY_RESTORE.

So, there is no case where the LEDGER_ENTRY_RESTORE meta resembles an update.

This PR removes code in ingestContractAssetBalance() which held the assumption that the LEDGER_ENTRY_RESTORE meta for TTL entries resembles an update.

### Known limitations

[N/A]
