### PR TITLE
.github: speedup go/horizon workflow tests by disabling postgres fsync

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -61,11 +61,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       postgres:
-        image: postgres:${{ matrix.pg }}
+        image: "bitnami/postgresql:${{ matrix.pg }}"
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRESQL_USERNAME: postgres
+          POSTGRESQL_DATABASE: postgres
+          POSTGRESQL_PASSWORD: postgres
+          POSTGRESQL_FSYNC: "off"
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,12 +63,13 @@ jobs:
       postgres:
         image: "bitnami/postgresql:${{ matrix.pg }}"
         env:
-          POSTGRESQL_USERNAME: postgres
-          POSTGRESQL_DATABASE: postgres
-          POSTGRESQL_PASSWORD: postgres
-          POSTGRESQL_FSYNC: "off"
+          POSTGRESQL_DATABASE: 'postgres'
+          POSTGRESQL_USERNAME: 'postgres'
+          POSTGRESQL_PASSWORD: 'postgres'
+          POSTGRESQL_POSTGRES_PASSWORD: 'postgres'
+          POSTGRESQL_FSYNC: 'off'
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -d postgres -U postgres -p 5432"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -19,12 +19,13 @@ jobs:
       postgres:
         image: "bitnami/postgresql:${{ matrix.pg }}"
         env:
-          POSTGRESQL_USERNAME: postgres
-          POSTGRESQL_DATABASE: postgres
-          POSTGRESQL_PASSWORD: postgres
-          POSTGRESQL_FSYNC: "off"
+          POSTGRESQL_DATABASE: 'postgres'
+          POSTGRESQL_USERNAME: 'postgres'
+          POSTGRESQL_PASSWORD: 'postgres'
+          POSTGRESQL_POSTGRES_PASSWORD: 'postgres'
+          POSTGRESQL_FSYNC: 'off'
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -d postgres -U postgres -p 5432"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -17,11 +17,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       postgres:
-        image: postgres:${{ matrix.pg }}
+        image: "bitnami/postgresql:${{ matrix.pg }}"
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRESQL_USERNAME: postgres
+          POSTGRESQL_DATABASE: postgres
+          POSTGRESQL_PASSWORD: postgres
+          POSTGRESQL_FSYNC: "off"
         options: >-
           --health-cmd pg_isready
           --health-interval 10s


### PR DESCRIPTION
## What

The CI PostgreSQL shouldn't write to disk, this is accomplished by disabling fsync.

## Why

The official Docker Hub [postgres](https://hub.docker.com/_/postgres) image doesn't expose an easy to use lever for this, [bitnami/postgresql](https://hub.docker.com/r/bitnami/postgresql) does.

This should speedup tests significantly, specially on GHA which has less than ideal I/O speeds.

## Known limitations

N/A