### PR TITLE
services/horizon/cmd:  add datastore config option to ingest verify-range cmd

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -7,6 +7,9 @@ file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Update default pubnet captive core configuration to replace Whalestack with Creit Technologies in the quorum set ([5564](https://github.com/stellar/go/pull/5564)).
 
+- Add `--ledgerbackend` and `--datastore-config` options to `ingest verify-range` command to support CDP datastore backend configuration ([5553](https://github.com/stellar/go/pull/5553)).
+
+
 ## 22.0.3
 
 ### Fixed

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -14,20 +14,20 @@ import (
 	horizon "github.com/stellar/go/services/horizon/internal"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
 	"github.com/stellar/go/services/horizon/internal/ingest"
+	"github.com/stellar/go/support/config"
 	support "github.com/stellar/go/support/config"
 	"github.com/stellar/go/support/db"
 	"github.com/stellar/go/support/log"
 )
 
-var ingestCmd = &cobra.Command{
-	Use:   "ingest",
-	Short: "ingestion related commands",
-}
-
 var ingestBuildStateSequence uint32
 var ingestBuildStateSkipChecks bool
 var ingestVerifyFrom, ingestVerifyTo, ingestVerifyDebugServerPort uint32
 var ingestVerifyState bool
+var ingestVerifyLedgerBackendStr string
+var ingestVerifyStorageBackendConfigPath string
+var ingestVerifyLedgerBackendType ingest.LedgerBackendType
+var processVerifyRangeFn = processVerifyRange
 
 var ingestBuildStateCmdOpts = []*support.ConfigOption{
 	{
@@ -48,7 +48,7 @@ var ingestBuildStateCmdOpts = []*support.ConfigOption{
 	},
 }
 
-var ingestVerifyRangeCmdOpts = []*support.ConfigOption{
+var ingestVerifyRangeCmdOpts = support.ConfigOptions{
 	{
 		Name:        "from",
 		ConfigKey:   &ingestVerifyFrom,
@@ -81,79 +81,13 @@ var ingestVerifyRangeCmdOpts = []*support.ConfigOption{
 		FlagDefault: uint32(0),
 		Usage:       "[optional] opens a net/http/pprof server at given port",
 	},
-}
-
-var ingestVerifyRangeCmd = &cobra.Command{
-	Use:   "verify-range",
-	Short: "runs ingestion pipeline within a range. warning! requires clean DB.",
-	Long:  "runs ingestion pipeline between X and Y sequence number (inclusive)",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		for _, co := range ingestVerifyRangeCmdOpts {
-			if err := co.RequireE(); err != nil {
-				return err
-			}
-			co.SetValue()
-		}
-
-		if err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}); err != nil {
-			return err
-		}
-
-		if ingestVerifyDebugServerPort != 0 {
-			go func() {
-				log.Infof("Starting debug server at: %d", ingestVerifyDebugServerPort)
-				err := http.ListenAndServe(
-					fmt.Sprintf("localhost:%d", ingestVerifyDebugServerPort),
-					nil,
-				)
-				if err != nil {
-					log.Error(err)
-				}
-			}()
-		}
-
-		horizonSession, err := db.Open("postgres", globalConfig.DatabaseURL)
-		if err != nil {
-			return fmt.Errorf("cannot open Horizon DB: %v", err)
-		}
-		mngr := historyarchive.NewCheckpointManager(globalConfig.CheckpointFrequency)
-		if !mngr.IsCheckpoint(ingestVerifyFrom) && ingestVerifyFrom != 1 {
-			return fmt.Errorf("`--from` must be a checkpoint ledger")
-		}
-
-		if ingestVerifyState && !mngr.IsCheckpoint(ingestVerifyTo) {
-			return fmt.Errorf("`--to` must be a checkpoint ledger when `--verify-state` is set")
-		}
-
-		ingestConfig := ingest.Config{
-			NetworkPassphrase:      globalConfig.NetworkPassphrase,
-			HistorySession:         horizonSession,
-			HistoryArchiveURLs:     globalConfig.HistoryArchiveURLs,
-			HistoryArchiveCaching:  globalConfig.HistoryArchiveCaching,
-			CaptiveCoreBinaryPath:  globalConfig.CaptiveCoreBinaryPath,
-			CaptiveCoreConfigUseDB: globalConfig.CaptiveCoreConfigUseDB,
-			CheckpointFrequency:    globalConfig.CheckpointFrequency,
-			CaptiveCoreToml:        globalConfig.CaptiveCoreToml,
-			CaptiveCoreStoragePath: globalConfig.CaptiveCoreStoragePath,
-			RoundingSlippageFilter: globalConfig.RoundingSlippageFilter,
-		}
-
-		system, err := ingest.NewSystem(ingestConfig)
-		if err != nil {
-			return err
-		}
-
-		err = system.VerifyRange(
-			ingestVerifyFrom,
-			ingestVerifyTo,
-			ingestVerifyState,
-		)
-		if err != nil {
-			return err
-		}
-
-		log.Info("Range run successfully!")
-		return nil
+	generateLedgerBackendOpt(&ingestVerifyLedgerBackendStr, &ingestVerifyLedgerBackendType),
+	{
+		Name:      "datastore-config",
+		ConfigKey: &ingestVerifyStorageBackendConfigPath,
+		OptType:   types.String,
+		Required:  false,
+		Usage:     "[optional] Specify the path to the datastore config file (required for datastore backend)",
 	},
 }
 
@@ -178,156 +112,220 @@ var stressTestCmdOpts = []*support.ConfigOption{
 	},
 }
 
-var ingestStressTestCmd = &cobra.Command{
-	Use:   "stress-test",
-	Short: "runs ingestion pipeline on a ledger with many changes. warning! requires clean DB.",
-	Long:  "runs ingestion pipeline on a ledger with many changes. warning! requires clean DB.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		for _, co := range stressTestCmdOpts {
-			if err := co.RequireE(); err != nil {
+func DefineIngestCommands(rootCmd *cobra.Command, horizonConfig *horizon.Config, horizonFlags config.ConfigOptions) {
+	var ingestCmd = &cobra.Command{
+		Use:   "ingest",
+		Short: "ingestion related commands",
+	}
+
+	var ingestVerifyRangeCmd = &cobra.Command{
+		Use:   "verify-range",
+		Short: "runs ingestion pipeline within a range. warning! requires clean DB.",
+		Long:  "runs ingestion pipeline between X and Y sequence number (inclusive)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := ingestVerifyRangeCmdOpts.RequireE(); err != nil {
 				return err
 			}
-			co.SetValue()
-		}
-
-		if err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}); err != nil {
-			return err
-		}
-
-		horizonSession, err := db.Open("postgres", globalConfig.DatabaseURL)
-		if err != nil {
-			return fmt.Errorf("cannot open Horizon DB: %v", err)
-		}
-
-		if stressTestNumTransactions <= 0 {
-			return fmt.Errorf("`--transactions` must be positive")
-		}
-
-		if stressTestChangesPerTransaction <= 0 {
-			return fmt.Errorf("`--changes` must be positive")
-		}
-
-		ingestConfig := ingest.Config{
-			NetworkPassphrase:      globalConfig.NetworkPassphrase,
-			HistorySession:         horizonSession,
-			HistoryArchiveURLs:     globalConfig.HistoryArchiveURLs,
-			HistoryArchiveCaching:  globalConfig.HistoryArchiveCaching,
-			RoundingSlippageFilter: globalConfig.RoundingSlippageFilter,
-			CaptiveCoreBinaryPath:  globalConfig.CaptiveCoreBinaryPath,
-			CaptiveCoreConfigUseDB: globalConfig.CaptiveCoreConfigUseDB,
-		}
-
-		system, err := ingest.NewSystem(ingestConfig)
-		if err != nil {
-			return err
-		}
-
-		err = system.StressTest(
-			stressTestNumTransactions,
-			stressTestChangesPerTransaction,
-		)
-		if err != nil {
-			return err
-		}
-
-		log.Info("Stress test completed successfully!")
-		return nil
-	},
-}
-
-var ingestTriggerStateRebuildCmd = &cobra.Command{
-	Use:   "trigger-state-rebuild",
-	Short: "updates a database to trigger state rebuild, state will be rebuilt by a running Horizon instance, DO NOT RUN production DB, some endpoints will be unavailable until state is rebuilt",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
-		if err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}); err != nil {
-			return err
-		}
-
-		horizonSession, err := db.Open("postgres", globalConfig.DatabaseURL)
-		if err != nil {
-			return fmt.Errorf("cannot open Horizon DB: %v", err)
-		}
-
-		historyQ := &history.Q{SessionInterface: horizonSession}
-		if err := historyQ.UpdateIngestVersion(ctx, 0); err != nil {
-			return fmt.Errorf("cannot trigger state rebuild: %v", err)
-		}
-
-		log.Info("Triggered state rebuild")
-		return nil
-	},
-}
-
-var ingestBuildStateCmd = &cobra.Command{
-	Use:   "build-state",
-	Short: "builds state at a given checkpoint. warning! requires clean DB.",
-	Long:  "useful for debugging or starting Horizon at specific checkpoint.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		for _, co := range ingestBuildStateCmdOpts {
-			if err := co.RequireE(); err != nil {
+			if err := ingestVerifyRangeCmdOpts.SetValues(); err != nil {
 				return err
 			}
-			co.SetValue()
-		}
 
-		if err := horizon.ApplyFlags(globalConfig, globalFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}); err != nil {
-			return err
-		}
+			if err := horizon.ApplyFlags(horizonConfig, horizonFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}); err != nil {
+				return err
+			}
 
