### PR TITLE
services/horizon/cmd: Run metrics server when invoking horizon ingest commands

### DIFF
--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -492,7 +492,7 @@ func runWithMetrics(metricsPort uint, system ingest.System, f func() error) erro
 		}
 		go func() {
 			if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				log.Warnf("error running metrics server: %v", err)
+				log.Fatalf("error running metrics server: %v", err)
 			}
 		}()
 		defer func() {

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi"
+	chimiddleware "github.com/go-chi/chi/middleware"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -475,6 +476,11 @@ func runWithMetrics(metricsPort uint, system ingest.System, f func() error) erro
 	if metricsPort != 0 {
 		log.Infof("Starting metrics server at: %d", metricsPort)
 		mux := chi.NewMux()
+		mux.Use(chimiddleware.StripSlashes)
+		mux.Use(chimiddleware.RequestID)
+		mux.Use(chimiddleware.RequestLogger(&chimiddleware.DefaultLogFormatter{
+			Logger: log.DefaultLogger,
+		}))
 		registry := prometheus.NewRegistry()
 		system.RegisterMetrics(registry)
 		httpx.AddMetricRoutes(mux, registry)

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -8,12 +8,15 @@ import (
 	_ "net/http/pprof"
 	"time"
 
+	"github.com/go-chi/chi"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/stellar/go/historyarchive"
 	horizon "github.com/stellar/go/services/horizon/internal"
 	"github.com/stellar/go/services/horizon/internal/db2/history"
+	"github.com/stellar/go/services/horizon/internal/httpx"
 	"github.com/stellar/go/services/horizon/internal/ingest"
 	"github.com/stellar/go/support/config"
 	support "github.com/stellar/go/support/config"
@@ -249,17 +252,12 @@ func DefineIngestCommands(rootCmd *cobra.Command, horizonConfig *horizon.Config,
 			if err != nil {
 				return err
 			}
-
-			err = system.StressTest(
-				stressTestNumTransactions,
-				stressTestChangesPerTransaction,
-			)
-			if err != nil {
-				return err
-			}
-
-			log.Info("Stress test completed successfully!")
-			return nil
+			return runWithMetrics(horizonConfig.AdminPort, system, func() error {
+				return system.StressTest(
+					stressTestNumTransactions,
+					stressTestChangesPerTransaction,
+				)
+			})
 		},
 	}
 
@@ -365,16 +363,12 @@ func DefineIngestCommands(rootCmd *cobra.Command, horizonConfig *horizon.Config,
 				return err
 			}
 
-			err = system.BuildState(
-				ingestBuildStateSequence,
-				ingestBuildStateSkipChecks,
-			)
-			if err != nil {
-				return err
-			}
-
-			log.Info("State built successfully!")
-			return nil
+			return runWithMetrics(horizonConfig.AdminPort, system, func() error {
+				return system.BuildState(
+					ingestBuildStateSequence,
+					ingestBuildStateSkipChecks,
+				)
+			})
 		},
 	}
 
@@ -444,11 +438,13 @@ func DefineIngestCommands(rootCmd *cobra.Command, horizonConfig *horizon.Config,
 				return err
 			}
 
-			return system.LoadTest(
-				ingestionLoadTestLedgersPath,
-				ingestionLoadTestCloseDuration,
-				ingestionLoadTestFixturesPath,
-			)
+			return runWithMetrics(horizonConfig.AdminPort, system, func() error {
+				return system.LoadTest(
+					ingestionLoadTestLedgersPath,
+					ingestionLoadTestCloseDuration,
+					ingestionLoadTestFixturesPath,
+				)
+			})
 		},
 	}
 
@@ -496,6 +492,32 @@ func DefineIngestCommands(rootCmd *cobra.Command, horizonConfig *horizon.Config,
 	)
 }
 
+func runWithMetrics(metricsPort uint, system ingest.System, f func() error) error {
+	if metricsPort != 0 {
+		log.Infof("Starting metrics server at: %d", metricsPort)
+		mux := chi.NewMux()
+		registry := prometheus.NewRegistry()
+		system.RegisterMetrics(registry)
+		httpx.AddMetricRoutes(mux, registry)
+		adminServer := &http.Server{
+			Addr:        fmt.Sprintf(":%d", metricsPort),
+			Handler:     mux,
+			ReadTimeout: 5 * time.Second,
+		}
+		go func() {
+			if err := adminServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				log.Warnf("error running admin server: %v", err)
+			}
+		}()
+		defer func() {
+			if err := adminServer.Shutdown(context.Background()); err != nil {
+				log.Warnf("error shutting down admin server: %v", err)
+			}
+		}()
+	}
+	return f()
+}
+
 func init() {
 	DefineIngestCommands(RootCmd, globalConfig, globalFlags)
 }
