### PR TITLE
services/horizon/docker: adjust verify range data file purge

### DIFF
--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -8,6 +8,19 @@ set -e
 CONTAINER_WORKING_DIR="/data/job_${AWS_BATCH_JOB_ARRAY_INDEX:-0}"
 echo "Job working directory path on data volume: $CONTAINER_WORKING_DIR"
 
+cleanup() {
+    # need to purge these files at end as the db and the downloaed datastore
+    # files can be significatn GB's in size and in a cloud batch environment
+    # we don't want to keep them around after the job is done, i.e. pay for that space still.
+    sudo -u postgres --preserve-env=PGDATA /usr/lib/postgresql/14/bin/pg_ctl stop -D "$PGDATA"
+    sudo chattr -R -i -a "$CONTAINER_WORKING_DIR"
+    if [ -d "$CONTAINER_WORKING_DIR" ]; then
+        sudo rm -rf "$CONTAINER_WORKING_DIR"
+        echo "Purged working data files from $CONTAINER_WORKING_DIR"
+    fi
+}
+trap cleanup EXIT
+
 # Ensure CONTAINER_WORKING_DIR exists and is empty
 rm -rf "$CONTAINER_WORKING_DIR"/*
 mkdir -p "$CONTAINER_WORKING_DIR"

--- a/services/horizon/docker/verify-range/start
+++ b/services/horizon/docker/verify-range/start
@@ -13,7 +13,6 @@ cleanup() {
     # files can be significatn GB's in size and in a cloud batch environment
     # we don't want to keep them around after the job is done, i.e. pay for that space still.
     sudo -u postgres --preserve-env=PGDATA /usr/lib/postgresql/14/bin/pg_ctl stop -D "$PGDATA"
-    sudo chattr -R -i -a "$CONTAINER_WORKING_DIR"
     if [ -d "$CONTAINER_WORKING_DIR" ]; then
         sudo rm -rf "$CONTAINER_WORKING_DIR"
         echo "Purged working data files from $CONTAINER_WORKING_DIR"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

remove file attribute reset during verify-range image's data file purge routine

### Why

the pre-emptive fle attribute reset with `chattr` is not necessary, once pg is stopped the working data files path is ready for deletion. additionally, the file attrib reset wasn't compatible if the images /data path is mounted to an efs volume which by default has a file system that `chattr` doesn't work.

Related to: #5741 

### Known limitations


