### PR TITLE
Add support for EMIT_VERBOSE_META cmdline boolean flag in horizon and…

### DIFF
--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -124,4 +124,7 @@ type Config struct {
 	DisableTxSub bool
 	// SkipTxmeta, when enabled, will not store meta xdr in history transaction table
 	SkipTxmeta bool
+	// EmitVerboseMeta, when enabled will include all kinds of events in txMeta - diagnosticEvents/classicEvents
+	// SkipTxMeta and EmitVerboseMeta dont go hand in hand. i.e EmitVerboseMeta cannot be TRUE if SkipTxMeta is set to TRUE
+	EmitVerboseMeta bool
 }


### PR DESCRIPTION
This PR deals with #5766 
Once validation is done in `ApplyFlags`, the config option is simply passed onto existing variable in the CaptiveCoreToml.

Added UTs as well