### PR TITLE
Update core binary to v23 rc

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -32,8 +32,8 @@ jobs:
     env:
       HORIZON_INTEGRATION_TESTS_ENABLED: true
       HORIZON_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL: ${{ matrix.protocol-version }}
-      PROTOCOL_22_CORE_DEBIAN_PKG_VERSION: 22.1.1-2291.a50f3f919.focal~do~not~use~in~prd
-      PROTOCOL_22_CORE_DOCKER_IMG: stellar/unsafe-stellar-core:22.1.1-2291.a50f3f919.focal-do-not-use-in-prd
+      PROTOCOL_22_CORE_DEBIAN_PKG_VERSION: 23.0.0.1-2488.23.0.0rc.1.472e3e69d.focal
+      PROTOCOL_22_CORE_DOCKER_IMG: stellar/stellar-core:23.0.0.1-2488.23.0.0rc.1.472e3e69d.focal
       PROTOCOL_22_STELLAR_RPC_DOCKER_IMG: stellar/stellar-rpc:22.1.2
       PGHOST: localhost
       PGPORT: 5432

--- a/clients/stellarcore/client.go
+++ b/clients/stellarcore/client.go
@@ -86,8 +86,7 @@ type GenSorobanConfig struct {
 	BaseSeqNum        uint32
 	NetworkPassphrase string
 	SigningKey        *keypair.Full
-	// looks for `stellar-core` in the system PATH if empty
-	StellarCorePath string
+	StellarCoreImage  string
 }
 
 func GenSorobanConfigUpgradeTxAndKey(
@@ -96,11 +95,18 @@ func GenSorobanConfigUpgradeTxAndKey(
 	if err != nil {
 		return nil, xdr.ConfigUpgradeSetKey{}, err
 	}
-	corePath := config.StellarCorePath
-	if corePath == "" {
-		corePath = "stellar-core"
+
+	cmd := exec.Command("docker", "pull", config.StellarCoreImage)
+	_, err = cmd.Output()
+	if err != nil {
+		return nil, xdr.ConfigUpgradeSetKey{}, err
 	}
-	cmd := exec.Command(corePath, "get-settings-upgrade-txs",
+
+	cmd = exec.Command("docker",
+		"run",
+		"-i",
+		config.StellarCoreImage,
+		"get-settings-upgrade-txs",
 		config.SigningKey.Address(),
 		strconv.FormatUint(uint64(config.BaseSeqNum), 10),
 		config.NetworkPassphrase,

--- a/clients/stellarcore/client_test.go
+++ b/clients/stellarcore/client_test.go
@@ -7,8 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
@@ -236,21 +234,13 @@ func TestGetLedgerEntries(t *testing.T) {
 }
 
 func TestGenSorobanConfigUpgradeTxAndKey(t *testing.T) {
-	coreBinary := os.Getenv("STELLAR_CORE_BINARY_PATH")
-	if coreBinary == "" {
-		var err error
-		coreBinary, err = exec.LookPath("stellar-core")
-		if err != nil {
-			t.Skip("couldn't find stellar core binary")
-		}
-	}
 	key, err := keypair.ParseFull("SB6VZS57IY25334Y6F6SPGFUNESWS7D2OSJHKDPIZ354BK3FN5GBTS6V")
 	require.NoError(t, err)
 	funcConfig := GenSorobanConfig{
 		BaseSeqNum:        1,
 		NetworkPassphrase: network.TestNetworkPassphrase,
 		SigningKey:        key,
-		StellarCorePath:   coreBinary,
+		StellarCoreImage:  "stellar/stellar-core:22",
 	}
 	config := xdr.ConfigUpgradeSet{
 		UpdatedEntry: []xdr.ConfigSettingEntry{

--- a/ingest/ledgerbackend/testdata/expected-disable-backfill-restore-meta.cfg
+++ b/ingest/ledgerbackend/testdata/expected-disable-backfill-restore-meta.cfg
@@ -1,0 +1,23 @@
+# Generated file, do not edit
+BACKFILL_RESTORE_META = false
+BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 12
+BUCKETLIST_DB_MEMORY_FOR_CACHING = 0
+DATABASE = "sqlite3://stellar.db"
+FAILURE_SAFETY = -1
+HTTP_PORT = 6789
+LOG_FILE_PATH = ""
+NETWORK_PASSPHRASE = "Public Global Stellar Network ; September 2015"
+PEER_PORT = 12345
+
+[[HOME_DOMAINS]]
+  HOME_DOMAIN = "testnet.stellar.org"
+  QUALITY = "MEDIUM"
+
+[[VALIDATORS]]
+  ADDRESS = "localhost:123"
+  HOME_DOMAIN = "testnet.stellar.org"
+  NAME = "sdf_testnet_1"
+  PUBLIC_KEY = "GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"
+
+[HISTORY.h0]
+  get = "curl -sf http://localhost:1170/{0} -o {1}"

--- a/ingest/ledgerbackend/testdata/expected-enable-backfill-restore-meta.cfg
+++ b/ingest/ledgerbackend/testdata/expected-enable-backfill-restore-meta.cfg
@@ -1,0 +1,23 @@
+# Generated file, do not edit
+BACKFILL_RESTORE_META = true
+BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 12
+BUCKETLIST_DB_MEMORY_FOR_CACHING = 0
+DATABASE = "sqlite3://stellar.db"
+FAILURE_SAFETY = -1
+HTTP_PORT = 6789
+LOG_FILE_PATH = ""
+NETWORK_PASSPHRASE = "Public Global Stellar Network ; September 2015"
+PEER_PORT = 12345
+
+[[HOME_DOMAINS]]
+  HOME_DOMAIN = "testnet.stellar.org"
+  QUALITY = "MEDIUM"
+
+[[VALIDATORS]]
+  ADDRESS = "localhost:123"
+  HOME_DOMAIN = "testnet.stellar.org"
+  NAME = "sdf_testnet_1"
+  PUBLIC_KEY = "GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"
+
+[HISTORY.h0]
+  get = "curl -sf http://localhost:1170/{0} -o {1}"

--- a/ingest/ledgerbackend/toml_test.go
+++ b/ingest/ledgerbackend/toml_test.go
@@ -17,6 +17,10 @@ func newString(s string) *string {
 	return &s
 }
 
+func newBool(b bool) *bool {
+	return &b
+}
+
 func TestCaptiveCoreTomlValidation(t *testing.T) {
 	for _, testCase := range []struct {
 		name              string
@@ -227,6 +231,7 @@ func TestGenerateConfig(t *testing.T) {
 		logPath                        *string
 		enforceSorobanDiagnosticEvents bool
 		enforceEmitMetaV1              bool
+		backfillRestoreMeta            *bool
 		coreVersion                    string
 	}{
 		{
@@ -288,6 +293,38 @@ func TestGenerateConfig(t *testing.T) {
 			peerPort:     newUint(12345),
 			logPath:      nil,
 			coreVersion:  "v22.2.0-124-ga50f3f919",
+		},
+		{
+			name:                "online config with restore meta backfill set to false",
+			mode:                stellarCoreRunnerModeOnline,
+			appendPath:          filepath.Join("testdata", "sample-appendix.cfg"),
+			expectedPath:        filepath.Join("testdata", "expected-disable-backfill-restore-meta.cfg"),
+			httpPort:            newUint(6789),
+			peerPort:            newUint(12345),
+			logPath:             nil,
+			backfillRestoreMeta: newBool(false),
+			coreVersion:         "v23.0.0rc.1",
+		},
+		{
+			name:                "online config with restore meta backfill set to true",
+			mode:                stellarCoreRunnerModeOnline,
+			appendPath:          filepath.Join("testdata", "sample-appendix.cfg"),
+			expectedPath:        filepath.Join("testdata", "expected-enable-backfill-restore-meta.cfg"),
+			httpPort:            newUint(6789),
+			peerPort:            newUint(12345),
+			logPath:             nil,
+			backfillRestoreMeta: newBool(true),
+			coreVersion:         "v23.0.0rc.1",
+		},
+		{
+			name:         "online config with restore meta backfill omitted",
+			mode:         stellarCoreRunnerModeOnline,
+			appendPath:   filepath.Join("testdata", "sample-appendix.cfg"),
+			expectedPath: filepath.Join("testdata", "expected-enable-backfill-restore-meta.cfg"),
+			httpPort:     newUint(6789),
+			peerPort:     newUint(12345),
+			logPath:      nil,
+			coreVersion:  "v23.0.0rc.1",
 		},
 		{
 			name:         "offline config with appendix",
@@ -381,6 +418,7 @@ func TestGenerateConfig(t *testing.T) {
 				CoreBuildVersionFn: func(string) (string, error) {
 					return testCase.coreVersion, nil
 				},
+				BackfillRestoreMeta: testCase.backfillRestoreMeta,
 			}
 			if testCase.appendPath != "" {
 				captiveCoreToml, err = NewCaptiveCoreTomlFromFile(testCase.appendPath, params)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update CI to use the new core v23 release candidate binary when running protocol 22 integration tests. I discovered some a difference in behavior in the `get-settings-upgrade-txs` stellar-core command which resulted in integration tests failing. To work around that, I'm using the v22 core binary to invoke `get-settings-upgrade-txs` when running protocol 22 integration tests.

I also had to add support for the `BACKFILL_RESTORE_META` core configuration field because horizon ingestion requires that field to be set to true in order to avoid the complexity supporting multiple versions of restoration meta.

### Known limitations

[N/A]
