### PR TITLE
services/horizon/docker: cdp enabled verify range image

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -124,8 +124,8 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       GO_VERSION: 1.23.4
-      STELLAR_CORE_VERSION: 22.3.0-2485.e643061a4.focal
-      CAPTIVE_CORE_STORAGE_PATH: /tmp
+      STELLAR_CORE_VERSION: 22.3.0-2485.e643061a4.jammy
+      CAPTIVE_CORE_STORAGE_PATH: /data/working
     steps:
       - uses: actions/checkout@v3
         with:
@@ -134,7 +134,7 @@ jobs:
 
       - name: Build and test the Verify Range Docker image
         run: |
-          docker build --build-arg="GO_VERSION=$GO_VERSION" -f services/horizon/docker/verify-range/Dockerfile -t stellar/horizon-verify-range services/horizon/docker/verify-range/
+          docker build --build-arg="GO_VERSION=$GO_VERSION" --build-arg="STELLAR_CORE_VERSION=$STELLAR_CORE_VERSION" -f services/horizon/docker/verify-range/Dockerfile -t stellar/horizon-verify-range services/horizon/docker/verify-range/
           # Any range should do for basic testing, this range was chosen pretty early in history so that it only takes a few mins to run
           docker run -e BRANCH=$(git rev-parse HEAD) -e FROM=10000063 -e TO=10000127 stellar/horizon-verify-range
 

--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -125,7 +125,6 @@ jobs:
     env:
       GO_VERSION: 1.23.4
       STELLAR_CORE_VERSION: 22.3.0-2485.e643061a4.jammy
-      CAPTIVE_CORE_STORAGE_PATH: /data/working
     steps:
       - uses: actions/checkout@v3
         with:

--- a/services/horizon/cmd/db.go
+++ b/services/horizon/cmd/db.go
@@ -44,16 +44,14 @@ var (
 	parallelWorkers          uint
 	retries                  uint
 	retryBackoffSeconds      uint
-	ledgerBackendStr         string
 	storageBackendConfigPath string
 	ledgerBackendType        ingest.LedgerBackendType
 )
 
 // generateLedgerBackendOpt creates a reusable ConfigOption for ledgerbackend parameter
-func generateLedgerBackendOpt(configKey *string, backendTypeVar *ingest.LedgerBackendType) *support.ConfigOption {
+func generateLedgerBackendOpt(backendTypeVar *ingest.LedgerBackendType) *support.ConfigOption {
 	return &support.ConfigOption{
 		Name:        "ledgerbackend",
-		ConfigKey:   configKey,
 		OptType:     types.String,
 		Required:    false,
 		FlagDefault: ingest.CaptiveCoreBackend.String(),
@@ -70,7 +68,6 @@ func generateLedgerBackendOpt(configKey *string, backendTypeVar *ingest.LedgerBa
 			default:
 				return fmt.Errorf("invalid ledger backend: %s, must be 'captive-core' or 'datastore'", val)
 			}
-			*co.ConfigKey.(*string) = val
 			return nil
 		},
 	}
@@ -160,14 +157,8 @@ func ingestRangeCmdOpts() support.ConfigOptions {
 			FlagDefault: uint(5),
 			Usage:       "[optional] backoff seconds between reingest retries",
 		},
-		generateLedgerBackendOpt(&ledgerBackendStr, &ledgerBackendType),
-		{
-			Name:      "datastore-config",
-			ConfigKey: &storageBackendConfigPath,
-			OptType:   types.String,
-			Required:  false,
-			Usage:     "[optional] Specify the path to the datastore config file (required for datastore backend)",
-		},
+		generateLedgerBackendOpt(&ledgerBackendType),
+		generateDatastoreConfigOpt(&storageBackendConfigPath),
 	}
 }
 

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -24,7 +24,6 @@ var ingestBuildStateSequence uint32
 var ingestBuildStateSkipChecks bool
 var ingestVerifyFrom, ingestVerifyTo, ingestVerifyDebugServerPort uint32
 var ingestVerifyState bool
-var ingestVerifyLedgerBackendStr string
 var ingestVerifyStorageBackendConfigPath string
 var ingestVerifyLedgerBackendType ingest.LedgerBackendType
 var processVerifyRangeFn = processVerifyRange
@@ -81,14 +80,8 @@ var ingestVerifyRangeCmdOpts = support.ConfigOptions{
 		FlagDefault: uint32(0),
 		Usage:       "[optional] opens a net/http/pprof server at given port",
 	},
-	generateLedgerBackendOpt(&ingestVerifyLedgerBackendStr, &ingestVerifyLedgerBackendType),
-	{
-		Name:      "datastore-config",
-		ConfigKey: &ingestVerifyStorageBackendConfigPath,
-		OptType:   types.String,
-		Required:  false,
-		Usage:     "[optional] Specify the path to the datastore config file (required for datastore backend)",
-	},
+	generateLedgerBackendOpt(&ingestVerifyLedgerBackendType),
+	generateDatastoreConfigOpt(&ingestVerifyStorageBackendConfigPath),
 }
 
 var stressTestNumTransactions, stressTestChangesPerTransaction int
@@ -396,4 +389,15 @@ func processVerifyRange(horizonConfig *horizon.Config, horizonFlags config.Confi
 		ingestVerifyTo,
 		ingestVerifyState,
 	)
+}
+
+// generateDatastoreConfigOpt returns a *support.ConfigOption for the datastore-config flag
+func generateDatastoreConfigOpt(configKey *string) *support.ConfigOption {
+	return &support.ConfigOption{
+		Name:      "datastore-config",
+		ConfigKey: configKey,
+		OptType:   types.String,
+		Required:  false,
+		Usage:     "[optional] Specify the path to the datastore config file (required for datastore backend)",
+	}
 }

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -130,10 +130,6 @@ func DefineIngestCommands(rootCmd *cobra.Command, horizonConfig *horizon.Config,
 				return err
 			}
 
