### PR TITLE
ingest: Update ingestion library and horizon to adapt to protocol 23 representation of evictions

### DIFF
--- a/ingest/change.go
+++ b/ingest/change.go
@@ -66,7 +66,9 @@ type Change struct {
 	Transaction *LedgerTransaction
 
 	// The LedgerCloseMeta that precipitated the change.
-	Ledger xdr.LedgerCloseMeta
+	// This field is not populated when the Change is obtained from enumerating
+	// ledger entries from a history archive snapshot (e.g. via CheckpointChangeReader).
+	Ledger *xdr.LedgerCloseMeta
 
 	// Information about the upgrade, if the change occurred as part of an upgrade
 	// This field is relevant only when the Reason is LedgerEntryChangeReasonUpgrade

--- a/ingest/change.go
+++ b/ingest/change.go
@@ -66,11 +66,7 @@ type Change struct {
 	Transaction *LedgerTransaction
 
 	// The LedgerCloseMeta that precipitated the change.
-	// This is useful only when the Change is caused by an upgrade or by an eviction, i.e. outside a transaction
-	// This field is populated only when the Reason is one of:
-	// LedgerEntryChangeReasonUpgrade or LedgerEntryChangeReasonEviction
-	// For changes caused by transaction or operations, look at the Transaction field
-	Ledger *xdr.LedgerCloseMeta
+	Ledger xdr.LedgerCloseMeta
 
 	// Information about the upgrade, if the change occurred as part of an upgrade
 	// This field is relevant only when the Reason is LedgerEntryChangeReasonUpgrade
@@ -95,9 +91,6 @@ const (
 
 	// LedgerEntryChangeReasonUpgrade indicates a change caused by a ledger upgrade.
 	LedgerEntryChangeReasonUpgrade
-
-	// LedgerEntryChangeReasonEviction indicates a change caused by entry eviction.
-	LedgerEntryChangeReasonEviction
 )
 
 // String returns a best effort string representation of the change.

--- a/ingest/ledger_change_reader.go
+++ b/ingest/ledger_change_reader.go
@@ -27,8 +27,6 @@ const (
 	feeChangesState ledgerChangeReaderState = iota
 	// metaChangesState is active when LedgerChangeReader is reading transaction meta changes.
 	metaChangesState
-	// evictionChangesState is active when LedgerChangeReader is reading ledger entry evictions.
-	evictionChangesState
 	// upgradeChanges is active when LedgerChangeReader is reading upgrade changes.
 	upgradeChangesState
 )
@@ -178,28 +176,6 @@ func (r *LedgerChangeReader) Read() (Change, error) {
 		}
 		return r.Read()
 
-	case evictionChangesState:
-		entries, err := r.lcm.EvictedPersistentLedgerEntries()
-		if err != nil {
-			return Change{}, err
-		}
-		changes := make([]Change, len(entries))
-		for i := range entries {
-			entry := entries[i]
-			// when a ledger entry is evicted it is removed from the ledger
-			changes[i] = Change{
-				Type:   entry.Data.Type,
-				Pre:    &entry,
-				Post:   nil,
-				Reason: LedgerEntryChangeReasonEviction,
-				Ledger: &r.lcm,
-			}
-		}
-		sortChanges(changes)
-		r.pending = append(r.pending, changes...)
-		r.state++
-		return r.Read()
-
 	case upgradeChangesState:
 		// Get upgrade changes
 		if r.upgradeIndex < len(r.LedgerTransactionReader.lcm.UpgradesProcessing()) {
@@ -209,7 +185,7 @@ func (r *LedgerChangeReader) Read() (Change, error) {
 			ledgerUpgrades := r.LedgerTransactionReader.lcm.UpgradesProcessing()
 			for i := range changes {
 				changes[i].Reason = LedgerEntryChangeReasonUpgrade
-				changes[i].Ledger = &r.lcm
+				changes[i].Ledger = r.lcm
 				changes[i].LedgerUpgrade = &ledgerUpgrades[r.upgradeIndex].Upgrade
 			}
 			r.pending = append(r.pending, changes...)

--- a/ingest/ledger_change_reader.go
+++ b/ingest/ledger_change_reader.go
@@ -185,7 +185,7 @@ func (r *LedgerChangeReader) Read() (Change, error) {
 			ledgerUpgrades := r.LedgerTransactionReader.lcm.UpgradesProcessing()
 			for i := range changes {
 				changes[i].Reason = LedgerEntryChangeReasonUpgrade
-				changes[i].Ledger = r.lcm
+				changes[i].Ledger = &r.lcm
 				changes[i].LedgerUpgrade = &ledgerUpgrades[r.upgradeIndex].Upgrade
 			}
 			r.pending = append(r.pending, changes...)

--- a/ingest/ledger_change_reader_test.go
+++ b/ingest/ledger_change_reader_test.go
@@ -536,22 +536,6 @@ func TestLedgerChangeLedgerCloseMetaV2(t *testing.T) {
 					},
 				},
 			},
-			EvictedPersistentLedgerEntries: []xdr.LedgerEntry{
-				{
-					LastModifiedLedgerSeq: 123,
-					Data: xdr.LedgerEntryData{
-						Type: xdr.LedgerEntryTypeContractData,
-						ContractData: &xdr.ContractDataEntry{
-							Contract: contractAddress,
-							Key: xdr.ScVal{
-								Type: xdr.ScValTypeScvSymbol,
-								Sym:  &persistentKey,
-							},
-							Durability: xdr.ContractDataDurabilityTemporary,
-						},
-					},
-				},
-			},
 		},
 	}
 	mock.On("GetLedger", ctx, seq).Return(ledger, nil).Once()
@@ -579,15 +563,6 @@ func TestLedgerChangeLedgerCloseMetaV2(t *testing.T) {
 		isBalance(metaAddress, 700),
 		isBalance(metaAddress, 800),
 		isBalance(metaAddress, 900),
-
-		// Evictions
-		isContractDataEviction(
-			contractAddress,
-			xdr.ScVal{
-				Type: xdr.ScValTypeScvSymbol,
-				Sym:  &persistentKey,
-			},
-		),
 
 		// Upgrades last
 		isBalance(upgradeAddress, 2),
@@ -781,22 +756,6 @@ func TestLedgerChangeLedgerCloseMetaV2ParallelPhases(t *testing.T) {
 					},
 				},
 			},
