### PR TITLE
protocols: Update Stellar Core's `getledgerentry` endpoint schema

### DIFF
--- a/clients/stellarcore/client_test.go
+++ b/clients/stellarcore/client_test.go
@@ -181,14 +181,13 @@ func TestGetLedgerEntries(t *testing.T) {
 	mockResp := proto.GetLedgerEntryResponse{
 		Ledger: 1215, // checkpoint align on expected request
 		Entries: []proto.LedgerEntryResponse{{
-			Entry: entryB64,
-			State: "live",
-			Ttl:   1234,
+			Entry:              entryB64,
+			State:              "live",
+			LiveUntilLedgerSeq: 1234,
 		}, {
 			Entry: entryB64,
 			State: "archived",
 		}, {
-			Entry: keyB64,
 			State: "new",
 		}},
 	}
@@ -224,12 +223,15 @@ func TestGetLedgerEntries(t *testing.T) {
 	require.Len(t, resp.Entries, 3)
 	require.Equal(t, entryB64, resp.Entries[0].Entry)
 	require.Equal(t, entryB64, resp.Entries[1].Entry)
-	require.Equal(t, keyB64, resp.Entries[2].Entry)
-	require.EqualValues(t, 1234, resp.Entries[0].Ttl)
+	require.Empty(t, resp.Entries[2].Entry)
+	require.EqualValues(t, 1234, resp.Entries[0].LiveUntilLedgerSeq)
+	require.EqualValues(t, 0, resp.Entries[1].LiveUntilLedgerSeq)
+	require.EqualValues(t, 0, resp.Entries[2].LiveUntilLedgerSeq)
 	require.EqualValues(t, "live", resp.Entries[0].State)
 	require.EqualValues(t, "archived", resp.Entries[1].State)
 	require.EqualValues(t, "new", resp.Entries[2].State)
 
+	// TTL keys aren't returned
 	key.Type = xdr.LedgerEntryTypeTtl
 	_, err = c.GetLedgerEntries(context.Background(), 1234, key)
 	require.Error(t, err)

--- a/protocols/stellarcore/getledgerentry_response.go
+++ b/protocols/stellarcore/getledgerentry_response.go
@@ -19,7 +19,7 @@ type GetLedgerEntryResponse struct {
 }
 
 type LedgerEntryResponse struct {
-	Entry string `json:"e"`             // base64-encoded xdr.LedgerEntry, or xdr.LedgerKey if state == new
-	State string `json:"state"`         // one of the above states
-	Ttl   uint32 `json:"ttl,omitempty"` // optionally, a Soroban entry's `liveUntilLedgerSeq`
+	State              string `json:"state"`                        // one of the above states
+	Entry              string `json:"entry,omitempty"`              // base64-encoded xdr.LedgerEntry, or missing if state == new
+	LiveUntilLedgerSeq uint32 `json:"liveUntilLedgerSeq,omitempty"` // optional, for live contract data/code
 }

--- a/protocols/stellarcore/getledgerentry_response.go
+++ b/protocols/stellarcore/getledgerentry_response.go
@@ -3,10 +3,9 @@ package stellarcore
 const (
 	// Indicates that the entry is live in the current state
 	LedgerEntryStateLive = "live"
-	// Indicates that the entry is proven to be brand new and will live in the
-	// current state when created. In this case, the `Entry` field will be an
-	// xdr.LedgerKey matching the one requested rather than an xdr.LedgerEntry.
-	LedgerEntryStateNew = "new"
+	// Indicates that the entry wasn't found (thus proven to be brand new) and
+	// will live in the current state if created.
+	LedgerEntryStateNew = "not-found"
 	// Indicates that the entry has been archived to the hot archive due to its
 	// TTL expiring
 	LedgerEntryStateArchived = "archived"

--- a/protocols/stellarcore/getledgerentry_response.go
+++ b/protocols/stellarcore/getledgerentry_response.go
@@ -5,7 +5,7 @@ const (
 	LedgerEntryStateLive = "live"
 	// Indicates that the entry wasn't found (thus proven to be brand new) and
 	// will live in the current state if created.
-	LedgerEntryStateNew = "not-found"
+	LedgerEntryStateNotFound = "not-found"
 	// Indicates that the entry has been archived to the hot archive due to its
 	// TTL expiring
 	LedgerEntryStateArchived = "archived"


### PR DESCRIPTION
### What
Update field names:
 * `state` is always present
 * `new` -> `not-found`
 * `ttl` -> `liveUntilLedgerSeq`
 * `e` -> `entry`, only present if `state == live|archived`

### Why
This matches the changes in https://github.com/stellar/stellar-core/pull/4721, cc @SirTyson.