@@ -525,11 +547,13 @@ func processVerifyRange(horizonConfig *horizon.Config, horizonFlags config.Confi
 		return err
 	}
 
-	return system.VerifyRange(
-		ingestVerifyFrom,
-		ingestVerifyTo,
-		ingestVerifyState,
-	)
+	return runWithMetrics(horizonConfig.AdminPort, system, func() error {
+		return system.VerifyRange(
+			ingestVerifyFrom,
+			ingestVerifyTo,
+			ingestVerifyState,
+		)
+	})
 }
 
 // generateDatastoreConfigOpt returns a *support.ConfigOption for the datastore-config flag

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -496,6 +496,9 @@ func runWithMetrics(metricsPort uint, system ingest.System, f func() error) erro
 			}
 		}()
 		defer func() {
+			log.Info("Waiting for metrics to be flushed")
+			time.Sleep(time.Minute)
+			log.Info("Shutting down metrics server...")
 			if err := metricsServer.Shutdown(context.Background()); err != nil {
 				log.Warnf("error shutting down metrics server: %v", err)
 			}

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -506,14 +506,16 @@ func runWithMetrics(metricsPort uint, system ingest.System, f func() error) erro
 		}
 		go func() {
 			if err := adminServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				log.Warnf("error running admin server: %v", err)
+				log.Warnf("error running metrics server: %v", err)
 			}
 		}()
 		defer func() {
 			if err := adminServer.Shutdown(context.Background()); err != nil {
-				log.Warnf("error shutting down admin server: %v", err)
+				log.Warnf("error shutting down metrics server: %v", err)
 			}
 		}()
