### PR TITLE
services/horizon/internal/integration: Add more eviction integration tests

### DIFF
--- a/services/horizon/internal/integration/sac_test.go
+++ b/services/horizon/internal/integration/sac_test.go
@@ -598,6 +598,10 @@ func TestEvictionAndRestoration(t *testing.T) {
 }
 
 func TestUnlinkContractIDFromAssetStat(t *testing.T) {
+	if integration.GetCoreMaxSupportedProtocol() < 23 {
+		t.Skip("This test run does not support less than Protocol 23")
+	}
+
 	itest := integration.NewTest(t, integration.Config{
 		EnableStellarRPC: true,
 		HorizonIngestParameters: map[string]string{
@@ -707,6 +711,10 @@ func TestUnlinkContractIDFromAssetStat(t *testing.T) {
 }
 
 func TestEvictionOfSACAndRestoration(t *testing.T) {
+	if integration.GetCoreMaxSupportedProtocol() < 23 {
+		t.Skip("This test run does not support less than Protocol 23")
+	}
+
 	itest := integration.NewTest(t, integration.Config{
 		EnableStellarRPC: true,
 		HorizonIngestParameters: map[string]string{

--- a/services/horizon/internal/integration/sac_test.go
+++ b/services/horizon/internal/integration/sac_test.go
@@ -116,6 +116,10 @@ func TestContractMintToAccount(t *testing.T) {
 }
 
 func createSAC(itest *integration.Test, asset xdr.Asset) {
+	createSACWithTTL(itest, asset, LongTermTTL)
+}
+
+func createSACWithTTL(itest *integration.Test, asset xdr.Asset, ttl uint32) {
 	invokeHostFunction := &txnbuild.InvokeHostFunction{
 		HostFunction: xdr.HostFunction{
 			Type: xdr.HostFunctionTypeHostFunctionTypeCreateContract,
@@ -136,7 +140,7 @@ func createSAC(itest *integration.Test, asset xdr.Asset) {
 	sourceAccount, extendTTLOp := itest.PreflightExtendExpiration(
 		itest.Master().Address(),
 		preFlightOp.Ext.SorobanData.Resources.Footprint.ReadWrite,
-		LongTermTTL,
+		ttl,
 	)
 	itest.MustSubmitOperations(&sourceAccount, itest.Master(), &extendTTLOp)
 }
@@ -590,6 +594,184 @@ func TestEvictionAndRestoration(t *testing.T) {
 		numContracts:     1,
 		balanceContracts: big.NewInt(37),
 		contractID:       storeContractID,
+	})
+}
+
+func TestUnlinkContractIDFromAssetStat(t *testing.T) {
+	itest := integration.NewTest(t, integration.Config{
+		EnableStellarRPC: true,
+		HorizonIngestParameters: map[string]string{
+			// disable state verification because we will insert
+			// a fake asset contract in the horizon db and we don't
+			// want state verification to detect this
+			"ingest-disable-state-verification": "true",
+		},
+		QuickExpiration: true,
+		QuickEviction:   true,
+	})
+
+	issuer := itest.Master().Address()
+	code := "USD"
+
+	// Create contract to store synthetic asset balances
+	storeContractID, _ := mustCreateAndInstallContractWithTTL(
+		itest,
+		itest.Master(),
+		"a1",
+		"soroban_store.wasm",
+		20,
+	)
+
+	syntheticAssetStat := history.ExpAssetStat{
+		AssetType:   xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AssetCode:   code,
+		AssetIssuer: issuer,
+		Accounts: history.ExpAssetStatAccounts{
+			Authorized:                      1,
+			AuthorizedToMaintainLiabilities: 0,
+			ClaimableBalances:               0,
+			LiquidityPools:                  0,
+			Unauthorized:                    0,
+		},
+		Balances: history.ExpAssetStatBalances{
+			Authorized:                      "0",
+			AuthorizedToMaintainLiabilities: "0",
+			ClaimableBalances:               "0",
+			LiquidityPools:                  "0",
+			Unauthorized:                    "0",
+		},
+		ContractID: nil,
+	}
+	syntheticAssetStat.SetContractID(storeContractID)
+	_, err := itest.HorizonIngest().HistoryQ().InsertAssetStat(
+		context.Background(),
+		syntheticAssetStat,
+	)
+	assert.NoError(t, err)
+
+	// create active balance
+	_, _, setOp := assertInvokeHostFnSucceeds(
+		itest,
+		itest.Master(),
+		invokeStoreSet(
+			itest,
+			storeContractID,
+			sac.BalanceToContractData(
+				storeContractID,
+				[32]byte{1},
+				23,
+			),
+		),
+	)
+	sourceAccount, extendTTLOp := itest.PreflightExtendExpiration(
+		itest.Master().Address(),
+		setOp.Ext.SorobanData.Resources.Footprint.ReadWrite,
+		LongTermTTL,
+	)
+	itest.MustSubmitOperations(&sourceAccount, itest.Master(), &extendTTLOp)
+	assertAssetStats(itest, assetStats{
+		code:             code,
+		issuer:           issuer,
+		numAccounts:      1,
+		balanceAccounts:  0,
+		numContracts:     1,
+		balanceContracts: big.NewInt(23),
+		contractID:       storeContractID,
+	})
+
+	contractToEvictLedgerKey := xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.LedgerKeyContractData{
+			Contract: xdr.ScAddress{
+				Type:       xdr.ScAddressTypeScAddressTypeContract,
+				AccountId:  nil,
+				ContractId: &storeContractID,
+			},
+			Key: xdr.ScVal{
+				Type: xdr.ScValTypeScvLedgerKeyContractInstance,
+			},
+			Durability: xdr.ContractDataDurabilityPersistent,
+		},
+	}
+	itest.WaitUntilLedgerEntryIsEvicted(contractToEvictLedgerKey, time.Minute)
+
+	assertAssetStats(itest, assetStats{
+		code:             code,
+		issuer:           issuer,
+		numAccounts:      1,
+		balanceAccounts:  0,
+		numContracts:     0,
+		balanceContracts: big.NewInt(0),
+		contractID:       [32]byte{},
+	})
+}
+
+func TestEvictionOfSACAndRestoration(t *testing.T) {
+	itest := integration.NewTest(t, integration.Config{
+		EnableStellarRPC: true,
+		HorizonIngestParameters: map[string]string{
+			// disable state verification because we will insert
+			// a fake asset contract in the horizon db and we don't
+			// want state verification to detect this
+			"ingest-disable-state-verification": "true",
+		},
+		QuickExpiration: true,
+		QuickEviction:   true,
+	})
+
+	issuer := itest.Master().Address()
+	code := "USD"
+	asset := xdr.MustNewCreditAsset(code, issuer)
+
+	createSACWithTTL(itest, asset, 30)
+	contractID := stellarAssetContractID(itest, asset)
+
+	assertAssetStats(itest, assetStats{
+		code:             code,
+		issuer:           issuer,
+		numAccounts:      0,
+		balanceAccounts:  0,
+		numContracts:     0,
+		balanceContracts: big.NewInt(0),
+		contractID:       contractID,
+	})
+
+	contractToEvictLedgerKey := xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.LedgerKeyContractData{
+			Contract: xdr.ScAddress{
+				Type:       xdr.ScAddressTypeScAddressTypeContract,
+				AccountId:  nil,
+				ContractId: &contractID,
+			},
+			Key: xdr.ScVal{
+				Type: xdr.ScValTypeScvLedgerKeyContractInstance,
+			},
+			Durability: xdr.ContractDataDurabilityPersistent,
+		},
+	}
+	itest.WaitUntilLedgerEntryIsEvicted(contractToEvictLedgerKey, time.Minute)
+
+	assets, err := itest.Client().Assets(horizonclient.AssetRequest{
+		ForAssetCode:   code,
+		ForAssetIssuer: issuer,
+		Limit:          1,
+	})
+	assert.NoError(itest.CurrentTest(), err)
+	assert.Empty(itest.CurrentTest(), assets.Embedded.Records)
+
+	// restore evicted contract
+	sourceAccount, restoreOp := itest.RestoreFootprint(itest.Master().Address(), contractToEvictLedgerKey)
+	itest.MustSubmitOperations(&sourceAccount, itest.Master(), &restoreOp)
+
+	assertAssetStats(itest, assetStats{
+		code:             code,
+		issuer:           issuer,
+		numAccounts:      0,
+		balanceAccounts:  0,
+		numContracts:     0,
+		balanceContracts: big.NewInt(0),
+		contractID:       contractID,
 	})
 }
 
@@ -1222,7 +1404,11 @@ func assertAssetStats(itest *integration.Test, expected assetStats) {
 	assert.Equal(itest.CurrentTest(), expected.numAccounts, asset.Accounts.Authorized)
 	assert.Equal(itest.CurrentTest(), expected.numContracts, asset.NumContracts)
 	assert.Equal(itest.CurrentTest(), expected.balanceContracts.String(), parseBalance(itest, asset.ContractsAmount).String())
-	assert.Equal(itest.CurrentTest(), strkey.MustEncode(strkey.VersionByteContract, expected.contractID[:]), asset.ContractID)
+	if expected.contractID == [32]byte{} {
+		assert.Empty(itest.CurrentTest(), asset.ContractID)
+	} else {
+		assert.Equal(itest.CurrentTest(), strkey.MustEncode(strkey.VersionByteContract, expected.contractID[:]), asset.ContractID)
+	}
 }
 
 func parseBalance(itest *integration.Test, balance string) *big.Int {
@@ -1551,6 +1737,10 @@ func stellarAssetContractID(itest *integration.Test, asset xdr.Asset) xdr.Contra
 }
 
 func mustCreateAndInstallContract(itest *integration.Test, signer *keypair.Full, contractSalt string, wasmFileName string) (xdr.ContractId, xdr.Hash) {
+	return mustCreateAndInstallContractWithTTL(itest, signer, contractSalt, wasmFileName, LongTermTTL)
+}
+
+func mustCreateAndInstallContractWithTTL(itest *integration.Test, signer *keypair.Full, contractSalt string, wasmFileName string, ttl uint32) (xdr.ContractId, xdr.Hash) {
 	_, _, installContractOp := assertInvokeHostFnSucceeds(
 		itest,
 		signer,
@@ -1574,7 +1764,7 @@ func mustCreateAndInstallContract(itest *integration.Test, signer *keypair.Full,
 	sourceAccount, extendTTLOp := itest.PreflightExtendExpiration(
 		itest.Master().Address(),
 		keys,
-		LongTermTTL,
+		ttl,
 	)
 	itest.MustSubmitOperations(&sourceAccount, itest.Master(), &extendTTLOp)
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Follow up to https://github.com/stellar/go/pull/5722 which adds more eviction integration tests that exercise the case where the SAC itself is evicted.

### Why

https://github.com/stellar/go/issues/5613

### Known limitations
N/A
