### PR TITLE
remove deprecated lobstr validator addresses from captive quorum sets

### DIFF
--- a/ingest/ledgerbackend/configs/captive-core-pubnet.cfg
+++ b/ingest/ledgerbackend/configs/captive-core-pubnet.cfg
@@ -55,13 +55,6 @@ HISTORY="curl -sf https://hercules-history.publicnode.org/{0} -o {1}"
 HOME_DOMAIN="publicnode.org"
 
 [[VALIDATORS]]
-NAME="lobstr_3_north_america"
-PUBLIC_KEY="GD5QWEVV4GZZTQP46BRXV5CUMMMLP4JTGFD7FWYJJWRL54CELY6JGQ63"
-ADDRESS="v3.stellar.lobstr.co:11625"
-HISTORY="curl -sf https://archive.v3.stellar.lobstr.co/{0} -o {1}"
-HOME_DOMAIN="lobstr"
-
-[[VALIDATORS]]
 NAME="lobstr_1_eu"
 PUBLIC_KEY="GCFONE23AB7Y6C5YZOMKUKGETPIAJA4QOYLS5VNS4JHBGKRZCPYHDLW7"
 ADDRESS="v1.stellar.lobstr.co:11625"
@@ -73,13 +66,6 @@ NAME="lobstr_2_eu"
 PUBLIC_KEY="GCB2VSADESRV2DDTIVTFLBDI562K6KE3KMKILBHUHUWFXCUBHGQDI7VL"
 ADDRESS="v2.stellar.lobstr.co:11625"
 HISTORY="curl -sf https://archive.v2.stellar.lobstr.co/{0} -o {1}"
-HOME_DOMAIN="lobstr"
-
-[[VALIDATORS]]
-NAME="lobstr_4_asia"
-PUBLIC_KEY="GA7TEPCBDQKI7JQLQ34ZURRMK44DVYCIGVXQQWNSWAEQR6KB4FMCBT7J"
-ADDRESS="v4.stellar.lobstr.co:11625"
-HISTORY="curl -sf https://archive.v4.stellar.lobstr.co/{0} -o {1}"
 HOME_DOMAIN="lobstr"
 
 [[VALIDATORS]]

--- a/services/galexie/internal/config_test.go
+++ b/services/galexie/internal/config_test.go
@@ -186,7 +186,7 @@ func TestValidCaptiveCoreOverridenArchiveUrls(t *testing.T) {
 	require.Equal(t, ccConfig.NetworkPassphrase, network.PublicNetworkPassphrase)
 	require.Equal(t, ccConfig.HistoryArchiveURLs, []string{"http://testarchive"})
 	require.Empty(t, ccConfig.Toml.HistoryEntries)
-	require.Len(t, ccConfig.Toml.Validators, 23)
+	require.Len(t, ccConfig.Toml.Validators, 21)
 	require.Equal(t, ccConfig.Toml.Validators[0].Name, "bootes")
 }
 

--- a/services/galexie/internal/config_test.go
+++ b/services/galexie/internal/config_test.go
@@ -123,7 +123,7 @@ func TestValidCaptiveCorePreconfiguredNetwork(t *testing.T) {
 	require.Equal(t, ccConfig.NetworkPassphrase, network.PublicNetworkPassphrase)
 	require.Equal(t, ccConfig.HistoryArchiveURLs, network.PublicNetworkhistoryArchiveURLs)
 	require.Empty(t, ccConfig.Toml.HistoryEntries)
-	require.Len(t, ccConfig.Toml.Validators, 23)
+	require.Len(t, ccConfig.Toml.Validators, 21)
 	require.Equal(t, ccConfig.Toml.Validators[0].Name, "bootes")
 }
 

--- a/services/horizon/docker/stellar-core-pubnet.cfg
+++ b/services/horizon/docker/stellar-core-pubnet.cfg
@@ -62,13 +62,6 @@ HISTORY="curl -sf https://hercules-history.publicnode.org/{0} -o {1}"
 HOME_DOMAIN="publicnode.org"
 
 [[VALIDATORS]]
-NAME="LOBSTR 3 (North America)"
-PUBLIC_KEY="GD5QWEVV4GZZTQP46BRXV5CUMMMLP4JTGFD7FWYJJWRL54CELY6JGQ63"
-ADDRESS="v3.stellar.lobstr.co:11625"
-HISTORY="curl -sf https://archive.v3.stellar.lobstr.co/{0} -o {1}"
-HOME_DOMAIN="lobstr.co"
-
-[[VALIDATORS]]
 NAME="LOBSTR 1 (Europe)"
 PUBLIC_KEY="GCFONE23AB7Y6C5YZOMKUKGETPIAJA4QOYLS5VNS4JHBGKRZCPYHDLW7"
 ADDRESS="v1.stellar.lobstr.co:11625"
@@ -80,13 +73,6 @@ NAME="LOBSTR 2 (Europe)"
 PUBLIC_KEY="GCB2VSADESRV2DDTIVTFLBDI562K6KE3KMKILBHUHUWFXCUBHGQDI7VL"
 ADDRESS="v2.stellar.lobstr.co:11625"
 HISTORY="curl -sf https://archive.v2.stellar.lobstr.co/{0} -o {1}"
-HOME_DOMAIN="lobstr.co"
-
-[[VALIDATORS]]
-NAME="LOBSTR 4 (Asia)"
-PUBLIC_KEY="GA7TEPCBDQKI7JQLQ34ZURRMK44DVYCIGVXQQWNSWAEQR6KB4FMCBT7J"
-ADDRESS="v4.stellar.lobstr.co:11625"
-HISTORY="curl -sf https://archive.v4.stellar.lobstr.co/{0} -o {1}"
 HOME_DOMAIN="lobstr.co"
 
 [[VALIDATORS]]


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

removed deprecated validator addresses from some hardcoded captive config quorum sets

### Why

better performance for captive core, avoid broken connection attempts to invalid qset addresses.
### Known limitations