-			if err := horizon.ApplyFlags(horizonConfig, horizonFlags, horizon.ApplyOptions{RequireCaptiveCoreFullConfig: false}); err != nil {
-				return err
-			}
-
 			if ingestVerifyDebugServerPort != 0 {
 				go func() {
 					log.Infof("Starting debug server at: %d", ingestVerifyDebugServerPort)
@@ -157,6 +153,7 @@ func DefineIngestCommands(rootCmd *cobra.Command, horizonConfig *horizon.Config,
 			}
 
 			storageBackendConfig := ingest.StorageBackendConfig{}
+			noCaptiveCore := false
 			if ingestVerifyLedgerBackendType == ingest.BufferedStorageBackend {
 				if ingestVerifyStorageBackendConfigPath == "" {
 					return fmt.Errorf("datastore-config file path is required with datastore backend")
@@ -165,8 +162,12 @@ func DefineIngestCommands(rootCmd *cobra.Command, horizonConfig *horizon.Config,
 				if storageBackendConfig, err = loadStorageBackendConfig(ingestVerifyStorageBackendConfigPath); err != nil {
 					return err
 				}
+				noCaptiveCore = true
 			}
 
+			if err := horizon.ApplyFlags(horizonConfig, horizonFlags, horizon.ApplyOptions{NoCaptiveCore: noCaptiveCore, RequireCaptiveCoreFullConfig: false}); err != nil {
+				return err
+			}
 			err := processVerifyRangeFn(horizonConfig, horizonFlags, storageBackendConfig)
 			if err != nil {
 				return err

--- a/services/horizon/cmd/ingest_test.go
+++ b/services/horizon/cmd/ingest_test.go
@@ -100,7 +100,6 @@ func (s *IngestCommandsTestSuite) TestIngestVerifyRangeCmd() {
 			args := append([]string{"ingest", "verify-range"}, tt.args...)
 			rootCmd.SetArgs(append([]string{
 				"--db-url", s.db.DSN,
-				"--stellar-core-binary-path", "/test/core/bin/path",
 			}, args...))
 
 			if tt.expectError {

--- a/services/horizon/cmd/ingest_test.go
+++ b/services/horizon/cmd/ingest_test.go
@@ -100,6 +100,7 @@ func (s *IngestCommandsTestSuite) TestIngestVerifyRangeCmd() {
 			args := append([]string{"ingest", "verify-range"}, tt.args...)
 			rootCmd.SetArgs(append([]string{
 				"--db-url", s.db.DSN,
+				"--stellar-core-binary-path", "/test/core/bin/path",
 			}, args...))
 
 			if tt.expectError {

--- a/services/horizon/docker/verify-range/README.md
+++ b/services/horizon/docker/verify-range/README.md
@@ -45,7 +45,7 @@ This image supports connecting to GCS buckets for ledger data instead of captive
       ```
 
 #### GCS Datastore settings
-- Purpose: Defines the GCS bucket name and ledger partioning used on the buckets.
+- Purpose: Defines the GCS bucket name and ledger partioning used on the buckets. These settings are referenced as a single toml file at runtime. Here is an example [datastore_config.toml](../../../galexie/config.example.toml)
 - Two options are available to provide this to container:
   - As an environment variable:
     - Pass the datastore TOML config as a string(including line breaks, tabs) in the `DATASTORE_CONFIG_PLAIN` environment variable:

--- a/services/horizon/docker/verify-range/README.md
+++ b/services/horizon/docker/verify-range/README.md
@@ -70,3 +70,25 @@ it will run the following ranges:
 | 1                           | 127    | 191  |
 | 2                           | 191    | 255  |
 | 3                           | 255    | 319  |
+
+Running the image locally with `docker run`
+* example to run verify range with captive, same as before:
+  ```
+  docker run -e FROM=63 \
+                      -e TO=127 \
+                      -e BRANCH=<target version> \
+                      -e BASE_BRANCH=master \
+                      verify-range:latest
+  ```  
+* example to run verify range with gcs datastore:
+  ```
+  docker run -e FROM=63 \
+                      -e TO=127 \
+                      -e BRANCH=<target version> \
+                      -e BASE_BRANCH=master \
+                      -v /host/path/to/gcreds.json:/tmp/gcp.json \
+                      -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp.json \
+                      -v /host/path/to/datastore-config.tom:/tmp/datastore-config.toml \
+                      -e DATASTORE_CONFIG=/tmp/datastore-config.toml \
+                      verify-range:latest
+  ```  

--- a/services/horizon/docker/verify-range/README.md
+++ b/services/horizon/docker/verify-range/README.md
@@ -28,33 +28,32 @@ to provide an external volume mount to the container for `/data` of at least 300
 
 ### Datastore and GCP Credentials Usage
 
-This image supports connecting to GCS buckets for ledger data instead of captive core. To use this feature, set three environment variables:
+This image supports connecting to GCS buckets for ledger data instead of captive core. To use this feature configure the container with these additional settings:
 
-#### 1. `GCP_CREDS`
-- **Purpose:** Provide GCP credentials to the container.
-- **Two ways to provide:**
-  - **As an environment variable:**
-    - Pass the JSON credentials as a string in the `GCP_CREDS` environment variable:
+#### GCP Credentials
+- Purpose: To access GCS buckets the image needs GCP credentials. 
+- Two options are available to provide this to container:
+  - As an environment variable:
+    - Pass the GCP JSON credentials as a string in a `GCP_CREDS` environment variable:
       ```sh
       docker run -e GCP_CREDS='{...}' ...
       ```
-  - **As a mounted file:**
-    - Mount a host file containing the credentials to the container, e.g.:
+  - As a volume mount:
+    - Mount the GCP json credentials file on host to the container, e.g.:
       ```sh
-      docker run -v /host/path/gcp.json:/tmp/gcp.json -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp.json ...
+      docker run -v /host/path/credentials.json:/tmp/credentials.json -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/credentials.json ...
       ```
-    - The application will use the credentials from the mounted file.
 
-#### 2. `DATASTORE_CONFIG_PLAIN`
-- **Purpose:** Supplies GCS Datastore backend configuration for the container.
-- **Two ways to provide:**
-  - **As an environment variable:**
-    - Pass the TOML config as a string(including line breaks, tabs) in the `DATASTORE_CONFIG_PLAIN` environment variable:
+#### GCS Datastore settings
+- Purpose: Defines the GCS bucket name and ledger partioning used on the buckets.
+- Two options are available to provide this to container:
+  - As an environment variable:
+    - Pass the datastore TOML config as a string(including line breaks, tabs) in the `DATASTORE_CONFIG_PLAIN` environment variable:
       ```sh
-      docker run -e DATASTORE_CONFIG_PLAIN='[datastore]\nproject_id = "..."' 
+      docker run -e DATASTORE_CONFIG_PLAIN='[buffered_storage_backend_config]\nbuffer_size = 5\n ...' 
       ```
-  - **As a mounted file:**
-    - Mount a host file containing the datastore config file to the container, e.g.:
+  - As a volume mount:
+    - Mount the datastore toml config file from host to the container, e.g.:
       ```sh
       docker run -v /host/path/datastore-config.toml:/tmp/datastore-config.toml -e DATASTORE_CONFIG=/tmp/datastore-config.toml 
       ```

--- a/services/horizon/docker/verify-range/README.md
+++ b/services/horizon/docker/verify-range/README.md
@@ -2,6 +2,11 @@
 
 This docker image allows running multiple instances of `horizon ingest verify-command` on a single machine or running it in [AWS Batch](https://aws.amazon.com/batch/).
 
+## Data directory
+The image by default stores all outputs of db, captive core, and buffered storage processes
+under the `/data` directory at runtime in the container. Therefore it is strongly recommended
+to provide an external volume mount to the container for `/data` of at least 300-500GB. Specify this at docker run time via - `docker run -v /host/volume:/data`
+
 ## Env variables
 
 ### Running locally
@@ -20,7 +25,41 @@ This docker image allows running multiple instances of `horizon ingest verify-co
 | `BATCH_START_LEDGER` | First ledger of the AWS Batch Job, must be a checkpoint ledger or 1. |
 | `BATCH_SIZE`         | Size of the batch, must be multiple of 64.                           |
 
-#### Example
+
+### Datastore and GCP Credentials Usage
+
+This image supports connecting to GCS buckets for ledger data instead of captive core. To use this feature, set three environment variables:
+
+#### 1. `GCP_CREDS`
+- **Purpose:** Provide GCP credentials to the container.
+- **Two ways to provide:**
+  - **As an environment variable:**
+    - Pass the JSON credentials as a string in the `GCP_CREDS` environment variable:
+      ```sh
+      docker run -e GCP_CREDS='{...}' ...
+      ```
+  - **As a mounted file:**
+    - Mount a host file containing the credentials to the container, e.g.:
+      ```sh
+      docker run -v /host/path/gcp.json:/tmp/gcp.json -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp.json ...
+      ```
+    - The application will use the credentials from the mounted file.
+
+#### 2. `DATASTORE_CONFIG_PLAIN`
+- **Purpose:** Supplies GCS Datastore backend configuration for the container.
+- **Two ways to provide:**
+  - **As an environment variable:**
+    - Pass the TOML config as a string(including line breaks, tabs) in the `DATASTORE_CONFIG_PLAIN` environment variable:
+      ```sh
+      docker run -e DATASTORE_CONFIG_PLAIN='[datastore]\nproject_id = "..."' 
+      ```
+  - **As a mounted file:**
+    - Mount a host file containing the datastore config file to the container, e.g.:
+      ```sh
+      docker run -v /host/path/datastore-config.toml:/tmp/datastore-config.toml -e DATASTORE_CONFIG=/tmp/datastore-config.toml 
+      ```
+
+### Example
 
 When you start 10 jobs with `BATCH_START_LEDGER=63` and `BATCH_SIZE=64`
 it will run the following ranges:
@@ -31,14 +70,3 @@ it will run the following ranges:
 | 1                           | 127    | 191  |
 | 2                           | 191    | 255  |
 | 3                           | 255    | 319  |
-
-## Tips when using AWS Batch
-
-* In "Job definition" set vCPUs to 2 and Memory to 4096. This represents the `c5.large` instances Horizon should be using.
-* In "Compute environments":
-    * Set instance type to "c5.large".
-    * Set "Maximum vCPUs" to 2x the number of instances you want to start (because "c5.large" has 2 vCPUs). Ex. 10 vCPUs = 5 x "c5.large" instances.
-* Use spot instances! It's much cheaper and speed of testing will be the same in 99% of cases.
-* You need to publish the image if there are any changes in `Dockerfile` or one of the scripts.
-* When batch processing is over check if instances have been terminated. Sometimes AWS doesn't terminate them.
-* Make sure the job timeout is set to a larger value if you verify larger ranges. Default is just 100 seconds.

--- a/services/horizon/docker/verify-range/README.md
+++ b/services/horizon/docker/verify-range/README.md
@@ -19,11 +19,11 @@ to provide an external volume mount to the container for `/data` of at least 300
 
 ### Running in AWS Batch
 
-| Name                 | Description                                                          |
-|----------------------|----------------------------------------------------------------------|
-| `BRANCH`             | Git branch to build (useful for testing PRs)                         |
-| `BATCH_START_LEDGER` | First ledger of the AWS Batch Job, must be a checkpoint ledger or 1. |
-| `BATCH_SIZE`         | Size of the batch, must be multiple of 64.                           |
+| Name                        | Description                                                          |
+|-----------------------------|----------------------------------------------------------------------|
+| `AWS_BATCH_JOB_ARRAY_INDEX` | The zero based index of a single batch Job.                          |
+| `BATCH_START_LEDGER`        | The `FROM` ledger of the requested ledger range to verify.           |
+| `BATCH_SIZE`                | Size of the batch, must be multiple of 64.                           |
 
 
 ### Datastore and GCP Credentials Usage
@@ -58,10 +58,12 @@ This image supports connecting to GCS buckets for ledger data instead of captive
       docker run -v /host/path/datastore-config.toml:/tmp/datastore-config.toml -e DATASTORE_CONFIG=/tmp/datastore-config.toml 
       ```
 
-### Example
+### Examples of running container
 
-When you start 10 jobs with `BATCH_START_LEDGER=63` and `BATCH_SIZE=64`
-it will run the following ranges:
+#### Batch jobs example
+When run from aws batch, given `BATCH_START_LEDGER=63` and `BATCH_SIZE=64`
+it will generate runner jobs and give them each a  `AWS_BATCH_JOB_ARRAY_INDEX`. 
+The verify-range container will then generate the associated ledger ranges per each job:
 
 | `AWS_BATCH_JOB_ARRAY_INDEX` | `FROM` | `TO` |
 |-----------------------------|--------|------|
@@ -70,8 +72,9 @@ it will run the following ranges:
 | 2                           | 191    | 255  |
 | 3                           | 255    | 319  |
 
-Running the image locally with `docker run`
-* example to run verify range with captive, same as before:
+#### `docker run` example
+Running the verify-range image as local container with `docker run`
+* run verify range and use captive core to get ledgers from pubnet:
   ```
   docker run -e FROM=63 \
                       -e TO=127 \
@@ -79,7 +82,7 @@ Running the image locally with `docker run`
                       -e BASE_BRANCH=master \
                       verify-range:latest
   ```  
-* example to run verify range with gcs datastore:
+* run verify range with gcs datastore to use precomputed ledger metadata from buckets, captive core is not used:
   ```
   docker run -e FROM=63 \
                       -e TO=127 \

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -169,11 +169,11 @@ if [ ! -z "$BRANCH" ]; then
 	fi
 fi
 git log -1 --pretty=oneline
-/usr/local/go/bin/go build -v -o /stellar-go/horizon_new ./services/horizon/. 
+/usr/local/go/bin/go build -v -o "$CONTAINER_WORKING_DIR/horizon_new" ./services/horizon/. 
 git clean -xfd
 git checkout "$BASE_BRANCH"
 git log -1 --pretty=oneline
-/usr/local/go/bin/go build -v -o /stellar-go/horizon_old ./services/horizon/.
+/usr/local/go/bin/go build -v -o "$CONTAINER_WORKING_DIR/horizon_old" ./services/horizon/.
 
 cd "$CONTAINER_WORKING_DIR"
 rm -rf "$CONTAINER_WORKING_DIR/compare"
@@ -183,9 +183,9 @@ run_new_horizon() {
     mkdir -p "$CONTAINER_WORKING_DIR"/new_runtime
     cd "$CONTAINER_WORKING_DIR"/new_runtime
     echo "Starting dump_horizon_db new_history"
-    /stellar-go/horizon_new --db-url "$DATABASE_URL_NEW" db migrate up 
+    "$CONTAINER_WORKING_DIR/horizon_new" --db-url "$DATABASE_URL_NEW" db migrate up 
     alter_tables_unlogged "new"
-    /stellar-go/horizon_new --db-url "$DATABASE_URL_NEW" ingest verify-range --from $FROM --to $TO --verify-state
+    "$CONTAINER_WORKING_DIR/horizon_new" --db-url "$DATABASE_URL_NEW" ingest verify-range --from $FROM --to $TO --verify-state
     dump_horizon_db "new" "$CONTAINER_WORKING_DIR/compare/new_history"
     echo "Done dump_horizon_db new_history"
 }
@@ -194,10 +194,10 @@ run_old_horizon() {
     mkdir -p "$CONTAINER_WORKING_DIR"/old_runtime
     cd "$CONTAINER_WORKING_DIR"/old_runtime
     echo "Starting dump_horizon_db old_history"
-    /stellar-go/horizon_old --db-url "$DATABASE_URL_OLD" db migrate up
+    "$CONTAINER_WORKING_DIR/horizon_old" --db-url "$DATABASE_URL_OLD" db migrate up
     alter_tables_unlogged "old"
     REINGEST_FROM=$((FROM + 1)) # verify-range does not ingest starting ledger
-    /stellar-go/horizon_old --db-url "$DATABASE_URL_OLD" db reingest range $REINGEST_FROM $TO
+    "$CONTAINER_WORKING_DIR/horizon_old" --db-url "$DATABASE_URL_OLD" db reingest range $REINGEST_FROM $TO
     dump_horizon_db "old" "$CONTAINER_WORKING_DIR/compare/old_history"
     echo "Done dump_horizon_db old_history"
 }

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -159,6 +159,11 @@ export DATABASE_URL_NEW="postgres://postgres:postgres@localhost:5432/horizon_new
 export DATABASE_URL_OLD="postgres://postgres:postgres@localhost:5432/horizon_old?sslmode=disable"
 export CAPTIVE_CORE_CONFIG_APPEND_PATH="/captive-core-pubnet.cfg"
 export STELLAR_CORE_BINARY_PATH="/usr/bin/stellar-core"
+# we configure captive-core storage path to job index specific working dir path.
+# horizon maps this env variable to a config setting which is 
+# referenced by the archive pool bucket cache configuration in ingestion system setup, 
+# temporary archive file content gets stored here.
+export CAPTIVE_CORE_STORAGE_PATH="$CONTAINER_WORKING_DIR"
 
 BASE_BRANCH=${BASE_BRANCH:-master}
 cd stellar-go

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -13,57 +13,63 @@ else
 fi
 
 dump_horizon_db() {
-	echo "dumping history_effects"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_effects.history_operation_id, history_effects.order, type, details, history_accounts.address, address_muxed from history_effects left join history_accounts on history_accounts.id = history_effects.history_account_id order by history_operation_id asc, \"order\" asc" > "${1}_effects"
-	echo "dumping history_ledgers"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select sequence, ledger_hash, previous_ledger_hash, transaction_count, operation_count, closed_at, id, total_coins, fee_pool, base_fee, base_reserve, max_tx_set_size, protocol_version, ledger_header, successful_transaction_count, failed_transaction_count from history_ledgers order by sequence asc" > "${1}_ledgers"
-	echo "dumping history_operations"
-	# skip is_payment column which was only introduced in the most recent horizon v2.27.0
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select id, transaction_id, application_order, type, details, source_account, source_account_muxed from history_operations order by id asc" > "${1}_operations"
-	echo "dumping history_operation_claimable_balances"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_operation_id, claimable_balance_id from history_operation_claimable_balances left join history_claimable_balances on history_claimable_balances.id = history_operation_claimable_balances.history_claimable_balance_id order by history_operation_id asc, claimable_balance_id asc" > "${1}_operation_claimable_balances"
-	echo "dumping history_operation_liquidity_pools"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_operation_id, liquidity_pool_id from history_operation_liquidity_pools left join history_liquidity_pools on history_liquidity_pools.id = history_operation_liquidity_pools.history_liquidity_pool_id order by history_operation_id asc, liquidity_pool_id asc" > "${1}_operation_liquidity_pools"
-	echo "dumping history_operation_participants"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_operation_id, address from history_operation_participants left join history_accounts on history_accounts.id = history_operation_participants.history_account_id order by history_operation_id asc, address asc" > "${1}_operation_participants"
-	echo "dumping history_trades"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_trades.history_operation_id, history_trades.order, history_trades.ledger_closed_at, CASE WHEN history_trades.base_is_seller THEN history_trades.price_n ELSE history_trades.price_d END, CASE WHEN history_trades.base_is_seller THEN history_trades.price_d ELSE history_trades.price_n END, CASE WHEN history_trades.base_is_seller THEN history_trades.base_offer_id ELSE history_trades.counter_offer_id END, CASE WHEN history_trades.base_is_seller THEN history_trades.counter_offer_id ELSE history_trades.base_offer_id END, CASE WHEN history_trades.base_is_seller THEN baccount.address ELSE caccount.address END, CASE WHEN history_trades.base_is_seller THEN caccount.address ELSE baccount.address END, CASE WHEN history_trades.base_is_seller THEN basset.asset_type ELSE casset.asset_type END, CASE WHEN history_trades.base_is_seller THEN basset.asset_code ELSE casset.asset_code END, CASE WHEN history_trades.base_is_seller THEN basset.asset_issuer ELSE casset.asset_issuer END, CASE WHEN history_trades.base_is_seller THEN casset.asset_type ELSE basset.asset_type END, CASE WHEN history_trades.base_is_seller THEN casset.asset_code ELSE basset.asset_code END, CASE WHEN history_trades.base_is_seller THEN casset.asset_issuer ELSE basset.asset_issuer END from history_trades left join history_accounts baccount on baccount.id = history_trades.base_account_id left join history_accounts caccount on caccount.id = history_trades.counter_account_id left join history_assets basset on basset.id = history_trades.base_asset_id left join history_assets casset on casset.id = history_trades.counter_asset_id order by history_operation_id asc, \"order\" asc" > "${1}_trades"
-	echo "dumping history_transactions"
-	# Note: we skip `tx_meta` field here because it's a data structure (C++ unordered_map) which can be in different order
-	# in different Stellar-Core instances. The final fix should probably: unmarshal `tx_meta`, sort it, marshal and compare.
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select transaction_hash, ledger_sequence, application_order, account, account_sequence, max_fee, operation_count, id, tx_envelope, tx_result, tx_fee_meta, signatures, memo_type, memo, time_bounds, successful, fee_charged, inner_transaction_hash, fee_account, inner_signatures, new_max_fee, account_muxed, fee_account_muxed from history_transactions order by id asc" > "${1}_transactions"
-	echo "dumping history_transaction_claimable_balances"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_transaction_id, claimable_balance_id from history_transaction_claimable_balances left join history_claimable_balances on history_claimable_balances.id = history_transaction_claimable_balances.history_claimable_balance_id order by history_transaction_id, claimable_balance_id" > "${1}_transaction_claimable_balances"
-	echo "dumping history_transaction_liquidity_pools"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_transaction_id, liquidity_pool_id from history_transaction_liquidity_pools left join history_liquidity_pools on history_liquidity_pools.id = history_transaction_liquidity_pools.history_liquidity_pool_id order by history_transaction_id, liquidity_pool_id" > "${1}_transaction_liquidity_pools"
-	echo "dumping history_transaction_participants"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_transaction_id, address from history_transaction_participants left join history_accounts on history_accounts.id = history_transaction_participants.history_account_id order by history_transaction_id, address" > "${1}_transaction_participants"
+    local db_version="$1"
+    local compare_dir_path="$2"
+    local db_url="postgres://postgres:postgres@localhost:5432/horizon_${db_version}?sslmode=disable"
+
+    echo "dumping history_effects"
+    psql "$db_url" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_effects.history_operation_id, history_effects.order, type, details, history_accounts.address, address_muxed from history_effects left join history_accounts on history_accounts.id = history_effects.history_account_id order by history_operation_id asc, \"order\" asc" > "${compare_dir_path}_effects"
+    echo "dumping history_ledgers"
+    psql "$db_url" -t -A -F"," --variable="FETCH_COUNT=100" -c "select sequence, ledger_hash, previous_ledger_hash, transaction_count, operation_count, closed_at, id, total_coins, fee_pool, base_fee, base_reserve, max_tx_set_size, protocol_version, ledger_header, successful_transaction_count, failed_transaction_count from history_ledgers order by sequence asc" > "${compare_dir_path}_ledgers"
+    echo "dumping history_operations"
+    # skip is_payment column which was only introduced in the most recent horizon v2.27.0
+    psql "$db_url" -t -A -F"," --variable="FETCH_COUNT=100" -c "select id, transaction_id, application_order, type, details, source_account, source_account_muxed from history_operations order by id asc" > "${compare_dir_path}_operations"
+    echo "dumping history_operation_claimable_balances"
+    psql "$db_url" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_operation_id, claimable_balance_id from history_operation_claimable_balances left join history_claimable_balances on history_claimable_balances.id = history_operation_claimable_balances.history_claimable_balance_id order by history_operation_id asc, claimable_balance_id asc" > "${compare_dir_path}_operation_claimable_balances"
+    echo "dumping history_operation_liquidity_pools"
+    psql "$db_url" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_operation_id, liquidity_pool_id from history_operation_liquidity_pools left join history_liquidity_pools on history_liquidity_pools.id = history_operation_liquidity_pools.history_liquidity_pool_id order by history_operation_id asc, liquidity_pool_id asc" > "${compare_dir_path}_operation_liquidity_pools"
+    echo "dumping history_operation_participants"
+    psql "$db_url" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_operation_id, address from history_operation_participants left join history_accounts on history_accounts.id = history_operation_participants.history_account_id order by history_operation_id asc, address asc" > "${compare_dir_path}_operation_participants"
+    echo "dumping history_trades"
+    psql "$db_url" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_trades.history_operation_id, history_trades.order, history_trades.ledger_closed_at, CASE WHEN history_trades.base_is_seller THEN history_trades.price_n ELSE history_trades.price_d END, CASE WHEN history_trades.base_is_seller THEN history_trades.price_d ELSE history_trades.price_n END, CASE WHEN history_trades.base_is_seller THEN history_trades.base_offer_id ELSE history_trades.counter_offer_id END, CASE WHEN history_trades.base_is_seller THEN history_trades.counter_offer_id ELSE history_trades.base_offer_id END, CASE WHEN history_trades.base_is_seller THEN baccount.address ELSE caccount.address END, CASE WHEN history_trades.base_is_seller THEN caccount.address ELSE baccount.address END, CASE WHEN history_trades.base_is_seller THEN basset.asset_type ELSE casset.asset_type END, CASE WHEN history_trades.base_is_seller THEN basset.asset_code ELSE casset.asset_code END, CASE WHEN history_trades.base_is_seller THEN basset.asset_issuer ELSE casset.asset_issuer END, CASE WHEN history_trades.base_is_seller THEN casset.asset_type ELSE basset.asset_type END, CASE WHEN history_trades.base_is_seller THEN casset.asset_code ELSE basset.asset_code END, CASE WHEN history_trades.base_is_seller THEN casset.asset_issuer ELSE basset.asset_issuer END from history_trades left join history_accounts baccount on baccount.id = history_trades.base_account_id left join history_accounts caccount on caccount.id = history_trades.counter_account_id left join history_assets basset on basset.id = history_trades.base_asset_id left join history_assets casset on casset.id = history_trades.counter_asset_id order by history_operation_id asc, \"order\" asc" > "${compare_dir_path}_trades"
+    echo "dumping history_transactions"
+    # Note: we skip `tx_meta` field here because it's a data structure (C++ unordered_map) which can be in different order
+    # in different Stellar-Core instances. The final fix should probably: unmarshal `tx_meta`, sort it, marshal and compare.
+    psql "$db_url" -t -A -F"," --variable="FETCH_COUNT=100" -c "select transaction_hash, ledger_sequence, application_order, account, account_sequence, max_fee, operation_count, id, tx_envelope, tx_result, tx_fee_meta, signatures, memo_type, memo, time_bounds, successful, fee_charged, inner_transaction_hash, fee_account, inner_signatures, new_max_fee, account_muxed, fee_account_muxed from history_transactions order by id asc" > "${compare_dir_path}_transactions"
+    echo "dumping history_transaction_claimable_balances"
+    psql "$db_url" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_transaction_id, claimable_balance_id from history_transaction_claimable_balances left join history_claimable_balances on history_claimable_balances.id = history_transaction_claimable_balances.history_claimable_balance_id order by history_transaction_id, claimable_balance_id" > "${compare_dir_path}_transaction_claimable_balances"
+    echo "dumping history_transaction_liquidity_pools"
+    psql "$db_url" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_transaction_id, liquidity_pool_id from history_transaction_liquidity_pools left join history_liquidity_pools on history_liquidity_pools.id = history_transaction_liquidity_pools.history_liquidity_pool_id order by history_transaction_id, liquidity_pool_id" > "${compare_dir_path}_transaction_liquidity_pools"
+    echo "dumping history_transaction_participants"
+    psql "$db_url" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_transaction_id, address from history_transaction_participants left join history_accounts on history_accounts.id = history_transaction_participants.history_account_id order by history_transaction_id, address" > "${compare_dir_path}_transaction_participants"
 }
 
-function alter_tables_unlogged() {
-	# UNLOGGED for performance reasons (order is important because some tables reference others)
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE accounts SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE accounts_data SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE accounts_signers SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE claimable_balances SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE exp_asset_stats SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_trades SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_accounts SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_assets SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_claimable_balances SET UNLOGGED;"
-    psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_liquidity_pools SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_effects SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_ledgers SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_operation_claimable_balances SET UNLOGGED;"
-    psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_operation_liquidity_pools SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_operation_participants SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_operations SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_transaction_claimable_balances SET UNLOGGED;"
-    psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_transaction_liquidity_pools SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_transaction_participants SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_transactions SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE offers SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE trust_lines SET UNLOGGED;"
+alter_tables_unlogged() {
+    local db_version="$1"
+    local db_url="postgres://postgres:postgres@localhost:5432/horizon_${db_version}?sslmode=disable"
+    # UNLOGGED for performance reasons (order is important because some tables reference others)
+    psql "$db_url" -c "ALTER TABLE accounts SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE accounts_data SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE accounts_signers SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE claimable_balances SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE exp_asset_stats SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_trades SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_accounts SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_assets SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_claimable_balances SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_liquidity_pools SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_effects SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_ledgers SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_operation_claimable_balances SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_operation_liquidity_pools SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_operation_participants SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_operations SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_transaction_claimable_balances SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_transaction_liquidity_pools SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_transaction_participants SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE history_transactions SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE offers SET UNLOGGED;"
+    psql "$db_url" -c "ALTER TABLE trust_lines SET UNLOGGED;"
 }
 
 function compare() {
@@ -100,12 +106,16 @@ if [ -z "${PGDATA}" ]; then
     export PGDATA="$CONTAINER_WORKING_DIR/postgres"
     mkdir -p "$PGDATA"
 fi
+
 rm -rf "$PGDATA"/* 
 sudo chown -R postgres "$PGDATA"
 sudo chmod -R 775 "$PGDATA"
+
 sudo -u postgres --preserve-env=PGDATA /usr/lib/postgresql/14/bin/initdb
 sudo -u postgres --preserve-env=PGDATA /usr/lib/postgresql/14/bin/pg_ctl start
-sudo -u postgres createdb horizon
+
+sudo -u postgres createdb horizon_new
+sudo -u postgres createdb horizon_old
 sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
 
 # Calculate params for AWS Batch
@@ -141,10 +151,12 @@ echo "FROM: $FROM TO: $TO"
 # pubnet horizon config
 export NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 export HISTORY_ARCHIVE_URLS="https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_001"
-export DATABASE_URL="postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable"
+export DATABASE_URL_NEW="postgres://postgres:postgres@localhost:5432/horizon_new?sslmode=disable"
+export DATABASE_URL_OLD="postgres://postgres:postgres@localhost:5432/horizon_old?sslmode=disable"
 export CAPTIVE_CORE_CONFIG_APPEND_PATH="/captive-core-pubnet.cfg"
 export STELLAR_CORE_BINARY_PATH="/usr/bin/stellar-core"
 
+BASE_BRANCH=${BASE_BRANCH:-horizon-v2.0.0}
 cd stellar-go
 if [ ! -z "$BRANCH" ]; then
 	if [[ "$BRANCH" == pull/* ]]; then
@@ -157,48 +169,57 @@ if [ ! -z "$BRANCH" ]; then
 	fi
 fi
 git log -1 --pretty=oneline
-
-/usr/local/go/bin/go build -v ./services/horizon
+/usr/local/go/bin/go build -v -o /stellar-go/horizon_new ./services/horizon/. 
+git clean -xfd
+git checkout "$BASE_BRANCH"
+git log -1 --pretty=oneline
+/usr/local/go/bin/go build -v -o /stellar-go/horizon_new ./services/horizon/.
 
 cd "$CONTAINER_WORKING_DIR"
-/stellar-go/horizon db migrate up
-alter_tables_unlogged
-/stellar-go/horizon ingest verify-range --from $FROM --to $TO --verify-state
-
-BASE_BRANCH=${BASE_BRANCH:-horizon-v2.0.0}
-
 rm -rf "$CONTAINER_WORKING_DIR/compare"
 mkdir -p "$CONTAINER_WORKING_DIR/compare"
-if [ ! -z "$VERIFY_HISTORY" ]; then
-	dump_horizon_db "$CONTAINER_WORKING_DIR/compare/new_history"
 
-	echo "Done dump_horizon_db new_history"
+# Run the new horizon branch in background
+(
+	mkdir -p "$CONTAINER_WORKING_DIR"/new_runtime
+	cd "$CONTAINER_WORKING_DIR"/new_runtime
+    echo "Starting dump_horizon_db new_history"
+    /stellar-go/horizon_new --db-url "$DATABASE_URL_NEW" db migrate up 
+    alter_tables_unlogged "new"
+    /stellar-go/horizon_new --db-url "$DATABASE_URL_NEW" ingest verify-range --from $FROM --to $TO --verify-state
+    dump_horizon_db "new" "$CONTAINER_WORKING_DIR/compare/new_history"
+    echo "Done dump_horizon_db new_history"
+) &
+NEW_PID=$!
 
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "DROP SCHEMA public CASCADE;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "CREATE SCHEMA public;"
+# Run the old horizon branch in background
+(
+	mkdir -p "$CONTAINER_WORKING_DIR"/old_runtime
+	cd "$CONTAINER_WORKING_DIR"/old_runtime
+    echo "Starting dump_horizon_db old_history"
+    /stellar-go/horizon_old --db-url "$DATABASE_URL_OLD" db migrate up
+    alter_tables_unlogged "old"
+    REINGEST_FROM=$((FROM + 1)) # verify-range does not ingest starting ledger
+    /stellar-go/horizon_old --db-url "$DATABASE_URL_OLD" db reingest range $REINGEST_FROM $TO
+    dump_horizon_db "old" "$CONTAINER_WORKING_DIR/compare/old_history"
+    echo "Done dump_horizon_db old_history"
+) &
+OLD_PID=$!
 
-    cd /stellar-go
-	git checkout "$BASE_BRANCH"
-	/usr/local/go/bin/go build -v ./services/horizon
-	
-	cd "$CONTAINER_WORKING_DIR"
-	/stellar-go/horizon db migrate up
-	alter_tables_unlogged
-	REINGEST_FROM=$((FROM + 1)) # verify-range does not ingest starting ledger
-	/stellar-go/horizon db reingest range $REINGEST_FROM $TO
+# Wait for both background jobs to finish
+wait $NEW_PID
+wait $OLD_PID
 
-	dump_horizon_db "$CONTAINER_WORKING_DIR/compare/old_history"
-	echo "Done dump_horizon_db old_history"
+# Now run the compare functions
+compare history_effects
+compare history_ledgers
+compare history_operations
+compare history_operation_claimable_balances
+compare history_operation_participants
+compare history_trades
+compare history_transactions
+compare history_transaction_claimable_balances
+compare history_transaction_participants
 
-	compare history_effects
-	compare history_ledgers
-	compare history_operations
-	compare history_operation_claimable_balances
-	compare history_operation_participants
-	compare history_trades
-	compare history_transactions
-	compare history_transaction_claimable_balances
-	compare history_transaction_participants
-fi
 
 echo "OK"

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -182,7 +182,7 @@ mkdir -p "$CONTAINER_WORKING_DIR/compare"
 run_new_horizon() {
     mkdir -p "$CONTAINER_WORKING_DIR"/new_runtime
     cd "$CONTAINER_WORKING_DIR"/new_runtime
-    echo "Starting dump_horizon_db new_history"
+    echo "Starting dump_horizon_db new_history with LEDGERBACKEND=$LEDGERBACKEND and DATASTORE_CONFIG=$DATASTORE_CONFIG"
     "$CONTAINER_WORKING_DIR/horizon_new" --db-url "$DATABASE_URL_NEW" db migrate up 
     alter_tables_unlogged "new"
     "$CONTAINER_WORKING_DIR/horizon_new" --db-url "$DATABASE_URL_NEW" ingest verify-range --from $FROM --to $TO --verify-state
@@ -193,7 +193,7 @@ run_new_horizon() {
 run_old_horizon() {
     mkdir -p "$CONTAINER_WORKING_DIR"/old_runtime
     cd "$CONTAINER_WORKING_DIR"/old_runtime
-    echo "Starting dump_horizon_db old_history"
+    echo "Starting dump_horizon_db old_history with LEDGERBACKEND=$LEDGERBACKEND and DATASTORE_CONFIG=$DATASTORE_CONFIG"
     "$CONTAINER_WORKING_DIR/horizon_old" --db-url "$DATABASE_URL_OLD" db migrate up
     alter_tables_unlogged "old"
     REINGEST_FROM=$((FROM + 1)) # verify-range does not ingest starting ledger

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -1,15 +1,15 @@
 #! /usr/bin/env bash
 set -e
 
-# the aws batch job provides a shared volume at /data, so we need to
-# partition it safely so each job worker(index) only uses it's sub-directory on the volume.
+# the container runtime can provide externally mounted volume at /data. 
+# in batch job environment, the volume is the same for all batch jobs. 
+# so we partition sub-directories under so if container is batch job worker 
+# at an index N, the concurrent jobs will safely use the same volume at same time
 CONTAINER_WORKING_DIR="/data/job_${AWS_BATCH_JOB_ARRAY_INDEX:-0}"
 echo "Job working directory path on data volume: $CONTAINER_WORKING_DIR"
 
 # Ensure CONTAINER_WORKING_DIR exists and is empty
-if [ -d "$CONTAINER_WORKING_DIR" ]; then
-    rm -rf "$CONTAINER_WORKING_DIR"
-fi	
+rm -rf "$CONTAINER_WORKING_DIR"/*
 mkdir -p "$CONTAINER_WORKING_DIR"
 
 dump_horizon_db() {
@@ -106,11 +106,8 @@ if [ -z "${PGDATA}" ]; then
     export PGDATA="$CONTAINER_WORKING_DIR/postgres"
 fi
 
-if [ ! -d "$PGDATA" ]; then
-    mkdir -p "$PGDATA"
-else
-    rm -rf "$PGDATA"/*
-fi
+rm -rf "$PGDATA"/*
+mkdir -p "$PGDATA"
 
 sudo chown -R postgres "$PGDATA"
 sudo chmod -R 775 "$PGDATA"

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -4,13 +4,13 @@ set -e
 # the aws batch job provides a shared volume at /data, so we need to
 # partition it safely so each job worker(index) only uses it's sub-directory on the volume.
 CONTAINER_WORKING_DIR="/data/job_${AWS_BATCH_JOB_ARRAY_INDEX:-0}"
+echo "Job working directory path on data volume: $CONTAINER_WORKING_DIR"
 
 # Ensure CONTAINER_WORKING_DIR exists and is empty
 if [ -d "$CONTAINER_WORKING_DIR" ]; then
-    rm -rf "$CONTAINER_WORKING_DIR"/*
-else
-    mkdir -p "$CONTAINER_WORKING_DIR"
-fi
+    rm -rf "$CONTAINER_WORKING_DIR"
+fi	
+mkdir -p "$CONTAINER_WORKING_DIR"
 
 dump_horizon_db() {
     local db_version="$1"
@@ -104,10 +104,14 @@ fi
 # configure postgres
 if [ -z "${PGDATA}" ]; then
     export PGDATA="$CONTAINER_WORKING_DIR/postgres"
-    mkdir -p "$PGDATA"
 fi
 
-rm -rf "$PGDATA"/* 
+if [ ! -d "$PGDATA" ]; then
+    mkdir -p "$PGDATA"
+else
+    rm -rf "$PGDATA"/*
+fi
+
 sudo chown -R postgres "$PGDATA"
 sudo chmod -R 775 "$PGDATA"
 

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -1,6 +1,17 @@
 #! /usr/bin/env bash
 set -e
 
+# the aws batch job provides a shared volume at /data, so we need to
+# partition it safely so each job worker(index) only uses it's sub-directory on the volume.
+CONTAINER_WORKING_DIR="/data/job_${AWS_BATCH_JOB_ARRAY_INDEX:-0}"
+
+# Ensure CONTAINER_WORKING_DIR exists and is empty
+if [ -d "$CONTAINER_WORKING_DIR" ]; then
+    rm -rf "$CONTAINER_WORKING_DIR"/*
+else
+    mkdir -p "$CONTAINER_WORKING_DIR"
+fi
+
 dump_horizon_db() {
 	echo "dumping history_effects"
 	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_effects.history_operation_id, history_effects.order, type, details, history_accounts.address, address_muxed from history_effects left join history_accounts on history_accounts.id = history_effects.history_account_id order by history_operation_id asc, \"order\" asc" > "${1}_effects"
@@ -56,8 +67,8 @@ function alter_tables_unlogged() {
 }
 
 function compare() {
-	local expected="/data/compare/old_$1"
-	local actual="/data/compare/new_$1"
+	local expected="$CONTAINER_WORKING_DIR/compare/old_$1"
+	local actual="$CONTAINER_WORKING_DIR/compare/new_$1"
 
 	# Files can be very large, leading to `diff` running out of memory.
 	# As a workaround, since files are expected to be identical,
@@ -86,7 +97,8 @@ fi
 
 # configure postgres
 if [ -z "${PGDATA}" ]; then
-    export PGDATA="/data"
+    export PGDATA="$CONTAINER_WORKING_DIR/postgres"
+    mkdir -p "$PGDATA"
 fi
 rm -rf "$PGDATA"/* 
 sudo chown -R postgres "$PGDATA"
@@ -95,9 +107,6 @@ sudo -u postgres --preserve-env=PGDATA /usr/lib/postgresql/14/bin/initdb
 sudo -u postgres --preserve-env=PGDATA /usr/lib/postgresql/14/bin/pg_ctl start
 sudo -u postgres createdb horizon
 sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
-
-# setup a consistent mount point for temp files which can grow large, can't use tmpfs
-mkdir /data/working
 
 # Calculate params for AWS Batch
 if [ ! -z "$AWS_BATCH_JOB_ARRAY_INDEX" ]; then
@@ -151,17 +160,17 @@ git log -1 --pretty=oneline
 
 /usr/local/go/bin/go build -v ./services/horizon
 
-cd /data/working
+cd "$CONTAINER_WORKING_DIR"
 /stellar-go/horizon db migrate up
 alter_tables_unlogged
 /stellar-go/horizon ingest verify-range --from $FROM --to $TO --verify-state
 
 BASE_BRANCH=${BASE_BRANCH:-horizon-v2.0.0}
 
-rm -rf /data/compare
-mkdir /data/compare
+rm -rf "$CONTAINER_WORKING_DIR/compare"
+mkdir -p "$CONTAINER_WORKING_DIR/compare"
 if [ ! -z "$VERIFY_HISTORY" ]; then
-	dump_horizon_db "/data/compare/new_history"
+	dump_horizon_db "$CONTAINER_WORKING_DIR/compare/new_history"
 
 	echo "Done dump_horizon_db new_history"
 
@@ -172,13 +181,13 @@ if [ ! -z "$VERIFY_HISTORY" ]; then
 	git checkout "$BASE_BRANCH"
 	/usr/local/go/bin/go build -v ./services/horizon
 	
-	cd /data/working
+	cd "$CONTAINER_WORKING_DIR"
 	/stellar-go/horizon db migrate up
 	alter_tables_unlogged
 	REINGEST_FROM=$((FROM + 1)) # verify-range does not ingest starting ledger
 	/stellar-go/horizon db reingest range $REINGEST_FROM $TO
 
-	dump_horizon_db "/data/compare/old_history"
+	dump_horizon_db "$CONTAINER_WORKING_DIR/compare/old_history"
 	echo "Done dump_horizon_db old_history"
 
 	compare history_effects

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -156,7 +156,7 @@ export DATABASE_URL_OLD="postgres://postgres:postgres@localhost:5432/horizon_old
 export CAPTIVE_CORE_CONFIG_APPEND_PATH="/captive-core-pubnet.cfg"
 export STELLAR_CORE_BINARY_PATH="/usr/bin/stellar-core"
 
-BASE_BRANCH=${BASE_BRANCH:-horizon-v2.0.0}
+BASE_BRANCH=${BASE_BRANCH:-master}
 cd stellar-go
 if [ ! -z "$BRANCH" ]; then
 	if [[ "$BRANCH" == pull/* ]]; then

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -87,14 +87,14 @@ function compare() {
 	fi
 }
 
-if [ ! -z "$GCP_SECRET" ]; then
-    echo "$GCP_SECRET" > /tmp/gcp.json
+if [ ! -z "$GCP_CREDS" ]; then
+    echo "$GCP_CREDS" > /tmp/gcp.json
 	chmod 600 /tmp/gcp.json
 	export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
 	echo "Configured GCP credentials"
 fi	
 
-if [ ! -z "$DATASTORE_CONFIG_PLAIN" ] && [ "$LEDGERBACKEND" = "datastore" ]; then
+if [ ! -z "$DATASTORE_CONFIG_PLAIN" ]; then
     echo "$DATASTORE_CONFIG_PLAIN" > /tmp/datastore-config.toml
 	export DATASTORE_CONFIG="/tmp/datastore-config.toml"
 	echo "Configured Datastore credentials"
@@ -152,11 +152,16 @@ fi
 export LEDGER_COUNT=`expr "$TO" - "$FROM" + "1"`
 echo "FROM: $FROM TO: $TO"
 
+if [ ! -z "$DATASTORE_CONFIG" ]; then
+    export LEDGERBACKEND=datastore
+fi
+
 # pubnet horizon config
 export NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 export HISTORY_ARCHIVE_URLS="https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_001"
 export DATABASE_URL_NEW="postgres://postgres:postgres@localhost:5432/horizon_new?sslmode=disable"
 export DATABASE_URL_OLD="postgres://postgres:postgres@localhost:5432/horizon_old?sslmode=disable"
+# set the ccore settings by default, 
 # if DATASTORE_CONFIG is set, horizon commands will ignore the captive core settings.
 export CAPTIVE_CORE_CONFIG_APPEND_PATH="/captive-core-pubnet.cfg"
 export STELLAR_CORE_BINARY_PATH="/usr/bin/stellar-core"

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -77,10 +77,11 @@ if [ ! -z "$GCP_SECRET" ]; then
 	echo "Configured GCP credentials"
 fi	
 
-if [ ! -z "$DATASTORE_SECRET" ] && [ "$LEDGERBACKEND" = "datastore" ]; then
-    echo "$DATASTORE_SECRET" > /tmp/datastore-config.json
-	export DATASTORE_CONFIG="/tmp/datastore-config.json"
+if [ ! -z "$DATASTORE_CONFIG_PLAIN" ] && [ "$LEDGERBACKEND" = "datastore" ]; then
+    echo "$DATASTORE_CONFIG_PLAIN" > /tmp/datastore-config.toml
+	export DATASTORE_CONFIG="/tmp/datastore-config.toml"
 	echo "Configured Datastore credentials"
+	cat /tmp/datastore-config.toml
 fi	
 
 # configure postgres

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -1,6 +1,88 @@
 #! /usr/bin/env bash
 set -e
 
+dump_horizon_db() {
+	echo "dumping history_effects"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_effects.history_operation_id, history_effects.order, type, details, history_accounts.address, address_muxed from history_effects left join history_accounts on history_accounts.id = history_effects.history_account_id order by history_operation_id asc, \"order\" asc" > "${1}_effects"
+	echo "dumping history_ledgers"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select sequence, ledger_hash, previous_ledger_hash, transaction_count, operation_count, closed_at, id, total_coins, fee_pool, base_fee, base_reserve, max_tx_set_size, protocol_version, ledger_header, successful_transaction_count, failed_transaction_count from history_ledgers order by sequence asc" > "${1}_ledgers"
+	echo "dumping history_operations"
+	# skip is_payment column which was only introduced in the most recent horizon v2.27.0
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select id, transaction_id, application_order, type, details, source_account, source_account_muxed from history_operations order by id asc" > "${1}_operations"
+	echo "dumping history_operation_claimable_balances"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_operation_id, claimable_balance_id from history_operation_claimable_balances left join history_claimable_balances on history_claimable_balances.id = history_operation_claimable_balances.history_claimable_balance_id order by history_operation_id asc, claimable_balance_id asc" > "${1}_operation_claimable_balances"
+	echo "dumping history_operation_liquidity_pools"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_operation_id, liquidity_pool_id from history_operation_liquidity_pools left join history_liquidity_pools on history_liquidity_pools.id = history_operation_liquidity_pools.history_liquidity_pool_id order by history_operation_id asc, liquidity_pool_id asc" > "${1}_operation_liquidity_pools"
+	echo "dumping history_operation_participants"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_operation_id, address from history_operation_participants left join history_accounts on history_accounts.id = history_operation_participants.history_account_id order by history_operation_id asc, address asc" > "${1}_operation_participants"
+	echo "dumping history_trades"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_trades.history_operation_id, history_trades.order, history_trades.ledger_closed_at, CASE WHEN history_trades.base_is_seller THEN history_trades.price_n ELSE history_trades.price_d END, CASE WHEN history_trades.base_is_seller THEN history_trades.price_d ELSE history_trades.price_n END, CASE WHEN history_trades.base_is_seller THEN history_trades.base_offer_id ELSE history_trades.counter_offer_id END, CASE WHEN history_trades.base_is_seller THEN history_trades.counter_offer_id ELSE history_trades.base_offer_id END, CASE WHEN history_trades.base_is_seller THEN baccount.address ELSE caccount.address END, CASE WHEN history_trades.base_is_seller THEN caccount.address ELSE baccount.address END, CASE WHEN history_trades.base_is_seller THEN basset.asset_type ELSE casset.asset_type END, CASE WHEN history_trades.base_is_seller THEN basset.asset_code ELSE casset.asset_code END, CASE WHEN history_trades.base_is_seller THEN basset.asset_issuer ELSE casset.asset_issuer END, CASE WHEN history_trades.base_is_seller THEN casset.asset_type ELSE basset.asset_type END, CASE WHEN history_trades.base_is_seller THEN casset.asset_code ELSE basset.asset_code END, CASE WHEN history_trades.base_is_seller THEN casset.asset_issuer ELSE basset.asset_issuer END from history_trades left join history_accounts baccount on baccount.id = history_trades.base_account_id left join history_accounts caccount on caccount.id = history_trades.counter_account_id left join history_assets basset on basset.id = history_trades.base_asset_id left join history_assets casset on casset.id = history_trades.counter_asset_id order by history_operation_id asc, \"order\" asc" > "${1}_trades"
+	echo "dumping history_transactions"
+	# Note: we skip `tx_meta` field here because it's a data structure (C++ unordered_map) which can be in different order
+	# in different Stellar-Core instances. The final fix should probably: unmarshal `tx_meta`, sort it, marshal and compare.
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select transaction_hash, ledger_sequence, application_order, account, account_sequence, max_fee, operation_count, id, tx_envelope, tx_result, tx_fee_meta, signatures, memo_type, memo, time_bounds, successful, fee_charged, inner_transaction_hash, fee_account, inner_signatures, new_max_fee, account_muxed, fee_account_muxed from history_transactions order by id asc" > "${1}_transactions"
+	echo "dumping history_transaction_claimable_balances"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_transaction_id, claimable_balance_id from history_transaction_claimable_balances left join history_claimable_balances on history_claimable_balances.id = history_transaction_claimable_balances.history_claimable_balance_id order by history_transaction_id, claimable_balance_id" > "${1}_transaction_claimable_balances"
+	echo "dumping history_transaction_liquidity_pools"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_transaction_id, liquidity_pool_id from history_transaction_liquidity_pools left join history_liquidity_pools on history_liquidity_pools.id = history_transaction_liquidity_pools.history_liquidity_pool_id order by history_transaction_id, liquidity_pool_id" > "${1}_transaction_liquidity_pools"
+	echo "dumping history_transaction_participants"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_transaction_id, address from history_transaction_participants left join history_accounts on history_accounts.id = history_transaction_participants.history_account_id order by history_transaction_id, address" > "${1}_transaction_participants"
+}
+
+function alter_tables_unlogged() {
+	# UNLOGGED for performance reasons (order is important because some tables reference others)
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE accounts SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE accounts_data SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE accounts_signers SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE claimable_balances SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE exp_asset_stats SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_trades SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_accounts SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_assets SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_claimable_balances SET UNLOGGED;"
+    psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_liquidity_pools SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_effects SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_ledgers SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_operation_claimable_balances SET UNLOGGED;"
+    psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_operation_liquidity_pools SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_operation_participants SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_operations SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_transaction_claimable_balances SET UNLOGGED;"
+    psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_transaction_liquidity_pools SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_transaction_participants SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_transactions SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE offers SET UNLOGGED;"
+	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE trust_lines SET UNLOGGED;"
+}
+
+function compare() {
+	local expected="/data/compare/old_$1"
+	local actual="/data/compare/new_$1"
+
+	# Files can be very large, leading to `diff` running out of memory.
+	# As a workaround, since files are expected to be identical,
+	# we compare the hashes first.
+	local hash=$(shasum -a 256 "$expected" | cut -f 1 -d ' ')
+	local check_command="$hash  $actual"
+
+	if ! ( echo "$check_command" | shasum -a 256 -c ); then
+		diff --speed-large-files "$expected" "$actual"
+	fi
+}
+
+if [ ! -z "$GCP_SECRET" ]; then
+    echo "$GCP_SECRET" > /tmp/gcp.json
+	chmod 600 /tmp/gcp.json
+	export GOOGLE_APPLICATION_CREDENTIALS="/tmp/gcp.json"
+	echo "Configured GCP credentials"
+fi	
+
+if [ ! -z "$DATASTORE_SECRET" ] && [ "$LEDGERBACKEND" = "datastore" ]; then
+    echo "$DATASTORE_SECRET" > /tmp/datastore-config.json
+	export DATASTORE_CONFIG="/tmp/datastore-config.json"
+	echo "Configured Datastore credentials"
+fi	
+
 # configure postgres
 if [ -z "${PGDATA}" ]; then
     export PGDATA="/data"
@@ -12,6 +94,9 @@ sudo -u postgres --preserve-env=PGDATA /usr/lib/postgresql/14/bin/initdb
 sudo -u postgres --preserve-env=PGDATA /usr/lib/postgresql/14/bin/pg_ctl start
 sudo -u postgres createdb horizon
 sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
+
+# setup a consistent mount point for temp files which can grow large, can't use tmpfs
+mkdir /data/working
 
 # Calculate params for AWS Batch
 if [ ! -z "$AWS_BATCH_JOB_ARRAY_INDEX" ]; then
@@ -41,36 +126,7 @@ if [ ! -z "$AWS_BATCH_JOB_ARRAY_INDEX" ]; then
 fi
 
 export LEDGER_COUNT=`expr "$TO" - "$FROM" + "1"`
-
 echo "FROM: $FROM TO: $TO"
-
-dump_horizon_db() {
-	echo "dumping history_effects"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_effects.history_operation_id, history_effects.order, type, details, history_accounts.address, address_muxed from history_effects left join history_accounts on history_accounts.id = history_effects.history_account_id order by history_operation_id asc, \"order\" asc" > "${1}_effects"
-	echo "dumping history_ledgers"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select sequence, ledger_hash, previous_ledger_hash, transaction_count, operation_count, closed_at, id, total_coins, fee_pool, base_fee, base_reserve, max_tx_set_size, protocol_version, ledger_header, successful_transaction_count, failed_transaction_count from history_ledgers order by sequence asc" > "${1}_ledgers"
-	echo "dumping history_operations"
-	# skip is_payment column which was only introduced in the most recent horizon v2.27.0
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select id, transaction_id, application_order, type, details, source_account, source_account_muxed from history_operations order by id asc" > "${1}_operations"
-	echo "dumping history_operation_claimable_balances"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_operation_id, claimable_balance_id from history_operation_claimable_balances left join history_claimable_balances on history_claimable_balances.id = history_operation_claimable_balances.history_claimable_balance_id order by history_operation_id asc, claimable_balance_id asc" > "${1}_operation_claimable_balances"
-  echo "dumping history_operation_liquidity_pools"
-  psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_operation_id, liquidity_pool_id from history_operation_liquidity_pools left join history_liquidity_pools on history_liquidity_pools.id = history_operation_liquidity_pools.history_liquidity_pool_id order by history_operation_id asc, liquidity_pool_id asc" > "${1}_operation_liquidity_pools"
-	echo "dumping history_operation_participants"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_operation_id, address from history_operation_participants left join history_accounts on history_accounts.id = history_operation_participants.history_account_id order by history_operation_id asc, address asc" > "${1}_operation_participants"
-	echo "dumping history_trades"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_trades.history_operation_id, history_trades.order, history_trades.ledger_closed_at, CASE WHEN history_trades.base_is_seller THEN history_trades.price_n ELSE history_trades.price_d END, CASE WHEN history_trades.base_is_seller THEN history_trades.price_d ELSE history_trades.price_n END, CASE WHEN history_trades.base_is_seller THEN history_trades.base_offer_id ELSE history_trades.counter_offer_id END, CASE WHEN history_trades.base_is_seller THEN history_trades.counter_offer_id ELSE history_trades.base_offer_id END, CASE WHEN history_trades.base_is_seller THEN baccount.address ELSE caccount.address END, CASE WHEN history_trades.base_is_seller THEN caccount.address ELSE baccount.address END, CASE WHEN history_trades.base_is_seller THEN basset.asset_type ELSE casset.asset_type END, CASE WHEN history_trades.base_is_seller THEN basset.asset_code ELSE casset.asset_code END, CASE WHEN history_trades.base_is_seller THEN basset.asset_issuer ELSE casset.asset_issuer END, CASE WHEN history_trades.base_is_seller THEN casset.asset_type ELSE basset.asset_type END, CASE WHEN history_trades.base_is_seller THEN casset.asset_code ELSE basset.asset_code END, CASE WHEN history_trades.base_is_seller THEN casset.asset_issuer ELSE basset.asset_issuer END from history_trades left join history_accounts baccount on baccount.id = history_trades.base_account_id left join history_accounts caccount on caccount.id = history_trades.counter_account_id left join history_assets basset on basset.id = history_trades.base_asset_id left join history_assets casset on casset.id = history_trades.counter_asset_id order by history_operation_id asc, \"order\" asc" > "${1}_trades"
-	echo "dumping history_transactions"
-	# Note: we skip `tx_meta` field here because it's a data structure (C++ unordered_map) which can be in different order
-	# in different Stellar-Core instances. The final fix should probably: unmarshal `tx_meta`, sort it, marshal and compare.
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select transaction_hash, ledger_sequence, application_order, account, account_sequence, max_fee, operation_count, id, tx_envelope, tx_result, tx_fee_meta, signatures, memo_type, memo, time_bounds, successful, fee_charged, inner_transaction_hash, fee_account, inner_signatures, new_max_fee, account_muxed, fee_account_muxed from history_transactions order by id asc" > "${1}_transactions"
-	echo "dumping history_transaction_claimable_balances"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_transaction_id, claimable_balance_id from history_transaction_claimable_balances left join history_claimable_balances on history_claimable_balances.id = history_transaction_claimable_balances.history_claimable_balance_id order by history_transaction_id, claimable_balance_id" > "${1}_transaction_claimable_balances"
-  echo "dumping history_transaction_liquidity_pools"
-  psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_transaction_id, liquidity_pool_id from history_transaction_liquidity_pools left join history_liquidity_pools on history_liquidity_pools.id = history_transaction_liquidity_pools.history_liquidity_pool_id order by history_transaction_id, liquidity_pool_id" > "${1}_transaction_liquidity_pools"
-	echo "dumping history_transaction_participants"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -t -A -F"," --variable="FETCH_COUNT=100" -c "select history_transaction_id, address from history_transaction_participants left join history_accounts on history_accounts.id = history_transaction_participants.history_account_id order by history_transaction_id, address" > "${1}_transaction_participants"
-}
 
 # pubnet horizon config
 export NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
@@ -80,58 +136,24 @@ export CAPTIVE_CORE_CONFIG_APPEND_PATH="/captive-core-pubnet.cfg"
 export STELLAR_CORE_BINARY_PATH="/usr/bin/stellar-core"
 
 cd stellar-go
-git pull origin
 if [ ! -z "$BRANCH" ]; then
-	git checkout $BRANCH
+	if [[ "$BRANCH" == pull/* ]]; then
+		# BRANCH is a PR ref like pull/1234/head
+		git fetch origin "$BRANCH"
+		git checkout -B remote-pr-branch FETCH_HEAD
+	else
+		git pull origin
+		git checkout $BRANCH
+	fi
 fi
 git log -1 --pretty=oneline
 
-function alter_tables_unlogged() {
-	# UNLOGGED for performance reasons (order is important because some tables reference others)
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE accounts SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE accounts_data SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE accounts_signers SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE claimable_balances SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE exp_asset_stats SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_trades SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_accounts SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_assets SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_claimable_balances SET UNLOGGED;"
-  psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_liquidity_pools SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_effects SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_ledgers SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_operation_claimable_balances SET UNLOGGED;"
-  psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_operation_liquidity_pools SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_operation_participants SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_operations SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_transaction_claimable_balances SET UNLOGGED;"
-  psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_transaction_liquidity_pools SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_transaction_participants SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE history_transactions SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE offers SET UNLOGGED;"
-	psql "postgres://postgres:postgres@localhost:5432/horizon?sslmode=disable" -c "ALTER TABLE trust_lines SET UNLOGGED;"
-}
-
 /usr/local/go/bin/go build -v ./services/horizon
-cd $CAPTIVE_CORE_STORAGE_PATH
+
+cd /data/working
 /stellar-go/horizon db migrate up
 alter_tables_unlogged
 /stellar-go/horizon ingest verify-range --from $FROM --to $TO --verify-state
-
-function compare() {
-  local expected="/data/compare/old_$1"
-  local actual="/data/compare/new_$1"
-
-  # Files can be very large, leading to `diff` running out of memory.
-  # As a workaround, since files are expected to be identical,
-  # we compare the hashes first.
-  local hash=$(shasum -a 256 "$expected" | cut -f 1 -d ' ')
-  local check_command="$hash  $actual"
-
-  if ! ( echo "$check_command" | shasum -a 256 -c ); then
-    diff --speed-large-files "$expected" "$actual"
-  fi
-}
 
 BASE_BRANCH=${BASE_BRANCH:-horizon-v2.0.0}
 
@@ -149,7 +171,7 @@ if [ ! -z "$VERIFY_HISTORY" ]; then
 	git checkout "$BASE_BRANCH"
 	/usr/local/go/bin/go build -v ./services/horizon
 	
-	cd $CAPTIVE_CORE_STORAGE_PATH
+	cd /data/working
 	/stellar-go/horizon db migrate up
 	alter_tables_unlogged
 	REINGEST_FROM=$((FROM + 1)) # verify-range does not ingest starting ledger

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -157,13 +157,11 @@ export NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 export HISTORY_ARCHIVE_URLS="https://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-live/core_live_001"
 export DATABASE_URL_NEW="postgres://postgres:postgres@localhost:5432/horizon_new?sslmode=disable"
 export DATABASE_URL_OLD="postgres://postgres:postgres@localhost:5432/horizon_old?sslmode=disable"
+# if DATASTORE_CONFIG is set, horizon commands will ignore the captive core settings.
 export CAPTIVE_CORE_CONFIG_APPEND_PATH="/captive-core-pubnet.cfg"
 export STELLAR_CORE_BINARY_PATH="/usr/bin/stellar-core"
-# we configure captive-core storage path to job index specific working dir path.
-# horizon maps this env variable to a config setting which is 
-# referenced by the archive pool bucket cache configuration in ingestion system setup, 
-# temporary archive file content gets stored here.
 export CAPTIVE_CORE_STORAGE_PATH="$CONTAINER_WORKING_DIR"
+export HISTORY_ARCHIVE_CACHING="FALSE"
 
 BASE_BRANCH=${BASE_BRANCH:-master}
 cd stellar-go

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -179,23 +179,20 @@ cd "$CONTAINER_WORKING_DIR"
 rm -rf "$CONTAINER_WORKING_DIR/compare"
 mkdir -p "$CONTAINER_WORKING_DIR/compare"
 
-# Run the new horizon branch in background
-(
-	mkdir -p "$CONTAINER_WORKING_DIR"/new_runtime
-	cd "$CONTAINER_WORKING_DIR"/new_runtime
+run_new_horizon() {
+    mkdir -p "$CONTAINER_WORKING_DIR"/new_runtime
+    cd "$CONTAINER_WORKING_DIR"/new_runtime
     echo "Starting dump_horizon_db new_history"
     /stellar-go/horizon_new --db-url "$DATABASE_URL_NEW" db migrate up 
     alter_tables_unlogged "new"
     /stellar-go/horizon_new --db-url "$DATABASE_URL_NEW" ingest verify-range --from $FROM --to $TO --verify-state
     dump_horizon_db "new" "$CONTAINER_WORKING_DIR/compare/new_history"
     echo "Done dump_horizon_db new_history"
-) &
-NEW_PID=$!
+}
 
-# Run the old horizon branch in background
-(
-	mkdir -p "$CONTAINER_WORKING_DIR"/old_runtime
-	cd "$CONTAINER_WORKING_DIR"/old_runtime
+run_old_horizon() {
+    mkdir -p "$CONTAINER_WORKING_DIR"/old_runtime
+    cd "$CONTAINER_WORKING_DIR"/old_runtime
     echo "Starting dump_horizon_db old_history"
     /stellar-go/horizon_old --db-url "$DATABASE_URL_OLD" db migrate up
     alter_tables_unlogged "old"
@@ -203,12 +200,17 @@ NEW_PID=$!
     /stellar-go/horizon_old --db-url "$DATABASE_URL_OLD" db reingest range $REINGEST_FROM $TO
     dump_horizon_db "old" "$CONTAINER_WORKING_DIR/compare/old_history"
     echo "Done dump_horizon_db old_history"
-) &
-OLD_PID=$!
+}
 
-# Wait for both background jobs to finish
-wait $NEW_PID
-wait $OLD_PID
+if [ ! -z "$DATASTORE_CONFIG" ]; then
+    (run_new_horizon) &
+    (run_old_horizon) &
+    wait
+else
+    # don't attempt to run parallel with captive cores
+    run_new_horizon
+    run_old_horizon
+fi
 
 # Now run the compare functions
 compare history_effects

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -173,7 +173,7 @@ git log -1 --pretty=oneline
 git clean -xfd
 git checkout "$BASE_BRANCH"
 git log -1 --pretty=oneline
-/usr/local/go/bin/go build -v -o /stellar-go/horizon_new ./services/horizon/.
+/usr/local/go/bin/go build -v -o /stellar-go/horizon_old ./services/horizon/.
 
 cd "$CONTAINER_WORKING_DIR"
 rm -rf "$CONTAINER_WORKING_DIR/compare"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

* Updated the verify-range image to use optional GCS Datastore settings if present from environment to use instead of captive core for accessing ledgers. Refer to [README.md](https://github.com/stellar/go/pull/5736/files#diff-689188d34f82a03e4e61112951c05f1870b2373356c1ea4e9da5e1a608423f03R29)
* Refactored the verify-range container to run the old and new horizon processes in parallel if CDP is enabled for additional performance optimization. Does not perform parallelization if captive core, as would require more config changes for unique ports on the captive instances per new/old.
  *  some early performance numbers on these changes as seen from batch execution of latest network Ledger ranges:
     * 3.75 hours processing time elapsed for 57609343 to  57794662 which is 185319 ledgers, equating to an hourly rate of about 50k/hr is observed. 
     * for comparison, roughly 2 hours processing time elapses on average for 20k ledgers when running the original verify-range image in batch executions with smaller recent network ranges of about 20k ledgers, equating to a rate of 10k/hr. 
     * It looks like the combination of pre-computed datastore ledgers and parallelized 'new' and 'old' range processors is yielding roughly 5x boost in throughput.
* this leverages the updated verify-range command which supports datastore config from [part #1](https://github.com/stellar/go/pull/5732)


closes #5553 

### Why

can save time/complexity of runtime when using pre-computed meta from cdp rather than live captive core.

to build and run verify-range locally and use a datastore, checkout the go repo, from top folder:
```
docker build --platform linux/amd64 \
--build-arg="GO_VERSION=1.23.4" \
--build-arg="STELLAR_CORE_VERSION=22.3.0-2485.e643061a4.jammy" \
-f services/horizon/docker/verify-range/Dockerfile \
-t verify-range:latest services/horizon/docker/verify-range/
```
```
docker run -e FROM=63 -e TO=127 -e BRANCH=<tag, branch, pr ref, commit> \
-e BASE_BRANCH=master \
-v /path/to/gcp_credentials.json:/tmp/gcp.json \
-e GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp.json \
-v /path/to/pubnet_datastore_config.toml:/tmp/datastore-config.toml \
-e DATASTORE_CONFIG=/tmp/datastore-config.toml \
verify-range:latest
```

### Known limitations