-		horizonSession, err := db.Open("postgres", globalConfig.DatabaseURL)
-		if err != nil {
-			return fmt.Errorf("cannot open Horizon DB: %v", err)
-		}
+			if ingestVerifyDebugServerPort != 0 {
+				go func() {
+					log.Infof("Starting debug server at: %d", ingestVerifyDebugServerPort)
+					err := http.ListenAndServe(
+						fmt.Sprintf("localhost:%d", ingestVerifyDebugServerPort),
+						nil,
+					)
+					if err != nil {
+						log.Error(err)
+					}
+				}()
+			}
 
-		historyQ := &history.Q{SessionInterface: horizonSession}
+			mngr := historyarchive.NewCheckpointManager(horizonConfig.CheckpointFrequency)
+			if !mngr.IsCheckpoint(ingestVerifyFrom) && ingestVerifyFrom != 1 {
+				return fmt.Errorf("`--from` must be a checkpoint ledger")
+			}
 
-		lastIngestedLedger, err := historyQ.GetLastLedgerIngestNonBlocking(context.Background())
-		if err != nil {
-			return fmt.Errorf("cannot get last ledger value: %v", err)
-		}
+			if ingestVerifyState && !mngr.IsCheckpoint(ingestVerifyTo) {
+				return fmt.Errorf("`--to` must be a checkpoint ledger when `--verify-state` is set")
+			}
 
