### PR TITLE
support/datastore: Use debug logging in DataStore implementations

### DIFF
--- a/support/datastore/gcs.go
+++ b/support/datastore/gcs.go
@@ -55,7 +55,7 @@ func FromGCSClient(ctx context.Context, client *storage.Client, bucketPath strin
 	prefix := strings.TrimPrefix(parsed.Path, "/")
 	bucketName := parsed.Host
 
-	log.Infof("creating GCS client for bucket: %s, prefix: %s", bucketName, prefix)
+	log.Debugf("creating GCS client for bucket: %s, prefix: %s", bucketName, prefix)
 	// Check the bucket exists
 	bucket := client.Bucket(bucketName)
 	if _, err := bucket.Attrs(ctx); err != nil {
@@ -109,11 +109,11 @@ func (b GCSDataStore) GetFile(ctx context.Context, filePath string) (io.ReadClos
 			return nil, os.ErrNotExist
 		}
 		if gcsError, ok := err.(*googleapi.Error); ok {
-			log.Errorf("GCS error: %s %s", gcsError.Message, gcsError.Body)
+			log.Debugf("GCS error: %s %s", gcsError.Message, gcsError.Body)
 		}
 		return nil, fmt.Errorf("error retrieving file %s: %w", filePath, err)
 	}
-	log.Infof("File retrieved successfully: %s", filePath)
+	log.Debugf("File retrieved successfully: %s", filePath)
 	return r, nil
 }
 
@@ -124,15 +124,15 @@ func (b GCSDataStore) PutFileIfNotExists(ctx context.Context, filePath string, i
 		if gcsError, ok := err.(*googleapi.Error); ok {
 			switch gcsError.Code {
 			case http.StatusPreconditionFailed:
-				log.Infof("Precondition failed: %s already exists in the bucket", filePath)
+				log.Debugf("Precondition failed: %s already exists in the bucket", filePath)
 				return false, nil // Treat as success
 			default:
-				log.Errorf("GCS error: %s %s", gcsError.Message, gcsError.Body)
+				log.Debugf("GCS error: %s %s", gcsError.Message, gcsError.Body)
 			}
 		}
 		return false, fmt.Errorf("error uploading file %s: %w", filePath, err)
 	}
-	log.Infof("File uploaded successfully: %s", filePath)
+	log.Debugf("File uploaded successfully: %s", filePath)
 	return true, nil
 }
 
@@ -142,11 +142,11 @@ func (b GCSDataStore) PutFile(ctx context.Context, filePath string, in io.Writer
 
 	if err != nil {
 		if gcsError, ok := err.(*googleapi.Error); ok {
-			log.Errorf("GCS error: %s %s", gcsError.Message, gcsError.Body)
+			log.Debugf("GCS error: %s %s", gcsError.Message, gcsError.Body)
 		}
 		return fmt.Errorf("error uploading file %s: %w", filePath, err)
 	}
-	log.Infof("File uploaded successfully: %s", filePath)
+	log.Debugf("File uploaded successfully: %s", filePath)
 	return nil
 }
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Change log level to debug in DataStore implementations.

### Why

It's unexpected for a library to be producing info and error level logs. For example, when using a BufferedStorageBackend to fetch ledgers on an unbounded range, there will be a point where we have caught up to the latest ledger and the request to get the next ledger will fail with a 404 status because it is not available yet. This error is expected and handled within the  BufferedStorageBackend. However, the 404 errors are still logged in the library which lead to a confusing experience for the operator of a service ingesting via BufferedStorageBackend.

Here is an example of library logs being interspersed with service logs:

```
ERRO[2025-09-02T09:42:38.726-07:00] Error retrieving file 'v1.1/stellar/ledgers/pubnet-p23/FC807DFF--58688000-58751999/FC7F9636--58747337.xdr.zst': operation error S3: GetObject, https response error StatusCode: 404, RequestID: QS66G8RXQ5R61D7B, HostID: Ek7nHeMpWRcwOD+CwbWtsHkQmuH31py2FqA3/vXIKN1qsx9uaa15yEBLqWPPTNMFMUAf8J8NqscVM/04XOJpSI2fsWrEwepf+445Pj0b6HQ=, NoSuchKey:   pid=91088
ERRO[2025-09-02T09:42:38.747-07:00] Error retrieving file 'v1.1/stellar/ledgers/pubnet-p23/FC807DFF--58688000-58751999/FC7F9635--58747338.xdr.zst': operation error S3: GetObject, https response error StatusCode: 404, RequestID: QS671G79RTBT3316, HostID: KV4JtjTDh58mmwSVGEUegRiBTCM2/HhTPw9fm1OnYbi6jA7HCl7JXym7AhHHY9P0Rq2P4wWm9L0=, NoSuchKey:   pid=91088
2025/09/02 09:42:38 ingest: processed ledger 58747239 (assetMovementRows=226, totalSupplyRows=2, getLedgerDuration=0.005918208, ingestDuration=0.020613083)
ERRO[2025-09-02T09:42:38.777-07:00] Error retrieving file 'v1.1/stellar/ledgers/pubnet-p23/FC807DFF--58688000-58751999/FC7F9634--58747339.xdr.zst': operation error S3: GetObject, https response error StatusCode: 404, RequestID: QS67TR2P6EE38TYS, HostID: VGqDLl0RWuQZ1KH3TyQ/RPauOlWGL5JM/a65PUz5K5buhz9TXF4tHXeZkNIXnjEzsWo5efRF3jYOomy28rrT4zIoJMeh0jntGRvc4hb5nqg=, NoSuchKey:   pid=91088
ERRO[2025-09-02T09:42:38.802-07:00] Error retrieving file 'v1.1/stellar/ledgers/pubnet-p23/FC807DFF--58688000-58751999/FC7F9633--58747340.xdr.zst': operation error S3: GetObject, https response error StatusCode: 404, RequestID: QS60G73TKTZZT7MZ, HostID: cbDukRk0ceuE65I9RGLV6TPHX0x+K3pbkS8Aghqd1ZB/fuPLjgxFfpCmJqhHKR/zi5fTWCyYRqQ=, NoSuchKey:   pid=91088
2025/09/02 09:42:38 ingest: processed ledger 58747240 (assetMovementRows=186, totalSupplyRows=31, getLedgerDuration=0.005279917, ingestDuration=0.070137291)
ERRO[2025-09-02T09:42:38.840-07:00] Error retrieving file 'v1.1/stellar/ledgers/pubnet-p23/FC807DFF--58688000-58751999/FC7F9632--58747341.xdr.zst': operation error S3: GetObject, https response error StatusCode: 404, RequestID: QS66QAPQR5QQEX3P, HostID: 5Uy1yzSvSTSf7PivjVFFhQOlEAvfOjtOjQO6j7P2DLBjcFWMAMrqdpXAlhXIGZPhF4mdIHV99wg=, NoSuchKey:   pid=91088
2025/09/02 09:42:38 ingest: processed ledger 58747241 (assetMovementRows=236, totalSupplyRows=3, getLedgerDuration=0.017957209, ingestDuration=0.038420125)
2025/09/02 09:42:38 ingest: processed ledger 58747242 (assetMovementRows=248, totalSupplyRows=3, getLedgerDuration=0.006079584, ingestDuration=0.021009708)
2025/09/02 09:42:38 ingest: processed ledger 58747243 (assetMovementRows=169, totalSupplyRows=2, getLedgerDuration=0.005012208, ingestDuration=0.018115958)
2025/09/02 09:42:38 ingest: processed ledger 58747244 (assetMovementRows=268, totalSupplyRows=5, getLedgerDuration=0.010322042, ingestDuration=0.022496792)
2025/09/02 09:42:38 ingest: processed ledger 58747245 (assetMovementRows=198, totalSupplyRows=3, getLedgerDuration=0.011168375, ingestDuration=0.019473875)
2025/09/02 09:42:39 ingest: processed ledger 58747246 (assetMovementRows=195, totalSupplyRows=4, getLedgerDuration=0.005646291, ingestDuration=0.01745575)
....
2025/09/02 09:48:40 ingest: processed ledger 58747390 (assetMovementRows=144, totalSupplyRows=5, getLedgerDuration=29.457032583, ingestDuration=0.071612042)
ERRO[2025-09-02T09:48:40.718-07:00] Error retrieving file 'v1.1/stellar/ledgers/pubnet-p23/FC807DFF--58688000-58751999/FC7F95F7--58747400.xdr.zst': operation error S3: GetObject, https response error StatusCode: 404, RequestID: PQA955Y1JDJZGNCE, HostID: gcCNrkq1drtoiCGjK9jWcrU5I9R2H5Yu1EF3k3iD3qXhlK+mHANcAMF2GO5mCJB3VY698aIGhYw=, NoSuchKey:   pid=91088
ERRO[2025-09-02T09:48:40.816-07:00] Error retrieving file 'v1.1/stellar/ledgers/pubnet-p23/FC807DFF--58688000-58751999/FC7F95FA--58747397.xdr.zst': operation error S3: GetObject, https response error StatusCode: 404, RequestID: PQADSSR1M5KRF3R5, HostID: vRUm7YC1jw5zUcsP3gZOApX2nwt2LPxMrRQJUHR2f5ulp22r739JLXW/OXWe1Vok5xsjek4g8Z0=, NoSuchKey:   pid=91088
ERRO[2025-09-02T09:48:40.825-07:00] Error retrieving file 'v1.1/stellar/ledgers/pubnet-p23/FC807DFF--58688000-58751999/FC7F95F9--58747398.xdr.zst': operation error S3: GetObject, https response error StatusCode: 404, RequestID: PQA6Y2X5JZEXHGH8, HostID: agFk2m2GDifJhDT1+G6HYJD3k4KfMUF+ucFx2jftMBOmH78WA2A9OnycOvbqYfcxVCEhGO8mJcU=, NoSuchKey:   pid=91088
ERRO[2025-09-02T09:48:41.078-07:00] Error retrieving file 'v1.1/stellar/ledgers/pubnet-p23/FC807DFF--58688000-58751999/FC7F95F6--58747401.xdr.zst': operation error S3: GetObject, https response error StatusCode: 404, RequestID: 6RPPA0BAP34GGYX4, HostID: Qt3gv+xx1pEssyN/0pJs1yBEB980CeggibR2K6ZQt2ylVpRYPVAMHIDe5gPj1tMXYPNeCdPB2qM=, NoSuchKey:   pid=91088
ERRO[2025-09-02T09:48:41.111-07:00] Error retrieving file 'v1.1/stellar/ledgers/pubnet-p23/FC807DFF--58688000-58751999/FC7F95F5--58747402.xdr.zst': operation error S3: GetObject, https response error StatusCode: 404, RequestID: 6RPJJR0S20W5CEYH, HostID: fRTgrM2BXV7fjVDI+bSpoowLGnfXf4DH5CJXfYTznz3cmq0QJ+oIP4IVKSuTaHbaGwQxvM/nZC4=, NoSuchKey:   pid=91088
ERRO[2025-09-02T09:48:41.233-07:00] Error retrieving file 'v1.1/stellar/ledgers/pubnet-p23/FC807DFF--58688000-58751999/FC7F95F8--58747399.xdr.zst': operation error S3: GetObject, https response error StatusCode: 404, RequestID: 6RPY8HCR58TBMVJE, HostID: OJR0l3B1yu1MUUWLFG5LVqbeOVnXKFbqo0inFpeCiNV1sjKl9tjIgAXM+S7/UrB02u2N6yRh1k0=, NoSuchKey:   pid=91088
2025/09/02 09:48:41 ingest: processed ledger 58747391 (assetMovementRows=235, totalSupplyRows=48, getLedgerDuration=0.344118333, ingestDuration=0.211260875)
```

### Known limitations

[N/A]
