### PR TITLE
services/horizon: Update changelog for protocol 23 release

### DIFF
--- a/services/horizon/CHANGELOG.md
+++ b/services/horizon/CHANGELOG.md
@@ -3,11 +3,36 @@
 All notable changes to this project will be documented in this
 file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 23.0.0-rc2
+
+**This release adds support for Protocol 23**
+
+**Upgrading to this version will trigger a state rebuild. During this process, Horizon will not ingest new ledgers.**
+
+**This release of Horizon requires stellar-core version [23.0.0rc.1](https://github.com/stellar/stellar-core/releases/tag/v23.0.0rc.1) or higher. Older versions of stellar-core are incompatible with this build of Horizon.**
+
+### Breaking Changes
+In Protocol 23, Stellar Core removes in-memory mode and requires on-disk mode (using BucketListDB) for captive core ([5627](https://github.com/stellar/go/pull/5627)). As a result, the following configurations are no longer supported and have been removed:
+- `CAPTIVE_CORE_USE_DB`
+- `DEPRECATED_SQL_LEDGER_STATE`
+
+### Added
+- Update default pubnet captive core configuration to replace Whalestack with Creit Technologies in the quorum set ([5564](https://github.com/stellar/go/pull/5564)).
+- Added 1 new optional string field `destination_muxed_id` in the `asset_balance_changes` section of the `/operations` endpoint which represents the muxed id in the case where an asset is transferred to a muxed account destination ([5715](https://github.com/stellar/go/pull/5715), [5739](https://github.com/stellar/go/pull/5739)). Note that the `destination_muxed_id_type` field was introduced in the `23.0.0-rc1` release, however, the field turned out to be unnecessary and was removed.
+
+### Removed
+
+- The `errorResultXdr` field from the response of the async transaction submission endpoint has been removed ([5737](https://github.com/stellar/go/pull/5737)).
+- The `num_archived_contracts` and `archived_contracts_amount` fields from the `/assets` response have been removed ([5611](https://github.com/stellar/go/pull/5611)).
+
+
 ## 23.0.0-rc1
 
 **This release adds support for Protocol 23**
 
 **Upgrading to this version will trigger a state rebuild. During this process, Horizon will not ingest new ledgers.**
+
+**This release of Horizon requires stellar-core version [23.0.0rc.1](https://github.com/stellar/stellar-core/releases/tag/v23.0.0rc.1) or higher. Older versions of stellar-core are incompatible with this build of Horizon.**
 
 ### Breaking Changes
 In Protocol 23, Stellar Core removes in-memory mode and requires on-disk mode (using BucketListDB) for captive core ([5627](https://github.com/stellar/go/pull/5627)). As a result, the following configurations are no longer supported and have been removed:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Update horizon changelog for the next protocol 23 release to reflect that the  `destination_muxed_id_type` field was removed (see https://github.com/stellar/go/pull/5739)

### Known limitations

[N/A]