-		if lastIngestedLedger != 0 {
-			return fmt.Errorf("cannot run on non-empty DB")
-		}
+			storageBackendConfig := ingest.StorageBackendConfig{}
+			if ingestVerifyLedgerBackendType == ingest.BufferedStorageBackend {
+				if ingestVerifyStorageBackendConfigPath == "" {
+					return fmt.Errorf("datastore-config file path is required with datastore backend")
+				}
+				var err error
+				if storageBackendConfig, err = loadStorageBackendConfig(ingestVerifyStorageBackendConfigPath); err != nil {
+					return err
+				}
+			}
 
-		mngr := historyarchive.NewCheckpointManager(globalConfig.CheckpointFrequency)
-		if !mngr.IsCheckpoint(ingestBuildStateSequence) {
-			return fmt.Errorf("`--sequence` must be a checkpoint ledger")
-		}
+			err := processVerifyRangeFn(horizonConfig, horizonFlags, storageBackendConfig)
+			if err != nil {
+				return err
+			}
 
-		ingestConfig := ingest.Config{
-			NetworkPassphrase:      globalConfig.NetworkPassphrase,
-			HistorySession:         horizonSession,
-			HistoryArchiveURLs:     globalConfig.HistoryArchiveURLs,
-			HistoryArchiveCaching:  globalConfig.HistoryArchiveCaching,
-			CaptiveCoreBinaryPath:  globalConfig.CaptiveCoreBinaryPath,
-			CaptiveCoreConfigUseDB: globalConfig.CaptiveCoreConfigUseDB,
-			CheckpointFrequency:    globalConfig.CheckpointFrequency,
-			CaptiveCoreToml:        globalConfig.CaptiveCoreToml,
-			CaptiveCoreStoragePath: globalConfig.CaptiveCoreStoragePath,
-			RoundingSlippageFilter: globalConfig.RoundingSlippageFilter,
-		}
+			log.Info("Range run successfully!")
+			return nil
+		},
+	}
 
