### PR TITLE
stellar/go: Customize well known path

### DIFF
--- a/clients/stellartoml/client.go
+++ b/clients/stellartoml/client.go
@@ -56,7 +56,7 @@ func (c *Client) GetStellarTomlByAddress(addr string) (*Response, error) {
 	return c.GetStellarToml(domain)
 }
 
-func getStellarTomlPathFromEnv() string {
+func getWellKnownPathFromEnv() string {
 	path := os.Getenv("STELLAR_TOML_PATH")
 	if path == "" {
 		return WellKnownPath
@@ -75,7 +75,7 @@ func (c *Client) url(domain string) string {
 		scheme = "https"
 	}
 
-	tomlPath := getStellarTomlPathFromEnv()
+	tomlPath := getWellKnownPathFromEnv()
 
 	return fmt.Sprintf("%s://%s%s", scheme, domain, tomlPath)
 }

--- a/clients/stellartoml/client.go
+++ b/clients/stellartoml/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 
 	"github.com/BurntSushi/toml"
 	"github.com/stellar/go/address"
@@ -55,6 +56,14 @@ func (c *Client) GetStellarTomlByAddress(addr string) (*Response, error) {
 	return c.GetStellarToml(domain)
 }
 
+func getStellarTomlPathFromEnv() string {
+	path := os.Getenv("STELLAR_TOML_PATH")
+	if path == "" {
+		return WellKnownPath
+	}
+	return path
+}
+
 // url returns the appropriate url to load for resolving domain's stellar.toml
 // file
 func (c *Client) url(domain string) string {
@@ -66,5 +75,7 @@ func (c *Client) url(domain string) string {
 		scheme = "https"
 	}
 
-	return fmt.Sprintf("%s://%s%s", scheme, domain, WellKnownPath)
+	tomlPath := getStellarTomlPathFromEnv()
+
+	return fmt.Sprintf("%s://%s%s", scheme, domain, tomlPath)
 }

--- a/clients/stellartoml/client_test.go
+++ b/clients/stellartoml/client_test.go
@@ -1,6 +1,7 @@
 package stellartoml
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -63,4 +64,18 @@ func TestClient(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "toml decode failed")
 	}
+}
+
+func TestGetStellarTomlPathFromEnv(t *testing.T) {
+	// Backup and defer restore
+	orig := os.Getenv("STELLAR_TOML_PATH")
+	defer os.Setenv("STELLAR_TOML_PATH", orig)
+
+	// Test default
+	os.Unsetenv("STELLAR_TOML_PATH")
+	assert.Equal(t, WellKnownPath, getStellarTomlPathFromEnv())
+
+	// Test custom path
+	os.Setenv("STELLAR_TOML_PATH", "/custom/path/stellar.toml")
+	assert.Equal(t, "/custom/path/stellar.toml", getStellarTomlPathFromEnv())
 }

--- a/clients/stellartoml/client_test.go
+++ b/clients/stellartoml/client_test.go
@@ -66,16 +66,16 @@ func TestClient(t *testing.T) {
 	}
 }
 
-func TestGetStellarTomlPathFromEnv(t *testing.T) {
+func TestGetWellKnownPathFromEnv(t *testing.T) {
 	// Backup and defer restore
 	orig := os.Getenv("STELLAR_TOML_PATH")
 	defer os.Setenv("STELLAR_TOML_PATH", orig)
 
 	// Test default
 	os.Unsetenv("STELLAR_TOML_PATH")
-	assert.Equal(t, WellKnownPath, getStellarTomlPathFromEnv())
+	assert.Equal(t, WellKnownPath, getWellKnownPathFromEnv())
 
 	// Test custom path
 	os.Setenv("STELLAR_TOML_PATH", "/custom/path/stellar.toml")
-	assert.Equal(t, "/custom/path/stellar.toml", getStellarTomlPathFromEnv())
+	assert.Equal(t, "/custom/path/stellar.toml", getWellKnownPathFromEnv())
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Enable configuration of a custom .well-known path via an environment variable.

### Why

Private networks built on Stellar may require a non-standard .well-known path. This change provides flexibility by allowing the path to be set through an environment variable.

### Known limitations

[TODO or N/A]
