### PR TITLE
ingest/ledgerbackend: Add support for accelerating eviction in integration tests

### DIFF
--- a/ingest/ledgerbackend/toml.go
+++ b/ingest/ledgerbackend/toml.go
@@ -113,6 +113,9 @@ type captiveCoreTomlValues struct {
 	BucketListDBMemoryForCaching          *uint                `toml:"BUCKETLIST_DB_MEMORY_FOR_CACHING,omitempty"`
 	EnableEmitClassicEvents               *bool                `toml:"EMIT_CLASSIC_EVENTS,omitempty"`
 	EnableBackfillStellarAssetEvents      *bool                `toml:"BACKFILL_STELLAR_ASSET_EVENTS,omitempty"`
+	OverrideEvictionParamsForTesting      *bool                `toml:"OVERRIDE_EVICTION_PARAMS_FOR_TESTING,omitempty"`
+	TestingStartingEvictionScanLevel      *uint                `toml:"TESTING_STARTING_EVICTION_SCAN_LEVEL,omitempty"`
+	TestingMaxEntriesToArchive            *uint                `toml:"TESTING_MAX_ENTRIES_TO_ARCHIVE,omitempty"`
 }
 
 // QuorumSetIsConfigured returns true if there is a quorum set defined in the configuration.

--- a/services/horizon/internal/test/integration/core_config.go
+++ b/services/horizon/internal/test/integration/core_config.go
@@ -5,6 +5,9 @@ type validatorCoreConfigTemplatePrams struct {
 	NetworkPassphrase                     string
 	TestingMinimumPersistentEntryLifetime int
 	TestingSorobanHighLimitOverride       bool
+	OverrideEvictionParamsForTesting      bool
+	TestingStartingEvictionScanLevel      uint
+	TestingMaxEntriesToArchive            uint
 }
 
 type captiveCoreConfigTemplatePrams struct {
@@ -19,6 +22,12 @@ NETWORK_PASSPHRASE="{{ .NetworkPassphrase }}"
 
 TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME={{ .TestingMinimumPersistentEntryLifetime }}
 TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE={{ .TestingSorobanHighLimitOverride }}
+
+{{if .OverrideEvictionParamsForTesting}}
+OVERRIDE_EVICTION_PARAMS_FOR_TESTING=true
+TESTING_MAX_ENTRIES_TO_ARCHIVE={{ .TestingMaxEntriesToArchive }}
+TESTING_STARTING_EVICTION_SCAN_LEVEL={{ .TestingStartingEvictionScanLevel }}
+{{end}}
 
 PEER_PORT=11625
 HTTP_PORT=11626
@@ -51,6 +60,12 @@ NETWORK_PASSPHRASE="{{ .NetworkPassphrase }}"
 TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME={{ .TestingMinimumPersistentEntryLifetime }}
 TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE={{ .TestingSorobanHighLimitOverride }}
 ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true
+
+{{if .OverrideEvictionParamsForTesting}}
+OVERRIDE_EVICTION_PARAMS_FOR_TESTING=true
+TESTING_MAX_ENTRIES_TO_ARCHIVE={{ .TestingMaxEntriesToArchive }}
+TESTING_STARTING_EVICTION_SCAN_LEVEL={{ .TestingStartingEvictionScanLevel }}
+{{end}}
 
 PEER_PORT=11725
 

--- a/services/horizon/internal/test/integration/integration.go
+++ b/services/horizon/internal/test/integration/integration.go
@@ -68,6 +68,7 @@ type Config struct {
 	StellarRPCDockerImage     string
 	SkipProtocolUpgrade       bool
 	QuickExpiration           bool
+	QuickEviction             bool
 	NetworkPassphrase         string
 
 	// Weird naming here because bools default to false, but we want to start
@@ -166,10 +167,16 @@ func NewTest(t *testing.T, config Config) *Test {
 		NetworkPassphrase:                     config.NetworkPassphrase,
 		TestingMinimumPersistentEntryLifetime: 65536,
 		TestingSorobanHighLimitOverride:       false,
+		OverrideEvictionParamsForTesting:      false,
 	}
 	if config.QuickExpiration {
 		validatorParams.TestingSorobanHighLimitOverride = true
 		validatorParams.TestingMinimumPersistentEntryLifetime = 10
+	}
+	if config.QuickEviction {
+		validatorParams.OverrideEvictionParamsForTesting = true
+		validatorParams.TestingStartingEvictionScanLevel = 2
+		validatorParams.TestingMaxEntriesToArchive = 100
 	}
 	var i *Test
 	if !config.SkipCoreContainerCreation {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

In protocol 23 eviction will be enabled and there are new fields in the stellar-core toml file which allow you to configure the speed at which archived ledger entries get evicted.

The new fields were added to core in https://github.com/stellar/stellar-core/pull/3922 . Some context on how the fields affect eviction speed can be found [here](https://stellarfoundation.slack.com/archives/C02B04RMK/p1748538755980169) and [here](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg).

We will need to enable accelerated eviction when implementing https://github.com/stellar/go/issues/5613

 
### Known limitations

[N/A]