-		system, err := ingest.NewSystem(ingestConfig)
-		if err != nil {
-			return err
-		}
+	var ingestStressTestCmd = &cobra.Command{
+		Use:   "stress-test",
+		Short: "runs ingestion pipeline on a ledger with many changes. warning! requires clean DB.",
+		Long:  "runs ingestion pipeline on a ledger with many changes. warning! requires clean DB.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, co := range stressTestCmdOpts {
+				if err := co.RequireE(); err != nil {
+					return err
+				}
+				co.SetValue()
+			}
 
-		err = system.BuildState(
-			ingestBuildStateSequence,
-			ingestBuildStateSkipChecks,
-		)
-		if err != nil {
-			return err
-		}
+			if err := horizon.ApplyFlags(horizonConfig, horizonFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}); err != nil {
+				return err
+			}
 
-		log.Info("State built successfully!")
-		return nil
-	},
-}
+			horizonSession, err := db.Open("postgres", horizonConfig.DatabaseURL)
+			if err != nil {
+				return fmt.Errorf("cannot open Horizon DB: %v", err)
+			}
 
-func init() {
+			if stressTestNumTransactions <= 0 {
+				return fmt.Errorf("`--transactions` must be positive")
+			}
+
+			if stressTestChangesPerTransaction <= 0 {
+				return fmt.Errorf("`--changes` must be positive")
+			}
+
+			ingestConfig := ingest.Config{
+				NetworkPassphrase:      horizonConfig.NetworkPassphrase,
+				HistorySession:         horizonSession,
+				HistoryArchiveURLs:     horizonConfig.HistoryArchiveURLs,
+				HistoryArchiveCaching:  horizonConfig.HistoryArchiveCaching,
+				RoundingSlippageFilter: horizonConfig.RoundingSlippageFilter,
+				CaptiveCoreBinaryPath:  horizonConfig.CaptiveCoreBinaryPath,
+				CaptiveCoreConfigUseDB: horizonConfig.CaptiveCoreConfigUseDB,
+			}
+
+			system, err := ingest.NewSystem(ingestConfig)
+			if err != nil {
+				return err
+			}
+
+			err = system.StressTest(
+				stressTestNumTransactions,
+				stressTestChangesPerTransaction,
+			)
+			if err != nil {
+				return err
+			}
+
+			log.Info("Stress test completed successfully!")
+			return nil
+		},
+	}
+
+	var ingestTriggerStateRebuildCmd = &cobra.Command{
+		Use:   "trigger-state-rebuild",
+		Short: "updates a database to trigger state rebuild, state will be rebuilt by a running Horizon instance, DO NOT RUN production DB, some endpoints will be unavailable until state is rebuilt",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			if err := horizon.ApplyFlags(horizonConfig, horizonFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}); err != nil {
+				return err
+			}
+
+			horizonSession, err := db.Open("postgres", horizonConfig.DatabaseURL)
+			if err != nil {
+				return fmt.Errorf("cannot open Horizon DB: %v", err)
+			}
+
+			historyQ := &history.Q{SessionInterface: horizonSession}
+			if err := historyQ.UpdateIngestVersion(ctx, 0); err != nil {
+				return fmt.Errorf("cannot trigger state rebuild: %v", err)
+			}
+
+			log.Info("Triggered state rebuild")
+			return nil
+		},
+	}
+
+	var ingestBuildStateCmd = &cobra.Command{
+		Use:   "build-state",
+		Short: "builds state at a given checkpoint. warning! requires clean DB.",
+		Long:  "useful for debugging or starting Horizon at specific checkpoint.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, co := range ingestBuildStateCmdOpts {
+				if err := co.RequireE(); err != nil {
+					return err
+				}
+				co.SetValue()
+			}
+
+			if err := horizon.ApplyFlags(horizonConfig, horizonFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}); err != nil {
+				return err
+			}
+
+			horizonSession, err := db.Open("postgres", horizonConfig.DatabaseURL)
+			if err != nil {
+				return fmt.Errorf("cannot open Horizon DB: %v", err)
+			}
+
+			historyQ := &history.Q{SessionInterface: horizonSession}
+
+			lastIngestedLedger, err := historyQ.GetLastLedgerIngestNonBlocking(context.Background())
+			if err != nil {
+				return fmt.Errorf("cannot get last ledger value: %v", err)
+			}
+
+			if lastIngestedLedger != 0 {
+				return fmt.Errorf("cannot run on non-empty DB")
+			}
+
+			mngr := historyarchive.NewCheckpointManager(globalConfig.CheckpointFrequency)
+			if !mngr.IsCheckpoint(ingestBuildStateSequence) {
+				return fmt.Errorf("`--sequence` must be a checkpoint ledger")
+			}
+
+			ingestConfig := ingest.Config{
+				NetworkPassphrase:      horizonConfig.NetworkPassphrase,
+				HistorySession:         horizonSession,
+				HistoryArchiveURLs:     horizonConfig.HistoryArchiveURLs,
+				HistoryArchiveCaching:  horizonConfig.HistoryArchiveCaching,
+				CaptiveCoreBinaryPath:  horizonConfig.CaptiveCoreBinaryPath,
+				CaptiveCoreConfigUseDB: horizonConfig.CaptiveCoreConfigUseDB,
+				CheckpointFrequency:    horizonConfig.CheckpointFrequency,
+				CaptiveCoreToml:        horizonConfig.CaptiveCoreToml,
+				CaptiveCoreStoragePath: horizonConfig.CaptiveCoreStoragePath,
+				RoundingSlippageFilter: horizonConfig.RoundingSlippageFilter,
+			}
+
+			system, err := ingest.NewSystem(ingestConfig)
+			if err != nil {
+				return err
+			}
+
+			err = system.BuildState(
+				ingestBuildStateSequence,
+				ingestBuildStateSkipChecks,
+			)
+			if err != nil {
+				return err
+			}
+
+			log.Info("State built successfully!")
+			return nil
+		},
+	}
+
 	for _, co := range ingestVerifyRangeCmdOpts {
 		err := co.Init(ingestVerifyRangeCmd)
 		if err != nil {
@@ -350,12 +348,51 @@ func init() {
 	}
 
 	viper.BindPFlags(ingestVerifyRangeCmd.PersistentFlags())
+	viper.BindPFlags(ingestBuildStateCmd.PersistentFlags())
+	viper.BindPFlags(ingestStressTestCmd.PersistentFlags())
 
-	RootCmd.AddCommand(ingestCmd)
+	rootCmd.AddCommand(ingestCmd)
 	ingestCmd.AddCommand(
 		ingestVerifyRangeCmd,
 		ingestStressTestCmd,
 		ingestTriggerStateRebuildCmd,
 		ingestBuildStateCmd,
+	)
+}
+
+func init() {
+	DefineIngestCommands(RootCmd, globalConfig, globalFlags)
+}
+
+func processVerifyRange(horizonConfig *horizon.Config, horizonFlags config.ConfigOptions, backendConfig ingest.StorageBackendConfig) error {
+	horizonSession, err := db.Open("postgres", horizonConfig.DatabaseURL)
+	if err != nil {
+		return fmt.Errorf("cannot open Horizon DB: %v", err)
+	}
+
+	ingestConfig := ingest.Config{
+		NetworkPassphrase:      horizonConfig.NetworkPassphrase,
+		HistorySession:         horizonSession,
+		HistoryArchiveURLs:     horizonConfig.HistoryArchiveURLs,
+		HistoryArchiveCaching:  horizonConfig.HistoryArchiveCaching,
+		CaptiveCoreBinaryPath:  horizonConfig.CaptiveCoreBinaryPath,
+		CaptiveCoreConfigUseDB: horizonConfig.CaptiveCoreConfigUseDB,
+		CheckpointFrequency:    horizonConfig.CheckpointFrequency,
+		CaptiveCoreToml:        horizonConfig.CaptiveCoreToml,
+		CaptiveCoreStoragePath: horizonConfig.CaptiveCoreStoragePath,
+		RoundingSlippageFilter: horizonConfig.RoundingSlippageFilter,
+		LedgerBackendType:      ingestVerifyLedgerBackendType,
+		StorageBackendConfig:   backendConfig,
+	}
+
+	system, err := ingest.NewSystem(ingestConfig)
+	if err != nil {
+		return err
+	}
+
+	return system.VerifyRange(
+		ingestVerifyFrom,
+		ingestVerifyTo,
+		ingestVerifyState,
 	)
 }

--- a/services/horizon/cmd/ingest_test.go
+++ b/services/horizon/cmd/ingest_test.go
@@ -100,6 +100,7 @@ func (s *IngestCommandsTestSuite) TestIngestVerifyRangeCmd() {
 			args := append([]string{"ingest", "verify-range"}, tt.args...)
 			rootCmd.SetArgs(append([]string{
 				"--db-url", s.db.DSN,
+				"--stellar-core-binary-path", "/test/core/bin/path",
 			}, args...))
 
 			if tt.expectError {

--- a/services/horizon/cmd/ingest_test.go
+++ b/services/horizon/cmd/ingest_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	horizon "github.com/stellar/go/services/horizon/internal"
+	"github.com/stellar/go/services/horizon/internal/ingest"
+	"github.com/stellar/go/support/config"
+	"github.com/stellar/go/support/db/dbtest"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type IngestCommandsTestSuite struct {
+	suite.Suite
+	db *dbtest.DB
+}
+
+func TestIngestCommandsTestSuite(t *testing.T) {
+	ingestCmdSuite := &IngestCommandsTestSuite{}
+	suite.Run(t, ingestCmdSuite)
+}
+
+func (s *IngestCommandsTestSuite) SetupSuite() {
+	// stub out the ingest command execution body,
+	// just test the cmd argument parsing and validation
+	processVerifyRangeFn = func(*horizon.Config, config.ConfigOptions, ingest.StorageBackendConfig) error {
+		return nil
+	}
+	s.db = dbtest.Postgres(s.T())
+	RootCmd.SetArgs([]string{
+		"db", "migrate", "up", "--db-url", s.db.DSN})
+	require.NoError(s.T(), RootCmd.Execute())
+}
+
+func (s *IngestCommandsTestSuite) TearDownSuite() {
+	s.db.Close()
+}
+
+func newIngestCmd() *cobra.Command {
+	rootCmd, horizonConfig, horizonFlags := newRootBaseCmd()
+	DefineIngestCommands(rootCmd, horizonConfig, horizonFlags)
+	return rootCmd
+}
+
+func (s *IngestCommandsTestSuite) TestIngestVerifyRangeCmd() {
+	tests := []struct {
+		name         string
+		args         []string
+		expectError  bool
+		errorMessage string
+	}{
+		{
+			name: "datastore backend without config",
+			args: []string{
+				"--from", "1", "--to", "10",
+				"--network", "testnet",
+				"--ledgerbackend", "datastore",
+			},
+			expectError:  true,
+			errorMessage: "datastore-config file path is required with datastore backend",
+		},
+		{
+			name: "invalid ledgerbackend type",
+			args: []string{
+				"--from", "1", "--to", "10",
+				"--network", "testnet",
+				"--ledgerbackend", "invalid-backend",
+			},
+			expectError:  true,
+			errorMessage: "invalid ledger backend: invalid-backend, must be 'captive-core' or 'datastore'",
+		},
+		{
+			name: "datastore with config",
+			args: []string{
+				"--from", "1", "--to", "10",
+				"--network", "testnet",
+				"--datastore-config", "../internal/ingest/testdata/config.storagebackend.toml",
+				"--ledgerbackend", "datastore",
+			},
+			expectError: false,
+		},
+		{
+			name: "datastore backend with missing config file",
+			args: []string{
+				"--from", "1", "--to", "10",
+				"--network", "testnet",
+				"--ledgerbackend", "datastore",
+				"--datastore-config", "nonexistent-config.toml",
+			},
+			expectError:  true,
+			errorMessage: "failed to load datastore ledgerbackend config file",
+		},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			rootCmd := newIngestCmd()
+			args := append([]string{"ingest", "verify-range"}, tt.args...)
+			rootCmd.SetArgs(append([]string{
+				"--db-url", s.db.DSN,
+			}, args...))
+
+			if tt.expectError {
+				err := rootCmd.Execute()
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMessage)
+			} else {
+				require.NoError(t, rootCmd.Execute())
+			}
+		})
+	}
+}

