### PR TITLE
Include muxed info for the case where sender and receiver are both th…

### DIFF
--- a/processors/token_transfer/token_transfer_processor.go
+++ b/processors/token_transfer/token_transfer_processor.go
@@ -406,7 +406,16 @@ func (p *EventsProcessor) mintOrBurnOrTransferEvent(tx ingest.LedgerTransaction,
 	// This has happened in ledgerSequence: 4522126 on pubnet
 	if isFromIssuer && isToIssuer {
 		// There is no need to check or set muxed info here.
-		return NewTransferEvent(meta, fromAddress, toAddress, amt, protoAsset), nil
+		transferEvent := NewTransferEvent(meta, fromAddress, toAddress, amt, protoAsset)
+		// set mux information here as well
+		// See txHash - 53a2cb344383bb6c3e521d773199fbfffe9463c34c61e6cb7b0f729d4a4e0e29 in ledger - 53738108
+		if includeMuxInfo {
+			err := transferEvent.setDestinationMuxedInfo(toStrkey, tx) // the addresses have to be the original from and to address
+			if err != nil {
+				return nil, fmt.Errorf("error setting destination muxed info for transfer event: %w", err)
+			}
+		}
+		return transferEvent, nil
 	} else if isFromIssuer {
 
 		// Check for Mint Event


### PR DESCRIPTION
Fix bug/inconsistent behavior b/w core unified events VS ledger-entry-changes generated events by TTP.
