### PR TITLE
Fee Event breakdown in token transfer processor

### DIFF
--- a/ingest/ledger_transaction.go
+++ b/ingest/ledger_transaction.go
@@ -222,10 +222,7 @@ func (t *LedgerTransaction) FeeCharged() (int64, bool) {
 	_, ok = t.GetSorobanData()
 	if ok {
 		if uint32(t.Ledger.LedgerHeaderHistoryEntry().Header.LedgerVersion) < 21 && t.Envelope.Type == xdr.EnvelopeTypeEnvelopeTypeTxFeeBump {
-			var resourceFeeRefund int64
-
-			resourceFeeRefund = t.SorobanResourceFeeRefund()
-
+			resourceFeeRefund := t.SorobanResourceFeeRefund()
 			return int64(t.Result.Result.FeeCharged) - resourceFeeRefund, true
 		}
 	}

--- a/ingest/ledger_transaction_test.go
+++ b/ingest/ledger_transaction_test.go
@@ -897,8 +897,7 @@ func TestTransactionHelperFunctions(t *testing.T) {
 	assert.Equal(t, int64(-1234), inclusionFee)
 
 	var sorobanResourceFeeRefund int64
-	sorobanResourceFeeRefund, ok = transaction.SorobanResourceFeeRefund()
-	assert.Equal(t, true, ok)
+	sorobanResourceFeeRefund = transaction.SorobanResourceFeeRefund()
 	assert.Equal(t, int64(0), sorobanResourceFeeRefund)
 
 	var sorobanTotalNonRefundableResourceFeeCharged int64

--- a/ingest/processors/token_transfer/token_transfer_processor.go
+++ b/ingest/processors/token_transfer/token_transfer_processor.go
@@ -400,10 +400,10 @@ func (p *EventsProcessor) generateFeeEvent(tx ingest.LedgerTransaction) ([]*Toke
 	var feeEvents []*TokenTransferEvent
 
 	originalSorobanFeeCharged := tx.OriginalFeeCharged()
-	sorobanFeeRefund := tx.SorobanResourceFeeRefund()
 	originalFeeEvent := NewFeeEvent(meta, protoAddressFromAccount(feeAccount), amount.String64Raw(xdr.Int64(originalSorobanFeeCharged)), xlmProtoAsset)
 	feeEvents = append(feeEvents, originalFeeEvent)
 
+	sorobanFeeRefund := tx.SorobanResourceFeeRefund()
 	if sorobanFeeRefund > 0 {
 		refundEvent := NewFeeEvent(meta, protoAddressFromAccount(feeAccount), amount.String64Raw(xdr.Int64(-sorobanFeeRefund)), xlmProtoAsset)
 		feeEvents = append(feeEvents, refundEvent)

--- a/ingest/processors/token_transfer/token_transfer_processor.go
+++ b/ingest/processors/token_transfer/token_transfer_processor.go
@@ -73,7 +73,7 @@ func (p *EventsProcessor) EventsFromLedger(lcm xdr.LedgerCloseMeta) ([]*TokenTra
 	var allEvents []*TokenTransferEvent
 
 	/*
-		For protocol version 22 and under, the following represents chronological ordering of events in a ledger
+		As of protocol 22, the following represents chronological ordering of events in a ledger
 			- FeeEvents from all Transactions upfront
 			- For each transaction
 				events from each operation

--- a/ingest/processors/token_transfer/token_transfer_processor_test.go
+++ b/ingest/processors/token_transfer/token_transfer_processor_test.go
@@ -638,10 +638,11 @@ func TestFeeEvent(t *testing.T) {
 		t.Run(fixture.name, func(t *testing.T) {
 			events, err := ttp.EventsFromTransaction(fixture.tx)
 			assert.NoError(t, err)
-			assert.Equal(t, len(fixture.expected), len(events))
-			for i := range events {
-				assert.True(t, proto.Equal(events[i], fixture.expected[i]),
-					"Expected event: %+v\nFound event: %+v", fixture.expected[i], events[i])
+			assert.Equal(t, len(fixture.expected), len(events.FeeEvents))
+			assert.Equal(t, 0, len(events.OperationEvents))
+			for i := range events.FeeEvents {
+				assert.True(t, proto.Equal(events.FeeEvents[i], fixture.expected[i]),
+					"Expected event: %+v\nFound event: %+v", fixture.expected[i], events.FeeEvents[i])
 			}
 		})
 	}

--- a/ingest/processors/token_transfer/token_transfer_processor_test.go
+++ b/ingest/processors/token_transfer/token_transfer_processor_test.go
@@ -119,6 +119,32 @@ var (
 		return resp
 	}
 
+	someSorobanTx = func(feeChanges xdr.LedgerEntryChanges, txApplyAfterChanges xdr.LedgerEntryChanges) ingest.LedgerTransaction {
+		resp := someTx
+		resp.UnsafeMeta.V = 3
+		resp.FeeChanges = feeChanges
+		resp.Envelope.V1.Tx.Ext = xdr.TransactionExt{
+			V: 1,
+			SorobanData: &xdr.SorobanTransactionData{
+				Ext: xdr.ExtensionPoint{
+					V: 0,
+				},
+				Resources: xdr.SorobanResources{
+					Footprint: xdr.LedgerFootprint{
+						ReadOnly:  []xdr.LedgerKey{},
+						ReadWrite: []xdr.LedgerKey{},
+					},
+				},
+				ResourceFee: 100,
+			},
+		}
+		resp.UnsafeMeta.V3 = &xdr.TransactionMetaV3{
+			TxChangesAfter: txApplyAfterChanges,
+		}
+		resp.Result.Result.Result.Code = xdr.TransactionResultCodeTxFailed
+		return resp
+	}
+
 	someTxWithOperationChangesAndMemo = func(changes xdr.LedgerEntryChanges, memo xdr.Memo) ingest.LedgerTransaction {
 		resp := someTxWithOperationChanges(changes)
 		resp.Envelope.V1 = &xdr.TransactionV1Envelope{
@@ -232,6 +258,44 @@ var (
 				},
 			},
 		}
+	}
+
+	accountEntry = func(acc xdr.MuxedAccount, balance xdr.Int64) *xdr.AccountEntry {
+		return &xdr.AccountEntry{
+			AccountId: acc.ToAccountId(),
+			Balance:   balance,
+			SeqNum:    xdr.SequenceNumber(12345),
+		}
+	}
+
+	generateAccountEntryChangState = func(accountEntry *xdr.AccountEntry) xdr.LedgerEntryChange {
+		return xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+			State: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type:    xdr.LedgerEntryTypeAccount,
+					Account: accountEntry,
+				},
+			},
+		}
+	}
+
+	generateAccountEntryUpdatedChange = func(accountEntry *xdr.AccountEntry, newBalance xdr.Int64) xdr.LedgerEntryChange {
+		accountEntry.Balance = newBalance
+		return xdr.LedgerEntryChange{
+			Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+			Updated: &xdr.LedgerEntry{
+				Data: xdr.LedgerEntryData{
+					Type:    xdr.LedgerEntryTypeAccount,
+					Account: accountEntry,
+				},
+			},
+		}
+	}
+
+	expectedFeeEvent = func(feeAmt string) *TokenTransferEvent {
+		return NewFeeEvent(NewEventMetaFromTx(someTx, nil, contractIdStrFromAsset(xlmAsset)),
+			protoAddressFromAccount(someTxAccount), feeAmt, xlmProtoAsset)
 	}
 
 	// Helpers to generate LedgerEntryChanges for Claimable Balances, to be fed to the operationMeta when creating sample transaction
@@ -568,7 +632,60 @@ func runTokenTransferEventTests(t *testing.T, tests []testFixture) {
 	}
 }
 
-func TestFeeEvent(t *testing.T) {
+func TestSorobanFeeEvents(t *testing.T) {
+	tests := []testFixture{
+		{
+			name: "Soroban Failed Tx with no refund",
+			tx: someSorobanTx(
+				// this is FeeChanges
+				xdr.LedgerEntryChanges{
+					generateAccountEntryChangState(accountEntry(someTxAccount, 1000*oneUnit)),
+					generateAccountEntryUpdatedChange(accountEntry(someTxAccount, 1000*oneUnit), 999*oneUnit),
+				},
+				// This is txApplyAfterChanges
+				nil),
+			expected: []*TokenTransferEvent{
+				expectedFeeEvent(unitsToStr(oneUnit)),
+			},
+		},
+		{
+			name: "Soroban Failed Tx with some refund",
+			tx: someSorobanTx(
+				// this is FeeChanges
+				xdr.LedgerEntryChanges{
+					// Fee is 300 units
+					generateAccountEntryChangState(accountEntry(someTxAccount, 1000*oneUnit)),
+					generateAccountEntryUpdatedChange(accountEntry(someTxAccount, 1000*oneUnit), 700*oneUnit),
+				},
+				// This is txApplyAfterChanges
+				xdr.LedgerEntryChanges{
+					// Refund is 30 units
+					generateAccountEntryChangState(accountEntry(someTxAccount, 700*oneUnit)),
+					generateAccountEntryUpdatedChange(accountEntry(someTxAccount, 700*oneUnit), 730*oneUnit),
+				},
+			),
+			expected: []*TokenTransferEvent{
+				expectedFeeEvent(unitsToStr(300 * oneUnit)),
+				expectedFeeEvent(unitsToStr(-30 * oneUnit)),
+			},
+		},
+	}
+	for _, fixture := range tests {
+		ttp := NewEventsProcessor(someNetworkPassphrase)
+		t.Run(fixture.name, func(t *testing.T) {
+			events, err := ttp.EventsFromTransaction(fixture.tx)
+			assert.NoError(t, err)
+			assert.Equal(t, len(fixture.expected), len(events.FeeEvents))
+			assert.Equal(t, 0, len(events.OperationEvents))
+			for i := range events.FeeEvents {
+				assert.True(t, proto.Equal(events.FeeEvents[i], fixture.expected[i]),
+					"Expected event: %+v\nFound event: %+v", fixture.expected[i], events.FeeEvents[i])
+			}
+		})
+	}
+}
+
+func TestClassicFeeEvent(t *testing.T) {
 	failedTx := func(envelopeType xdr.EnvelopeType, txFee xdr.Int64) ingest.LedgerTransaction {
 		tx := ingest.LedgerTransaction{
 			Index:    1,
@@ -609,11 +726,6 @@ func TestFeeEvent(t *testing.T) {
 			tx.Result.Result.Result.Code = xdr.TransactionResultCodeTxFailed
 		}
 		return tx
-	}
-
-	expectedFeeEvent := func(feeAmt string) *TokenTransferEvent {
-		return NewFeeEvent(NewEventMetaFromTx(someTx, nil, contractIdStrFromAsset(xlmAsset)),
-			protoAddressFromAccount(someTxAccount), feeAmt, xlmProtoAsset)
 	}
 
 	tests := []testFixture{
@@ -676,38 +788,6 @@ func TestAccountCreateEvents(t *testing.T) {
 }
 
 func TestReconciliation(t *testing.T) {
-	accountEntry := func(acc xdr.MuxedAccount, balance xdr.Int64) *xdr.AccountEntry {
-		return &xdr.AccountEntry{
-			AccountId: acc.ToAccountId(),
-			Balance:   1000 * oneUnit,
-			SeqNum:    xdr.SequenceNumber(12345),
-		}
-	}
-
-	generateAccountEntryChangState := func(accountEntry *xdr.AccountEntry) xdr.LedgerEntryChange {
-		return xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
-			State: &xdr.LedgerEntry{
-				Data: xdr.LedgerEntryData{
-					Type:    xdr.LedgerEntryTypeAccount,
-					Account: accountEntry,
-				},
-			},
-		}
-	}
-
-	generateAccountEntryUpdatedChange := func(accountEntry *xdr.AccountEntry, newBalance xdr.Int64) xdr.LedgerEntryChange {
-		accountEntry.Balance = newBalance
-		return xdr.LedgerEntryChange{
-			Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
-			Updated: &xdr.LedgerEntry{
-				Data: xdr.LedgerEntryData{
-					Type:    xdr.LedgerEntryTypeAccount,
-					Account: accountEntry,
-				},
-			},
-		}
-	}
 
 	tests := []testFixture{
 		{


### PR DESCRIPTION
Add support for fee refund events.
The comments in the `NewEventsFromLedger` function highlight the chronological order before P22 (i.e. the status quo)

I had to modify the signature of `NewEventsFromTransaction` to return FeeEvents and OperationEvents separately.
The coalescing is done in chronological order in `NewEventsFromLedger`