### PR TITLE
services/galexie: Fix missing stellar-core binary path

### DIFF
--- a/services/galexie/internal/config.go
+++ b/services/galexie/internal/config.go
@@ -178,6 +178,7 @@ func (config *Config) GenerateCaptiveCoreConfig(coreBinFromPath string) (ledgerb
 	}
 
 	params := ledgerbackend.CaptiveCoreTomlParams{
+		CoreBinaryPath:     config.StellarCoreConfig.StellarCoreBinaryPath,
 		NetworkPassphrase:  config.StellarCoreConfig.NetworkPassphrase,
 		HistoryArchiveURLs: config.StellarCoreConfig.HistoryArchiveUrls,
 		EmitVerboseMeta:    true,


### PR DESCRIPTION

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Set the stellar-core binary path in the params when generating the captive-core config for Galexie.

### Why
This [PR](https://github.com/stellar/go/pull/5759) added recently, [sets several flags](https://github.com/stellar/go/pull/5759/files#diff-c7702ef819e52917ed3868588dff5273774c61a6aa8d36c1644d7ba251fb7756R608-R639) based on the protocol version. However, it relies on the stellar-core binary path being set in order to run the stellar-core version command to get the protocol version. Since that path wasn't previously set for Galexie, the flags weren’t applied correctly. This PR addresses that issue.

### Known limitations
I've tested this manually but I still need to figure out how to unit test it.