--- a/services/horizon/cmd/root.go
+++ b/services/horizon/cmd/root.go
@@ -60,12 +60,17 @@ func initRootCmd(cmd *cobra.Command,
 	}
 }
 
-func NewRootCmd() *cobra.Command {
+func newRootBaseCmd() (*cobra.Command, *horizon.Config, config.ConfigOptions) {
 	horizonGlobalConfig, horizonGlobalFlags := horizon.Flags()
 	cmd := createRootCmd(horizonGlobalConfig, horizonGlobalFlags)
 	initRootCmd(cmd, cmd.HelpFunc(), cmd.UsageFunc(), horizonGlobalFlags)
-	DefineDBCommands(cmd, horizonGlobalConfig, horizonGlobalFlags)
-	return cmd
+	return cmd, horizonGlobalConfig, horizonGlobalFlags
+}
+
+func NewRootCmd() *cobra.Command {
+	rootCmd, horizonGlobalConfig, horizonGlobalFlags := newRootBaseCmd()
+	DefineDBCommands(rootCmd, horizonGlobalConfig, horizonGlobalFlags)
+	return rootCmd
 }
 
 // ErrUsage indicates we should print the usage string and exit with code 1


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

added `--ledgerbackend` and `--datastore-config` options to `ingest verify-range` command

working example invocation:

```
./horizon ingest verify-range --from 57609343 --to 57609353 \
--ledgerbackend datastore \
--datastore-config <my gcs datastore config file for pubnet> \
--db-url <my empty horizon db url> \
--network-passphrase "Public Global Stellar Network ; September 2015"\
 --history-archive-urls https://history.stellar.org/prd/core-live/core_live_001
```

### Why

Enable the verify ledger range procedure to optionally use pre-computed ledger metadata from a datastore instead of captive core for performance.

This is the first of two overall changes needed to accomplish #5553 , next up after this is to change some verify range bench deployments to use these new CDP arguments instead of captive core settings.