+	} else {
+		log.Info("Metrics server disabled")
 	}
 	return f()
 }

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -497,7 +497,10 @@ func runWithMetrics(metricsPort uint, system ingest.System, f func() error) erro
 		}()
 		defer func() {
 			log.Info("Waiting for metrics to be flushed")
-			time.Sleep(time.Minute)
+			// by default, the scrape_interval for prometheus is 1 minute
+			// so if we sleep for 1.5 minutes we ensure that all remaining metrics
+			// will be picked up by the prometheus scraper
+			time.Sleep(time.Minute + time.Second*30)
 			log.Info("Shutting down metrics server...")
 			if err := metricsServer.Shutdown(context.Background()); err != nil {
 				log.Warnf("error shutting down metrics server: %v", err)

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -479,7 +479,8 @@ func runWithMetrics(metricsPort uint, system ingest.System, f func() error) erro
 		mux.Use(chimiddleware.StripSlashes)
 		mux.Use(chimiddleware.RequestID)
 		mux.Use(chimiddleware.RequestLogger(&chimiddleware.DefaultLogFormatter{
-			Logger: log.DefaultLogger,
+			Logger:  log.DefaultLogger,
+			NoColor: true,
 		}))
 		registry := prometheus.NewRegistry()
 		system.RegisterMetrics(registry)

--- a/services/horizon/cmd/ingest.go
+++ b/services/horizon/cmd/ingest.go
@@ -26,7 +26,7 @@ import (
 
 var ingestBuildStateSequence uint32
 var ingestBuildStateSkipChecks bool
-var ingestVerifyFrom, ingestVerifyTo, ingestVerifyDebugServerPort uint32
+var ingestVerifyFrom, ingestVerifyTo uint32
 var ingestVerifyState bool
 var ingestVerifyStorageBackendConfigPath string
 var ingestVerifyLedgerBackendType ingest.LedgerBackendType
@@ -75,14 +75,6 @@ var ingestVerifyRangeCmdOpts = support.ConfigOptions{
 		Required:    false,
 		FlagDefault: false,
 		Usage:       "[optional] verifies state at the last ledger of the range when true",
-	},
-	{
-		Name:        "debug-server-port",
-		ConfigKey:   &ingestVerifyDebugServerPort,
-		OptType:     types.Uint32,
-		Required:    false,
-		FlagDefault: uint32(0),
-		Usage:       "[optional] opens a net/http/pprof server at given port",
 	},
 	generateLedgerBackendOpt(&ingestVerifyLedgerBackendType),
 	generateDatastoreConfigOpt(&ingestVerifyStorageBackendConfigPath),
@@ -160,19 +152,6 @@ func DefineIngestCommands(rootCmd *cobra.Command, horizonConfig *horizon.Config,
 			}
 			if err := ingestVerifyRangeCmdOpts.SetValues(); err != nil {
 				return err
-			}
-
-			if ingestVerifyDebugServerPort != 0 {
-				go func() {
-					log.Infof("Starting debug server at: %d", ingestVerifyDebugServerPort)
-					err := http.ListenAndServe(
-						fmt.Sprintf("localhost:%d", ingestVerifyDebugServerPort),
-						nil,
-					)
-					if err != nil {
-						log.Error(err)
-					}
-				}()
 			}
 
 			mngr := historyarchive.NewCheckpointManager(horizonConfig.CheckpointFrequency)
@@ -499,18 +478,18 @@ func runWithMetrics(metricsPort uint, system ingest.System, f func() error) erro
 		registry := prometheus.NewRegistry()
 		system.RegisterMetrics(registry)
 		httpx.AddMetricRoutes(mux, registry)
-		adminServer := &http.Server{
+		metricsServer := &http.Server{
 			Addr:        fmt.Sprintf(":%d", metricsPort),
 			Handler:     mux,
 			ReadTimeout: 5 * time.Second,
 		}
 		go func() {
-			if err := adminServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 				log.Warnf("error running metrics server: %v", err)
 			}
 		}()
 		defer func() {
-			if err := adminServer.Shutdown(context.Background()); err != nil {
+			if err := metricsServer.Shutdown(context.Background()); err != nil {
 				log.Warnf("error shutting down metrics server: %v", err)
 			}
 		}()

--- a/services/horizon/internal/httpx/router.go
+++ b/services/horizon/internal/httpx/router.go
@@ -394,9 +394,7 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 		w.Header().Set("Content-Type", "application/openapi+yaml")
 		w.Write(p)
 	})
-	r.Internal.Get("/metrics", promhttp.HandlerFor(config.PrometheusRegistry, promhttp.HandlerOpts{}).ServeHTTP)
-	r.Internal.Get("/debug/pprof/heap", pprof.Index)
-	r.Internal.Get("/debug/pprof/profile", pprof.Profile)
+	AddMetricRoutes(r.Internal, config.PrometheusRegistry)
 	r.Internal.Route("/ingestion/filters", func(r chi.Router) {
 		handler := actions.FilterConfigHandler{}
 		r.With(historyMiddleware).Put("/asset", handler.UpdateAssetConfig)
@@ -404,4 +402,10 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 		r.With(historyMiddleware).Get("/asset", handler.GetAssetConfig)
 		r.With(historyMiddleware).Get("/account", handler.GetAccountConfig)
 	})
+}
+
+func AddMetricRoutes(mux *chi.Mux, metrics *prometheus.Registry) {
+	mux.Get("/metrics", promhttp.HandlerFor(metrics, promhttp.HandlerOpts{}).ServeHTTP)
+	mux.Get("/debug/pprof/heap", pprof.Index)
+	mux.Get("/debug/pprof/profile", pprof.Profile)
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://developers.stellar.org/api/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've reviewed the changes in this PR and if I consider them worthwhile for being mentioned on release notes then I have updated the relevant `CHANGELOG.md` within the  component folder structure. For example, if I changed horizon, then I updated ([services/horizon/CHANGELOG.md](services/horizon/CHANGELOG.md). I add a new line item describing the change and reference to this PR. If I don't update a CHANGELOG, I acknowledge this PR's change may not be mentioned in future release notes.  
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Run a metrics server which can provide prometheus metrics while running long running ingest commands.

### Why

This is particularly useful for the recently introduced load-test command because we want to observe ingestion performance in grafana and compare it to our regular baseline. Without running a metrics server, we would only be able to analyze ingestion performance by looking at logs.


### Known limitations

[N/A]