-			EvictedPersistentLedgerEntries: []xdr.LedgerEntry{
-				{
-					LastModifiedLedgerSeq: 123,
-					Data: xdr.LedgerEntryData{
-						Type: xdr.LedgerEntryTypeContractData,
-						ContractData: &xdr.ContractDataEntry{
-							Contract: contractAddress,
-							Key: xdr.ScVal{
-								Type: xdr.ScValTypeScvSymbol,
-								Sym:  &persistentKey,
-							},
-							Durability: xdr.ContractDataDurabilityTemporary,
-						},
-					},
-				},
-			},
 		},
 	}
 	mock.On("GetLedger", ctx, seq).Return(ledger, nil).Once()
@@ -824,15 +783,6 @@ func TestLedgerChangeLedgerCloseMetaV2ParallelPhases(t *testing.T) {
 		isBalance(metaAddress, 700),
 		isBalance(metaAddress, 800),
 		isBalance(metaAddress, 900),
-
-		// Evictions
-		isContractDataEviction(
-			contractAddress,
-			xdr.ScVal{
-				Type: xdr.ScValTypeScvSymbol,
-				Sym:  &persistentKey,
-			},
-		),
 
 		// Upgrades last
 		isBalance(upgradeAddress, 2),

--- a/ingest/ledger_transaction.go
+++ b/ingest/ledger_transaction.go
@@ -39,7 +39,7 @@ func (t *LedgerTransaction) GetFeeChanges() []Change {
 	for i := range changes {
 		changes[i].Reason = LedgerEntryChangeReasonFee
 		changes[i].Transaction = t
-		changes[i].Ledger = t.Ledger
+		changes[i].Ledger = &t.Ledger
 	}
 	return changes
 }
@@ -49,7 +49,7 @@ func (t *LedgerTransaction) getTransactionChanges(ledgerEntryChanges xdr.LedgerE
 	for i := range changes {
 		changes[i].Reason = LedgerEntryChangeReasonTransaction
 		changes[i].Transaction = t
-		changes[i].Ledger = t.Ledger
+		changes[i].Ledger = &t.Ledger
 	}
 	return changes
 }
@@ -182,7 +182,7 @@ func (t *LedgerTransaction) operationChanges(ops []xdr.OperationMeta, index uint
 		changes[i].Reason = LedgerEntryChangeReasonOperation
 		changes[i].Transaction = t
 		changes[i].OperationIndex = index
-		changes[i].Ledger = t.Ledger
+		changes[i].Ledger = &t.Ledger
 	}
 	return changes
 }

--- a/ingest/ledger_transaction.go
+++ b/ingest/ledger_transaction.go
@@ -39,6 +39,7 @@ func (t *LedgerTransaction) GetFeeChanges() []Change {
 	for i := range changes {
 		changes[i].Reason = LedgerEntryChangeReasonFee
 		changes[i].Transaction = t
+		changes[i].Ledger = t.Ledger
 	}
 	return changes
 }
@@ -48,6 +49,7 @@ func (t *LedgerTransaction) getTransactionChanges(ledgerEntryChanges xdr.LedgerE
 	for i := range changes {
 		changes[i].Reason = LedgerEntryChangeReasonTransaction
 		changes[i].Transaction = t
+		changes[i].Ledger = t.Ledger
 	}
 	return changes
 }
@@ -180,6 +182,7 @@ func (t *LedgerTransaction) operationChanges(ops []xdr.OperationMeta, index uint
 		changes[i].Reason = LedgerEntryChangeReasonOperation
 		changes[i].Transaction = t
 		changes[i].OperationIndex = index
+		changes[i].Ledger = t.Ledger
 	}
 	return changes
 }

--- a/ingest/stats_change_processor.go
+++ b/ingest/stats_change_processor.go
@@ -57,6 +57,8 @@ type StatsChangeProcessorResults struct {
 	TtlUpdated  int64
 	TtlRemoved  int64
 	TtlRestored int64
+
+	LedgerEntriesEvicted int64
 }
 
 func (p *StatsChangeProcessor) ProcessChange(ctx context.Context, change Change) error {
@@ -194,6 +196,10 @@ func (p *StatsChangeProcessor) ProcessChange(ctx context.Context, change Change)
 	return nil
 }
 
+func (p *StatsChangeProcessor) ProcessEvictions(evictions []xdr.LedgerKey) {
+	p.results.LedgerEntriesEvicted += int64(len(evictions))
+}
+
 func (p *StatsChangeProcessor) GetResults() StatsChangeProcessorResults {
 	return p.results
 }
@@ -242,5 +248,7 @@ func (stats *StatsChangeProcessorResults) Map() map[string]interface{} {
 		"stats_ttl_updated":  stats.TtlUpdated,
 		"stats_ttl_removed":  stats.TtlRemoved,
 		"stats_ttl_restored": stats.TtlRestored,
+
+		"stats_ledger_entries_evicted": stats.LedgerEntriesEvicted,
 	}
 }

--- a/ingest/stats_change_processor_test.go
+++ b/ingest/stats_change_processor_test.go
@@ -56,7 +56,7 @@ func TestStatsChangeProcessor(t *testing.T) {
 		}
 	}
 
-	processor.ProcessEvictions([]xdr.LedgerKey{xdr.LedgerKey{}})
+	processor.ProcessEvictions([]xdr.LedgerKey{{}})
 
 	results := processor.GetResults()
 

--- a/ingest/stats_change_processor_test.go
+++ b/ingest/stats_change_processor_test.go
@@ -56,6 +56,8 @@ func TestStatsChangeProcessor(t *testing.T) {
 		}
 	}
 
+	processor.ProcessEvictions([]xdr.LedgerKey{xdr.LedgerKey{}})
+
 	results := processor.GetResults()
 
 	assert.Equal(t, int64(1), results.AccountsCreated)
@@ -95,6 +97,9 @@ func TestStatsChangeProcessor(t *testing.T) {
 	assert.Equal(t, int64(1), results.ContractDataRestored)
 	assert.Equal(t, int64(1), results.TtlRestored)
 
+	assert.Equal(t, int64(1), results.LedgerEntriesEvicted)
+
 	// "+3" for the three entry types (Ttl, Contract Code, and Contract Data) that will have a "restored" change type.
-	assert.Equal(t, len(xdr.LedgerEntryTypeMap)*3+3, len(results.Map()))
+	// "+1" for the ledger entries evicted stat
+	assert.Equal(t, len(xdr.LedgerEntryTypeMap)*3+3+1, len(results.Map()))
 }

