### PR TITLE
support/datastore: bug fix in prefix matching

### DIFF
--- a/support/datastore/gcs_test.go
+++ b/support/datastore/gcs_test.go
@@ -409,6 +409,10 @@ func TestGCSGetFileValidatesCRC32C(t *testing.T) {
 func TestGCSListFilePaths(t *testing.T) {
 	server := fakestorage.NewServer([]fakestorage.Object{
 		{
+			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-bucket", Name: "objects/testnet-1/a"},
+			Content:     []byte("1"),
+		},
+		{
 			ObjectAttrs: fakestorage.ObjectAttrs{BucketName: "test-bucket", Name: "objects/testnet/a"},
 			Content:     []byte("1"),
 		},

--- a/support/datastore/s3_test.go
+++ b/support/datastore/s3_test.go
@@ -231,9 +231,10 @@ func setupTestS3DataStore(t *testing.T, ctx context.Context, bucketPath string, 
 func TestS3ListFilePaths(t *testing.T) {
 	ctx := context.Background()
 	store, teardown := setupTestS3DataStore(t, ctx, "test-bucket/objects/testnet", map[string]mockS3Object{
-		"objects/testnet/a": {body: []byte("1")},
-		"objects/testnet/b": {body: []byte("1")},
-		"objects/testnet/c": {body: []byte("1")},
+		"objects/testnet-1/a": {body: []byte("1")},
+		"objects/testnet/a":   {body: []byte("1")},
+		"objects/testnet/b":   {body: []byte("1")},
+		"objects/testnet/c":   {body: []byte("1")},
 	})
 	defer teardown()
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What
Updated `ListFilePaths` to ensure an exact match on the `destination_bucket_path`. 


### Why

Without this fix, the function returns all files that share a prefix with the destination path.
For example, if the `destination_bucket_path` was `bucket/ledgers/testnet/`, the function would incorrectly return files from both `bucket/ledgers/testnet/` and `bucket/ledgers/testnet-1/` because they share a common prefix.


### Known limitations
N/A
