### PR TITLE
refactor(ingest): use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/ingest/ledgerbackend/captive_core_backend_test.go
+++ b/ingest/ledgerbackend/captive_core_backend_test.go
@@ -138,9 +138,7 @@ type testLedgerHeader struct {
 }
 
 func TestCaptiveNew(t *testing.T) {
-	storagePath, err := os.MkdirTemp("", "captive-core-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(storagePath)
+	storagePath := t.TempDir()
 
 	var userAgent string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -173,9 +171,7 @@ func TestCaptiveNew(t *testing.T) {
 }
 
 func TestCaptiveNewUnsupportedProtocolVersion(t *testing.T) {
-	storagePath, err := os.MkdirTemp("", "captive-core-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(storagePath)
+	storagePath := t.TempDir()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -186,7 +182,7 @@ func TestCaptiveNewUnsupportedProtocolVersion(t *testing.T) {
 	networkPassphrase := network.PublicNetworkPassphrase
 	historyURLs := []string{server.URL}
 
-	_, err = NewCaptive(
+	_, err := NewCaptive(
 		CaptiveCoreConfig{
 			BinaryPath:            executablePath,
 			NetworkPassphrase:     networkPassphrase,
@@ -1022,9 +1018,7 @@ func TestCaptiveGetLedger_NextLedger0RangeFromIsSmallerThanLedgerFromBuffer(t *t
 }
 
 func TestCaptiveStellarCore_PrepareRangeAfterClose(t *testing.T) {
-	storagePath, err := os.MkdirTemp("", "captive-core-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(storagePath)
+	storagePath := t.TempDir()
 
 	ctx := context.Background()
 	executablePath := "/etc/stellar-core"

--- a/ingest/ledgerbackend/file_watcher_test.go
+++ b/ingest/ledgerbackend/file_watcher_test.go
@@ -3,7 +3,6 @@ package ledgerbackend
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -11,7 +10,6 @@ import (
 	"github.com/stellar/go/support/log"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type mockHash struct {
@@ -45,9 +43,7 @@ func (m *mockHash) hashFile(fp string) (hash, error) {
 }
 
 func createFWFixtures(t *testing.T) (*mockHash, *stellarCoreRunner, *fileWatcher) {
-	storagePath, err := os.MkdirTemp("", "captive-core-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(storagePath)
+	storagePath := t.TempDir()
 
 	ms := &mockHash{
 		hashResult:   hash{},
@@ -75,9 +71,7 @@ func createFWFixtures(t *testing.T) (*mockHash, *stellarCoreRunner, *fileWatcher
 }
 
 func TestNewFileWatcherError(t *testing.T) {
-	storagePath, err := os.MkdirTemp("", "captive-core-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(storagePath)
+	storagePath := t.TempDir()
 
 	ms := &mockHash{
 		hashResult:   hash{},


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

`TempDir()` is a method introduced in Go 1.15 for `testing.T`. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup.

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
