### PR TITLE
support/datastore: Use default limit when listing files for determining extension

### DIFF
--- a/ingest/cdp/producer_test.go
+++ b/ingest/cdp/producer_test.go
@@ -116,7 +116,7 @@ func TestBSBProducerFnConfigError(t *testing.T) {
 	}
 	mockDataStore.On("GetFile", mock.Anything, ".config.json").
 		Return(io.NopCloser(bytes.NewReader(configManifestJSON(t))), nil).Once()
-	mockDataStore.On("ListFilePaths", mock.Anything, "", 2).Return(nil, nil)
+	mockDataStore.On("ListFilePaths", mock.Anything, "", 0).Return(nil, nil)
 
 	datastoreFactory = func(_ context.Context, _ datastore.DataStoreConfig) (datastore.DataStore, error) {
 		return mockDataStore, nil
@@ -136,7 +136,7 @@ func TestBSBProducerFnInvalidRange(t *testing.T) {
 	mockDataStore := new(datastore.MockDataStore)
 	mockDataStore.On("GetFile", mock.Anything, ".config.json").
 		Return(io.NopCloser(bytes.NewReader(configManifestJSON(t))), nil).Once()
-	mockDataStore.On("ListFilePaths", mock.Anything, "", 2).Return(nil, nil)
+	mockDataStore.On("ListFilePaths", mock.Anything, "", 0).Return(nil, nil)
 
 	appCallback := func(lcm xdr.LedgerCloseMeta) error {
 		return nil
@@ -168,7 +168,7 @@ func TestBSBProducerFnGetLedgerError(t *testing.T) {
 	// since buffer is multi-worker async, it may get to this on other worker, but not deterministic,
 	// don't assert on it
 	mockDataStore.On("GetFile", mock.Anything, "FFFFFFFC--3.xdr.zst").Return(makeSingleLCMBatch(3), nil).Maybe()
-	mockDataStore.On("ListFilePaths", mock.Anything, "", 2).Return(nil, nil)
+	mockDataStore.On("ListFilePaths", mock.Anything, "", 0).Return(nil, nil)
 
 	appCallback := func(lcm xdr.LedgerCloseMeta) error {
 		return nil
@@ -232,7 +232,7 @@ func createMockdataStore(t *testing.T, start, end, partitionSize uint32) *datast
 
 	mockDataStore.On("GetFile", mock.Anything, ".config.json").
 		Return(io.NopCloser(bytes.NewReader(configJSON)), nil).Once()
-	mockDataStore.On("ListFilePaths", mock.Anything, "", 2).Return(nil, nil)
+	mockDataStore.On("ListFilePaths", mock.Anything, "", 0).Return(nil, nil)
 
 	partition := partitionSize - 1
 	for i := start; i <= end; i++ {

--- a/services/galexie/internal/app_test.go
+++ b/services/galexie/internal/app_test.go
@@ -158,7 +158,7 @@ func TestValidateExistingFileExtension(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ds := new(datastore.MockDataStore)
-			ds.On("ListFilePaths", context.Background(), "", 2).Return(tc.files, tc.getExtError)
+			ds.On("ListFilePaths", context.Background(), "", 0).Return(tc.files, tc.getExtError)
 
 			actualErr := validateExistingFileExtension(context.Background(), ds)
 

--- a/support/datastore/configure.go
+++ b/support/datastore/configure.go
@@ -187,7 +187,7 @@ func LoadSchema(ctx context.Context, dataStore DataStore, cfg DataStoreConfig) (
 var ErrNoLedgerFiles = errors.New("no ledger files found")
 
 func GetLedgerFileExtension(ctx context.Context, dataStore DataStore) (string, error) {
-	files, err := dataStore.ListFilePaths(ctx, "", 2)
+	files, err := dataStore.ListFilePaths(ctx, "", 0)
 	if err != nil {
 		return "", fmt.Errorf("failed to list ledger files: %w", err)
 	}

--- a/support/datastore/configure_test.go
+++ b/support/datastore/configure_test.go
@@ -193,7 +193,7 @@ func TestLoadSchema(t *testing.T) {
 	t.Run("Manifest found and valid", func(t *testing.T) {
 		mockOS := new(MockDataStore)
 		mockOS.On("GetFile", ctx, manifestFilename).Return(io.NopCloser(bytes.NewReader(validManifestBytes)), nil).Once()
-		mockOS.On("ListFilePaths", ctx, "", 2).Return(nil, nil)
+		mockOS.On("ListFilePaths", ctx, "", 0).Return(nil, nil)
 		schema, err := LoadSchema(ctx, mockOS, defaultCfg)
 		require.NoError(t, err)
 		require.NotNil(t, schema)
@@ -206,7 +206,7 @@ func TestLoadSchema(t *testing.T) {
 	t.Run("Manifest not found", func(t *testing.T) {
 		mockOS := new(MockDataStore)
 		mockOS.On("GetFile", ctx, manifestFilename).Return(nil, os.ErrNotExist).Once()
-		mockOS.On("ListFilePaths", ctx, "", 2).Return(nil, nil)
+		mockOS.On("ListFilePaths", ctx, "", 0).Return(nil, nil)
 
 		schema, err := LoadSchema(ctx, mockOS, defaultCfg)
 		require.NoError(t, err)
@@ -219,7 +219,7 @@ func TestLoadSchema(t *testing.T) {
 	t.Run("Manifest found but invalid JSON", func(t *testing.T) {
 		mockOS := new(MockDataStore)
 		mockOS.On("GetFile", ctx, manifestFilename).Return(io.NopCloser(bytes.NewReader([]byte(`{"invalid": "json"`))), nil).Once()
-		mockOS.On("ListFilePaths", ctx, "", 2).Return(nil, nil)
+		mockOS.On("ListFilePaths", ctx, "", 0).Return(nil, nil)
 
 		schema, err := LoadSchema(ctx, mockOS, defaultCfg)
 		require.Error(t, err)
@@ -237,7 +237,7 @@ func TestLoadSchema(t *testing.T) {
 		require.NoError(t, err)
 
 		mockOS.On("GetFile", ctx, manifestFilename).Return(io.NopCloser(bytes.NewReader(invalidManifestBytes)), nil).Once()
-		mockOS.On("ListFilePaths", ctx, "", 2).Return(nil, nil)
+		mockOS.On("ListFilePaths", ctx, "", 0).Return(nil, nil)
 
 		schema, err := LoadSchema(ctx, mockOS, defaultCfg)
 		require.Error(t, err)
@@ -249,7 +249,7 @@ func TestLoadSchema(t *testing.T) {
 	t.Run("Manifest not found, and incomplete config", func(t *testing.T) {
 		mockOS := new(MockDataStore)
 		mockOS.On("GetFile", ctx, manifestFilename).Return(nil, os.ErrNotExist).Once()
-		mockOS.On("ListFilePaths", ctx, "", 2).Return(nil, nil)
+		mockOS.On("ListFilePaths", ctx, "", 0).Return(nil, nil)
 
 		schema, err := LoadSchema(ctx, mockOS, DataStoreConfig{})
 		require.Error(t, err)
@@ -311,7 +311,7 @@ func TestGetLedgerFileExtension(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			ds := new(MockDataStore)
-			ds.On("ListFilePaths", mock.Anything, "", 2).Return(tt.files, tt.listErr).Once()
+			ds.On("ListFilePaths", mock.Anything, "", 0).Return(tt.files, tt.listErr).Once()
 
 			ext, err := GetLedgerFileExtension(context.Background(), ds)
 			require.Equal(t, tt.ExpectedExt, ext)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Use default limit when listing files for determining extension to use in the ledger data lake.

### Why

2 is chosen because it assumes the data lake will contain only 1 file  (`.config.json`) apart from the ledgers. If that assumption breaks (for example if the data lake contains another file besides `.config.json` which is not a ledger) then it's possible it will impact the detection of file extensions in the data lake.

### Known limitations

[N/A]
