### PR TITLE
services/horizon: Add robustness to checks for the existence of an effect

### DIFF
--- a/services/horizon/internal/integration/sac_test.go
+++ b/services/horizon/internal/integration/sac_test.go
@@ -1570,13 +1570,13 @@ func assertContainsEffect(t *testing.T, fx []effects.Effect, effectTypes ...effe
 		found[effect.GetType()] = idx
 	}
 
-	for _, type_ := range effectTypes {
-		assert.Containsf(t, found, effects.EffectTypeNames[type_], "effects: %v", fx)
-	}
-
 	var rv []effects.Effect
-	for _, i := range found {
-		rv = append(rv, fx[i])
+	for _, type_ := range effectTypes {
+		key := effects.EffectTypeNames[type_]
+		assert.Containsf(t, found, key, "effects: %v", fx)
+		if idx, exists := found[key]; exists {
+			rv = append(rv, fx[idx])
+		}
 	}
 
 	return rv


### PR DESCRIPTION
### What
Tests for the presence of effects in a robust manner.

### Why
Their order isn't guaranteed.

### Known Limitations
Why hasn't this come up before?