--- a/services/horizon/internal/ingest/processor_runner.go
+++ b/services/horizon/internal/ingest/processor_runner.go
@@ -114,7 +114,9 @@ func buildChangeProcessor(
 	source ingestionSource,
 	ledgerSequence uint32,
 	networkPassphrase string,
+	evictedLedgerKeys []xdr.LedgerKey,
 ) *groupChangeProcessors {
+	changeStats.ProcessEvictions(evictedLedgerKeys)
 	statsChangeProcessor := &statsChangeProcessor{
 		StatsChangeProcessor: changeStats,
 	}
@@ -124,7 +126,13 @@ func buildChangeProcessor(
 		processors.NewAccountDataProcessor(historyQ),
 		processors.NewAccountsProcessor(historyQ),
 		processors.NewOffersProcessor(historyQ, ledgerSequence),
-		processors.NewAssetStatsProcessor(historyQ, networkPassphrase, source == historyArchiveSource, ledgerSequence),
+		processors.NewAssetStatsProcessor(
+			historyQ,
+			networkPassphrase,
+			source == historyArchiveSource,
+			ledgerSequence,
+			evictedLedgerKeys,
+		),
 		processors.NewSignersProcessor(historyQ),
 		processors.NewTrustLinesProcessor(historyQ),
 		processors.NewClaimableBalancesChangeProcessor(historyQ),
@@ -204,6 +212,7 @@ func (s *ProcessorRunner) RunHistoryArchiveIngestion(
 		historyArchiveSource,
 		checkpointLedger,
 		s.config.NetworkPassphrase,
+		[]xdr.LedgerKey{},
 	)
 
 	if err := registerChangeProcessors(
@@ -588,12 +597,17 @@ func (s *ProcessorRunner) RunAllProcessorsOnLedger(ledger xdr.LedgerCloseMeta) (
 		return
 	}
 
+	var evictedLedgerKeys []xdr.LedgerKey
+	if evictedLedgerKeys, err = ledger.EvictedLedgerKeys(); err != nil {
+		err = errors.Wrap(err, "Error getting evicted ledger keys")
+	}
 	groupChangeProcessors := buildChangeProcessor(
 		s.historyQ,
 		&changeStatsProcessor,
 		ledgerSource,
 		ledger.LedgerSequence(),
 		s.config.NetworkPassphrase,
+		evictedLedgerKeys,
 	)
 
 	registry := nameRegistry{}

--- a/services/horizon/internal/ingest/processor_runner.go
+++ b/services/horizon/internal/ingest/processor_runner.go
@@ -600,6 +600,7 @@ func (s *ProcessorRunner) RunAllProcessorsOnLedger(ledger xdr.LedgerCloseMeta) (
 	var evictedLedgerKeys []xdr.LedgerKey
 	if evictedLedgerKeys, err = ledger.EvictedLedgerKeys(); err != nil {
 		err = errors.Wrap(err, "Error getting evicted ledger keys")
+		return
 	}
 	groupChangeProcessors := buildChangeProcessor(
 		s.historyQ,

--- a/services/horizon/internal/ingest/processor_runner_test.go
+++ b/services/horizon/internal/ingest/processor_runner_test.go
@@ -152,7 +152,7 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 	}
 
 	stats := &ingest.StatsChangeProcessor{}
-	processor := buildChangeProcessor(runner.historyQ, stats, ledgerSource, 123, "")
+	processor := buildChangeProcessor(runner.historyQ, stats, ledgerSource, 123, "", nil)
 	assert.IsType(t, &groupChangeProcessors{}, processor)
 
 	assert.IsType(t, &statsChangeProcessor{}, processor.processors[0])
@@ -171,7 +171,7 @@ func TestProcessorRunnerBuildChangeProcessor(t *testing.T) {
 		filters:  &MockFilters{},
 	}
 
-	processor = buildChangeProcessor(runner.historyQ, stats, historyArchiveSource, 456, "")
+	processor = buildChangeProcessor(runner.historyQ, stats, historyArchiveSource, 456, "", nil)
 	assert.IsType(t, &groupChangeProcessors{}, processor)
 
 	assert.IsType(t, &statsChangeProcessor{}, processor.processors[0])

--- a/services/horizon/internal/ingest/processors/asset_stats_processor.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"encoding/hex"
+	pkgerrors "errors"
 	"fmt"
 	"math/big"
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/support/collections/set"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/xdr"
 )
@@ -23,6 +25,9 @@ type AssetStatsProcessor struct {
 	updatedExpirationEntries map[xdr.Hash][2]uint32
 	ingestFromHistoryArchive bool
 	networkPassphrase        string
+	// evictedAssetContractCandidates is a list of evicted contracts
+	// that are possibly SACs
+	possibleEvictedAssetContracts set.Set[xdr.Hash]
 }
 
 // NewAssetStatsProcessor constructs a new AssetStatsProcessor instance.
@@ -31,19 +36,39 @@ func NewAssetStatsProcessor(
 	networkPassphrase string,
 	ingestFromHistoryArchive bool,
 	currentLedger uint32,
+	evictedLedgerKeys []xdr.LedgerKey,
 ) *AssetStatsProcessor {
 	p := &AssetStatsProcessor{
-		currentLedger:            currentLedger,
-		assetStatsQ:              assetStatsQ,
-		ingestFromHistoryArchive: ingestFromHistoryArchive,
-		networkPassphrase:        networkPassphrase,
-		assetStatSet:             NewAssetStatSet(),
-		contractDataChanges:      []ingest.Change{},
-		removedExpirationEntries: map[xdr.Hash]uint32{},
-		createdExpirationEntries: map[xdr.Hash]uint32{},
-		updatedExpirationEntries: map[xdr.Hash][2]uint32{},
+		currentLedger:                 currentLedger,
+		assetStatsQ:                   assetStatsQ,
+		ingestFromHistoryArchive:      ingestFromHistoryArchive,
+		networkPassphrase:             networkPassphrase,
+		assetStatSet:                  NewAssetStatSet(),
+		contractDataChanges:           []ingest.Change{},
+		removedExpirationEntries:      map[xdr.Hash]uint32{},
+		createdExpirationEntries:      map[xdr.Hash]uint32{},
+		updatedExpirationEntries:      map[xdr.Hash][2]uint32{},
+		possibleEvictedAssetContracts: findAssetContractCandidates(evictedLedgerKeys),
 	}
 	return p
+}
+
+func findAssetContractCandidates(evictedLedgerKeys []xdr.LedgerKey) set.Set[xdr.Hash] {
+	candidates := set.Set[xdr.Hash]{}
+	for _, key := range evictedLedgerKeys {
+		contractData, ok := key.GetContractData()
+		if !ok ||
+			contractData.Durability != xdr.ContractDataDurabilityPersistent ||
+			contractData.Key.Type != xdr.ScValTypeScvLedgerKeyContractInstance {
+			continue
+		}
+		contractID, ok := contractData.Contract.GetContractId()
+		if !ok {
+			continue
+		}
+		candidates.Add(contractID)
+	}
+	return candidates
 }
 
 func (p *AssetStatsProcessor) Name() string {
@@ -74,17 +99,9 @@ func (p *AssetStatsProcessor) ProcessChange(ctx context.Context, change ingest.C
 		if ledgerEntry == nil {
 			ledgerEntry = change.Pre
 		}
-		asset := AssetFromContractData(*ledgerEntry, p.networkPassphrase)
+		_, assetFound := AssetFromContractData(*ledgerEntry, p.networkPassphrase)
 		_, _, balanceFound := ContractBalanceFromContractData(*ledgerEntry, p.networkPassphrase)
-		if asset == nil && !balanceFound {
-			return nil
-		}
-		// We don't need to handle evictions for contract balances because we immediately delete
-		// contract balances upon expiration. So by the time an archived ledger entry is evicted
-		// it will already be deleted from the horizon DB.
-		// However, we do handle evictions if the asset contract itself is evicted. In that
-		// scenario we will omit contract asset stats for that asset in the /assets response.
-		if change.Reason == ingest.LedgerEntryChangeReasonEviction && asset == nil {
+		if !assetFound && !balanceFound {
 			return nil
 		}
 		p.contractDataChanges = append(p.contractDataChanges, change)
@@ -174,7 +191,6 @@ func (p *AssetStatsProcessor) addExpirationChange(change ingest.Change) error {
 }
 
 func (p *AssetStatsProcessor) Commit(ctx context.Context) error {
-
 	contractAssetStatSet := NewContractAssetStatSet(
 		p.assetStatsQ,
 		p.networkPassphrase,
@@ -184,7 +200,7 @@ func (p *AssetStatsProcessor) Commit(ctx context.Context) error {
 		p.currentLedger,
 	)
 	for _, change := range p.contractDataChanges {
-		if err := contractAssetStatSet.AddContractData(ctx, change); err != nil {
+		if err := contractAssetStatSet.AddContractData(change); err != nil {
 			return errors.Wrap(err, "Error ingesting contract data")
 		}
 	}
@@ -292,7 +308,7 @@ func (p *AssetStatsProcessor) updateContractAssetBalanceExpirations(ctx context.
 func IncludeContractIDsInAssetStats(
 	networkPassphrase string,
 	assetStatsDeltas []history.ExpAssetStat,
-	contractToAsset map[xdr.Hash]*xdr.Asset,
+	contractToAsset map[xdr.Hash]xdr.Asset,
 ) ([]history.ExpAssetStat, error) {
 	included := map[xdr.Hash]bool{}
 	// modify the asset stat row to update the contract_id column whenever we encounter a
@@ -304,12 +320,7 @@ func IncludeContractIDsInAssetStats(
 		if err != nil {
 			return nil, errors.Wrap(err, "cannot compute contract id for asset")
 		}
-		if asset, ok := contractToAsset[contractID]; ok && asset == nil {
-			return nil, ingest.NewStateError(fmt.Errorf(
-				"unexpected contract data removal in history archives: %s",
-				hex.EncodeToString(contractID[:]),
-			))
-		} else if ok {
+		if _, ok := contractToAsset[contractID]; ok {
 			assetStatDelta.SetContractID(contractID)
 			included[contractID] = true
 		}
@@ -324,12 +335,6 @@ func IncludeContractIDsInAssetStats(
 	for contractID, asset := range contractToAsset {
 		if included[contractID] {
 			continue
-		}
-		if asset == nil {
-			return nil, ingest.NewStateError(fmt.Errorf(
-				"unexpected contract data removal in history archives: %s",
-				hex.EncodeToString(contractID[:]),
-			))
 		}
 		var assetType xdr.AssetType
 		var assetCode, assetIssuer string
@@ -351,7 +356,7 @@ func IncludeContractIDsInAssetStats(
 func (p *AssetStatsProcessor) updateAssetStats(
 	ctx context.Context,
 	assetStatsDeltas []history.ExpAssetStat,
-	contractToAsset map[xdr.Hash]*xdr.Asset,
+	contractToAsset map[xdr.Hash]xdr.Asset,
 ) error {
 	for _, delta := range assetStatsDeltas {
 		var rowsAffected int64
@@ -378,7 +383,18 @@ func (p *AssetStatsProcessor) updateAssetStats(
 			delta.ContractID = stat.ContractID
 		}
 
-		if asset, ok := contractToAsset[contractID]; ok && asset == nil {
+		if asset, ok := contractToAsset[contractID]; ok {
+			if assetStatFound && stat.ContractID != nil {
+				return ingest.NewStateError(errors.Errorf(
+					"attempting to set contract id %s but row %s already has contract id set: %s",
+					hex.EncodeToString(contractID[:]),
+					asset.String(),
+					hex.EncodeToString((*stat.ContractID)[:]),
+				))
+			}
+			delta.SetContractID(contractID)
+			delete(contractToAsset, contractID)
+		} else if p.possibleEvictedAssetContracts.Contains(contractID) {
 			if assetStatFound && stat.ContractID == nil {
 				return ingest.NewStateError(errors.Errorf(
 					"row has no contract id to remove %s: %s %s %s",
@@ -389,18 +405,8 @@ func (p *AssetStatsProcessor) updateAssetStats(
 				))
 			}
 			delta.ContractID = nil
-		} else if ok {
-			if assetStatFound && stat.ContractID != nil {
-				return ingest.NewStateError(errors.Errorf(
-					"attempting to set contract id %s but row %s already has contract id set: %s",
-					hex.EncodeToString(contractID[:]),
-					asset.String(),
-					hex.EncodeToString((*stat.ContractID)[:]),
-				))
-			}
-			delta.SetContractID(contractID)
+			p.possibleEvictedAssetContracts.Remove(contractID)
 		}
-		delete(contractToAsset, contractID)
 
 		if assetStatNotFound {
 			// Safety checks
@@ -512,98 +518,66 @@ func (p *AssetStatsProcessor) updateAssetStats(
 
 func (p *AssetStatsProcessor) updateContractIDs(
 	ctx context.Context,
-	contractToAsset map[xdr.Hash]*xdr.Asset,
+	contractToAsset map[xdr.Hash]xdr.Asset,
 ) error {
 	for contractID, asset := range contractToAsset {
-		if err := p.updateContractID(ctx, contractID, asset); err != nil {
+		if err := p.setContractID(ctx, contractID, asset); err != nil {
+			return err
+		}
+	}
+
+	for contractID := range p.possibleEvictedAssetContracts {
+		if err := p.removeContractID(ctx, contractID); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// updateContractID will update the asset stat row for the corresponding asset to either
-// add or remove the given contract id
-func (p *AssetStatsProcessor) updateContractID(
+// setContractID will update the asset stat row for the corresponding asset to assign
+// the given contract id
+func (p *AssetStatsProcessor) setContractID(
 	ctx context.Context,
 	contractID xdr.Hash,
-	asset *xdr.Asset,
+	asset xdr.Asset,
 ) error {
 	var rowsAffected int64
-	// asset is nil so we need to set the contract_id column to NULL
-	if asset == nil {
-		stat, err := p.assetStatsQ.GetAssetStatByContract(ctx, contractID)
-		if err == sql.ErrNoRows {
-			return ingest.NewStateError(errors.Errorf(
-				"row for asset with contract %s is missing",
-				hex.EncodeToString(contractID[:]),
-			))
+
+	var assetType xdr.AssetType
+	var assetCode, assetIssuer string
+	asset.MustExtract(&assetType, &assetCode, &assetIssuer)
+	stat, err := p.assetStatsQ.GetAssetStat(ctx, assetType, assetCode, assetIssuer)
+	if pkgerrors.Is(err, sql.ErrNoRows) {
+		// there is no asset stat for the given asset so we need to create a new row
+		row := history.ExpAssetStat{
+			AssetType:   assetType,
+			AssetCode:   assetCode,
+			AssetIssuer: assetIssuer,
+			Accounts:    history.ExpAssetStatAccounts{},
+			Balances:    newAssetStatBalance().ConvertToHistoryObject(),
 		}
+		row.SetContractID(contractID)
+
+		rowsAffected, err = p.assetStatsQ.InsertAssetStat(ctx, row)
 		if err != nil {
-			return errors.Wrap(err, "error querying asset by contract id")
+			return errors.Wrap(err, "could not insert asset stat")
 		}
-
-		if stat.Accounts.IsZero() {
-			if !stat.Balances.IsZero() {
-				return ingest.NewStateError(errors.Errorf(
-					"asset stat has 0 holders but non zero balance: %s",
-					hex.EncodeToString(contractID[:]),
-				))
-			}
-			// the asset stat is empty so we can remove the row entirely
-			rowsAffected, err = p.assetStatsQ.RemoveAssetStat(ctx,
-				stat.AssetType,
-				stat.AssetCode,
-				stat.AssetIssuer,
-			)
-			if err != nil {
-				return errors.Wrap(err, "could not remove asset stat")
-			}
-		} else {
-			// update the row to set the contract_id column to NULL
-			stat.ContractID = nil
-			rowsAffected, err = p.assetStatsQ.UpdateAssetStat(ctx, stat)
-			if err != nil {
-				return errors.Wrap(err, "could not update asset stat")
-			}
-		}
-	} else { // asset is non nil, so we need to populate the contract_id column
-		var assetType xdr.AssetType
-		var assetCode, assetIssuer string
-		asset.MustExtract(&assetType, &assetCode, &assetIssuer)
-		stat, err := p.assetStatsQ.GetAssetStat(ctx, assetType, assetCode, assetIssuer)
-		if err == sql.ErrNoRows {
-			// there is no asset stat for the given asset so we need to create a new row
-			row := history.ExpAssetStat{
-				AssetType:   assetType,
-				AssetCode:   assetCode,
-				AssetIssuer: assetIssuer,
-				Accounts:    history.ExpAssetStatAccounts{},
-				Balances:    newAssetStatBalance().ConvertToHistoryObject(),
-			}
-			row.SetContractID(contractID)
-
-			rowsAffected, err = p.assetStatsQ.InsertAssetStat(ctx, row)
-			if err != nil {
-				return errors.Wrap(err, "could not insert asset stat")
-			}
-		} else if err != nil {
-			return errors.Wrap(err, "error querying asset by asset code and issuer")
-		} else if dbContractID, ok := stat.GetContractID(); ok {
-			// the asset stat already has a column_id set which is unexpected (the column should be NULL)
-			return ingest.NewStateError(errors.Errorf(
-				"attempting to set contract id %s but row %s already has contract id set: %s",
-				hex.EncodeToString(contractID[:]),
-				asset.String(),
-				hex.EncodeToString(dbContractID[:]),
-			))
-		} else {
-			// update the column_id column
-			stat.SetContractID(contractID)
-			rowsAffected, err = p.assetStatsQ.UpdateAssetStat(ctx, stat)
-			if err != nil {
-				return errors.Wrap(err, "could not update asset stat")
-			}
+	} else if err != nil {
+		return errors.Wrap(err, "error querying asset by asset code and issuer")
+	} else if dbContractID, ok := stat.GetContractID(); ok {
+		// the asset stat already has a column_id set which is unexpected (the column should be NULL)
+		return ingest.NewStateError(errors.Errorf(
+			"attempting to set contract id %s but row %s already has contract id set: %s",
+			hex.EncodeToString(contractID[:]),
+			asset.String(),
+			hex.EncodeToString(dbContractID[:]),
+		))
+	} else {
+		// update the column_id column
+		stat.SetContractID(contractID)
+		rowsAffected, err = p.assetStatsQ.UpdateAssetStat(ctx, stat)
+		if err != nil {
+			return errors.Wrap(err, "could not update asset stat")
 		}
 	}
 
@@ -613,6 +587,60 @@ func (p *AssetStatsProcessor) updateContractID(
 			"%d rows affected (expected exactly 1) when adjusting asset stat for asset: %s",
 			rowsAffected,
 			asset.String(),
+		))
+	}
+	return nil
+}
+
+// removeContractID will update the asset stat row for the corresponding asset to
+// remove the given contract id
+func (p *AssetStatsProcessor) removeContractID(
+	ctx context.Context,
+	contractID xdr.Hash,
+) error {
+	var rowsAffected int64
+	stat, err := p.assetStatsQ.GetAssetStatByContract(ctx, contractID)
+	if pkgerrors.Is(err, sql.ErrNoRows) {
+		// we cannot know for sure if the contract id belongs to a legitimate SAC
+		// so we will assume that if the row is not found then the evicted contract
+		// does not belong to a SAC
+		return nil
+	}
+	if err != nil {
+		return errors.Wrap(err, "error querying asset by contract id")
+	}
+
+	if stat.Accounts.IsZero() {
+		if !stat.Balances.IsZero() {
+			return ingest.NewStateError(errors.Errorf(
+				"asset stat has 0 holders but non zero balance: %s",
+				hex.EncodeToString(contractID[:]),
+			))
+		}
+		// the asset stat is empty so we can remove the row entirely
+		rowsAffected, err = p.assetStatsQ.RemoveAssetStat(ctx,
+			stat.AssetType,
+			stat.AssetCode,
+			stat.AssetIssuer,
+		)
+		if err != nil {
+			return errors.Wrap(err, "could not remove asset stat")
+		}
+	} else {
+		// update the row to set the contract_id column to NULL
+		stat.ContractID = nil
+		rowsAffected, err = p.assetStatsQ.UpdateAssetStat(ctx, stat)
+		if err != nil {
+			return errors.Wrap(err, "could not update asset stat")
+		}
+	}
+
+	if rowsAffected != 1 {
+		// assert that we have updated exactly one row
+		return ingest.NewStateError(errors.Errorf(
+			"%d rows affected (expected exactly 1) when adjusting asset stat for asset: %s",
+			rowsAffected,
+			fmt.Sprintf("%s %s %s", stat.AssetType, stat.AssetCode, stat.AssetIssuer),
 		))
 	}
 	return nil

--- a/services/horizon/internal/ingest/processors/asset_stats_processor.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor.go
@@ -25,7 +25,7 @@ type AssetStatsProcessor struct {
 	updatedExpirationEntries map[xdr.Hash][2]uint32
 	ingestFromHistoryArchive bool
 	networkPassphrase        string
-	// evictedAssetContractCandidates is a list of evicted contracts
+	// possibleEvictedAssetContracts is a list of evicted contracts
 	// that are possibly SACs
 	possibleEvictedAssetContracts set.Set[xdr.Hash]
 }

--- a/services/horizon/internal/ingest/processors/asset_stats_processor.go
+++ b/services/horizon/internal/ingest/processors/asset_stats_processor.go
@@ -48,12 +48,12 @@ func NewAssetStatsProcessor(
 		removedExpirationEntries:      map[xdr.Hash]uint32{},
 		createdExpirationEntries:      map[xdr.Hash]uint32{},
 		updatedExpirationEntries:      map[xdr.Hash][2]uint32{},
-		possibleEvictedAssetContracts: findAssetContractCandidates(evictedLedgerKeys),
+		possibleEvictedAssetContracts: findEvictedAssetContractCandidates(evictedLedgerKeys),
 	}
 	return p
 }
 
-func findAssetContractCandidates(evictedLedgerKeys []xdr.LedgerKey) set.Set[xdr.Hash] {
+func findEvictedAssetContractCandidates(evictedLedgerKeys []xdr.LedgerKey) set.Set[xdr.Hash] {
 	candidates := set.Set[xdr.Hash]{}
 	for _, key := range evictedLedgerKeys {
 		contractData, ok := key.GetContractData()

--- a/services/horizon/internal/ingest/processors/contract_asset_stats_test.go
+++ b/services/horizon/internal/ingest/processors/contract_asset_stats_test.go
@@ -46,7 +46,7 @@ func TestAddContractData(t *testing.T) {
 
 	xlmContractData, err := AssetToContractData(true, "", "", xlmID)
 	assert.NoError(t, err)
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Post: &xdr.LedgerEntry{
 			Data: xlmContractData,
@@ -57,7 +57,7 @@ func TestAddContractData(t *testing.T) {
 	xlmBalanceKeyHash := getKeyHashForBalance(t, xlmID, [32]byte{})
 	assert.NoError(t, err)
 	set.createdExpirationEntries[xlmBalanceKeyHash] = 150
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Post: &xdr.LedgerEntry{
 			Data: BalanceToContractData(xlmID, [32]byte{}, 100),
@@ -67,7 +67,7 @@ func TestAddContractData(t *testing.T) {
 
 	uniBalanceKeyHash := getKeyHashForBalance(t, uniID, [32]byte{})
 	set.createdExpirationEntries[uniBalanceKeyHash] = 150
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Post: &xdr.LedgerEntry{
 			Data: BalanceToContractData(uniID, [32]byte{}, 0),
@@ -77,7 +77,7 @@ func TestAddContractData(t *testing.T) {
 
 	usdcContractData, err := AssetToContractData(false, "USDC", usdcIssuer, usdcID)
 	assert.NoError(t, err)
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Post: &xdr.LedgerEntry{
 			Data: usdcContractData,
@@ -87,7 +87,7 @@ func TestAddContractData(t *testing.T) {
 
 	etherContractData, err := AssetToContractData(false, "ETHER", etherIssuer, etherID)
 	assert.NoError(t, err)
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Post: &xdr.LedgerEntry{
 			Data: etherContractData,
@@ -97,7 +97,7 @@ func TestAddContractData(t *testing.T) {
 
 	etherBalanceKeyHash := getKeyHashForBalance(t, etherID, [32]byte{})
 	set.createdExpirationEntries[etherBalanceKeyHash] = 100
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Post: &xdr.LedgerEntry{
 			Data: BalanceToContractData(etherID, [32]byte{}, 50),
@@ -107,7 +107,7 @@ func TestAddContractData(t *testing.T) {
 
 	otherEtherBalanceKeyHash := getKeyHashForBalance(t, etherID, [32]byte{1})
 	set.createdExpirationEntries[otherEtherBalanceKeyHash] = 150
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Post: &xdr.LedgerEntry{
 			Data: BalanceToContractData(etherID, [32]byte{1}, 150),
@@ -116,7 +116,7 @@ func TestAddContractData(t *testing.T) {
 	assert.NoError(t, err)
 
 	// negative balances will be ignored
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Post: &xdr.LedgerEntry{
 			Data: balanceToContractData(etherID, [32]byte{1}, xdr.Int128Parts{Hi: -1, Lo: 0}),
@@ -128,7 +128,7 @@ func TestAddContractData(t *testing.T) {
 	btcID, err := btcAsset.ContractID("passphrase")
 	assert.NoError(t, err)
 
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Post: &xdr.LedgerEntry{
 			Data: BalanceToContractData(btcID, [32]byte{2}, 300),
@@ -203,7 +203,7 @@ func TestUpdateContractBalance(t *testing.T) {
 	keyHash := getKeyHashForBalance(t, usdcID, [32]byte{})
 	set.updatedExpirationEntries[keyHash] = [2]uint32{160, 170}
 	expectedBalances[keyHash] = "100"
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Pre: &xdr.LedgerEntry{
 			Data: BalanceToContractData(usdcID, [32]byte{}, 50),
@@ -216,7 +216,7 @@ func TestUpdateContractBalance(t *testing.T) {
 
 	keyHash = getKeyHashForBalance(t, usdcID, [32]byte{2})
 	expectedBalances[keyHash] = "100"
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Pre: &xdr.LedgerEntry{
 			Data: BalanceToContractData(usdcID, [32]byte{2}, 30),
@@ -229,7 +229,7 @@ func TestUpdateContractBalance(t *testing.T) {
 
 	keyHash = getKeyHashForBalance(t, etherID, [32]byte{})
 	expectedBalances[keyHash] = "50"
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Pre: &xdr.LedgerEntry{
 			Data: BalanceToContractData(etherID, [32]byte{}, 200),
@@ -241,7 +241,7 @@ func TestUpdateContractBalance(t *testing.T) {
 	assert.NoError(t, err)
 
 	// negative balances will be ignored
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Pre: &xdr.LedgerEntry{
 			Data: BalanceToContractData(etherID, [32]byte{}, 200),
@@ -253,7 +253,7 @@ func TestUpdateContractBalance(t *testing.T) {
 	assert.NoError(t, err)
 
 	// negative balances will be ignored
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Pre: &xdr.LedgerEntry{
 			Data: balanceToContractData(etherID, [32]byte{1}, xdr.Int128Parts{Hi: -1, Lo: 0}),
@@ -265,7 +265,7 @@ func TestUpdateContractBalance(t *testing.T) {
 	assert.NoError(t, err)
 
 	// balances where the amount doesn't change will be ignored
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Pre: &xdr.LedgerEntry{
 			Data: BalanceToContractData(btcID, [32]byte{2}, 300),
@@ -279,7 +279,7 @@ func TestUpdateContractBalance(t *testing.T) {
 	keyHash = getKeyHashForBalance(t, uniID, [32]byte{4})
 	set.updatedExpirationEntries[keyHash] = [2]uint32{150, 170}
 	expectedBalances[keyHash] = "75"
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Pre: &xdr.LedgerEntry{
 			Data: BalanceToContractData(uniID, [32]byte{4}, 50),
@@ -342,19 +342,9 @@ func TestRemoveContractData(t *testing.T) {
 		150,
 	)
 
-	usdcContractData, err := AssetToContractData(false, "USDC", usdcIssuer, usdcID)
-	assert.NoError(t, err)
-	err = set.AddContractData(context.Background(), ingest.Change{
-		Type: xdr.LedgerEntryTypeContractData,
-		Pre: &xdr.LedgerEntry{
-			Data: usdcContractData,
-		},
-	})
-	assert.NoError(t, err)
-
 	keyHash := getKeyHashForBalance(t, usdcID, [32]byte{})
 	set.removedExpirationEntries[keyHash] = 170
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Pre: &xdr.LedgerEntry{
 			Data: BalanceToContractData(usdcID, [32]byte{}, 50),
@@ -364,7 +354,7 @@ func TestRemoveContractData(t *testing.T) {
 
 	keyHash1 := getKeyHashForBalance(t, usdcID, [32]byte{1})
 	set.removedExpirationEntries[keyHash1] = 100
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Pre: &xdr.LedgerEntry{
 			Data: BalanceToContractData(usdcID, [32]byte{1}, 20),
@@ -373,7 +363,7 @@ func TestRemoveContractData(t *testing.T) {
 	assert.NoError(t, err)
 
 	keyHash2 := getKeyHashForBalance(t, usdcID, [32]byte{2})
-	err = set.AddContractData(context.Background(), ingest.Change{
+	err = set.AddContractData(ingest.Change{
 		Type: xdr.LedgerEntryTypeContractData,
 		Pre: &xdr.LedgerEntry{
 			Data: BalanceToContractData(usdcID, [32]byte{2}, 34),
@@ -382,10 +372,7 @@ func TestRemoveContractData(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, []xdr.Hash{keyHash, keyHash1, keyHash2}, set.removedBalances)
-	assert.Len(t, set.contractToAsset, 1)
-	asset, ok := set.contractToAsset[usdcID]
-	assert.Nil(t, asset)
-	assert.True(t, ok)
+	assert.Empty(t, set.contractToAsset)
 
 	assert.ElementsMatch(t, set.GetContractStats(), []history.ContractAssetStatRow{
 		{

--- a/services/horizon/internal/ingest/verify.go
+++ b/services/horizon/internal/ingest/verify.go
@@ -307,7 +307,7 @@ func (s *system) verifyState(verifyAgainstLatestCheckpoint bool, checkpointSeque
 	)
 	for i := range contractDataEntries {
 		entry := contractDataEntries[i]
-		if err = contractAssetStatSet.AddContractData(ctx, ingest.Change{
+		if err = contractAssetStatSet.AddContractData(ingest.Change{
 			Type: xdr.LedgerEntryTypeContractData,
 			Post: &entry,
 		}); err != nil {
@@ -443,15 +443,6 @@ func checkAssetStats(
 
 			if contractID, ok := assetStat.GetContractID(); ok {
 				asset := contractToAsset[contractID]
-				if asset == nil {
-					return ingest.NewStateError(
-						fmt.Errorf(
-							"asset %v has contract id %v in db but contract id is not in HAS",
-							key,
-							contractID,
-						),
-					)
-				}
 
 				var assetType xdr.AssetType
 				var code, issuer string

--- a/services/horizon/internal/ingest/verify_test.go
+++ b/services/horizon/internal/ingest/verify_test.go
@@ -294,7 +294,7 @@ func TestTruncateIngestStateTables(t *testing.T) {
 	// insert ledger entries of all types into the DB
 	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 	checkpointLedger := uint32(63)
-	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, historyArchiveSource, checkpointLedger, "")
+	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, historyArchiveSource, checkpointLedger, "", nil)
 	for _, change := range ingest.GetChangesFromLedgerEntryChanges(ledgerEntries) {
 		tt.Assert.NoError(changeProcessor.ProcessChange(tt.Ctx, change))
 	}
@@ -306,7 +306,7 @@ func TestTruncateIngestStateTables(t *testing.T) {
 
 	// reinsert the same ledger entries from before
 	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
-	changeProcessor = buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, historyArchiveSource, checkpointLedger, "")
+	changeProcessor = buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, historyArchiveSource, checkpointLedger, "", nil)
 	for _, change := range ingest.GetChangesFromLedgerEntryChanges(ledgerEntries) {
 		tt.Assert.NoError(changeProcessor.ProcessChange(tt.Ctx, change))
 	}
@@ -326,7 +326,7 @@ func TestStateVerifierLockBusy(t *testing.T) {
 	tt.Assert.NoError(q.BeginTx(tt.Ctx, &sql.TxOptions{}))
 
 	checkpointLedger := uint32(63)
-	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, historyArchiveSource, checkpointLedger, "")
+	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, historyArchiveSource, checkpointLedger, "", nil)
 
 	for _, change := range ingest.GetChangesFromLedgerEntryChanges(generateRandomLedgerEntries(tt)) {
 		tt.Assert.NoError(changeProcessor.ProcessChange(tt.Ctx, change))
@@ -372,7 +372,7 @@ func TestStateVerifier(t *testing.T) {
 
 	ledger := rand.Int31()
 	checkpointLedger := uint32(ledger - (ledger % 64) - 1)
-	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, historyArchiveSource, checkpointLedger, "")
+	changeProcessor := buildChangeProcessor(q, &ingest.StatsChangeProcessor{}, historyArchiveSource, checkpointLedger, "", nil)
 	mockChangeReader := &ingest.MockChangeReader{}
 
 	for _, change := range ingest.GetChangesFromLedgerEntryChanges(generateRandomLedgerEntries(tt)) {

--- a/services/horizon/internal/integration/change_test.go
+++ b/services/horizon/internal/integration/change_test.go
@@ -79,7 +79,7 @@ func TestOneTxOneOperationChanges(t *testing.T) {
 	for _, change := range changes {
 		tt.Equal(change.Transaction.Hash.HexString(), txResp.Hash)
 		tt.Equal(change.Transaction.Ledger.LedgerSequence(), ledgerSeq)
-		tt.Empty(change.Ledger)
+		tt.Equal(change.Ledger.LedgerSequence(), ledgerSeq)
 		tt.Empty(change.LedgerUpgrade)
 	}
 

--- a/xdr/ledger_close_meta.go
+++ b/xdr/ledger_close_meta.go
@@ -144,27 +144,14 @@ func (l LedgerCloseMeta) UpgradesProcessing() []UpgradeEntryMeta {
 	}
 }
 
-// EvictedTemporaryLedgerKeys returns a slice of ledger keys for
-// temporary ledger entries that have been evicted in this ledger.
-func (l LedgerCloseMeta) EvictedTemporaryLedgerKeys() ([]LedgerKey, error) {
+// EvictedLedgerKeys returns a slice of ledger keys for entries that have been
+// evicted in this ledger.
+func (l LedgerCloseMeta) EvictedLedgerKeys() ([]LedgerKey, error) {
 	switch l.V {
 	case 0:
 		return nil, nil
 	case 1:
 		return l.MustV1().EvictedTemporaryLedgerKeys, nil
-	default:
-		panic(fmt.Sprintf("Unsupported LedgerCloseMeta.V: %d", l.V))
-	}
-}
-
-// EvictedPersistentLedgerEntries returns the persistent ledger entries
-// which have been evicted in this ledger.
-func (l LedgerCloseMeta) EvictedPersistentLedgerEntries() ([]LedgerEntry, error) {
-	switch l.V {
-	case 0:
-		return nil, nil
-	case 1:
-		return l.MustV1().EvictedPersistentLedgerEntries, nil
 	default:
 		panic(fmt.Sprintf("Unsupported LedgerCloseMeta.V: %d", l.V))
 	}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

[CAP-62](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0062.md#meta) and [CAP-66](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0066.md#xdr-changes) updates the LedgerCloseMeta xdr to no longer populate  the  `evictedPersistentLedgerEntries` field. Instead, both persistent and temporary ledger keys will be included in the `evictedTemporaryLedgerKeys` field which will be renamed to `evictedKeys` in protocol 23.

The ingestion library previously presented evictions of persistent ledger entries as a [`Change`](https://github.com/stellar/go/blob/master/ingest/change.go#L41) instance with the `Reason` set to [`LedgerEntryChangeReasonEviction`](https://github.com/stellar/go/blob/master/ingest/change.go#L96-L97). This allowed downstream consumers of a [`Change`](https://github.com/stellar/go/blob/master/ingest/change.go#L41) stream to handle evictions as if they were equivalent to ledger entry deletions. However, in protocol 23 we can no longer maintain this strategy because the full contents of the evicted ledger entry will not be present in the LedgerCloseMeta xdr. We will only have the ledger key for the evicted ledger entry.

This means that ledger entry evictions will need to be handled outside of [`Change`](https://github.com/stellar/go/blob/master/ingest/change.go#L41) stream processing by downstream services. The second commit of this PR fixes the asset stats processor in Horizon to adapt to this new reality where evictions no longer appear in the [`Change`](https://github.com/stellar/go/blob/master/ingest/change.go#L41) stream.

The asset stats processor can ignore evicted contract balance ledger entries because contract balance ledger entries are deleted from the horizon db immediately upon expiration. However, the asset stats processor still needs to ingest the stellar asset contract instance storage so that we can link stellar classic assets with their corresponding contract id. So when the stellar asset contract instance storage is evicted we also need to handle that event so we can remove the link between stellar classic asset and the stellar asset contract id.

Also fixes https://github.com/stellar/go/issues/5578

### Known limitations

[N/A]
